### PR TITLE
Scaffold pgNimbus: PostgreSQL GUI client (.NET 10 + Avalonia 11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+## .NET / Visual Studio / Rider
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Oo]ut/
+msbuild.log
+msbuild.err
+msbuild.wrn
+
+# Visual Studio cache/options
+.vs/
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Rider
+.idea/
+*.sln.iml
+
+# NuGet
+*.nupkg
+*.snupkg
+**/[Pp]ackages/*
+!**/[Pp]ackages/build/
+.nuget/
+
+# Publish output
+publish/
+*.pubxml
+*.publishproj
+
+# ASP.NET / general
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# Rider/VS Code
+.vscode/
+*.DotSettings.user
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test results
+[Tt]est[Rr]esult*/
+*.trx
+*.coverage
+*.coveragexml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# pgNimbus — project memory
+
+## What this is
+
+A fast, open-source PostgreSQL GUI client (.NET 10 + Avalonia 11), MIT
+licensed. Windows is the primary target; the core engine stays
+cross-platform-capable. The thesis: **truly fast + open source + modern UI** —
+a gap none of pgAdmin/DBeaver (heavy), TablePlus (fast but paid/closed), or
+HeidiSQL (fast but dated, MySQL-first) fill. pgNimbus aims for HeidiSQL's
+speed with TablePlus's polish, PostgreSQL-first.
+
+## Hard architectural rules
+
+1. **`PgNimbus.Core` has zero Avalonia/UI dependencies.** It references only
+   `Npgsql`. Anything UI-related belongs in `PgNimbus.App`. This keeps the
+   engine reusable for a future CLI or test harness — don't leak
+   `Avalonia.*` or `CommunityToolkit.Mvvm` types into `Core`.
+2. **Streaming + cancellation are non-negotiable.** `QueryEngine.ExecuteAsync`
+   returns result rows via `IAsyncEnumerable<RowBatch>` in ~200-row batches so
+   the UI can render before the full result set arrives. Every execution
+   takes a `CancellationToken` and must actually stop mid-flight, not just at
+   the start.
+3. **PostgreSQL-first, not lowest-common-denominator.** `SchemaService` reads
+   `pg_catalog` directly (not `information_schema`) so it can see materialized
+   views, partitioned tables, and real Postgres semantics (e.g. primary-key
+   flags via `pg_constraint`).
+4. **No passwords on `ConnectionProfile`.** Passwords come from the OS
+   credential store at connect time (currently a `// TODO`), never persisted
+   on the profile record itself.
+
+## Tech stack
+
+- `net10.0` for both projects.
+- Core: `Npgsql`.
+- App: `Avalonia`, `Avalonia.Desktop`, `Avalonia.Themes.Fluent`,
+  `Avalonia.Fonts.Inter`, `Avalonia.Controls.DataGrid`, `Avalonia.AvaloniaEdit`,
+  `CommunityToolkit.Mvvm`, `Avalonia.Diagnostics` (Debug only).
+- `AvaloniaUseCompiledBindingsByDefault` is on — don't add uncompiled
+  (reflection) bindings.
+
+## Coding conventions
+
+- DTOs are `record`s (see `QueryResult.cs`, `SchemaService.cs`).
+- MVVM via CommunityToolkit source generators (`[ObservableProperty]`,
+  `[RelayCommand]`) — no hand-written `INotifyPropertyChanged`.
+- Async all the way; no sync-over-async, no blocking `.Result`/`.Wait()`.
+- `Nullable` is enabled — respect it, don't silence with `!` unless truly
+  provably non-null.
+- `AvaloniaEdit.TextEditor` does not expose `Text` as a bindable
+  `AvaloniaProperty` — it's a plain CLR property backed by a `TextDocument`.
+  Two-way sync with the ViewModel is done manually in `MainWindow.axaml.cs`
+  (via `TextChanged` + `PropertyChanged`, with a re-entrancy guard), not via
+  XAML `Binding`.
+- Known accepted warning: Avalonia's Linux X11 backend transitively pulls
+  `Tmds.DBus.Protocol` 0.20.0, which has an open low-relevance advisory
+  (GHSA-xrw6-gwf8-vvr9). The only fixed line (0.90.0+) is a breaking rewrite
+  that Avalonia 11.2.3 can't load (TypeLoadException at startup). Don't try to
+  force-bump this package without confirming Avalonia has moved first.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shman4ik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PgNimbus.App/App.axaml
+++ b/PgNimbus.App/App.axaml
@@ -1,0 +1,12 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="PgNimbus.App.App"
+             RequestedThemeVariant="Default">
+
+    <Application.Styles>
+        <FluentTheme />
+        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
+        <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml" />
+    </Application.Styles>
+
+</Application>

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -1,0 +1,39 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using Npgsql;
+using PgNimbus.App.ViewModels;
+using PgNimbus.App.Views;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.App;
+
+public partial class App : Application
+{
+    private const string DefaultConnectionString =
+        "Host=localhost;Port=5432;Database=postgres;Username=postgres;Password=postgres;Application Name=pgNimbus";
+
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            // TODO: replace with a real connection manager UI; for now the
+            // app connects using whatever PGNIMBUS_CONN provides.
+            var connectionString = Environment.GetEnvironmentVariable("PGNIMBUS_CONN") ?? DefaultConnectionString;
+            var dataSource = NpgsqlDataSource.Create(connectionString);
+            var engine = new QueryEngine(dataSource);
+
+            desktop.MainWindow = new MainWindow
+            {
+                DataContext = new QueryViewModel(engine),
+            };
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/PgNimbus.App/PgNimbus.App.csproj
+++ b/PgNimbus.App/PgNimbus.App.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>PgNimbus.App</RootNamespace>
+    <AssemblyName>PgNimbus.App</AssemblyName>
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.3" />
+    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.3" />
+  </ItemGroup>
+
+  <!--
+    NU1903: Avalonia's X11 backend transitively pulls Tmds.DBus.Protocol 0.20.0,
+    which carries a known DoS advisory (GHSA-xrw6-gwf8-vvr9). The only fixed
+    releases (0.90.0+) are a breaking rewrite that Avalonia 11.2.3 cannot load
+    (TypeLoadException at startup on Linux), so this is accepted until Avalonia
+    itself bumps the dependency. Not reachable on the Windows-primary target.
+  -->
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);NU1903</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PgNimbus.Core\PgNimbus.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PgNimbus.App/Program.cs
+++ b/PgNimbus.App/Program.cs
@@ -1,0 +1,16 @@
+using Avalonia;
+
+namespace PgNimbus.App;
+
+internal static class Program
+{
+    // Avalonia configuration, don't remove; also used by visual designer.
+    [STAThread]
+    public static void Main(string[] args) => BuildAvaloniaApp()
+        .StartWithClassicDesktopLifetime(args);
+
+    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>()
+        .UsePlatformDetect()
+        .WithInterFont()
+        .LogToTrace();
+}

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -1,0 +1,115 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.App.ViewModels;
+
+public sealed partial class QueryViewModel : ObservableObject
+{
+    private readonly QueryEngine _engine;
+    private CancellationTokenSource? _cts;
+
+    [ObservableProperty]
+    private string _sql = "SELECT 1;";
+
+    [ObservableProperty]
+    private string _status = "Ready";
+
+    [ObservableProperty]
+    private bool _isRunning;
+
+    public ObservableCollection<string> ColumnNames { get; } = [];
+
+    public ObservableCollection<object?[]> Rows { get; } = [];
+
+    public QueryViewModel(QueryEngine engine)
+    {
+        _engine = engine;
+    }
+
+    private bool CanRun() => !IsRunning;
+
+    [RelayCommand(CanExecute = nameof(CanRun))]
+    private async Task RunAsync()
+    {
+        _cts = new CancellationTokenSource();
+        var ct = _cts.Token;
+
+        IsRunning = true;
+        Status = "Running...";
+        ColumnNames.Clear();
+        Rows.Clear();
+
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var result = await _engine.ExecuteAsync(Sql, ct);
+
+            switch (result)
+            {
+                case ResultSet resultSet:
+                    foreach (var column in resultSet.Columns)
+                    {
+                        ColumnNames.Add(column.Name);
+                    }
+
+                    var rowCount = 0;
+                    var firstByteMs = -1L;
+
+                    await foreach (var batch in resultSet.Batches.WithCancellation(ct))
+                    {
+                        if (firstByteMs < 0)
+                        {
+                            firstByteMs = stopwatch.ElapsedMilliseconds;
+                        }
+
+                        foreach (var row in batch.Rows)
+                        {
+                            Rows.Add(row);
+                        }
+
+                        rowCount += batch.Rows.Count;
+                        Status = $"{rowCount} rows ({firstByteMs} ms to first byte, {resultSet.Elapsed.TotalMilliseconds:F0} ms elapsed)";
+                    }
+
+                    Status = $"{rowCount} rows in {stopwatch.Elapsed.TotalMilliseconds:F0} ms ({firstByteMs} ms to first byte)";
+                    break;
+
+                case CommandResult commandResult:
+                    Status = $"{commandResult.CommandTag} — {commandResult.RowsAffected} row(s) affected in {commandResult.Elapsed.TotalMilliseconds:F0} ms";
+                    break;
+
+                case QueryError error:
+                    Status = $"Error: {error.Message}";
+                    break;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            Status = "Cancelled";
+        }
+        finally
+        {
+            IsRunning = false;
+            _cts?.Dispose();
+            _cts = null;
+        }
+    }
+
+    private bool CanCancel() => IsRunning;
+
+    [RelayCommand(CanExecute = nameof(CanCancel))]
+    private void Cancel()
+    {
+        _cts?.Cancel();
+    }
+
+    partial void OnIsRunningChanged(bool value)
+    {
+        RunCommand.NotifyCanExecuteChanged();
+        CancelCommand.NotifyCanExecuteChanged();
+    }
+}

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -1,0 +1,47 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:ae="using:AvaloniaEdit"
+        xmlns:vm="using:PgNimbus.App.ViewModels"
+        mc:Ignorable="d"
+        d:DesignWidth="1000" d:DesignHeight="650"
+        x:Class="PgNimbus.App.Views.MainWindow"
+        x:DataType="vm:QueryViewModel"
+        Title="pgNimbus"
+        Width="1100" Height="700"
+        FontFamily="{StaticResource InterFont}">
+
+    <Window.KeyBindings>
+        <KeyBinding Gesture="Ctrl+Enter" Command="{Binding RunCommand}" />
+        <KeyBinding Gesture="Escape" Command="{Binding CancelCommand}" />
+    </Window.KeyBindings>
+
+    <Grid RowDefinitions="Auto,*,*,Auto" Margin="8">
+
+        <StackPanel Orientation="Horizontal" Grid.Row="0" Spacing="8" Margin="0,0,0,8">
+            <Button Content="Run" Command="{Binding RunCommand}" ToolTip.Tip="Ctrl+Enter" />
+            <Button Content="Cancel" Command="{Binding CancelCommand}" ToolTip.Tip="Esc" />
+        </StackPanel>
+
+        <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+            <ae:TextEditor Name="SqlEditor"
+                           ShowLineNumbers="True"
+                           FontFamily="Cascadia Code,Consolas,Menlo,monospace"
+                           FontSize="14" />
+        </Border>
+
+        <Border Grid.Row="2" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Margin="0,8,0,8">
+            <DataGrid Name="ResultsGrid"
+                      IsReadOnly="True"
+                      GridLinesVisibility="All"
+                      AutoGenerateColumns="False" />
+        </Border>
+
+        <Border Grid.Row="3" Padding="4">
+            <TextBlock Text="{Binding Status}" />
+        </Border>
+
+    </Grid>
+
+</Window>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel;
+using Avalonia.Controls;
+using Avalonia.Data;
+using PgNimbus.App.ViewModels;
+
+namespace PgNimbus.App.Views;
+
+public partial class MainWindow : Window
+{
+    private QueryViewModel? _viewModel;
+    private bool _suppressEditorSync;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        SqlEditor.TextChanged += (_, _) =>
+        {
+            if (_viewModel is null || _suppressEditorSync)
+            {
+                return;
+            }
+
+            _viewModel.Sql = SqlEditor.Text;
+        };
+
+        DataContextChanged += (_, _) =>
+        {
+            if (DataContext is QueryViewModel vm)
+            {
+                Attach(vm);
+            }
+        };
+    }
+
+    private void Attach(QueryViewModel vm)
+    {
+        if (_viewModel is not null)
+        {
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        }
+
+        _viewModel = vm;
+        _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+
+        SqlEditor.Text = vm.Sql;
+        ResultsGrid.ItemsSource = vm.Rows;
+        RebuildColumns(vm);
+
+        vm.ColumnNames.CollectionChanged += (_, _) => RebuildColumns(vm);
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(QueryViewModel.Sql) || _viewModel is null)
+        {
+            return;
+        }
+
+        if (SqlEditor.Text == _viewModel.Sql)
+        {
+            return;
+        }
+
+        _suppressEditorSync = true;
+        SqlEditor.Text = _viewModel.Sql;
+        _suppressEditorSync = false;
+    }
+
+    private void RebuildColumns(QueryViewModel vm)
+    {
+        ResultsGrid.Columns.Clear();
+
+        for (var i = 0; i < vm.ColumnNames.Count; i++)
+        {
+            var index = i;
+            ResultsGrid.Columns.Add(new DataGridTextColumn
+            {
+                Header = vm.ColumnNames[index],
+                Binding = new Binding($"[{index}]"),
+            });
+        }
+    }
+}

