### PR TITLE
Add SSH tunnel support for connections

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -40,9 +40,9 @@ public partial class App : Application
         var viewModel = new ConnectionDialogViewModel(new ConnectionProfileStore(), CredentialStore.Create());
         var dialog = new ConnectionDialog { DataContext = viewModel };
 
-        viewModel.Connected += connectionString =>
+        viewModel.Connected += (connectionString, tunnel) =>
         {
-            var mainWindow = BuildMainWindow(connectionString);
+            var mainWindow = BuildMainWindow(connectionString, tunnel);
             desktop.MainWindow = mainWindow;
             mainWindow.Show();
             dialog.Close();
@@ -51,7 +51,7 @@ public partial class App : Application
         return dialog;
     }
 
-    private static MainWindow BuildMainWindow(string connectionString)
+    private static MainWindow BuildMainWindow(string connectionString, SshTunnel? tunnel = null)
     {
         var dataSource = NpgsqlDataSource.Create(connectionString);
         var engine = new QueryEngine(dataSource);
@@ -62,6 +62,11 @@ public partial class App : Application
         {
             DataContext = new MainViewModel(new QueryViewModel(engine), schemaTree, schemaService),
         };
+
+        if (tunnel is not null)
+        {
+            window.Closed += (_, _) => tunnel.Dispose();
+        }
 
         _ = schemaTree.RefreshCommand.ExecuteAsync(null);
 

--- a/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
+++ b/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
@@ -14,6 +14,8 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
 
     public IReadOnlyList<SslMode> SslModes { get; } = Enum.GetValues<SslMode>();
 
+    public IReadOnlyList<SshAuthMethod> SshAuthMethods { get; } = Enum.GetValues<SshAuthMethod>();
+
     [ObservableProperty]
     private ConnectionProfile? _selectedProfile;
 
@@ -39,10 +41,34 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
     private string _password = string.Empty;
 
     [ObservableProperty]
+    private bool _useSshTunnel;
+
+    [ObservableProperty]
+    private string _sshHost = string.Empty;
+
+    [ObservableProperty]
+    private int _sshPort = SshTunnelOptions.DefaultPort;
+
+    [ObservableProperty]
+    private string _sshUsername = string.Empty;
+
+    [ObservableProperty]
+    private SshAuthMethod _sshAuthMethod = SshAuthMethod.Password;
+
+    [ObservableProperty]
+    private string _sshPrivateKeyPath = string.Empty;
+
+    [ObservableProperty]
+    private string _sshPassword = string.Empty;
+
+    [ObservableProperty]
     private string? _errorMessage;
 
-    /// <summary>Raised with the built connection string when the user clicks Connect.</summary>
-    public event Action<string>? Connected;
+    [ObservableProperty]
+    private bool _isConnecting;
+
+    /// <summary>Raised with the built connection string and, if a tunnel was used, the live SshTunnel to keep alive.</summary>
+    public event Action<string, SshTunnel?>? Connected;
 
     public ConnectionDialogViewModel(ConnectionProfileStore store, ICredentialStore credentialStore)
     {
@@ -69,6 +95,14 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         Username = value.Username;
         SslMode = value.SslMode;
         Password = _credentialStore.LoadPassword(value.Id) ?? string.Empty;
+
+        UseSshTunnel = value.SshTunnel is not null;
+        SshHost = value.SshTunnel?.Host ?? string.Empty;
+        SshPort = value.SshTunnel?.Port ?? SshTunnelOptions.DefaultPort;
+        SshUsername = value.SshTunnel?.Username ?? string.Empty;
+        SshAuthMethod = value.SshTunnel?.AuthMethod ?? SshAuthMethod.Password;
+        SshPrivateKeyPath = value.SshTunnel?.PrivateKeyPath ?? string.Empty;
+        SshPassword = _credentialStore.LoadPassword(DeriveSshCredentialId(value.Id)) ?? string.Empty;
     }
 
     [RelayCommand]
@@ -82,6 +116,13 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         Username = "postgres";
         SslMode = SslMode.Prefer;
         Password = string.Empty;
+        UseSshTunnel = false;
+        SshHost = string.Empty;
+        SshPort = SshTunnelOptions.DefaultPort;
+        SshUsername = string.Empty;
+        SshAuthMethod = SshAuthMethod.Password;
+        SshPrivateKeyPath = string.Empty;
+        SshPassword = string.Empty;
         ErrorMessage = null;
     }
 
@@ -111,6 +152,11 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
             _credentialStore.SavePassword(profile.Id, Password);
         }
 
+        if (UseSshTunnel && !string.IsNullOrEmpty(SshPassword))
+        {
+            _credentialStore.SavePassword(DeriveSshCredentialId(profile.Id), SshPassword);
+        }
+
         SelectedProfile = profile;
     }
 
