### PR TITLE
Add inline data editing in the results grid

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -60,7 +60,7 @@ public partial class App : Application
 
         var window = new MainWindow
         {
-            DataContext = new MainViewModel(new QueryViewModel(engine), schemaTree),
+            DataContext = new MainViewModel(new QueryViewModel(engine), schemaTree, schemaService),
         };
 
         _ = schemaTree.RefreshCommand.ExecuteAsync(null);

--- a/PgNimbus.App/ViewModels/EditableTableContext.cs
+++ b/PgNimbus.App/ViewModels/EditableTableContext.cs
@@ -1,0 +1,9 @@
+namespace PgNimbus.App.ViewModels;
+
+/// <summary>
+/// Tracks the single table a result set maps to, so inline cell edits can be
+/// turned into targeted UPDATE statements. Cleared whenever the SQL text
+/// changes, so edits are only ever attempted against the exact query that
+/// produced this context (see <see cref="QueryViewModel"/>).
+/// </summary>
+public sealed record EditableTableContext(string Schema, string Table, IReadOnlyList<string> PrimaryKeyColumns);

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -1,19 +1,33 @@
+using PgNimbus.Core.Query;
+using PgNimbus.Core.Schema;
+
 namespace PgNimbus.App.ViewModels;
 
 public sealed class MainViewModel
 {
+    private readonly SchemaService _schemaService;
+
     public QueryViewModel Query { get; }
 
     public SchemaTreeViewModel SchemaTree { get; }
 
-    public MainViewModel(QueryViewModel query, SchemaTreeViewModel schemaTree)
+    public MainViewModel(QueryViewModel query, SchemaTreeViewModel schemaTree, SchemaService schemaService)
     {
         Query = query;
         SchemaTree = schemaTree;
+        _schemaService = schemaService;
     }
 
-    public void PreviewTable(TableNode table)
+    public async Task PreviewTableAsync(TableNode table)
     {
-        Query.Sql = $"SELECT * FROM \"{table.Schema}\".\"{table.Name}\" LIMIT 100;";
+        Query.Sql = $"SELECT * FROM {SqlIdentifier.Quote(table.Schema)}.{SqlIdentifier.Quote(table.Name)} LIMIT 100;";
+
+        var columns = await _schemaService.GetColumnsAsync(table.Schema, table.Name, CancellationToken.None);
+        var primaryKeyColumns = columns.Where(c => c.IsPrimaryKey).Select(c => c.Name).ToList();
+
+        if (primaryKeyColumns.Count > 0)
+        {
+            Query.EditContext = new EditableTableContext(table.Schema, table.Name, primaryKeyColumns);
+        }
     }
 }

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -20,6 +20,11 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private bool _isRunning;
 
+    [ObservableProperty]
+    private EditableTableContext? _editContext;
+
+    public bool IsEditable => EditContext is { PrimaryKeyColumns.Count: > 0 };
+
     public ObservableCollection<string> ColumnNames { get; } = [];
 
     public ObservableCollection<object?[]> Rows { get; } = [];
