### PR TITLE
Add schema tree sidebar (schemas → tables → columns)

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -5,6 +5,7 @@ using Npgsql;
 using PgNimbus.App.ViewModels;
 using PgNimbus.App.Views;
 using PgNimbus.Core.Query;
+using PgNimbus.Core.Schema;
 
 namespace PgNimbus.App;
 
@@ -27,11 +28,15 @@ public partial class App : Application
             var connectionString = Environment.GetEnvironmentVariable("PGNIMBUS_CONN") ?? DefaultConnectionString;
             var dataSource = NpgsqlDataSource.Create(connectionString);
             var engine = new QueryEngine(dataSource);
+            var schemaService = new SchemaService(dataSource);
+            var schemaTree = new SchemaTreeViewModel(schemaService);
 
             desktop.MainWindow = new MainWindow
             {
-                DataContext = new QueryViewModel(engine),
+                DataContext = new MainViewModel(new QueryViewModel(engine), schemaTree),
             };
+
+            _ = schemaTree.RefreshCommand.ExecuteAsync(null);
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/PgNimbus.App/ViewModels/ColumnNode.cs
+++ b/PgNimbus.App/ViewModels/ColumnNode.cs
@@ -1,0 +1,22 @@
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.App.ViewModels;
+
+public sealed class ColumnNode : SchemaTreeNode
+{
+    public ColumnNode(ColumnDetail detail)
+    {
+        Name = detail.Name;
+        DataType = detail.DataType;
+        NotNull = detail.NotNull;
+        IsPrimaryKey = detail.IsPrimaryKey;
+    }
+
+    public string DataType { get; }
+
+    public bool NotNull { get; }
+
+    public bool IsPrimaryKey { get; }
+
+    public string PrimaryKeyGlyph => IsPrimaryKey ? "🔑" : string.Empty;
+}

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -1,0 +1,19 @@
+namespace PgNimbus.App.ViewModels;
+
+public sealed class MainViewModel
+{
+    public QueryViewModel Query { get; }
+
+    public SchemaTreeViewModel SchemaTree { get; }
+
+    public MainViewModel(QueryViewModel query, SchemaTreeViewModel schemaTree)
+    {
+        Query = query;
+        SchemaTree = schemaTree;
+    }
+
+    public void PreviewTable(TableNode table)
+    {
+        Query.Sql = $"SELECT * FROM \"{table.Schema}\".\"{table.Name}\" LIMIT 100;";
+    }
+}

--- a/PgNimbus.App/ViewModels/SchemaNode.cs
+++ b/PgNimbus.App/ViewModels/SchemaNode.cs
@@ -1,0 +1,21 @@
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.App.ViewModels;
+
+public sealed class SchemaNode : SchemaTreeNode
+{
+    private readonly SchemaService _schemaService;
+
+    public SchemaNode(SchemaService schemaService, string name)
+    {
+        _schemaService = schemaService;
+        Name = name;
+        MarkExpandable();
+    }
+
+    protected override async Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync()
+    {
+        var tables = await _schemaService.GetTablesAsync(Name, CancellationToken.None);
+        return tables.Select(t => (SchemaTreeNode)new TableNode(_schemaService, Name, t.Name, t.Kind)).ToList();
+    }
+}