@@ -126,11 +172,12 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         Profiles.Remove(SelectedProfile);
         _store.Save(Profiles);
         _credentialStore.DeletePassword(idToDelete);
+        _credentialStore.DeletePassword(DeriveSshCredentialId(idToDelete));
         New();
     }
 
     [RelayCommand]
-    private void Connect()
+    private async Task ConnectAsync()
     {
         if (!TryBuildProfile(out var profile, out var error))
         {
@@ -139,8 +186,32 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         }
 
         ErrorMessage = null;
-        var connectionString = profile.BuildConnectionString(string.IsNullOrEmpty(Password) ? null : Password);
-        Connected?.Invoke(connectionString);
+        IsConnecting = true;
+
+        try
+        {
+            if (profile.SshTunnel is { } sshOptions)
+            {
+                var tunnel = await Task.Run(() => SshTunnel.Connect(sshOptions, SshPassword, profile.Host, profile.Port));
+                var connectionString = profile.BuildConnectionString(
+                    string.IsNullOrEmpty(Password) ? null : Password,
+                    (tunnel.LocalHost, tunnel.LocalPort));
+                Connected?.Invoke(connectionString, tunnel);
+            }
+            else
+            {
+                var connectionString = profile.BuildConnectionString(string.IsNullOrEmpty(Password) ? null : Password);
+                Connected?.Invoke(connectionString, null);
+            }
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = $"SSH tunnel failed: {ex.Message}";
+        }
+        finally
+        {
+            IsConnecting = false;
+        }
     }
 
     private bool TryBuildProfile(out ConnectionProfile profile, out string? error)
@@ -152,6 +223,17 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
             return false;
         }
 
+        if (UseSshTunnel && (string.IsNullOrWhiteSpace(SshHost) || string.IsNullOrWhiteSpace(SshUsername)))
+        {
+            profile = null!;
+            error = "SSH host and username are required when the tunnel is enabled.";
+            return false;
+        }
+
+        var sshTunnel = UseSshTunnel
+            ? new SshTunnelOptions(SshHost, SshPort, SshUsername, SshAuthMethod, string.IsNullOrWhiteSpace(SshPrivateKeyPath) ? null : SshPrivateKeyPath)
+            : null;
+
         profile = new ConnectionProfile(
             SelectedProfile?.Id ?? Guid.NewGuid(),
             string.IsNullOrWhiteSpace(Name) ? Host : Name,
@@ -159,8 +241,25 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
             Port,
             Database,
             Username,
-            SslMode);
+            SslMode,
+            SshTunnel: sshTunnel);
         error = null;
         return true;
+    }
+
+    /// <summary>
+    /// SSH credentials are stored via the same ICredentialStore as the DB
+    /// password, keyed by a distinct id derived from the connection's own id
+    /// (a simple byte-wise XOR) so the two secrets never collide on disk.
+    /// </summary>
+    private static Guid DeriveSshCredentialId(Guid connectionId)
+    {
+        var bytes = connectionId.ToByteArray();
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            bytes[i] ^= 0x5A;
+        }
+
+        return new Guid(bytes);
     }
 }

--- a/PgNimbus.App/Views/ConnectionDialog.axaml
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml
@@ -6,7 +6,7 @@
         x:Class="PgNimbus.App.Views.ConnectionDialog"
         x:DataType="vm:ConnectionDialogViewModel"
         Title="pgNimbus — Connect"
-        Width="640" Height="440"
+        Width="640" Height="620"
         CanResize="False"
         WindowStartupLocation="CenterScreen">
 
@@ -29,7 +29,8 @@
             <Button Grid.Row="2" Content="New" Command="{Binding NewCommand}" Margin="0,6,0,0" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" />
         </Grid>
 
-        <Grid Grid.Column="1" Margin="16,0,0,0" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,*,Auto">
+        <ScrollViewer Grid.Column="1" Margin="16,0,0,0" HorizontalScrollBarVisibility="Disabled">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
 
             <TextBlock Grid.Row="0" Text="Name" />
             <TextBox Grid.Row="1" Text="{Binding Name}" Margin="0,0,0,8" />
@@ -59,16 +60,53 @@
                 <TextBox Text="{Binding Password}" PasswordChar="•" />
             </StackPanel>
 
-            <TextBlock Grid.Row="8" Text="{Binding ErrorMessage}" Foreground="IndianRed" TextWrapping="Wrap"
-                       IsVisible="{Binding ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
+            <CheckBox Grid.Row="8" Content="Connect through an SSH tunnel" IsChecked="{Binding UseSshTunnel}" Margin="0,0,0,8" />
 