@@ -111,5 +116,80 @@ public sealed partial class QueryViewModel : ObservableObject
     {
         RunCommand.NotifyCanExecuteChanged();
         CancelCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnSqlChanged(string value) => EditContext = null;
+
+    partial void OnEditContextChanged(EditableTableContext? value) => OnPropertyChanged(nameof(IsEditable));
+
+    /// <summary>
+    /// Commits an inline grid edit as a targeted UPDATE, or reverts the cell
+    /// (with a proper UI refresh) if the edit context is missing/invalid or
+    /// the statement fails.
+    /// </summary>
+    public async Task CommitCellEditAsync(object?[] originalRow, object?[] editedRow, int columnIndex)
+    {
+        if (EditContext is not { } context)
+        {
+            RevertCell(originalRow, editedRow, columnIndex);
+            return;
+        }
+
+        var columnName = ColumnNames[columnIndex];
+
+        if (context.PrimaryKeyColumns.Contains(columnName))
+        {
+            RevertCell(originalRow, editedRow, columnIndex);
+            Status = "Editing primary key columns isn't supported yet.";
+            return;
+        }
+
+        var pkIndexes = context.PrimaryKeyColumns.Select(pk => ColumnNames.IndexOf(pk)).ToList();
+        if (pkIndexes.Any(i => i < 0))
+        {
+            RevertCell(originalRow, editedRow, columnIndex);
+            Status = "Cannot edit: primary key column isn't present in this result set.";
+            return;
+        }
+
+        var whereClause = string.Join(
+            " AND ",
+            context.PrimaryKeyColumns.Select((pk, n) => $"{SqlIdentifier.Quote(pk)} = @pk{n}"));
+
+        var sql = $"""
+            UPDATE {SqlIdentifier.Quote(context.Schema)}.{SqlIdentifier.Quote(context.Table)}
+            SET {SqlIdentifier.Quote(columnName)} = @value
+            WHERE {whereClause}
+            """;
+
+        var parameters = new Dictionary<string, object?> { ["value"] = editedRow[columnIndex] };
+        for (var n = 0; n < pkIndexes.Count; n++)
+        {
+            parameters[$"pk{n}"] = originalRow[pkIndexes[n]];
+        }
+
+        try
+        {
+            await _engine.ExecuteNonQueryAsync(sql, parameters, CancellationToken.None);
+            Status = $"Saved {context.Schema}.{context.Table}.{columnName}";
+        }
+        catch (Exception ex)
+        {
+            RevertCell(originalRow, editedRow, columnIndex);
+            Status = $"Update failed: {ex.Message}";
+        }
+    }
+
+    private void RevertCell(object?[] originalRow, object?[] editedRow, int columnIndex)
+    {
+        var index = Rows.IndexOf(editedRow);
+        if (index < 0)
+        {
+            return;
+        }
+
+        var reverted = (object?[])editedRow.Clone();
+        reverted[columnIndex] = originalRow[columnIndex];
+        Rows[index] = reverted;
     }
 }

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -87,7 +87,8 @@
 
             <Border Grid.Row="2" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Margin="0,8,0,8">
                 <DataGrid Name="ResultsGrid"
-                          IsReadOnly="True"
+                          IsReadOnly="{Binding !Query.IsEditable}"
+                          CanUserReorderColumns="False"
                           GridLinesVisibility="All"
                           AutoGenerateColumns="False" />
             </Border>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -14,6 +14,7 @@ public partial class MainWindow : Window
     private MainViewModel? _viewModel;
     private QueryViewModel? _queryViewModel;
     private bool _suppressEditorSync;
+    private object?[]? _pendingEditOriginalRow;
 
     public MainWindow()
     {
@@ -33,6 +34,8 @@ public partial class MainWindow : Window
         // event Handled, so it never reaches a plain `+=` subscription on the
         // parent TreeView. Use AddHandler with handledEventsToo to still see it.
         SchemaTreeView.AddHandler(Gestures.DoubleTappedEvent, OnSchemaTreeDoubleTapped, RoutingStrategies.Bubble, handledEventsToo: true);
+        ResultsGrid.CellEditEnding += OnCellEditEnding;
+        ResultsGrid.CellEditEnded += OnCellEditEnded;
 
         DataContextChanged += (_, _) =>
         {
@@ -70,8 +73,31 @@ public partial class MainWindow : Window
         var container = (e.Source as Visual)?.FindAncestorOfType<TreeViewItem>(includeSelf: true);
         if (_viewModel is not null && container?.DataContext is TableNode table)
         {
-            _viewModel.PreviewTable(table);
+            _ = _viewModel.PreviewTableAsync(table);
         }
+    }
+
+    private void OnCellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
+    {
+        _pendingEditOriginalRow = e.Row.DataContext is object?[] row ? (object?[])row.Clone() : null;
+    }
+
+    private async void OnCellEditEnded(object? sender, DataGridCellEditEndedEventArgs e)
+    {
+        var originalRow = _pendingEditOriginalRow;
+        _pendingEditOriginalRow = null;
+
+        if (_queryViewModel is null || originalRow is null || e.EditAction != DataGridEditAction.Commit)
+        {
+            return;
+        }
+
+        if (e.Row.DataContext is not object?[] editedRow)
+        {
+            return;
+        }
+
+        await _queryViewModel.CommitCellEditAsync(originalRow, editedRow, e.Column.DisplayIndex);
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -20,6 +20,24 @@ public sealed class QueryEngine
         _dataSource = dataSource;
     }
 
+    /// <summary>
+    /// Executes a parameterized statement that returns no rows (used for
+    /// inline cell-edit UPDATEs). Unlike <see cref="ExecuteAsync"/>, callers
+    /// supply real parameters instead of a raw user-typed statement.
+    /// </summary>
+    public async Task ExecuteNonQueryAsync(string sql, IReadOnlyDictionary<string, object?> parameters, CancellationToken ct)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+
+        foreach (var (name, value) in parameters)
+        {
+            command.Parameters.AddWithValue(name, value ?? DBNull.Value);
+        }
+
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
     public async Task<StatementResult> ExecuteAsync(string sql, CancellationToken ct)
     {
         var stopwatch = Stopwatch.StartNew();

--- a/PgNimbus.Core/Query/SqlIdentifier.cs
+++ b/PgNimbus.Core/Query/SqlIdentifier.cs
@@ -1,0 +1,7 @@
+namespace PgNimbus.Core.Query;
+
+/// <summary>Quotes a Postgres identifier (schema/table/column name) for safe interpolation into SQL text.</summary>
+public static class SqlIdentifier
+{
+    public static string Quote(string identifier) => $"\"{identifier.Replace("\"", "\"\"")}\"";
+}


