### PR TITLE
Add saved queries and run history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Oo]ut/
+.avalonia-build-tasks/
 msbuild.log
 msbuild.err
 msbuild.wrn

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -59,10 +59,12 @@ public partial class App : Application
         var schemaService = new SchemaService(dataSource);
         var schemaTree = new SchemaTreeViewModel(schemaService);
         var completionProvider = new SqlCompletionProvider(schemaService);
+        var queryViewModel = new QueryViewModel(engine);
+        var savedQueries = new SavedQueriesViewModel(new SavedQueryStore(), new QueryHistoryStore(), queryViewModel);
 
         var window = new MainWindow
         {
-            DataContext = new MainViewModel(new QueryViewModel(engine), schemaTree, schemaService, completionProvider),
+            DataContext = new MainViewModel(queryViewModel, schemaTree, schemaService, completionProvider, savedQueries),
         };
 
         if (tunnel is not null)

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -14,12 +14,20 @@ public sealed class MainViewModel
 
     public SqlCompletionProvider CompletionProvider { get; }
 
-    public MainViewModel(QueryViewModel query, SchemaTreeViewModel schemaTree, SchemaService schemaService, SqlCompletionProvider completionProvider)
+    public SavedQueriesViewModel SavedQueries { get; }
+
+    public MainViewModel(
+        QueryViewModel query,
+        SchemaTreeViewModel schemaTree,
+        SchemaService schemaService,
+        SqlCompletionProvider completionProvider,
+        SavedQueriesViewModel savedQueries)
     {
         Query = query;
         SchemaTree = schemaTree;
         _schemaService = schemaService;
         CompletionProvider = completionProvider;
+        SavedQueries = savedQueries;
     }
 
     public async Task PreviewTableAsync(TableNode table)

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -32,6 +32,9 @@ public sealed partial class QueryViewModel : ObservableObject
 
     public ObservableCollection<object?[]> Rows { get; } = [];
 
