### PR TITLE
Add multi-tab query editor

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -59,12 +59,10 @@ public partial class App : Application
         var schemaService = new SchemaService(dataSource);
         var schemaTree = new SchemaTreeViewModel(schemaService);
         var completionProvider = new SqlCompletionProvider(schemaService);
-        var queryViewModel = new QueryViewModel(engine);
-        var savedQueries = new SavedQueriesViewModel(new SavedQueryStore(), new QueryHistoryStore(), queryViewModel);
 
         var window = new MainWindow
         {
-            DataContext = new MainViewModel(queryViewModel, schemaTree, schemaService, completionProvider, savedQueries),
+            DataContext = new MainViewModel(engine, schemaTree, schemaService, completionProvider),
         };
 
         if (tunnel is not null)

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -1,14 +1,16 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using PgNimbus.App.Completion;
 using PgNimbus.Core.Query;
 using PgNimbus.Core.Schema;
 
 namespace PgNimbus.App.ViewModels;
 
-public sealed class MainViewModel
+public sealed partial class MainViewModel : ObservableObject
 {
+    private readonly QueryEngine _engine;
     private readonly SchemaService _schemaService;
-
-    public QueryViewModel Query { get; }
 
     public SchemaTreeViewModel SchemaTree { get; }
 
@@ -16,30 +18,74 @@ public sealed class MainViewModel
 
     public SavedQueriesViewModel SavedQueries { get; }
 
+    public ObservableCollection<QueryViewModel> Tabs { get; } = [];
+
+    [ObservableProperty]
+    private QueryViewModel _activeTab = null!;
+
     public MainViewModel(
-        QueryViewModel query,
+        QueryEngine engine,
         SchemaTreeViewModel schemaTree,
         SchemaService schemaService,
-        SqlCompletionProvider completionProvider,
-        SavedQueriesViewModel savedQueries)
+        SqlCompletionProvider completionProvider)
     {
-        Query = query;
+        _engine = engine;
         SchemaTree = schemaTree;
         _schemaService = schemaService;
         CompletionProvider = completionProvider;
-        SavedQueries = savedQueries;
+        SavedQueries = new SavedQueriesViewModel(new SavedQueryStore(), new QueryHistoryStore(), () => ActiveTab);
+
+        AddTab();
+    }
+
+    private bool CanCloseTab() => Tabs.Count > 1;
+
+    [RelayCommand]
+    private void AddTab()
+    {
+        var tab = new QueryViewModel(_engine) { TabTitle = $"Query {Tabs.Count + 1}" };
+        tab.Executed += SavedQueries.RecordExecution;
+        Tabs.Add(tab);
+        ActiveTab = tab;
+        CloseTabCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCloseTab))]
+    private void CloseTab(QueryViewModel? tab)
+    {
+        tab ??= ActiveTab;
+        if (Tabs.Count <= 1)
+        {
+            return;
+        }
+
+        var index = Tabs.IndexOf(tab);
+        if (index < 0)
+        {
+            return;
+        }
+
+        tab.Executed -= SavedQueries.RecordExecution;
+        Tabs.RemoveAt(index);
+
+        if (ReferenceEquals(ActiveTab, tab))
+        {
+            ActiveTab = Tabs[Math.Min(index, Tabs.Count - 1)];
+        }
+
+        CloseTabCommand.NotifyCanExecuteChanged();
     }
 
     public async Task PreviewTableAsync(TableNode table)
     {
-        Query.Sql = $"SELECT * FROM {SqlIdentifier.Quote(table.Schema)}.{SqlIdentifier.Quote(table.Name)} LIMIT 100;";
+        ActiveTab.Sql = $"SELECT * FROM {SqlIdentifier.Quote(table.Schema)}.{SqlIdentifier.Quote(table.Name)} LIMIT 100;";
 
         var columns = await _schemaService.GetColumnsAsync(table.Schema, table.Name, CancellationToken.None);
         var primaryKeyColumns = columns.Where(c => c.IsPrimaryKey).Select(c => c.Name).ToList();
 
         if (primaryKeyColumns.Count > 0)
         {
-            Query.EditContext = new EditableTableContext(table.Schema, table.Name, primaryKeyColumns);
+            ActiveTab.EditContext = new EditableTableContext(table.Schema, table.Name, primaryKeyColumns);
         }
     }
 }

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -26,6 +26,9 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private EditableTableContext? _editContext;
 