--- a/PgNimbus.App/app.manifest
+++ b/PgNimbus.App/app.manifest
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="PgNimbus.App"/>
+
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Per-monitor v2 DPI awareness -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+    </windowsSettings>
+  </application>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10/11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+    </application>
+  </compatibility>
+</assembly>

--- a/PgNimbus.Core/Connections/ConnectionProfile.cs
+++ b/PgNimbus.Core/Connections/ConnectionProfile.cs
@@ -1,0 +1,62 @@
+using Npgsql;
+
+namespace PgNimbus.Core.Connections;
+
+public enum SslMode
+{
+    Disable,
+    Allow,
+    Prefer,
+    Require,
+    VerifyCa,
+    VerifyFull,
+}
+
+/// <summary>
+/// A saved connection target. Never carries a password — the password is
+/// supplied at connect time from wherever the caller retrieves it.
+/// </summary>
+public sealed record ConnectionProfile(
+    Guid Id,
+    string Name,
+    string Host,
+    int Port,
+    string Database,
+    string Username,
+    SslMode SslMode,
+    string? AccentColor = null)
+{
+    public const int DefaultPort = 5432;
+
+    // TODO: OS credential store (Windows Credential Manager / macOS Keychain / libsecret)
+    // should supply the password here instead of it ever living on the profile.
+    public string BuildConnectionString(string? password)
+    {
+        var builder = new NpgsqlConnectionStringBuilder
+        {
+            Host = Host,
+            Port = Port,
+            Database = Database,
+            Username = Username,
+            Password = password,
+            SslMode = MapSslMode(SslMode),
+            Timeout = 8,
+            CommandTimeout = 0,
+            IncludeErrorDetail = true,
+            ApplicationName = "pgNimbus",
+        };
+
+        return builder.ConnectionString;
+    }
+
+    private static Npgsql.SslMode MapSslMode(SslMode mode) => mode switch
+    {
+        SslMode.Disable => Npgsql.SslMode.Disable,
+        SslMode.Allow => Npgsql.SslMode.Allow,
+        SslMode.Prefer => Npgsql.SslMode.Prefer,
+        SslMode.Require => Npgsql.SslMode.Require,
+        SslMode.VerifyCa => Npgsql.SslMode.VerifyCA,
+        SslMode.VerifyFull => Npgsql.SslMode.VerifyFull,
+        _ => Npgsql.SslMode.Prefer,
+    };
+}