-            <StackPanel Grid.Row="9" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Border Grid.Row="9" IsVisible="{Binding UseSshTunnel}"
+                    BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
+                    Padding="8" Margin="0,0,0,8">
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
+                    <TextBlock Grid.Row="0" Text="SSH Host / Port" />
+                    <Grid Grid.Row="1" ColumnDefinitions="*,100" Margin="0,0,0,8">
+                        <TextBox Grid.Column="0" Text="{Binding SshHost}" Margin="0,0,6,0" />
+                        <NumericUpDown Grid.Column="1" Value="{Binding SshPort}" Minimum="1" Maximum="65535" FormatString="0" />
+                    </Grid>
+
+                    <Grid Grid.Row="2" ColumnDefinitions="*,*" Margin="0,0,0,8">
+                        <StackPanel Grid.Column="0" Margin="0,0,6,0">
+                            <TextBlock Text="SSH Username" />
+                            <TextBox Text="{Binding SshUsername}" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="1">
+                            <TextBlock Text="Auth Method" />
+                            <ComboBox ItemsSource="{Binding SshAuthMethods}" SelectedItem="{Binding SshAuthMethod}" HorizontalAlignment="Stretch" />
+                        </StackPanel>
+                    </Grid>
+
+                    <StackPanel Grid.Row="3" Margin="0,0,0,8"
+                                IsVisible="{Binding SshAuthMethod, Converter={x:Static conv:ObjectConverters.Equal}, ConverterParameter={x:Static conn:SshAuthMethod.PrivateKey}}">
+                        <TextBlock Text="Private Key Path" />
+                        <TextBox Text="{Binding SshPrivateKeyPath}" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="4">
+                        <TextBlock Text="SSH Password / Passphrase" />
+                        <TextBox Text="{Binding SshPassword}" PasswordChar="•" />
+                    </StackPanel>
+                </Grid>
+            </Border>
+
+            <TextBlock Grid.Row="10" Text="{Binding ErrorMessage}" Foreground="IndianRed" TextWrapping="Wrap"
+                       IsVisible="{Binding ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" Margin="0,0,0,8" />
+
+            <StackPanel Grid.Row="12" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="0,8,0,0">
                 <Button Content="Delete" Command="{Binding DeleteCommand}" />
                 <Button Content="Save" Command="{Binding SaveCommand}" />
-                <Button Content="Connect" Command="{Binding ConnectCommand}" />
+                <Button Content="Connect" Command="{Binding ConnectCommand}" IsEnabled="{Binding !IsConnecting}" />
             </StackPanel>
 
         </Grid>
+        </ScrollViewer>
 
     </Grid>
 