+    [ObservableProperty]
+    private string _tabTitle = "Query";
+
     public bool IsEditable => EditContext is { PrimaryKeyColumns.Count: > 0 };
 
     public ObservableCollection<string> ColumnNames { get; } = [];

--- a/PgNimbus.App/ViewModels/SavedQueriesViewModel.cs
+++ b/PgNimbus.App/ViewModels/SavedQueriesViewModel.cs
@@ -7,14 +7,16 @@ namespace PgNimbus.App.ViewModels;
 
 /// <summary>
 /// Owns the saved-query list and run history, persisting both through their
-/// respective stores. Subscribes to <see cref="QueryViewModel.Executed"/> so
-/// history is recorded without QueryViewModel knowing about persistence.
+/// respective stores. Save/load act on whichever tab <paramref name="getActiveQuery"/>
+/// currently resolves to; history recording is driven by <see cref="RecordExecution"/>,
+/// which callers wire up to each tab's <see cref="QueryViewModel.Executed"/> event, since
+/// there can be more than one open tab at a time.
 /// </summary>
 public sealed partial class SavedQueriesViewModel : ObservableObject
 {
     private readonly SavedQueryStore _savedQueryStore;
     private readonly QueryHistoryStore _historyStore;
-    private readonly QueryViewModel _query;
+    private readonly Func<QueryViewModel?> _getActiveQuery;
 
     [ObservableProperty]
     private string _newQueryName = string.Empty;
@@ -23,11 +25,11 @@ public sealed partial class SavedQueriesViewModel : ObservableObject
 
     public ObservableCollection<QueryHistoryEntry> History { get; } = [];
 
-    public SavedQueriesViewModel(SavedQueryStore savedQueryStore, QueryHistoryStore historyStore, QueryViewModel query)
+    public SavedQueriesViewModel(SavedQueryStore savedQueryStore, QueryHistoryStore historyStore, Func<QueryViewModel?> getActiveQuery)
     {
         _savedQueryStore = savedQueryStore;
         _historyStore = historyStore;
-        _query = query;
+        _getActiveQuery = getActiveQuery;
 
         foreach (var saved in _savedQueryStore.Load())
         {
@@ -38,22 +40,25 @@ public sealed partial class SavedQueriesViewModel : ObservableObject
         {
             History.Add(entry);
         }
-
-        _query.Executed += OnQueryExecuted;
     }
 
-    private void OnQueryExecuted(QueryHistoryEntry entry)
+    public void RecordExecution(QueryHistoryEntry entry)
     {
         History.Insert(0, entry);
         _historyStore.Append(entry);
     }
 
-    private bool CanSave() => !string.IsNullOrWhiteSpace(NewQueryName) && !string.IsNullOrWhiteSpace(_query.Sql);
+    private bool CanSave() => !string.IsNullOrWhiteSpace(NewQueryName) && !string.IsNullOrWhiteSpace(_getActiveQuery()?.Sql);
 
     [RelayCommand(CanExecute = nameof(CanSave))]
     private void SaveCurrentQuery()
     {
-        var saved = new SavedQuery(Guid.NewGuid(), NewQueryName.Trim(), _query.Sql);
+        if (_getActiveQuery() is not { } query)
+        {
+            return;
+        }
+
+        var saved = new SavedQuery(Guid.NewGuid(), NewQueryName.Trim(), query.Sql);
         SavedQueries.Add(saved);
         _savedQueryStore.Save(SavedQueries);
         NewQueryName = string.Empty;
@@ -74,18 +79,18 @@ public sealed partial class SavedQueriesViewModel : ObservableObject
     [RelayCommand]
     private void LoadSavedQuery(SavedQuery? query)
     {
-        if (query is not null)
+        if (query is not null && _getActiveQuery() is { } active)
         {
-            _query.Sql = query.Sql;
+            active.Sql = query.Sql;
         }
     }
 
     [RelayCommand]
     private void LoadHistoryEntry(QueryHistoryEntry? entry)
     {
-        if (entry is not null)
+        if (entry is not null && _getActiveQuery() is { } active)
         {
-            _query.Sql = entry.Sql;
+            active.Sql = entry.Sql;
         }
     }
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -43,8 +43,8 @@
     </Window.DataTemplates>
 
     <Window.KeyBindings>
-        <KeyBinding Gesture="Ctrl+Enter" Command="{Binding Query.RunCommand}" />
-        <KeyBinding Gesture="Escape" Command="{Binding Query.CancelCommand}" />
+        <KeyBinding Gesture="Ctrl+Enter" Command="{Binding ActiveTab.RunCommand}" />
+        <KeyBinding Gesture="Escape" Command="{Binding ActiveTab.CancelCommand}" />
     </Window.KeyBindings>
 
     <Grid ColumnDefinitions="260,Auto,*" Margin="8">
@@ -114,11 +114,31 @@
 
         <GridSplitter Grid.Column="1" Width="4" />
 
-        <Grid Grid.Column="2" RowDefinitions="Auto,*,*,Auto">
+        <Grid Grid.Column="2" RowDefinitions="Auto,Auto,*,*,Auto">
 
-            <StackPanel Orientation="Horizontal" Grid.Row="0" Spacing="8" Margin="0,0,0,8">
-                <Button Content="Run" Command="{Binding Query.RunCommand}" ToolTip.Tip="Ctrl+Enter" />
-                <Button Content="Cancel" Command="{Binding Query.CancelCommand}" ToolTip.Tip="Esc" />
+            <DockPanel Grid.Row="0" Margin="0,0,0,4">
+                <Button DockPanel.Dock="Right" Content="+" Command="{Binding AddTabCommand}" ToolTip.Tip="New query tab" />
+                <ListBox Name="TabsList" ItemsSource="{Binding Tabs}" SelectedItem="{Binding ActiveTab, Mode=TwoWay}"
+                          SelectionMode="Single">
+                    <ListBox.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Horizontal" />
+                        </ItemsPanelTemplate>
+                    </ListBox.ItemsPanel>
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="vm:QueryViewModel">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <TextBlock Text="{Binding TabTitle}" VerticalAlignment="Center" />
+                                <Button Content="✕" Padding="2,0" FontSize="10" Tag="{Binding}" Click="OnCloseTabClick" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </DockPanel>
+
+            <StackPanel Orientation="Horizontal" Grid.Row="1" Spacing="8" Margin="0,0,0,8">
+                <Button Content="Run" Command="{Binding ActiveTab.RunCommand}" ToolTip.Tip="Ctrl+Enter" />
+                <Button Content="Cancel" Command="{Binding ActiveTab.CancelCommand}" ToolTip.Tip="Esc" />
                 <Button Name="ExportButton" Content="Export">
                     <Button.Flyout>
                         <MenuFlyout>
@@ -129,23 +149,23 @@
                 </Button>
             </StackPanel>
 
-            <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+            <Border Grid.Row="2" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
                 <ae:TextEditor Name="SqlEditor"
                                ShowLineNumbers="True"
                                FontFamily="Cascadia Code,Consolas,Menlo,monospace"
                                FontSize="14" />
             </Border>
 
-            <Border Grid.Row="2" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Margin="0,8,0,8">
+            <Border Grid.Row="3" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Margin="0,8,0,8">
                 <DataGrid Name="ResultsGrid"
-                          IsReadOnly="{Binding !Query.IsEditable}"
+                          IsReadOnly="{Binding !ActiveTab.IsEditable}"
                           CanUserReorderColumns="False"
                           GridLinesVisibility="All"
                           AutoGenerateColumns="False" />
             </Border>
 
-            <Border Grid.Row="3" Padding="4">
-                <TextBlock Text="{Binding Query.Status}" />
+            <Border Grid.Row="4" Padding="4">
+                <TextBlock Text="{Binding ActiveTab.Status}" />
             </Border>
 
         </Grid>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using System.ComponentModel;
 using Avalonia;
 using Avalonia.Controls;
@@ -56,20 +57,56 @@ public partial class MainWindow : Window
 
     private void Attach(MainViewModel vm)
     {
-        if (_queryViewModel is not null)
+        if (_viewModel is not null)
         {
-            _queryViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            _viewModel.PropertyChanged -= OnMainViewModelPropertyChanged;
         }
 
         _viewModel = vm;
-        _queryViewModel = vm.Query;
+        _viewModel.PropertyChanged += OnMainViewModelPropertyChanged;
+
+        AttachQuery(vm.ActiveTab);
+    }
+
+    private void OnMainViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(MainViewModel.ActiveTab) && _viewModel is not null)
+        {
+            AttachQuery(_viewModel.ActiveTab);
+        }
+    }
+
+    // Switching the active tab swaps which QueryViewModel the shared editor/grid
+    // controls reflect - each tab keeps its own Sql/Rows/Status, but there's only
+    // one on-screen editor and grid, so this re-points them at the new tab.
+    private void AttachQuery(QueryViewModel query)
+    {
+        if (_queryViewModel is not null)
+        {
+            _queryViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            _queryViewModel.ColumnNames.CollectionChanged -= OnColumnNamesChanged;
+        }
+
+        _queryViewModel = query;
         _queryViewModel.PropertyChanged += OnViewModelPropertyChanged;
+        _queryViewModel.ColumnNames.CollectionChanged += OnColumnNamesChanged;
 
-        SqlEditor.Text = vm.Query.Sql;
-        ResultsGrid.ItemsSource = vm.Query.Rows;
-        RebuildColumns(vm.Query);
+        _suppressEditorSync = true;
+        SqlEditor.Text = query.Sql;
+        _suppressEditorSync = false;
 
-        vm.Query.ColumnNames.CollectionChanged += (_, _) => RebuildColumns(vm.Query);
+        ResultsGrid.ItemsSource = query.Rows;
+        RebuildColumns(query);
+    }
+
+    private void OnColumnNamesChanged(object? sender, NotifyCollectionChangedEventArgs e) => RebuildColumns(_queryViewModel!);
+
+    private void OnCloseTabClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Button { Tag: QueryViewModel tab })
+        {
+            _viewModel?.CloseTabCommand.Execute(tab);
+        }
     }
 
     private void OnSchemaTreeDoubleTapped(object? sender, TappedEventArgs e)