--- a/PgNimbus.Core/PgNimbus.Core.csproj
+++ b/PgNimbus.Core/PgNimbus.Core.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>PgNimbus.Core</RootNamespace>
+    <AssemblyName>PgNimbus.Core</AssemblyName>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Npgsql" Version="9.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -1,0 +1,154 @@
+using System.Data;
+using System.Diagnostics;
+using Npgsql;
+
+namespace PgNimbus.Core.Query;
+
+/// <summary>
+/// Executes SQL against a Postgres server. Result rows stream out in small
+/// batches so the caller can render the first screenful before the whole
+/// result set has arrived, and every execution can be cancelled mid-flight.
+/// </summary>
+public sealed class QueryEngine
+{
+    private const int BatchSize = 200;
+
+    private readonly NpgsqlDataSource _dataSource;
+
+    public QueryEngine(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    public async Task<StatementResult> ExecuteAsync(string sql, CancellationToken ct)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        NpgsqlConnection? connection = null;
+        NpgsqlCommand? command = null;
+        NpgsqlDataReader? reader = null;
+
+        try
+        {
+            connection = await _dataSource.OpenConnectionAsync(ct);
+            command = new NpgsqlCommand(sql, connection);
+            reader = await command.ExecuteReaderAsync(CommandBehavior.Default, ct);
+
+            if (reader.FieldCount == 0)
+            {
+                var rowsAffected = reader.RecordsAffected;
+                var tag = BuildCommandTag(sql);
+
+                await reader.DisposeAsync();
+                await command.DisposeAsync();
+                await connection.DisposeAsync();
+
+                return new CommandResult
+                {
+                    Elapsed = stopwatch.Elapsed,
+                    RowsAffected = rowsAffected < 0 ? 0 : rowsAffected,
+                    CommandTag = tag,
+                };
+            }
+
+            var columns = BuildColumns(reader);
+
+            // Ownership of connection/command/reader passes to the streaming
+            // enumerable below; it disposes them once enumeration ends.
+            return new ResultSet
+            {
+                Elapsed = stopwatch.Elapsed,
+                Columns = columns,
+                Batches = StreamBatches(connection, command, reader, ct),
+            };
+        }
+        catch (Exception ex)
+        {
+            if (reader is not null) await reader.DisposeAsync();
+            if (command is not null) await command.DisposeAsync();
+            if (connection is not null) await connection.DisposeAsync();
+
+            if (ex is OperationCanceledException)
+            {
+                throw;
+            }
+
+            if (ex is PostgresException pg)
+            {
+                return new QueryError
+                {
+                    Elapsed = stopwatch.Elapsed,
+                    Message = pg.MessageText,
+                    SqlState = pg.SqlState,
+                    Detail = pg.Detail,
+                    Hint = pg.Hint,
+                    Position = ParsePosition(pg.Position),
+                };
+            }
+
+            return new QueryError { Elapsed = stopwatch.Elapsed, Message = ex.Message };
+        }
+    }
+
+    private static IReadOnlyList<ColumnInfo> BuildColumns(NpgsqlDataReader reader)
+    {
+        var columns = new ColumnInfo[reader.FieldCount];
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            columns[i] = new ColumnInfo(reader.GetName(i), reader.GetDataTypeName(i), reader.GetFieldType(i));
+        }
+
+        return columns;
+    }
+
+    private static async IAsyncEnumerable<RowBatch> StreamBatches(
+        NpgsqlConnection connection,
+        NpgsqlCommand command,
+        NpgsqlDataReader reader,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+    {
+        try
+        {
+            var fieldCount = reader.FieldCount;
+            var buffer = new List<object?[]>(BatchSize);
+
+            while (await reader.ReadAsync(ct))
+            {
+                var row = new object?[fieldCount];
+                for (var i = 0; i < fieldCount; i++)
+                {
+                    row[i] = await reader.IsDBNullAsync(i, ct) ? null : reader.GetValue(i);
+                }
+
+                buffer.Add(row);
+
+                if (buffer.Count >= BatchSize)
+                {
+                    yield return new RowBatch(buffer);
+                    buffer = new List<object?[]>(BatchSize);
+                }
+            }
+
+            if (buffer.Count > 0)
+            {
+                yield return new RowBatch(buffer);
+            }
+        }
+        finally
+        {
+            await reader.DisposeAsync();
+            await command.DisposeAsync();
+            await connection.DisposeAsync();
+        }
+    }
+
+    private static string BuildCommandTag(string sql)
+    {
+        var trimmed = sql.AsSpan().TrimStart();
+        var end = trimmed.IndexOfAny(" \t\r\n".AsSpan());
+        var keyword = end < 0 ? trimmed : trimmed[..end];
+        return keyword.IsEmpty ? "OK" : keyword.ToString().ToUpperInvariant();
+    }
+
+    private static int? ParsePosition(int position) => position > 0 ? position : null;
+}

