### PR TITLE
Add OS credential store for connection passwords

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,11 @@ speed with TablePlus's polish, PostgreSQL-first.
    `pg_catalog` directly (not `information_schema`) so it can see materialized
    views, partitioned tables, and real Postgres semantics (e.g. primary-key
    flags via `pg_constraint`).
-4. **No passwords on `ConnectionProfile`.** Passwords come from the OS
-   credential store at connect time (currently a `// TODO`), never persisted
-   on the profile record itself.
+4. **No passwords on `ConnectionProfile`.** Passwords come from
+   `ICredentialStore` (DPAPI on Windows via `WindowsDpapiCredentialStore`, a
+   permission-restricted file fallback elsewhere via
+   `PlainFileCredentialStore`) at connect time, never persisted on the
+   profile record itself.
 
 ## Tech stack
 

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -36,7 +36,7 @@ public partial class App : Application
 
     private static ConnectionDialog BuildConnectionDialog(IClassicDesktopStyleApplicationLifetime desktop)
     {
-        var viewModel = new ConnectionDialogViewModel(new ConnectionProfileStore());
+        var viewModel = new ConnectionDialogViewModel(new ConnectionProfileStore(), CredentialStore.Create());
         var dialog = new ConnectionDialog { DataContext = viewModel };
 
         viewModel.Connected += connectionString =>

--- a/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
+++ b/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
@@ -8,6 +8,7 @@ namespace PgNimbus.App.ViewModels;
 public sealed partial class ConnectionDialogViewModel : ObservableObject
 {
     private readonly ConnectionProfileStore _store;
+    private readonly ICredentialStore _credentialStore;
 
     public ObservableCollection<ConnectionProfile> Profiles { get; } = [];
 
@@ -43,9 +44,10 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
     /// <summary>Raised with the built connection string when the user clicks Connect.</summary>
     public event Action<string>? Connected;
 
-    public ConnectionDialogViewModel(ConnectionProfileStore store)
+    public ConnectionDialogViewModel(ConnectionProfileStore store, ICredentialStore credentialStore)
     {
         _store = store;
+        _credentialStore = credentialStore;
 
         foreach (var profile in _store.Load())
         {
@@ -66,7 +68,7 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         Database = value.Database;
         Username = value.Username;
         SslMode = value.SslMode;
-        Password = string.Empty;
+        Password = _credentialStore.LoadPassword(value.Id) ?? string.Empty;
     }
 
     [RelayCommand]
@@ -103,6 +105,12 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         }
 
         _store.Save(Profiles);
+
+        if (!string.IsNullOrEmpty(Password))
+        {
+            _credentialStore.SavePassword(profile.Id, Password);
+        }
+
         SelectedProfile = profile;
     }
 
@@ -114,8 +122,10 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
             return;
         }
 
+        var idToDelete = SelectedProfile.Id;
         Profiles.Remove(SelectedProfile);
         _store.Save(Profiles);
+        _credentialStore.DeletePassword(idToDelete);
         New();
     }
 

--- a/PgNimbus.Core/Connections/AppDataPaths.cs
+++ b/PgNimbus.Core/Connections/AppDataPaths.cs
@@ -1,0 +1,29 @@
+namespace PgNimbus.Core.Connections;
+
+internal static class AppDataPaths
+{
+    /// <summary>
+    /// Root directory for pgNimbus's local application data (saved connection
+    /// profiles, cached credentials, etc).
+    /// </summary>
+    public static string GetRootDirectory() => Path.Combine(ResolveAppDataDirectory(), "pgNimbus");
+
+    /// <summary>
+    /// <see cref="Environment.SpecialFolder.ApplicationData"/> can resolve to an
+    /// empty string in minimal/containerized Linux environments (e.g. no usable
+    /// passwd entry for the current UID), which would otherwise make callers
+    /// silently use a path relative to the working directory. Fall back to
+    /// $HOME, then the OS temp directory, rather than risk that.
+    /// </summary>
+    private static string ResolveAppDataDirectory()
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        if (!string.IsNullOrEmpty(appData))
+        {
+            return appData;
+        }
+
+        var home = Environment.GetEnvironmentVariable("HOME");
+        return string.IsNullOrEmpty(home) ? Path.GetTempPath() : Path.Combine(home, ".config");
+    }
+}