+    /// <summary>Raised once per <see cref="RunAsync"/> completion (success, command, error, or cancellation) so a history tracker can record it without RunAsync knowing about persistence.</summary>
+    public event Action<QueryHistoryEntry>? Executed;
+
     public QueryViewModel(QueryEngine engine)
     {
         _engine = engine;
@@ -44,6 +47,7 @@ public sealed partial class QueryViewModel : ObservableObject
     {
         _cts = new CancellationTokenSource();
         var ct = _cts.Token;
+        var executedSql = Sql;
 
         IsRunning = true;
         Status = "Running...";
@@ -55,7 +59,7 @@ public sealed partial class QueryViewModel : ObservableObject
 
         try
         {
-            var result = await _engine.ExecuteAsync(Sql, ct);
+            var result = await _engine.ExecuteAsync(executedSql, ct);
 
             switch (result)
             {
@@ -96,10 +100,13 @@ public sealed partial class QueryViewModel : ObservableObject
                     Status = $"Error: {error.Message}";
                     break;
             }
+
+            Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, Status));
         }
         catch (OperationCanceledException)
         {
             Status = "Cancelled";
+            Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, Status));
         }
         finally
         {

--- a/PgNimbus.App/ViewModels/SavedQueriesViewModel.cs
+++ b/PgNimbus.App/ViewModels/SavedQueriesViewModel.cs
@@ -1,0 +1,100 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.App.ViewModels;
+
+/// <summary>
+/// Owns the saved-query list and run history, persisting both through their
+/// respective stores. Subscribes to <see cref="QueryViewModel.Executed"/> so
+/// history is recorded without QueryViewModel knowing about persistence.
+/// </summary>
+public sealed partial class SavedQueriesViewModel : ObservableObject
+{
+    private readonly SavedQueryStore _savedQueryStore;
+    private readonly QueryHistoryStore _historyStore;
+    private readonly QueryViewModel _query;
+
+    [ObservableProperty]
+    private string _newQueryName = string.Empty;
+
+    public ObservableCollection<SavedQuery> SavedQueries { get; } = [];
+
+    public ObservableCollection<QueryHistoryEntry> History { get; } = [];
+
+    public SavedQueriesViewModel(SavedQueryStore savedQueryStore, QueryHistoryStore historyStore, QueryViewModel query)
+    {
+        _savedQueryStore = savedQueryStore;
+        _historyStore = historyStore;
+        _query = query;
+
+        foreach (var saved in _savedQueryStore.Load())
+        {
+            SavedQueries.Add(saved);
+        }
+
+        foreach (var entry in _historyStore.Load())
+        {
+            History.Add(entry);
+        }
+
+        _query.Executed += OnQueryExecuted;
+    }
+
+    private void OnQueryExecuted(QueryHistoryEntry entry)
+    {
+        History.Insert(0, entry);
+        _historyStore.Append(entry);
+    }
+
+    private bool CanSave() => !string.IsNullOrWhiteSpace(NewQueryName) && !string.IsNullOrWhiteSpace(_query.Sql);
+
+    [RelayCommand(CanExecute = nameof(CanSave))]
+    private void SaveCurrentQuery()
+    {
+        var saved = new SavedQuery(Guid.NewGuid(), NewQueryName.Trim(), _query.Sql);
+        SavedQueries.Add(saved);
+        _savedQueryStore.Save(SavedQueries);
+        NewQueryName = string.Empty;
+    }
+
+    [RelayCommand]
+    private void DeleteSavedQuery(SavedQuery? query)
+    {
+        if (query is null)
+        {
+            return;
+        }
+
+        SavedQueries.Remove(query);
+        _savedQueryStore.Save(SavedQueries);
+    }
+
+    [RelayCommand]
+    private void LoadSavedQuery(SavedQuery? query)
+    {
+        if (query is not null)
+        {
+            _query.Sql = query.Sql;
+        }
+    }
+
+    [RelayCommand]
+    private void LoadHistoryEntry(QueryHistoryEntry? entry)
+    {
+        if (entry is not null)
+        {
+            _query.Sql = entry.Sql;
+        }
+    }
+
+    [RelayCommand]
+    private void ClearHistory()
+    {
+        History.Clear();
+        _historyStore.Clear();
+    }
+
+    partial void OnNewQueryNameChanged(string value) => SaveCurrentQueryCommand.NotifyCanExecuteChanged();
+}

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -4,6 +4,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:ae="using:AvaloniaEdit"
         xmlns:vm="using:PgNimbus.App.ViewModels"
+        xmlns:query="using:PgNimbus.Core.Query"
         xmlns:conv="using:Avalonia.Data.Converters"
         mc:Ignorable="d"
         d:DesignWidth="1000" d:DesignHeight="650"
@@ -48,26 +49,68 @@
 
     <Grid ColumnDefinitions="260,Auto,*" Margin="8">
 
-        <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto">
-            <TextBlock Grid.Row="0" Text="Schemas" FontWeight="SemiBold" Margin="4" />
-            <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
-                <TreeView Name="SchemaTreeView" ItemsSource="{Binding SchemaTree.Schemas}">
-                    <TreeView.Styles>
-                        <Style Selector="TreeViewItem">
-                            <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay, DataType=vm:SchemaTreeNode}" />
-                        </Style>
-                    </TreeView.Styles>
-                    <TreeView.ItemTemplate>
-                        <TreeDataTemplate ItemsSource="{Binding Children}">
-                            <ContentControl Content="{Binding}" />
-                        </TreeDataTemplate>
-                    </TreeView.ItemTemplate>
-                </TreeView>
-            </Border>
-            <TextBlock Grid.Row="2" Text="{Binding SchemaTree.ErrorMessage}"
-                       IsVisible="{Binding SchemaTree.ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}"
-                       Foreground="IndianRed" TextWrapping="Wrap" Margin="4" FontSize="11" />
-        </Grid>
+        <TabControl Grid.Column="0">
+            <TabItem Header="Schemas">
+                <Grid RowDefinitions="*,Auto">
+                    <Border Grid.Row="0" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+                        <TreeView Name="SchemaTreeView" ItemsSource="{Binding SchemaTree.Schemas}">
+                            <TreeView.Styles>
+                                <Style Selector="TreeViewItem">
+                                    <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay, DataType=vm:SchemaTreeNode}" />
+                                </Style>
+                            </TreeView.Styles>
+                            <TreeView.ItemTemplate>
+                                <TreeDataTemplate ItemsSource="{Binding Children}">
+                                    <ContentControl Content="{Binding}" />
+                                </TreeDataTemplate>
+                            </TreeView.ItemTemplate>
+                        </TreeView>
+                    </Border>
+                    <TextBlock Grid.Row="1" Text="{Binding SchemaTree.ErrorMessage}"
+                               IsVisible="{Binding SchemaTree.ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}"
+                               Foreground="IndianRed" TextWrapping="Wrap" Margin="4" FontSize="11" />
+                </Grid>
+            </TabItem>
+            <TabItem Header="Queries">
+                <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,*,Auto" x:DataType="vm:SavedQueriesViewModel" DataContext="{Binding SavedQueries}">
+                    <TextBlock Grid.Row="0" Text="Saved queries" FontWeight="SemiBold" Margin="4" />
+                    <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" MinHeight="80">
+                        <ListBox Name="SavedQueriesList" ItemsSource="{Binding SavedQueries}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="query:SavedQuery">
+                                    <TextBlock Text="{Binding Name}" ToolTip.Tip="{Binding Sql}" />
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Border>
+                    <TextBox Grid.Row="2" Name="NewQueryNameBox" Text="{Binding NewQueryName}" Watermark="Query name" Margin="4,4,4,0" />
+                    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="4" Margin="4">
+                        <Button Content="Save" Command="{Binding SaveCurrentQueryCommand}" />
+                        <Button Content="Load" Command="{Binding LoadSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}" />
+                        <Button Content="Delete" Command="{Binding DeleteSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}" />
+                    </StackPanel>
+                    <Grid Grid.Row="4" RowDefinitions="Auto">
+                        <TextBlock Grid.Row="0" Text="History" FontWeight="SemiBold" Margin="4" />
+                    </Grid>
+                    <Border Grid.Row="5" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" MinHeight="80">
+                        <ListBox Name="HistoryList" ItemsSource="{Binding History}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="query:QueryHistoryEntry">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Sql}" TextTrimming="CharacterEllipsis" MaxLines="2" TextWrapping="Wrap" FontSize="12" />
+                                        <TextBlock Text="{Binding ExecutedAt}" Opacity="0.6" FontSize="10" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Border>
+                    <StackPanel Grid.Row="6" Orientation="Horizontal" Spacing="4" Margin="4">
+                        <Button Content="Load selected" Command="{Binding LoadHistoryEntryCommand}" CommandParameter="{Binding #HistoryList.SelectedItem}" />
+                        <Button Content="Clear history" Command="{Binding ClearHistoryCommand}" />
+                    </StackPanel>
+                </Grid>
+            </TabItem>
+        </TabControl>
 
         <GridSplitter Grid.Column="1" Width="4" />
 