--- a/PgNimbus.Core/Query/QueryResult.cs
+++ b/PgNimbus.Core/Query/QueryResult.cs
@@ -1,0 +1,43 @@
+namespace PgNimbus.Core.Query;
+
+public sealed record ColumnInfo(string Name, string DataTypeName, Type ClrType);
+
+public sealed record RowBatch(IReadOnlyList<object?[]> Rows);
+
+/// <summary>
+/// Outcome of executing a single SQL statement. One of <see cref="ResultSet"/>,
+/// <see cref="CommandResult"/>, or <see cref="QueryError"/>.
+/// </summary>
+public abstract record StatementResult
+{
+    public required TimeSpan Elapsed { get; init; }
+}
+
+/// <summary>
+/// A result-returning statement (SELECT, RETURNING, etc). Rows stream in
+/// batches so the UI can render the first screenful before the query finishes.
+/// </summary>
+public sealed record ResultSet : StatementResult
+{
+    public required IReadOnlyList<ColumnInfo> Columns { get; init; }
+    public required IAsyncEnumerable<RowBatch> Batches { get; init; }
+}
+
+/// <summary>A non-result statement (INSERT/UPDATE/DDL/etc).</summary>
+public sealed record CommandResult : StatementResult
+{
+    public required long RowsAffected { get; init; }
+    public required string CommandTag { get; init; }
+}
+
+/// <summary>A failed statement, carrying enough detail to highlight the offending SQL.</summary>
+public sealed record QueryError : StatementResult
+{
+    public required string Message { get; init; }
+    public string? SqlState { get; init; }
+    public string? Detail { get; init; }
+    public string? Hint { get; init; }
+
+    /// <summary>1-based character position into the submitted SQL, for editor error highlighting.</summary>
+    public int? Position { get; init; }
+}