### PR DESCRIPTION
## Summary
- `MainViewModel` now owns an `ObservableCollection<QueryViewModel> Tabs` and an `ActiveTab`, replacing the single fixed `QueryViewModel` it held before. Each tab keeps its own SQL, result rows, status, and edit context.
- A tab strip above the SQL editor (bound to `Tabs`, selection two-way bound to `ActiveTab`) lets the user switch tabs, open a new one (`+`), or close one (`✕`, guarded so the last tab can't be closed).
- The shared `SqlEditor`/`ResultsGrid` controls are re-pointed at the active tab's state whenever `ActiveTab` changes (`MainWindow.AttachQuery`), so switching tabs swaps the visible SQL/results/status without needing a separate editor instance per tab.
- `SavedQueriesViewModel` and `MainViewModel.PreviewTableAsync` now resolve the target tab via a `Func<QueryViewModel?>` accessor instead of a single injected `QueryViewModel`, so saving/loading a query or double-clicking a table in the schema tree always acts on whichever tab is active.

## Test plan
Verified end-to-end against a local Postgres instance (headless Xvfb + xdotool):
- [x] Opening a new tab creates an independent "Query N" tab with its own default SQL
- [x] Running different SQL in two tabs keeps separate results/status per tab (switching back shows unchanged state)
- [x] Closing a tab falls back to a neighboring tab and reattaches its state
- [x] Closing the last remaining tab is a no-op (can't go to zero tabs)
- [x] Double-clicking a table in the schema tree writes `SELECT * FROM ...` into the *active* tab only, leaving other tabs untouched
- [x] `dotnet build` — 0 warnings, 0 errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_