--- a/PgNimbus.Core/Connections/ConnectionProfile.cs
+++ b/PgNimbus.Core/Connections/ConnectionProfile.cs
@@ -24,19 +24,25 @@ public sealed record ConnectionProfile(
     string Database,
     string Username,
     SslMode SslMode,
-    string? AccentColor = null)
+    string? AccentColor = null,
+    SshTunnelOptions? SshTunnel = null)
 {
     public const int DefaultPort = 5432;
 
     // Callers resolve the password via ICredentialStore (DPAPI on Windows, a
     // permission-restricted file fallback elsewhere) and pass it in here -
     // it never lives on this record itself.
-    public string BuildConnectionString(string? password)
+    //
+    // When tunneling through SSH, pass the tunnel's local endpoint as
+    // `endpointOverride` - Npgsql then connects to 127.0.0.1:<local port>
+    // instead of the real host, while the rest of the profile (database,
+    // username, SSL mode) still applies.
+    public string BuildConnectionString(string? password, (string Host, int Port)? endpointOverride = null)
     {
         var builder = new NpgsqlConnectionStringBuilder
         {
-            Host = Host,
-            Port = Port,
+            Host = endpointOverride?.Host ?? Host,
+            Port = endpointOverride?.Port ?? Port,
             Database = Database,
             Username = Username,
             Password = password,

--- a/PgNimbus.Core/Connections/SshTunnel.cs
+++ b/PgNimbus.Core/Connections/SshTunnel.cs
@@ -1,0 +1,69 @@
+using Renci.SshNet;
+
+namespace PgNimbus.Core.Connections;
+
+/// <summary>
+/// A live local port forward through an SSH jump host to a database target.
+/// Callers connect to <see cref="LocalHost"/>:<see cref="LocalPort"/> instead
+/// of the real database endpoint. Disposing tears down both the forwarded
+/// port and the underlying SSH connection.
+/// </summary>
+public sealed class SshTunnel : IDisposable
+{
+    private readonly SshClient _client;
+    private readonly ForwardedPortLocal _forwardedPort;
+
+    private SshTunnel(SshClient client, ForwardedPortLocal forwardedPort)
+    {
+        _client = client;
+        _forwardedPort = forwardedPort;
+    }
+
+    public string LocalHost => "127.0.0.1";
+
+    public int LocalPort => (int)_forwardedPort.BoundPort;
+
+    public static SshTunnel Connect(SshTunnelOptions options, string password, string targetHost, int targetPort)
+    {
+        var connectionInfo = BuildConnectionInfo(options, password);
+
+        var client = new SshClient(connectionInfo);
+        client.Connect();
+
+        var forwardedPort = new ForwardedPortLocal("127.0.0.1", 0, targetHost, (uint)targetPort);
+
+        try
+        {
+            client.AddForwardedPort(forwardedPort);
+            forwardedPort.Start();
+        }
+        catch
+        {
+            forwardedPort.Dispose();
+            client.Disconnect();
+            client.Dispose();
+            throw;
+        }
+
+        return new SshTunnel(client, forwardedPort);
+    }
+
+    private static ConnectionInfo BuildConnectionInfo(SshTunnelOptions options, string password) => options.AuthMethod switch
+    {
+        SshAuthMethod.Password => new PasswordConnectionInfo(options.Host, options.Port, options.Username, password),
+        SshAuthMethod.PrivateKey => new PrivateKeyConnectionInfo(
+            options.Host,
+            options.Port,
+            options.Username,
+            new PrivateKeyFile(options.PrivateKeyPath ?? throw new InvalidOperationException("Private key path is required."), password)),
+        _ => throw new ArgumentOutOfRangeException(nameof(options)),
+    };
+
+    public void Dispose()
+    {
+        _forwardedPort.Stop();
+        _forwardedPort.Dispose();
+        _client.Disconnect();
+        _client.Dispose();
+    }
+}

--- a/PgNimbus.Core/Connections/SshTunnelOptions.cs
+++ b/PgNimbus.Core/Connections/SshTunnelOptions.cs
@@ -1,0 +1,23 @@
+namespace PgNimbus.Core.Connections;
+
+public enum SshAuthMethod
+{
+    Password,
+    PrivateKey,
+}
+
+/// <summary>
+/// Optional SSH jump-host config for a connection. When present, the app
+/// tunnels through this host instead of connecting to the database
+/// directly. Never carries a password/passphrase - same rule as
+/// <see cref="ConnectionProfile"/> itself.
+/// </summary>
+public sealed record SshTunnelOptions(
+    string Host,
+    int Port,
+    string Username,
+    SshAuthMethod AuthMethod,
+    string? PrivateKeyPath = null)
+{
+    public const int DefaultPort = 22;
+}

--- a/PgNimbus.Core/PgNimbus.Core.csproj
+++ b/PgNimbus.Core/PgNimbus.Core.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.9" />
+    <PackageReference Include="SSH.NET" Version="2025.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
Matches TablePlus, DBeaver, DataGrip, HeidiSQL, and PostgresGUI, all of which support connecting to a database through an SSH jump host; pgNimbus had no way to do this.

- `SshTunnelOptions` (Core): optional SSH config on `ConnectionProfile` — host/port/username/auth method/private key path. No password field, same rule as the profile itself.
- `SshTunnel` (Core): wraps Renci.SshNet's `SshClient` + `ForwardedPortLocal` into a local port forward; callers connect to `127.0.0.1:<bound port>` instead of the real database endpoint.
- `ConnectionProfile.BuildConnectionString` gets an optional endpoint override so the rest of the profile (database, username, SSL mode) still applies when tunneling.
- `ConnectionDialogViewModel.ConnectAsync`: when a tunnel is configured, establishes it (off the UI thread) before building the connection string, and surfaces SSH failures (auth, unreachable host) as a dialog error instead of crashing. The SSH password/passphrase is stored via the same `ICredentialStore` as the DB password, keyed by an id derived from the connection's own id (byte-wise XOR) so the two secrets never collide on disk.
- The live `SshTunnel` is kept alive for the `MainWindow`'s lifetime and disposed on `Window.Closed`.

## Test plan
- [x] `dotnet build` — clean, 0 warnings/errors
- [x] Installed a real local SSH server (`openssh-server`, password auth) in the sandbox and ran the app headlessly (Xvfb + xdotool + screenshots) tunneling to a real local PostgreSQL 16 instance:
  - [x] Filled in the dialog with the tunnel enabled, connected, and ran a real query through the tunnel — correct results
  - [x] Wrong SSH password surfaces `SSH tunnel failed: Permission denied (password).` in the dialog, Connect re-enabled, no crash
  - [x] Saved a tunneled profile — confirmed `connections.json` holds the full `SshTunnel` object with zero secrets, confirmed two separate `0600` credential files exist (DB password + SSH password)
  - [x] Restarted the app and reselected the profile — both the DB and SSH passwords auto-fill correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_