--- a/PgNimbus.Core/Schema/SchemaService.cs
+++ b/PgNimbus.Core/Schema/SchemaService.cs
@@ -1,0 +1,132 @@
+using Npgsql;
+
+namespace PgNimbus.Core.Schema;
+
+public sealed record SchemaInfo(string Name);
+
+public enum RelationKind
+{
+    Table,
+    View,
+    MaterializedView,
+    PartitionedTable,
+}
+
+public sealed record TableInfo(string Name, RelationKind Kind);
+
+public sealed record ColumnDetail(string Name, string DataType, bool NotNull, bool IsPrimaryKey);
+
+/// <summary>
+/// Reads structure straight from pg_catalog rather than relying on
+/// information_schema, so it reflects the real Postgres model (matviews,
+/// partitioned tables, actual type names) instead of the SQL-standard
+/// lowest common denominator.
+/// </summary>
+public sealed class SchemaService
+{
+    private readonly NpgsqlDataSource _dataSource;
+
+    public SchemaService(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    public async Task<IReadOnlyList<SchemaInfo>> GetSchemasAsync(CancellationToken ct)
+    {
+        const string sql = """
+            SELECT nspname
+            FROM pg_catalog.pg_namespace
+            WHERE nspname NOT LIKE 'pg\_%'
+              AND nspname <> 'information_schema'
+            ORDER BY nspname
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<SchemaInfo>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new SchemaInfo(reader.GetString(0)));
+        }
+
+        return results;
+    }
+
+    public async Task<IReadOnlyList<TableInfo>> GetTablesAsync(string schema, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT c.relname, c.relkind
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = @schema
+              AND c.relkind IN ('r', 'v', 'm', 'p')
+            ORDER BY c.relname
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("schema", schema);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<TableInfo>();
+        while (await reader.ReadAsync(ct))
+        {
+            var kind = reader.GetString(1) switch
+            {
+                "r" => RelationKind.Table,
+                "v" => RelationKind.View,
+                "m" => RelationKind.MaterializedView,
+                "p" => RelationKind.PartitionedTable,
+                _ => RelationKind.Table,
+            };
+
+            results.Add(new TableInfo(reader.GetString(0), kind));
+        }
+
+        return results;
+    }
+
+    public async Task<IReadOnlyList<ColumnDetail>> GetColumnsAsync(string schema, string table, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT
+                a.attname,
+                format_type(a.atttypid, a.atttypmod) AS data_type,
+                a.attnotnull,
+                COALESCE(pk.is_primary_key, false) AS is_primary_key
+            FROM pg_catalog.pg_attribute a
+            JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            LEFT JOIN (
+                SELECT con.conrelid, unnest(con.conkey) AS attnum, true AS is_primary_key
+                FROM pg_catalog.pg_constraint con
+                WHERE con.contype = 'p'
+            ) pk ON pk.conrelid = a.attrelid AND pk.attnum = a.attnum
+            WHERE n.nspname = @schema
+              AND c.relname = @table
+              AND a.attnum > 0
+              AND NOT a.attisdropped
+            ORDER BY a.attnum
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("schema", schema);
+        command.Parameters.AddWithValue("table", table);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<ColumnDetail>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new ColumnDetail(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetBoolean(2),
+                reader.GetBoolean(3)));
+        }
+
+        return results;
+    }
+}

--- a/PgNimbus.sln
+++ b/PgNimbus.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PgNimbus.Core", "PgNimbus.Core\PgNimbus.Core.csproj", "{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PgNimbus.App", "PgNimbus.App\PgNimbus.App.csproj", "{71A0E9C7-691D-467D-A94B-930E15342B4B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Debug|x64.Build.0 = Debug|Any CPU
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Debug|x86.Build.0 = Debug|Any CPU
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Release|x64.ActiveCfg = Release|Any CPU
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Release|x64.Build.0 = Release|Any CPU
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Release|x86.ActiveCfg = Release|Any CPU
+		{7E165D7F-B11E-4691-B7BB-34BE03D35FE4}.Release|x86.Build.0 = Release|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Debug|x64.Build.0 = Debug|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Debug|x86.Build.0 = Debug|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Release|x64.ActiveCfg = Release|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Release|x64.Build.0 = Release|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Release|x86.ActiveCfg = Release|Any CPU
+		{71A0E9C7-691D-467D-A94B-930E15342B4B}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,92 @@
 # pgNimbus
+
+A fast, native-feeling, open-source **PostgreSQL** GUI client, built with **.NET
+10 + Avalonia 11**. MIT licensed. Windows is the primary target, but the
+codebase stays cross-platform-capable — no Windows-only APIs live in the core
+engine.
+
+## The market thesis
+
+The gap in the Postgres client market: **truly fast + open source + modern
+UI**.
+
+- pgAdmin and DBeaver are heavy and slow.
+- TablePlus is fast, but closed-source and paid.
+- Beekeeper Studio is open source, but Electron.
+- HeidiSQL is native and fast, but dated in its UI and MySQL-first.
+
+pgNimbus targets HeidiSQL's speed with TablePlus's polish — PostgreSQL-first,
+from the ground up.
+
+### Differentiators
+
+1. **Native performance** — NativeAOT-friendly code, cold start under 500 ms.
+2. **PostgreSQL-first** — deep `pg_catalog` introspection (materialized views,
+   real types, primary-key flags, and later EXPLAIN visualization); never the
+   lowest-common-denominator SQL dialect.
+3. **Keyboard-first** — run, cancel, and navigate without touching the mouse.
+4. **Streaming results** — the first screenful renders before the full result
+   set arrives, backed by a virtualized grid for large results.
+
+## Architecture
+
+```
+pgNimbus/
+├── PgNimbus.sln
+├── PgNimbus.Core/                # Engine. Zero Avalonia/UI dependencies.
+│   ├── Connections/ConnectionProfile.cs
+│   ├── Query/QueryResult.cs
+│   ├── Query/QueryEngine.cs
+│   └── Schema/SchemaService.cs
+└── PgNimbus.App/                 # Avalonia MVVM front-end.
+    ├── ViewModels/QueryViewModel.cs
+    ├── Views/MainWindow.axaml(.cs)
+    ├── App.axaml(.cs)
+    └── Program.cs
+```
+
+`PgNimbus.Core` is a plain class library that depends only on `Npgsql`. It
+knows nothing about Avalonia or any UI framework, which keeps the engine
+reusable for a future CLI or test harness. `PgNimbus.App` is the Avalonia
+MVVM shell built on top of it, using CommunityToolkit.Mvvm source generators.
+
+## Building and running
+
+Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download).
+
+```bash
+dotnet build
+
+dotnet run --project PgNimbus.App
+```
+
+### Connecting to a database
+
+The app currently reads its connection string from the `PGNIMBUS_CONN`
+environment variable (falling back to a `localhost:5432/postgres` default if
+unset) — there's no connection-manager UI yet, see the roadmap below.
+
+```bash
+export PGNIMBUS_CONN="Host=localhost;Port=5432;Database=mydb;Username=postgres;Password=secret"
+dotnet run --project PgNimbus.App
+```
+
+### Publishing a NativeAOT build (Windows)
+
+```bash
+dotnet publish PgNimbus.App -c Release -r win-x64 -p:PublishAot=true
+```
+
+## Roadmap (post-MVP)
+
+- Command palette
+- Schema-aware SQL autocomplete
+- EXPLAIN tree visualization
+- Inline cell editing in the results grid
+- Per-connection accent color (e.g. red for production)
+- LISTEN/NOTIFY monitor
+- Extension manager
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Sets up the project from scratch per the pgNimbus brief:

- PgNimbus.Core: UI-free engine (Npgsql only) with a streaming, cancellable
  QueryEngine (200-row batches via IAsyncEnumerable), a SchemaService that
  introspects pg_catalog directly (schemas/tables/columns incl. PK flags),
  and a password-free ConnectionProfile.
- PgNimbus.App: Avalonia 11 MVVM shell (CommunityToolkit.Mvvm source-gen,
  compiled bindings) with an AvaloniaEdit-based SQL editor, a virtualized
  DataGrid for results, Ctrl+Enter/Esc run-cancel key bindings, and a
  QueryViewModel that streams batches into the grid with a status line.
- README, CLAUDE.md, MIT LICENSE, and .gitignore.

Both projects target net10.0 (SDK available in this environment) rather
than net9.0 as in the original brief; package versions otherwise match
the brief where they exist on NuGet. `dotnet build` is clean with zero
warnings, and the app was smoke-tested headlessly (Xvfb) to confirm it
starts without exceptions.