### PR TITLE
Add schema-aware SQL autocomplete

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Npgsql;
+using PgNimbus.App.Completion;
 using PgNimbus.App.ViewModels;
 using PgNimbus.App.Views;
 using PgNimbus.Core.Connections;
@@ -57,10 +58,11 @@ public partial class App : Application
         var engine = new QueryEngine(dataSource);
         var schemaService = new SchemaService(dataSource);
         var schemaTree = new SchemaTreeViewModel(schemaService);
+        var completionProvider = new SqlCompletionProvider(schemaService);
 
         var window = new MainWindow
         {
-            DataContext = new MainViewModel(new QueryViewModel(engine), schemaTree, schemaService),
+            DataContext = new MainViewModel(new QueryViewModel(engine), schemaTree, schemaService, completionProvider),
         };
 
         if (tunnel is not null)
@@ -69,6 +71,7 @@ public partial class App : Application
         }
 
         _ = schemaTree.RefreshCommand.ExecuteAsync(null);
+        _ = completionProvider.RefreshAsync(CancellationToken.None);
 
         return window;
     }

--- a/PgNimbus.App/Completion/SqlCompletionData.cs
+++ b/PgNimbus.App/Completion/SqlCompletionData.cs
@@ -1,0 +1,28 @@
+using Avalonia.Media;
+using AvaloniaEdit.CodeCompletion;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Editing;
+
+namespace PgNimbus.App.Completion;
+
+public sealed class SqlCompletionData : ICompletionData
+{
+    public SqlCompletionData(string text, string description)
+    {
+        Text = text;
+        Description = description;
+    }
+
+    public IImage? Image => null;
+
+    public string Text { get; }
+
+    public object Content => Text;
+
+    public object Description { get; }
+
+    public double Priority => 0;
+
+    public void Complete(TextArea textArea, ISegment completionSegment, EventArgs insertionRequestEventArgs) =>
+        textArea.Document.Replace(completionSegment, Text);
+}

--- a/PgNimbus.App/Completion/SqlCompletionProvider.cs
+++ b/PgNimbus.App/Completion/SqlCompletionProvider.cs
@@ -1,0 +1,62 @@
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.App.Completion;
+
+/// <summary>
+/// Builds the flat candidate list AvaloniaEdit's CompletionWindow filters
+/// against: SQL keywords plus every schema/table/column name reachable from
+/// the current connection. Rebuilt on demand (e.g. after connecting, or via
+/// a manual refresh) rather than tracked incrementally - schemas rarely
+/// change mid-session, and a full rebuild is a handful of queries.
+/// </summary>
+public sealed class SqlCompletionProvider
+{
+    private static readonly string[] Keywords =
+    [
+        "SELECT", "FROM", "WHERE", "INSERT", "INTO", "VALUES", "UPDATE", "SET",
+        "DELETE", "JOIN", "INNER", "LEFT", "RIGHT", "FULL", "OUTER", "ON",
+        "GROUP", "BY", "ORDER", "HAVING", "LIMIT", "OFFSET", "AS", "AND", "OR",
+        "NOT", "NULL", "IS", "IN", "EXISTS", "DISTINCT", "UNION", "ALL",
+        "CREATE", "TABLE", "ALTER", "DROP", "INDEX", "VIEW", "WITH", "CASE",
+        "WHEN", "THEN", "ELSE", "END", "RETURNING", "LIKE", "ILIKE", "BETWEEN",
+        "ASC", "DESC", "COUNT", "SUM", "AVG", "MIN", "MAX", "TRUE", "FALSE",
+    ];
+
+    private readonly SchemaService _schemaService;
+    private IReadOnlyList<SqlCompletionData> _cache = [];
+
+    public SqlCompletionProvider(SchemaService schemaService)
+    {
+        _schemaService = schemaService;
+    }
+
+    public async Task RefreshAsync(CancellationToken ct)
+    {
+        var items = new List<SqlCompletionData>(Keywords.Select(k => new SqlCompletionData(k, "keyword")));
+
+        var schemas = await _schemaService.GetSchemasAsync(ct);
+        foreach (var schema in schemas)
+        {
+            items.Add(new SqlCompletionData(schema.Name, "schema"));
+
+            var tables = await _schemaService.GetTablesAsync(schema.Name, ct);
+            foreach (var table in tables)
+            {
+                items.Add(new SqlCompletionData(table.Name, $"table ({schema.Name})"));
+            }
+
+            var columns = await _schemaService.GetAllColumnsAsync(schema.Name, ct);
+            foreach (var column in columns)
+            {
+                items.Add(new SqlCompletionData(column.Column, $"column ({column.Table})"));
+            }
+        }
+
+        _cache = items
+            .GroupBy(i => i.Text, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToList();
+    }
+
+    public IReadOnlyList<SqlCompletionData> GetCompletionData() => _cache;
+}

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -1,3 +1,4 @@
+using PgNimbus.App.Completion;
 using PgNimbus.Core.Query;
 using PgNimbus.Core.Schema;
 
@@ -11,11 +12,14 @@ public sealed class MainViewModel
 
     public SchemaTreeViewModel SchemaTree { get; }
 
-    public MainViewModel(QueryViewModel query, SchemaTreeViewModel schemaTree, SchemaService schemaService)
+    public SqlCompletionProvider CompletionProvider { get; }
+
+    public MainViewModel(QueryViewModel query, SchemaTreeViewModel schemaTree, SchemaService schemaService, SqlCompletionProvider completionProvider)
     {
         Query = query;
         SchemaTree = schemaTree;
         _schemaService = schemaService;
+        CompletionProvider = completionProvider;
     }
 
     public async Task PreviewTableAsync(TableNode table)

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
+using AvaloniaEdit.CodeCompletion;
 using PgNimbus.App.ViewModels;
 
 namespace PgNimbus.App.Views;
@@ -18,6 +19,7 @@ public partial class MainWindow : Window
     private object?[]? _pendingEditRow;
     private int _pendingEditColumnIndex;
     private string? _pendingEditText;
+    private CompletionWindow? _completionWindow;
 
     public MainWindow()
     {
@@ -39,6 +41,9 @@ public partial class MainWindow : Window
         SchemaTreeView.AddHandler(Gestures.DoubleTappedEvent, OnSchemaTreeDoubleTapped, RoutingStrategies.Bubble, handledEventsToo: true);
         ResultsGrid.CellEditEnding += OnCellEditEnding;
         ResultsGrid.CellEditEnded += OnCellEditEnded;
+
+        SqlEditor.TextArea.TextEntered += OnSqlTextEntered;
+        SqlEditor.KeyDown += OnSqlEditorKeyDown;
 
         DataContextChanged += (_, _) =>
         {
@@ -105,6 +110,53 @@ public partial class MainWindow : Window
         }
 
         await _queryViewModel.CommitCellEditAsync(row, columnIndex, text);
+    }
+
+    private void OnSqlTextEntered(object? sender, TextInputEventArgs e)
+    {
+        if (string.IsNullOrEmpty(e.Text) || _completionWindow is not null)
+        {
+            return;
+        }
+
+        var c = e.Text[0];
+        if (char.IsLetter(c) || c == '_')
+        {
+            ShowCompletion(includeTypedChar: true);
+        }
+    }
+
+    private void OnSqlEditorKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Space && e.KeyModifiers == KeyModifiers.Control)
+        {
+            ShowCompletion(includeTypedChar: false);
+            e.Handled = true;
+        }
+    }
+
+    private void ShowCompletion(bool includeTypedChar)
+    {
+        var data = _viewModel?.CompletionProvider.GetCompletionData();
+        if (data is not { Count: > 0 })
+        {
+            return;
+        }
+
+        var completionWindow = new CompletionWindow(SqlEditor.TextArea);
+        if (includeTypedChar)
+        {
+            completionWindow.StartOffset -= 1;
+        }
+
+        foreach (var item in data)
+        {
+            completionWindow.CompletionList.CompletionData.Add(item);
+        }
+
+        completionWindow.Show();
+        completionWindow.Closed += (_, _) => _completionWindow = null;
+        _completionWindow = completionWindow;
     }
 
     private async void OnExportCsvClick(object? sender, RoutedEventArgs e)

