### PR TITLE
Add CSV/JSON export, fix data-corruption bug in inline editing

### DIFF
--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -1,7 +1,9 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core.Export;
 using PgNimbus.Core.Query;
 
 namespace PgNimbus.App.ViewModels;
@@ -10,6 +12,7 @@ public sealed partial class QueryViewModel : ObservableObject
 {
     private readonly QueryEngine _engine;
     private CancellationTokenSource? _cts;
+    private IReadOnlyList<ColumnInfo> _columns = [];
 
     [ObservableProperty]
     private string _sql = "SELECT 1;";
@@ -46,6 +49,7 @@ public sealed partial class QueryViewModel : ObservableObject
         Status = "Running...";
         ColumnNames.Clear();
         Rows.Clear();
+        _columns = [];
 
         var stopwatch = Stopwatch.StartNew();
 
@@ -56,6 +60,7 @@ public sealed partial class QueryViewModel : ObservableObject
             switch (result)
             {
                 case ResultSet resultSet:
+                    _columns = resultSet.Columns;
                     foreach (var column in resultSet.Columns)
                     {
                         ColumnNames.Add(column.Name);
@@ -123,15 +128,19 @@ public sealed partial class QueryViewModel : ObservableObject
     partial void OnEditContextChanged(EditableTableContext? value) => OnPropertyChanged(nameof(IsEditable));
 
     /// <summary>
-    /// Commits an inline grid edit as a targeted UPDATE, or reverts the cell
-    /// (with a proper UI refresh) if the edit context is missing/invalid or
-    /// the statement fails.
+    /// Commits an inline grid edit (the raw text typed into the cell editor)
+    /// as a targeted UPDATE. The grid's own column bindings are one-way, so
+    /// <paramref name="row"/> is never mutated by the UI itself - on success
+    /// this applies the converted value and replaces the row (via
+    /// ObservableCollection replace, since mutating an array element in
+    /// place doesn't raise a UI change notification); on failure it simply
+    /// does nothing, since the row was never touched.
     /// </summary>
-    public async Task CommitCellEditAsync(object?[] originalRow, object?[] editedRow, int columnIndex)
+    public async Task CommitCellEditAsync(object?[] row, int columnIndex, string newValueText)
     {
         if (EditContext is not { } context)
         {
-            RevertCell(originalRow, editedRow, columnIndex);
+            Status = "Editing isn't available for this result set.";
             return;
         }
 
@@ -139,7 +148,6 @@ public sealed partial class QueryViewModel : ObservableObject
 
         if (context.PrimaryKeyColumns.Contains(columnName))
         {
-            RevertCell(originalRow, editedRow, columnIndex);
             Status = "Editing primary key columns isn't supported yet.";
             return;
         }
@@ -147,7 +155,6 @@ public sealed partial class QueryViewModel : ObservableObject
         var pkIndexes = context.PrimaryKeyColumns.Select(pk => ColumnNames.IndexOf(pk)).ToList();
         if (pkIndexes.Any(i => i < 0))
         {
-            RevertCell(originalRow, editedRow, columnIndex);
             Status = "Cannot edit: primary key column isn't present in this result set.";
             return;
         }
@@ -162,34 +169,78 @@ public sealed partial class QueryViewModel : ObservableObject
             WHERE {whereClause}
             """;
 
-        var parameters = new Dictionary<string, object?> { ["value"] = editedRow[columnIndex] };
+        object? newValue;
+        try
+        {
+            newValue = ConvertEditedValue(newValueText, columnIndex);
+        }
+        catch (Exception ex)
+        {
+            Status = $"Invalid value for {columnName}: {ex.Message}";
+            return;
+        }
+
+        var parameters = new Dictionary<string, object?> { ["value"] = newValue };
         for (var n = 0; n < pkIndexes.Count; n++)
         {
-            parameters[$"pk{n}"] = originalRow[pkIndexes[n]];
+            parameters[$"pk{n}"] = row[pkIndexes[n]];
         }
 
         try
         {
             await _engine.ExecuteNonQueryAsync(sql, parameters, CancellationToken.None);
+
+            var rowIndex = Rows.IndexOf(row);
+            if (rowIndex >= 0)
+            {
+                var updated = (object?[])row.Clone();
+                updated[columnIndex] = newValue;
+                Rows[rowIndex] = updated;
+            }
+
             Status = $"Saved {context.Schema}.{context.Table}.{columnName}";
         }
         catch (Exception ex)
         {
-            RevertCell(originalRow, editedRow, columnIndex);
             Status = $"Update failed: {ex.Message}";
         }
     }
 
-    private void RevertCell(object?[] originalRow, object?[] editedRow, int columnIndex)
+    /// <summary>
+    /// Converts the cell editor's raw text back to the column's real CLR
+    /// type, so the parameter Npgsql sends matches what the column expects
+    /// (a bare string parameter against, say, a numeric column fails with a
+    /// Postgres type-mismatch error, since text isn't assignment-castable to
+    /// most non-text types).
+    /// </summary>
+    private object ConvertEditedValue(string text, int columnIndex)
     {
-        var index = Rows.IndexOf(editedRow);
-        if (index < 0)
+        var targetType = columnIndex < _columns.Count ? _columns[columnIndex].ClrType : typeof(string);
+        var underlying = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
+        if (underlying == typeof(string))
         {
-            return;
+            return text;
         }
 
-        var reverted = (object?[])editedRow.Clone();
-        reverted[columnIndex] = originalRow[columnIndex];
-        Rows[index] = reverted;
+        if (underlying == typeof(Guid))
+        {
+            return Guid.Parse(text);
+        }
+
+        if (typeof(IConvertible).IsAssignableFrom(underlying))
+        {
+            return Convert.ChangeType(text, underlying, CultureInfo.InvariantCulture);
+        }
+
+        return text;
     }
+
+    public void ExportCsv(Stream stream)
+    {
+        using var writer = new StreamWriter(stream, leaveOpen: true);
+        ResultExporter.WriteCsv(writer, ColumnNames, Rows);
+    }
+
+    public void ExportJson(Stream stream) => ResultExporter.WriteJson(stream, ColumnNames, Rows);
 }

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -76,6 +76,14 @@
             <StackPanel Orientation="Horizontal" Grid.Row="0" Spacing="8" Margin="0,0,0,8">
                 <Button Content="Run" Command="{Binding Query.RunCommand}" ToolTip.Tip="Ctrl+Enter" />
                 <Button Content="Cancel" Command="{Binding Query.CancelCommand}" ToolTip.Tip="Esc" />
+                <Button Name="ExportButton" Content="Export">
+                    <Button.Flyout>
+                        <MenuFlyout>
+                            <MenuItem Header="Export as CSV..." Click="OnExportCsvClick" />
+                            <MenuItem Header="Export as JSON..." Click="OnExportJsonClick" />
+                        </MenuFlyout>
+                    </Button.Flyout>
+                </Button>
             </StackPanel>
 
             <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
 using PgNimbus.App.ViewModels;
 
@@ -14,7 +15,9 @@ public partial class MainWindow : Window
     private MainViewModel? _viewModel;
     private QueryViewModel? _queryViewModel;
     private bool _suppressEditorSync;
-    private object?[]? _pendingEditOriginalRow;
+    private object?[]? _pendingEditRow;
+    private int _pendingEditColumnIndex;
+    private string? _pendingEditText;
 
     public MainWindow()
     {
@@ -79,25 +82,75 @@ public partial class MainWindow : Window
 
     private void OnCellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
     {
-        _pendingEditOriginalRow = e.Row.DataContext is object?[] row ? (object?[])row.Clone() : null;
+        // Column bindings are one-way (see RebuildColumns), so the grid never
+        // mutates Row's array elements itself - the edited text has to be
+        // read directly off the editing TextBox here, before it's torn down.
+        // (DataGridCellEditEndedEventArgs doesn't expose EditingElement.)
+        _pendingEditRow = e.Row.DataContext as object?[];
+        _pendingEditColumnIndex = e.Column.DisplayIndex;
+        _pendingEditText = (e.EditingElement as TextBox)?.Text;
     }
 
     private async void OnCellEditEnded(object? sender, DataGridCellEditEndedEventArgs e)
     {
-        var originalRow = _pendingEditOriginalRow;
-        _pendingEditOriginalRow = null;
+        var row = _pendingEditRow;
+        var columnIndex = _pendingEditColumnIndex;
+        var text = _pendingEditText;
+        _pendingEditRow = null;
+        _pendingEditText = null;
 
-        if (_queryViewModel is null || originalRow is null || e.EditAction != DataGridEditAction.Commit)
+        if (_queryViewModel is null || row is null || text is null || e.EditAction != DataGridEditAction.Commit)
         {
             return;
         }
 
-        if (e.Row.DataContext is not object?[] editedRow)
+        await _queryViewModel.CommitCellEditAsync(row, columnIndex, text);
+    }
+
+    private async void OnExportCsvClick(object? sender, RoutedEventArgs e)
+    {
+        var query = _queryViewModel;
+        if (query is not null)
+        {
+            await ExportAsync("csv", "CSV", ["*.csv"], stream => query.ExportCsv(stream));
+        }
+    }
+
+    private async void OnExportJsonClick(object? sender, RoutedEventArgs e)
+    {
+        var query = _queryViewModel;
+        if (query is not null)
+        {
+            await ExportAsync("json", "JSON", ["*.json"], stream => query.ExportJson(stream));
+        }
+    }
+
+    private async Task ExportAsync(string extension, string typeName, string[] patterns, Action<Stream>? write)
+    {
+        if (write is null || _queryViewModel is null || _queryViewModel.Rows.Count == 0)
         {
             return;
         }
 
-        await _queryViewModel.CommitCellEditAsync(originalRow, editedRow, e.Column.DisplayIndex);
+        var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+        if (storageProvider is null)
+        {
+            return;
+        }
+
+        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            SuggestedFileName = $"export.{extension}",
+            FileTypeChoices = [new FilePickerFileType(typeName) { Patterns = patterns }],
+        });
+
+        if (file is null)
+        {
+            return;
+        }
+
+        await using var stream = await file.OpenWriteAsync();
+        write(stream);
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -127,7 +180,7 @@ public partial class MainWindow : Window
             ResultsGrid.Columns.Add(new DataGridTextColumn
             {
                 Header = query.ColumnNames[index],
-                Binding = new Binding($"[{index}]"),
+                Binding = new Binding($"[{index}]") { Mode = BindingMode.OneWay },
             });
         }
     }

--- a/PgNimbus.Core/Export/ResultExporter.cs
+++ b/PgNimbus.Core/Export/ResultExporter.cs
@@ -1,0 +1,128 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace PgNimbus.Core.Export;
+
+/// <summary>
+/// Writes query result rows as CSV or JSON. Values come back from Npgsql as
+/// arbitrary CLR types (int, string, DateTime, byte[], arrays, ...), so JSON
+/// output is built with Utf8JsonWriter by hand rather than via
+/// JsonSerializer's reflection-based object-graph serialization - that
+/// keeps this trim/NativeAOT-safe, matching the rest of Core.
+/// </summary>
+public static class ResultExporter
+{
+    public static void WriteCsv(TextWriter writer, IReadOnlyList<string> columns, IEnumerable<object?[]> rows)
+    {
+        writer.Write(string.Join(',', columns.Select(EscapeCsvField)));
+        writer.Write("\r\n");
+
+        foreach (var row in rows)
+        {
+            writer.Write(string.Join(',', row.Select(v => EscapeCsvField(FormatCsvValue(v)))));
+            writer.Write("\r\n");
+        }
+    }
+
+    public static void WriteJson(Stream stream, IReadOnlyList<string> columns, IEnumerable<object?[]> rows)
+    {
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+
+        writer.WriteStartArray();
+        foreach (var row in rows)
+        {
+            writer.WriteStartObject();
+            for (var i = 0; i < columns.Count; i++)
+            {
+                writer.WritePropertyName(columns[i]);
+                WriteJsonValue(writer, row[i]);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private static string FormatCsvValue(object? value) => value switch
+    {
+        null or DBNull => string.Empty,
+        DateTime dt => dt.ToString("O", CultureInfo.InvariantCulture),
+        DateTimeOffset dto => dto.ToString("O", CultureInfo.InvariantCulture),
+        byte[] bytes => Convert.ToBase64String(bytes),
+        Array array => string.Join(';', array.Cast<object?>().Select(FormatCsvValue)),
+        IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+        _ => value.ToString() ?? string.Empty,
+    };
+
+    private static string EscapeCsvField(string value) =>
+        value.IndexOfAny([',', '"', '\n', '\r']) < 0 ? value : $"\"{value.Replace("\"", "\"\"")}\"";
+
+    private static void WriteJsonValue(Utf8JsonWriter writer, object? value)
+    {
+        switch (value)
+        {
+            case null or DBNull:
+                writer.WriteNullValue();
+                break;
+            case bool b:
+                writer.WriteBooleanValue(b);
+                break;
+            case byte or sbyte or short or ushort or int or uint or long:
+                writer.WriteNumberValue(Convert.ToInt64(value, CultureInfo.InvariantCulture));
+                break;
+            case ulong ul:
+                writer.WriteNumberValue(ul);
+                break;
+            case float f:
+                if (float.IsFinite(f))
+                {
+                    writer.WriteNumberValue(f);
+                }
+                else
+                {
+                    writer.WriteStringValue(f.ToString(CultureInfo.InvariantCulture));
+                }
+
+                break;
+            case double d:
+                if (double.IsFinite(d))
+                {
+                    writer.WriteNumberValue(d);
+                }
+                else
+                {
+                    writer.WriteStringValue(d.ToString(CultureInfo.InvariantCulture));
+                }
+
+                break;
+            case decimal m:
+                writer.WriteNumberValue(m);
+                break;
+            case DateTime dt:
+                writer.WriteStringValue(dt.ToString("O", CultureInfo.InvariantCulture));
+                break;
+            case DateTimeOffset dto:
+                writer.WriteStringValue(dto.ToString("O", CultureInfo.InvariantCulture));
+                break;
+            case Guid g:
+                writer.WriteStringValue(g);
+                break;
+            case byte[] bytes:
+                writer.WriteStringValue(Convert.ToBase64String(bytes));
+                break;
+            case Array array:
+                writer.WriteStartArray();
+                foreach (var item in array)
+                {
+                    WriteJsonValue(writer, item);
+                }
+
+                writer.WriteEndArray();
+                break;
+            default:
+                writer.WriteStringValue(value.ToString());
+                break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Matches TablePlus, DBeaver, pgAdmin, HeidiSQL, and Beekeeper Studio, all of which let you export a result set; pgNimbus had no way to get data back out except copy-pasting from the grid.

- `ResultExporter` (Core): writes CSV (RFC4180-ish quoting) and JSON (via `Utf8JsonWriter`, not `JsonSerializer`'s reflection-based object graph — Npgsql returns arbitrary CLR types per column, and hand-rolling the writer keeps this trim/NativeAOT-safe like the rest of Core). Handles null/DBNull, `byte[]` (base64), Postgres arrays, and non-finite floats (NaN/Infinity aren't valid JSON numbers, so those fall back to their string form).
- `MainWindow`: an Export button with a CSV/JSON flyout, wired to Avalonia's native save-file picker.

## A real bug found while testing this
Exporting the `id` column of a plain `SELECT * FROM users` came back as `"1"` (a JSON string) instead of `1` (a number) — even though Npgsql hands back a genuine boxed `Int32` and `QueryEngine` never touches it. Bisected by disconnecting the `DataGrid`'s `ItemsSource` entirely: with the grid disconnected the row keeps its real `Int32`; reconnect it, and the type flips to `String` the moment the row renders — before any user ever touches a cell.

**Root cause:** the `DataGridTextColumn` bindings (`new Binding($"[{index}]")`) had no explicit `Mode`, so Avalonia's `DataGridBoundColumn` defaults them to `TwoWay`. Just realizing a row for display was enough to round-trip the cell's display `TextBlock`, which happens to be string-typed, back through the two-way binding into the `object?[]` array — permanently replacing the original `Int32` with a formatted string. **This is a real, independently-shipped bug in the already-merged inline-editing PR**: any row a user so much as looked at would have its column values silently stringified, corrupting the WHERE-clause parameter fidelity for edits after that point (and now the export data too).

**Fix:** the column bindings are now explicit `OneWay`, so display can never write back. This meant inline editing could no longer rely on the grid auto-writing the typed value into the row array, so `QueryViewModel.CommitCellEditAsync` now takes the edited text directly from the cell's editing `TextBox` (captured in `CellEditEnding`, since `CellEditEndedEventArgs` doesn't expose the editing element) and converts it to the target column's real CLR type before sending it as the SQL parameter — editing a non-text column (e.g. an integer) with a bare string parameter would otherwise fail in Postgres, since text isn't assignment-castable to most non-text types. On success the row is explicitly replaced (rather than relied upon to already reflect the edit); on failure nothing is touched, since the row was never mutated in the first place.

## Test plan
- [x] `dotnet build` — clean, 0 warnings/errors
- [x] CSV/JSON export verified end to end through the real Avalonia native file-save dialog (headless via Xvfb + xdotool + screenshots), confirming both the on-disk file content and, critically, that `id` now exports as a JSON number instead of a string
- [x] The type-corruption bug was bisected by toggling `ItemsSource` on/off and confirmed fixed by re-checking export output after switching the binding to `OneWay`
- [x] The restructured `CommitCellEditAsync` was verified directly against a real local PostgreSQL 16 instance (added a temporary integer column): editing a numeric column via typed text now correctly converts and updates the database, editing a text column still works, and typing a non-numeric value into a numeric column fails gracefully with a clear message and leaves the database untouched


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_