--- a/PgNimbus.App/ViewModels/SchemaTreeNode.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeNode.cs
@@ -1,0 +1,68 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace PgNimbus.App.ViewModels;
+
+/// <summary>
+/// Base node for the schema sidebar tree. Children load lazily on first
+/// expand so opening a connection doesn't eagerly walk the whole catalog.
+/// </summary>
+public abstract partial class SchemaTreeNode : ObservableObject
+{
+    private bool _loaded;
+
+    [ObservableProperty]
+    private bool _isExpanded;
+
+    [ObservableProperty]
+    private bool _isLoading;
+
+    public string Name { get; init; } = string.Empty;
+
+    public ObservableCollection<SchemaTreeNode> Children { get; } = [];
+
+    /// <summary>Seeds a placeholder child so an as-yet-unloaded expandable node still shows an expand arrow.</summary>
+    protected void MarkExpandable() => Children.Add(new PlaceholderNode());
+
+    partial void OnIsExpandedChanged(bool value)
+    {
+        if (!value || _loaded)
+        {
+            return;
+        }
+
+        _loaded = true;
+        _ = LoadChildrenAsync();
+    }
+
+    private async Task LoadChildrenAsync()
+    {
+        IsLoading = true;
+        try
+        {
+            var children = await FetchChildrenAsync();
+            Children.Clear();
+            foreach (var child in children)
+            {
+                Children.Add(child);
+            }
+        }
+        catch (Exception ex)
+        {
+            Children.Clear();
+            Children.Add(new ErrorNode { Name = ex.Message });
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    protected virtual Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync() =>
+        Task.FromResult<IReadOnlyList<SchemaTreeNode>>([]);
+}
+
+/// <summary>Placeholder child so a lazily-loaded node still shows an expand arrow.</summary>
+public sealed class PlaceholderNode : SchemaTreeNode;
+
+public sealed class ErrorNode : SchemaTreeNode;

--- a/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
@@ -1,0 +1,49 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.App.ViewModels;
+
+public sealed partial class SchemaTreeViewModel : ObservableObject
+{
+    private readonly SchemaService _schemaService;
+
+    [ObservableProperty]
+    private bool _isLoading;
+
+    [ObservableProperty]
+    private string? _errorMessage;
+
+    public ObservableCollection<SchemaTreeNode> Schemas { get; } = [];
+
+    public SchemaTreeViewModel(SchemaService schemaService)
+    {
+        _schemaService = schemaService;
+    }
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        IsLoading = true;
+        ErrorMessage = null;
+
+        try
+        {
+            var schemas = await _schemaService.GetSchemasAsync(CancellationToken.None);
+            Schemas.Clear();
+            foreach (var schema in schemas)
+            {
+                Schemas.Add(new SchemaNode(_schemaService, schema.Name));
+            }
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+}

--- a/PgNimbus.App/ViewModels/TableNode.cs
+++ b/PgNimbus.App/ViewModels/TableNode.cs
@@ -1,0 +1,36 @@
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.App.ViewModels;
+
+public sealed class TableNode : SchemaTreeNode
+{
+    private readonly SchemaService _schemaService;
+
+    public TableNode(SchemaService schemaService, string schema, string name, RelationKind kind)
+    {
+        _schemaService = schemaService;
+        Schema = schema;
+        Name = name;
+        Kind = kind;
+        MarkExpandable();
+    }
+
+    public string Schema { get; }
+
+    public RelationKind Kind { get; }
+
+    public string Glyph => Kind switch
+    {
+        RelationKind.Table => "▤",
+        RelationKind.View => "▥",
+        RelationKind.MaterializedView => "▦",
+        RelationKind.PartitionedTable => "▧",
+        _ => "▤",
+    };
+
+    protected override async Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync()
+    {
+        var columns = await _schemaService.GetColumnsAsync(Schema, Name, CancellationToken.None);
+        return columns.Select(c => (SchemaTreeNode)new ColumnNode(c)).ToList();
+    }
+}

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -4,43 +4,99 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:ae="using:AvaloniaEdit"
         xmlns:vm="using:PgNimbus.App.ViewModels"
+        xmlns:conv="using:Avalonia.Data.Converters"
         mc:Ignorable="d"
         d:DesignWidth="1000" d:DesignHeight="650"
         x:Class="PgNimbus.App.Views.MainWindow"
-        x:DataType="vm:QueryViewModel"
+        x:DataType="vm:MainViewModel"
         Title="pgNimbus"
         Width="1100" Height="700"
         FontFamily="{StaticResource InterFont}">
 
+    <Window.DataTemplates>
+        <DataTemplate DataType="vm:SchemaNode">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <TextBlock Text="🗄" />
+                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:TableNode">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <TextBlock Text="{Binding Glyph}" />
+                <TextBlock Text="{Binding Name}" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:ColumnNode">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <TextBlock Text="{Binding PrimaryKeyGlyph}" Width="14" />
+                <TextBlock Text="{Binding Name}" />
+                <TextBlock Text="{Binding DataType}" Opacity="0.6" FontSize="11" VerticalAlignment="Center" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:PlaceholderNode">
+            <TextBlock Text="Loading..." Opacity="0.5" FontStyle="Italic" />
+        </DataTemplate>
+        <DataTemplate DataType="vm:ErrorNode">
+            <TextBlock Text="{Binding Name}" Foreground="IndianRed" TextWrapping="Wrap" />
+        </DataTemplate>
+    </Window.DataTemplates>
+
     <Window.KeyBindings>
-        <KeyBinding Gesture="Ctrl+Enter" Command="{Binding RunCommand}" />
-        <KeyBinding Gesture="Escape" Command="{Binding CancelCommand}" />
+        <KeyBinding Gesture="Ctrl+Enter" Command="{Binding Query.RunCommand}" />
+        <KeyBinding Gesture="Escape" Command="{Binding Query.CancelCommand}" />
     </Window.KeyBindings>
 
-    <Grid RowDefinitions="Auto,*,*,Auto" Margin="8">
+    <Grid ColumnDefinitions="260,Auto,*" Margin="8">
 
-        <StackPanel Orientation="Horizontal" Grid.Row="0" Spacing="8" Margin="0,0,0,8">
-            <Button Content="Run" Command="{Binding RunCommand}" ToolTip.Tip="Ctrl+Enter" />
-            <Button Content="Cancel" Command="{Binding CancelCommand}" ToolTip.Tip="Esc" />
-        </StackPanel>
+        <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto">
+            <TextBlock Grid.Row="0" Text="Schemas" FontWeight="SemiBold" Margin="4" />
+            <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+                <TreeView Name="SchemaTreeView" ItemsSource="{Binding SchemaTree.Schemas}">
+                    <TreeView.Styles>
+                        <Style Selector="TreeViewItem">
+                            <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay, DataType=vm:SchemaTreeNode}" />
+                        </Style>
+                    </TreeView.Styles>
+                    <TreeView.ItemTemplate>
+                        <TreeDataTemplate ItemsSource="{Binding Children}">
+                            <ContentControl Content="{Binding}" />
+                        </TreeDataTemplate>
+                    </TreeView.ItemTemplate>
+                </TreeView>
+            </Border>
+            <TextBlock Grid.Row="2" Text="{Binding SchemaTree.ErrorMessage}"
+                       IsVisible="{Binding SchemaTree.ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}"
+                       Foreground="IndianRed" TextWrapping="Wrap" Margin="4" FontSize="11" />
+        </Grid>
 
-        <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
-            <ae:TextEditor Name="SqlEditor"
-                           ShowLineNumbers="True"
-                           FontFamily="Cascadia Code,Consolas,Menlo,monospace"
-                           FontSize="14" />
-        </Border>
+        <GridSplitter Grid.Column="1" Width="4" />
 
-        <Border Grid.Row="2" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Margin="0,8,0,8">
-            <DataGrid Name="ResultsGrid"
-                      IsReadOnly="True"
-                      GridLinesVisibility="All"
-                      AutoGenerateColumns="False" />
-        </Border>
+        <Grid Grid.Column="2" RowDefinitions="Auto,*,*,Auto">
 
-        <Border Grid.Row="3" Padding="4">
-            <TextBlock Text="{Binding Status}" />
-        </Border>
+            <StackPanel Orientation="Horizontal" Grid.Row="0" Spacing="8" Margin="0,0,0,8">
+                <Button Content="Run" Command="{Binding Query.RunCommand}" ToolTip.Tip="Ctrl+Enter" />
+                <Button Content="Cancel" Command="{Binding Query.CancelCommand}" ToolTip.Tip="Esc" />
+            </StackPanel>
+
+            <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+                <ae:TextEditor Name="SqlEditor"
+                               ShowLineNumbers="True"
+                               FontFamily="Cascadia Code,Consolas,Menlo,monospace"
+                               FontSize="14" />
+            </Border>
+
+            <Border Grid.Row="2" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Margin="0,8,0,8">
+                <DataGrid Name="ResultsGrid"
+                          IsReadOnly="True"
+                          GridLinesVisibility="All"
+                          AutoGenerateColumns="False" />
+            </Border>
+
+            <Border Grid.Row="3" Padding="4">
+                <TextBlock Text="{Binding Query.Status}" />
+            </Border>
+
+        </Grid>
 
     </Grid>
 

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1,7 +1,10 @@
 using System.ComponentModel;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 using PgNimbus.App.ViewModels;
 
 namespace PgNimbus.App.Views;
@@ -26,7 +29,10 @@ public partial class MainWindow : Window
             _queryViewModel.Sql = SqlEditor.Text;
         };
 
-        SchemaTreeView.DoubleTapped += OnSchemaTreeDoubleTapped;
+        // TreeViewItem's own DoubleTapped handling (toggling expand) marks the
+        // event Handled, so it never reaches a plain `+=` subscription on the
+        // parent TreeView. Use AddHandler with handledEventsToo to still see it.
+        SchemaTreeView.AddHandler(Gestures.DoubleTappedEvent, OnSchemaTreeDoubleTapped, RoutingStrategies.Bubble, handledEventsToo: true);
 
         DataContextChanged += (_, _) =>
         {
@@ -57,7 +63,12 @@ public partial class MainWindow : Window
 
     private void OnSchemaTreeDoubleTapped(object? sender, TappedEventArgs e)
     {
-        if (_viewModel is not null && SchemaTreeView.SelectedItem is TableNode table)
+        // Read the node off the tapped TreeViewItem's DataContext rather than
+        // SchemaTreeView.SelectedItem: on the very first click of a row that
+        // wasn't already selected, SelectedItem can still be stale/null at
+        // the point this handler runs.
+        var container = (e.Source as Visual)?.FindAncestorOfType<TreeViewItem>(includeSelf: true);
+        if (_viewModel is not null && container?.DataContext is TableNode table)
         {
             _viewModel.PreviewTable(table);
         }

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1,13 +1,15 @@
 using System.ComponentModel;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Input;
 using PgNimbus.App.ViewModels;
 
 namespace PgNimbus.App.Views;
 
 public partial class MainWindow : Window
 {
-    private QueryViewModel? _viewModel;
+    private MainViewModel? _viewModel;
+    private QueryViewModel? _queryViewModel;
     private bool _suppressEditorSync;
 
     public MainWindow()
@@ -16,67 +18,78 @@ public partial class MainWindow : Window
 
         SqlEditor.TextChanged += (_, _) =>
         {
-            if (_viewModel is null || _suppressEditorSync)
+            if (_queryViewModel is null || _suppressEditorSync)
             {
                 return;
             }
 
-            _viewModel.Sql = SqlEditor.Text;
+            _queryViewModel.Sql = SqlEditor.Text;
         };
+
+        SchemaTreeView.DoubleTapped += OnSchemaTreeDoubleTapped;
 
         DataContextChanged += (_, _) =>
         {
-            if (DataContext is QueryViewModel vm)
+            if (DataContext is MainViewModel vm)
             {
                 Attach(vm);
             }
         };
     }
 
-    private void Attach(QueryViewModel vm)
+    private void Attach(MainViewModel vm)
     {
-        if (_viewModel is not null)
+        if (_queryViewModel is not null)
         {
-            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            _queryViewModel.PropertyChanged -= OnViewModelPropertyChanged;
         }
 
         _viewModel = vm;
-        _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+        _queryViewModel = vm.Query;
+        _queryViewModel.PropertyChanged += OnViewModelPropertyChanged;
 
-        SqlEditor.Text = vm.Sql;
-        ResultsGrid.ItemsSource = vm.Rows;
-        RebuildColumns(vm);
+        SqlEditor.Text = vm.Query.Sql;
+        ResultsGrid.ItemsSource = vm.Query.Rows;
+        RebuildColumns(vm.Query);
 
-        vm.ColumnNames.CollectionChanged += (_, _) => RebuildColumns(vm);
+        vm.Query.ColumnNames.CollectionChanged += (_, _) => RebuildColumns(vm.Query);
+    }
+
+    private void OnSchemaTreeDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (_viewModel is not null && SchemaTreeView.SelectedItem is TableNode table)
+        {
+            _viewModel.PreviewTable(table);
+        }
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName != nameof(QueryViewModel.Sql) || _viewModel is null)
+        if (e.PropertyName != nameof(QueryViewModel.Sql) || _queryViewModel is null)
         {
             return;
         }
 
-        if (SqlEditor.Text == _viewModel.Sql)
+        if (SqlEditor.Text == _queryViewModel.Sql)
         {
             return;
         }
 
         _suppressEditorSync = true;
-        SqlEditor.Text = _viewModel.Sql;
+        SqlEditor.Text = _queryViewModel.Sql;
         _suppressEditorSync = false;
     }
 
-    private void RebuildColumns(QueryViewModel vm)
+    private void RebuildColumns(QueryViewModel query)
     {
         ResultsGrid.Columns.Clear();
 
-        for (var i = 0; i < vm.ColumnNames.Count; i++)
+        for (var i = 0; i < query.ColumnNames.Count; i++)
         {
             var index = i;
             ResultsGrid.Columns.Add(new DataGridTextColumn
             {
-                Header = vm.ColumnNames[index],
+                Header = query.ColumnNames[index],
                 Binding = new Binding($"[{index}]"),
             });
         }

--- a/PgNimbus.Core/Schema/SchemaService.cs
+++ b/PgNimbus.Core/Schema/SchemaService.cs
@@ -57,7 +57,7 @@ public sealed class SchemaService
     public async Task<IReadOnlyList<TableInfo>> GetTablesAsync(string schema, CancellationToken ct)
     {
         const string sql = """
-            SELECT c.relname, c.relkind
+            SELECT c.relname, c.relkind::text
             FROM pg_catalog.pg_class c
             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
             WHERE n.nspname = @schema


### PR DESCRIPTION
## Summary
- Wires the existing `SchemaService` into the UI via a lazy-loading `TreeView` sidebar (schemas → tables/views → columns), closing the biggest UX gap versus every competitor (pgAdmin, DBeaver, TablePlus, DataGrip, HeidiSQL, Beekeeper Studio all have a schema browser).
- Adds `MainViewModel` as a composition root (`Query` + `SchemaTree`); `MainWindow` bindings move to `Query.*` / `SchemaTree.*`.
- Double-clicking a table/view inserts `SELECT * FROM "schema"."table" LIMIT 100;` into the editor, ready to run.
- Primary-key columns get a key glyph; tables/views/matviews/partitioned tables get distinct glyphs.

## Bugs caught and fixed during end-to-end testing
- `pg_class.relkind` is Postgres's internal `"char"` type, not text — Npgsql's `GetString()` throws on it. Cast to `::text` in `SchemaService.GetTablesAsync`.
- `TreeViewItem.IsExpanded` was never bound back to the node view model, so the lazy-load trigger never actually fired on real user interaction (only the static "Loading..." placeholder ever showed, forever). Fixed with a `TreeView.Styles` `Setter` using a two-way binding.

## Test plan
- [x] `dotnet build` — clean, 0 warnings/errors
- [x] Installed a local PostgreSQL 16 and ran the app headlessly (Xvfb + xdotool + screenshots) against a real database with a table, a view, and a primary key
- [x] Verified: schema expands → tables/views list with correct icons → table expands → columns list with correct PK glyph and types → double-click inserts and the query runs successfully against the live DB, results render in the grid


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_