### PR DESCRIPTION
## Summary
Makes the results `DataGrid` editable when browsing a table via the schema tree — TablePlus, DBeaver, pgAdmin, DataGrip, and Beekeeper Studio all support this; pgNimbus's grid was read-only.

- `QueryEngine.ExecuteNonQueryAsync`: a parameterized non-query execution path for targeted UPDATEs, separate from the raw-SQL `ExecuteAsync` used for user-typed queries.
- `SqlIdentifier.Quote`: safe identifier quoting for schema/table/column names embedded in generated SQL (values are always parameterized, never string-interpolated).
- `EditableTableContext` + `QueryViewModel.EditContext`: tracks the single table + PK columns a result set maps to. Cleared whenever the SQL text changes (including our own programmatic edits), so a cell edit can only ever target the exact query that produced it — never a stale/mismatched table after the user edits the SQL by hand.
- `QueryViewModel.CommitCellEditAsync`: builds a parameterized UPDATE keyed on the row's original PK values (snapshotted before the edit commits, so editing a column doesn't corrupt its own WHERE clause), and reverts the cell via an `ObservableCollection` replace (mutating an array element in place doesn't raise a UI change notification) on failure or on an unsupported PK-column edit.
- `MainViewModel.PreviewTableAsync`: now looks up PK columns via `SchemaService` when previewing a table, to build the `EditContext`.

## Bug fixed along the way
Found via end-to-end testing: double-clicking a schema-tree row that wasn't already selected did nothing, because `TreeViewItem`'s own `DoubleTapped` handling (toggling expand) marks the event `Handled` before it reaches a plain `+=` subscription on the parent `TreeView`. Fixed with `AddHandler(..., handledEventsToo: true)` and by reading the node off the tapped `TreeViewItem`'s `DataContext` instead of `SchemaTreeView.SelectedItem` (which can be stale on a row's very first click). This same fix already shipped to `main` via the schema-tree-sidebar PR once it was found there.

## Test plan — and an honest note on scope
- [x] `dotnet build` — clean, 0 warnings/errors
- [x] The update/revert **logic** was verified directly against a real local PostgreSQL 16 instance via a standalone harness exercising `QueryViewModel.CommitCellEditAsync`:
  - [x] A successful edit (confirmed the new value via `psql`)
  - [x] An attempted edit of the primary key column itself — blocked, cell reverted
  - [x] A real `NOT NULL` constraint violation — caught, cell reverted, no crash
- [x] `IsReadOnly` was confirmed to correctly flip to `false` once a table is previewed (checked via a temporary debug binding, since removed)
- [ ] The `DataGrid`'s own double-click/F2-to-edit gesture could **not** be reliably driven via headless `xdotool` synthetic clicks in this sandbox (unlike the `TreeView`'s double-tap gesture, which does respond correctly). This is standard Avalonia `DataGrid` framework behavior, not new code in this PR, but it's worth a quick real-mouse sanity check before considering this fully done.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_