--- a/PgNimbus.Core/Query/QueryHistoryEntry.cs
+++ b/PgNimbus.Core/Query/QueryHistoryEntry.cs
@@ -1,0 +1,4 @@
+namespace PgNimbus.Core.Query;
+
+/// <summary>A single past execution, kept for quick recall - not for audit purposes.</summary>
+public sealed record QueryHistoryEntry(string Sql, DateTimeOffset ExecutedAt, double ElapsedMs, string Summary);

--- a/PgNimbus.Core/Query/QueryHistoryStore.cs
+++ b/PgNimbus.Core/Query/QueryHistoryStore.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PgNimbus.Core.Connections;
+
+namespace PgNimbus.Core.Query;
+
+/// <summary>Persists the last <see cref="MaxEntries"/> executions, most recent first.</summary>
+public sealed class QueryHistoryStore
+{
+    private const int MaxEntries = 200;
+
+    private readonly string _filePath;
+
+    public QueryHistoryStore(string? filePath = null)
+    {
+        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "history.json");
+    }
+
+    public IReadOnlyList<QueryHistoryEntry> Load()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return [];
+        }
+
+        var json = File.ReadAllText(_filePath);
+        return JsonSerializer.Deserialize(json, QueryHistoryJsonContext.Default.ListQueryHistoryEntry) ?? [];
+    }
+
+    public void Append(QueryHistoryEntry entry)
+    {
+        var entries = Load().ToList();
+        entries.Insert(0, entry);
+        if (entries.Count > MaxEntries)
+        {
+            entries.RemoveRange(MaxEntries, entries.Count - MaxEntries);
+        }
+
+        Save(entries);
+    }
+
+    public void Clear() => Save([]);
+
+    private void Save(IReadOnlyList<QueryHistoryEntry> entries)
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(entries.ToList(), QueryHistoryJsonContext.Default.ListQueryHistoryEntry);
+        File.WriteAllText(_filePath, json);
+    }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(List<QueryHistoryEntry>))]
+internal sealed partial class QueryHistoryJsonContext : JsonSerializerContext;