--- a/PgNimbus.Core/Schema/SchemaService.cs
+++ b/PgNimbus.Core/Schema/SchemaService.cs
@@ -16,6 +16,8 @@ public sealed record TableInfo(string Name, RelationKind Kind);
 
 public sealed record ColumnDetail(string Name, string DataType, bool NotNull, bool IsPrimaryKey);
 
+public sealed record TableColumn(string Table, string Column);
+
 /// <summary>
 /// Reads structure straight from pg_catalog rather than relying on
 /// information_schema, so it reflects the real Postgres model (matviews,
@@ -125,6 +127,38 @@ public sealed class SchemaService
                 reader.GetString(1),
                 reader.GetBoolean(2),
                 reader.GetBoolean(3)));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Column names for every table/view in a schema, in one query - used to
+    /// power SQL autocomplete without an N+1 GetColumnsAsync call per table.
+    /// </summary>
+    public async Task<IReadOnlyList<TableColumn>> GetAllColumnsAsync(string schema, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT c.relname, a.attname
+            FROM pg_catalog.pg_attribute a
+            JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = @schema
+              AND c.relkind IN ('r', 'v', 'm', 'p')
+              AND a.attnum > 0
+              AND NOT a.attisdropped
+            ORDER BY c.relname, a.attnum
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("schema", schema);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<TableColumn>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new TableColumn(reader.GetString(0), reader.GetString(1)));
         }
 
         return results;


### PR DESCRIPTION
## Summary
Matches pgAdmin, DBeaver, TablePlus, DataGrip, HeidiSQL, and Beekeeper Studio, all of which offer schema-aware completion; pgNimbus's editor had none.

- `SchemaService.GetAllColumnsAsync` (Core): all table/column pairs for a schema in one query, avoiding an N+1 `GetColumnsAsync`-per-table call when building the completion cache.
- `SqlCompletionProvider` (App): builds a flat candidate list once per connection — ~50 SQL keywords plus every schema/table/column name reachable from the connection — refreshed alongside the schema tree at connect time.
- `SqlCompletionData`: a minimal `AvaloniaEdit.CodeCompletion.ICompletionData` implementation (text + a short "keyword"/"schema"/"table (x)"/"column (x)" description).
- `MainWindow` wires AvaloniaEdit's `CompletionWindow`: typing a letter opens it (auto-filtering as you keep typing, built into `CompletionList`), Ctrl+Space opens it manually at any point, and Tab/Enter accept the highlighted match.

## Test plan
- [x] `dotnet build` — clean, 0 warnings/errors
- [x] Ran the app headlessly (Xvfb + xdotool + screenshots) against a real local PostgreSQL 16 instance:
  - [x] Typing `use` pops the completion window filtered down to the `users` table
  - [x] Tab expands `use` to `users`
  - [x] Enter expands `sele` to the `SELECT` keyword
  - [x] Ctrl+Space on an empty editor opens the full unfiltered candidate list


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_