--- a/PgNimbus.Core/Connections/ConnectionProfile.cs
+++ b/PgNimbus.Core/Connections/ConnectionProfile.cs
@@ -28,8 +28,9 @@ public sealed record ConnectionProfile(
 {
     public const int DefaultPort = 5432;
 
-    // TODO: OS credential store (Windows Credential Manager / macOS Keychain / libsecret)
-    // should supply the password here instead of it ever living on the profile.
+    // Callers resolve the password via ICredentialStore (DPAPI on Windows, a
+    // permission-restricted file fallback elsewhere) and pass it in here -
+    // it never lives on this record itself.
     public string BuildConnectionString(string? password)
     {
         var builder = new NpgsqlConnectionStringBuilder

--- a/PgNimbus.Core/Connections/ConnectionProfileStore.cs
+++ b/PgNimbus.Core/Connections/ConnectionProfileStore.cs
@@ -14,26 +14,7 @@ public sealed class ConnectionProfileStore
 
     public ConnectionProfileStore(string? filePath = null)
     {
-        _filePath = filePath ?? Path.Combine(ResolveAppDataDirectory(), "pgNimbus", "connections.json");
-    }
-
-    /// <summary>
-    /// <see cref="Environment.SpecialFolder.ApplicationData"/> can resolve to an
-    /// empty string in minimal/containerized Linux environments (e.g. no usable
-    /// passwd entry for the current UID), which would otherwise make Save/Load
-    /// silently use a path relative to the working directory. Fall back to
-    /// $HOME, then the OS temp directory, rather than risk that.
-    /// </summary>
-    private static string ResolveAppDataDirectory()
-    {
-        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-        if (!string.IsNullOrEmpty(appData))
-        {
-            return appData;
-        }
-
-        var home = Environment.GetEnvironmentVariable("HOME");
-        return string.IsNullOrEmpty(home) ? Path.GetTempPath() : Path.Combine(home, ".config");
+        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "connections.json");
     }
 
     public IReadOnlyList<ConnectionProfile> Load()

--- a/PgNimbus.Core/Connections/CredentialStore.cs
+++ b/PgNimbus.Core/Connections/CredentialStore.cs
@@ -1,0 +1,8 @@
+namespace PgNimbus.Core.Connections;
+
+/// <summary>Picks the right <see cref="ICredentialStore"/> backend for the current OS.</summary>
+public static class CredentialStore
+{
+    public static ICredentialStore Create() =>
+        OperatingSystem.IsWindows() ? new WindowsDpapiCredentialStore() : new PlainFileCredentialStore();
+}

--- a/PgNimbus.Core/Connections/ICredentialStore.cs
+++ b/PgNimbus.Core/Connections/ICredentialStore.cs
@@ -1,0 +1,11 @@
+namespace PgNimbus.Core.Connections;
+
+/// <summary>Stores connection passwords outside of <see cref="ConnectionProfile"/> itself.</summary>
+public interface ICredentialStore
+{
+    void SavePassword(Guid connectionId, string password);
+
+    string? LoadPassword(Guid connectionId);
+
+    void DeletePassword(Guid connectionId);
+}

--- a/PgNimbus.Core/Connections/PlainFileCredentialStore.cs
+++ b/PgNimbus.Core/Connections/PlainFileCredentialStore.cs
@@ -1,0 +1,53 @@
+using System.Text;
+
+namespace PgNimbus.Core.Connections;
+
+/// <summary>
+/// Fallback credential store for non-Windows platforms. Passwords are only
+/// base64-encoded, not encrypted - this is a stopgap until real macOS
+/// Keychain / Linux libsecret integration lands. The file is restricted to
+/// the owning user where the OS supports POSIX permissions.
+/// </summary>
+public sealed class PlainFileCredentialStore : ICredentialStore
+{
+    private readonly string _directory;
+
+    public PlainFileCredentialStore(string? directory = null)
+    {
+        _directory = directory ?? Path.Combine(AppDataPaths.GetRootDirectory(), "credentials");
+    }
+
+    public void SavePassword(Guid connectionId, string password)
+    {
+        Directory.CreateDirectory(_directory);
+        var path = GetFilePath(connectionId);
+        File.WriteAllText(path, Convert.ToBase64String(Encoding.UTF8.GetBytes(password)));
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+    }
+
+    public string? LoadPassword(Guid connectionId)
+    {
+        var path = GetFilePath(connectionId);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        return Encoding.UTF8.GetString(Convert.FromBase64String(File.ReadAllText(path)));
+    }
+
+    public void DeletePassword(Guid connectionId)
+    {
+        var path = GetFilePath(connectionId);
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private string GetFilePath(Guid connectionId) => Path.Combine(_directory, $"{connectionId:N}.cred");
+}

--- a/PgNimbus.Core/Connections/WindowsDpapiCredentialStore.cs
+++ b/PgNimbus.Core/Connections/WindowsDpapiCredentialStore.cs
@@ -1,0 +1,53 @@
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PgNimbus.Core.Connections;
+
+/// <summary>
+/// Encrypts each connection's password at rest using Windows DPAPI, scoped to
+/// the current user account. Only the user who saved a password (on the
+/// machine it was saved on) can decrypt it back.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class WindowsDpapiCredentialStore : ICredentialStore
+{
+    private readonly string _directory;
+
+    public WindowsDpapiCredentialStore(string? directory = null)
+    {
+        _directory = directory ?? Path.Combine(AppDataPaths.GetRootDirectory(), "credentials");
+    }
+
+    public void SavePassword(Guid connectionId, string password)
+    {
+        Directory.CreateDirectory(_directory);
+        var plainBytes = Encoding.UTF8.GetBytes(password);
+        var protectedBytes = ProtectedData.Protect(plainBytes, optionalEntropy: null, DataProtectionScope.CurrentUser);
+        File.WriteAllBytes(GetFilePath(connectionId), protectedBytes);
+    }
+
+    public string? LoadPassword(Guid connectionId)
+    {
+        var path = GetFilePath(connectionId);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        var protectedBytes = File.ReadAllBytes(path);
+        var plainBytes = ProtectedData.Unprotect(protectedBytes, optionalEntropy: null, DataProtectionScope.CurrentUser);
+        return Encoding.UTF8.GetString(plainBytes);
+    }
+
+    public void DeletePassword(Guid connectionId)
+    {
+        var path = GetFilePath(connectionId);
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+
+    private string GetFilePath(Guid connectionId) => Path.Combine(_directory, $"{connectionId:N}.dpapi");
+}

--- a/PgNimbus.Core/PgNimbus.Core.csproj
+++ b/PgNimbus.Core/PgNimbus.Core.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="9.0.2" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Resolves the `// TODO` on `ConnectionProfile.BuildConnectionString`: passwords now come from an `ICredentialStore` rather than needing to be retyped every time or (worse) persisted on the profile record.

- `ICredentialStore` abstraction with two backends: `WindowsDpapiCredentialStore` (`System.Security.Cryptography.ProtectedData`, scoped to the current user account) and `PlainFileCredentialStore` (base64, 0600 permissions) as the non-Windows fallback until real macOS Keychain / Linux libsecret support lands. `CredentialStore.Create()` picks the right one via `OperatingSystem.IsWindows()`.
- Each password is a separate file per connection ID under `<appdata>/pgNimbus/credentials/`, kept out of `connections.json` entirely.
- `ConnectionDialogViewModel` now auto-fills the password field when a saved profile is selected, saves it on Save (only if non-empty, so leaving the field blank during an edit doesn't clobber an existing stored password), and cleans it up on Delete.
- Extracted the app-data directory resolution into a shared `AppDataPaths` helper used by both `ConnectionProfileStore` and the credential store backends.

## Base branch
This targets `feature/connection-manager-ui` (#3) rather than `main`, since it directly extends `ConnectionDialogViewModel` and `ConnectionProfileStore` from that PR. Should merge after it.

## Test plan
- [x] `dotnet build` — clean, 0 warnings/errors
- [x] Ran headlessly (Xvfb + xdotool + screenshots) against a real local PostgreSQL 16 instance:
  - [x] Saved a profile with a password — confirmed it lands in a separate `0600` file (base64), not in the JSON profile file
  - [x] Restarted the app, selected the saved profile — password field auto-fills
  - [x] Clicked Connect without retyping the password — connected and ran a real query successfully
  - [x] Deleted the profile — confirmed the credential file is removed too


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_