--- a/PgNimbus.Core/Query/SavedQuery.cs
+++ b/PgNimbus.Core/Query/SavedQuery.cs
@@ -1,0 +1,3 @@
+namespace PgNimbus.Core.Query;
+
+public sealed record SavedQuery(Guid Id, string Name, string Sql);

--- a/PgNimbus.Core/Query/SavedQueryStore.cs
+++ b/PgNimbus.Core/Query/SavedQueryStore.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PgNimbus.Core.Connections;
+
+namespace PgNimbus.Core.Query;
+
+/// <summary>Persists user-named saved queries (no cap - the user manages these explicitly).</summary>
+public sealed class SavedQueryStore
+{
+    private readonly string _filePath;
+
+    public SavedQueryStore(string? filePath = null)
+    {
+        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "saved-queries.json");
+    }
+
+    public IReadOnlyList<SavedQuery> Load()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return [];
+        }
+
+        var json = File.ReadAllText(_filePath);
+        return JsonSerializer.Deserialize(json, SavedQueryJsonContext.Default.ListSavedQuery) ?? [];
+    }
+
+    public void Save(IEnumerable<SavedQuery> queries)
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(queries.ToList(), SavedQueryJsonContext.Default.ListSavedQuery);
+        File.WriteAllText(_filePath, json);
+    }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(List<SavedQuery>))]
+internal sealed partial class SavedQueryJsonContext : JsonSerializerContext;


### PR DESCRIPTION
## Summary
- Adds a "Queries" tab in the left sidebar (alongside "Schemas") backed by two new `PgNimbus.Core.Query` stores: `SavedQueryStore` (uncapped, user-named queries) and `QueryHistoryStore` (last 200 executions, most recent first) — both JSON-backed under the app data directory using the same source-generated persistence pattern as `ConnectionProfileStore`.
- `QueryViewModel` gains an `Executed` event, raised after every `RunAsync` completion (result set, command, error, or cancellation), which a new `SavedQueriesViewModel` subscribes to in order to append history entries without `QueryViewModel` knowing about persistence.
- UI: save the current query under a name, load a saved query or a history entry back into the editor, delete a saved query, clear history.

## Test plan
Verified end-to-end against a local Postgres instance (headless Xvfb + xdotool):
- [x] Running a query records an entry in History with timestamp and status
- [x] History persists across an app restart
- [x] Saving a query under a name adds it to the Saved queries list and persists to disk
- [x] Loading a saved query overwrites the editor's current SQL
- [x] Saved queries persist across an app restart
- [x] Deleting a saved query removes it from disk and the list
- [x] Clearing history empties the list and the on-disk file
- [x] `dotnet build` — 0 warnings, 0 errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_