### PR TITLE
Add graphical EXPLAIN visualization

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -56,13 +56,14 @@ public partial class App : Application
     {
         var dataSource = NpgsqlDataSource.Create(connectionString);
         var engine = new QueryEngine(dataSource);
+        var explainService = new ExplainService(dataSource);
         var schemaService = new SchemaService(dataSource);
         var schemaTree = new SchemaTreeViewModel(schemaService);
         var completionProvider = new SqlCompletionProvider(schemaService);
 
         var window = new MainWindow
         {
-            DataContext = new MainViewModel(engine, schemaTree, schemaService, completionProvider),
+            DataContext = new MainViewModel(engine, explainService, schemaTree, schemaService, completionProvider),
         };
 
         if (tunnel is not null)

--- a/PgNimbus.App/ViewModels/ExplainNodeViewModel.cs
+++ b/PgNimbus.App/ViewModels/ExplainNodeViewModel.cs
@@ -1,0 +1,35 @@
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.App.ViewModels;
+
+/// <summary>
+/// Presentation wrapper around a single <see cref="ExplainNode"/>: formats the
+/// cost/row/timing figures Postgres reports and derives a bar width (relative
+/// to the plan's total cost) so the tree reads as a rough visual profile, not
+/// just a wall of numbers.
+/// </summary>
+public sealed class ExplainNodeViewModel
+{
+    private const double MaxBarWidth = 200;
+
+    public ExplainNodeViewModel(ExplainNode node, double rootTotalCost)
+    {
+        Node = node;
+        Children = node.Children.Select(c => new ExplainNodeViewModel(c, rootTotalCost)).ToList();
+        BarWidth = rootTotalCost > 0 ? Math.Clamp(node.TotalCost / rootTotalCost, 0, 1) * MaxBarWidth : 0;
+    }
+
+    public ExplainNode Node { get; }
+
+    public IReadOnlyList<ExplainNodeViewModel> Children { get; }
+
+    public double BarWidth { get; }
+
+    public string Title => Node.RelationName is { Length: > 0 } rel ? $"{Node.NodeType} on {rel}" : Node.NodeType;
+
+    public string CostLabel => $"cost={Node.StartupCost:F2}..{Node.TotalCost:F2} rows={Node.PlanRows} width={Node.PlanWidth}";
+
+    public string? ActualLabel => Node.ActualTotalTimeMs is { } total
+        ? $"actual time={Node.ActualStartupTimeMs:F3}..{total:F3} ms rows={Node.ActualRows} loops={Node.ActualLoops}"
+        : null;
+}

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -10,6 +10,7 @@ namespace PgNimbus.App.ViewModels;
 public sealed partial class MainViewModel : ObservableObject
 {
     private readonly QueryEngine _engine;
+    private readonly ExplainService _explainService;
     private readonly SchemaService _schemaService;
 
     public SchemaTreeViewModel SchemaTree { get; }
@@ -25,11 +26,13 @@ public sealed partial class MainViewModel : ObservableObject
 
     public MainViewModel(
         QueryEngine engine,
+        ExplainService explainService,
         SchemaTreeViewModel schemaTree,
         SchemaService schemaService,
         SqlCompletionProvider completionProvider)
     {
         _engine = engine;
+        _explainService = explainService;
         SchemaTree = schemaTree;
         _schemaService = schemaService;
         CompletionProvider = completionProvider;
@@ -43,7 +46,7 @@ public sealed partial class MainViewModel : ObservableObject
     [RelayCommand]
     private void AddTab()
     {
-        var tab = new QueryViewModel(_engine) { TabTitle = $"Query {Tabs.Count + 1}" };
+        var tab = new QueryViewModel(_engine, _explainService) { TabTitle = $"Query {Tabs.Count + 1}" };
         tab.Executed += SavedQueries.RecordExecution;
         Tabs.Add(tab);
         ActiveTab = tab;

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Npgsql;
 using PgNimbus.Core.Export;
 using PgNimbus.Core.Query;
 
@@ -11,6 +12,7 @@ namespace PgNimbus.App.ViewModels;
 public sealed partial class QueryViewModel : ObservableObject
 {
     private readonly QueryEngine _engine;
+    private readonly ExplainService _explainService;
     private CancellationTokenSource? _cts;
     private IReadOnlyList<ColumnInfo> _columns = [];
 
@@ -29,7 +31,21 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private string _tabTitle = "Query";
 
+    [ObservableProperty]
+    private ExplainNodeViewModel? _explainRoot;
+
+    [ObservableProperty]
+    private string? _explainSummary;
+
+    [ObservableProperty]
+    private bool _isShowingPlan;
+
     public bool IsEditable => EditContext is { PrimaryKeyColumns.Count: > 0 };
+
+    /// <summary>Single-root wrapper so the plan tree's TreeView can bind an IEnumerable ItemsSource to one node.</summary>
+    public IReadOnlyList<ExplainNodeViewModel> ExplainRoots => ExplainRoot is null ? [] : [ExplainRoot];
+
+    partial void OnExplainRootChanged(ExplainNodeViewModel? value) => OnPropertyChanged(nameof(ExplainRoots));
 
     public ObservableCollection<string> ColumnNames { get; } = [];
 
@@ -38,9 +54,10 @@ public sealed partial class QueryViewModel : ObservableObject
     /// <summary>Raised once per <see cref="RunAsync"/> completion (success, command, error, or cancellation) so a history tracker can record it without RunAsync knowing about persistence.</summary>
     public event Action<QueryHistoryEntry>? Executed;
 
-    public QueryViewModel(QueryEngine engine)
+    public QueryViewModel(QueryEngine engine, ExplainService explainService)
     {
         _engine = engine;
+        _explainService = explainService;
     }
 
     private bool CanRun() => !IsRunning;
@@ -54,6 +71,7 @@ public sealed partial class QueryViewModel : ObservableObject
 
         IsRunning = true;
         Status = "Running...";
+        IsShowingPlan = false;
         ColumnNames.Clear();
         Rows.Clear();
         _columns = [];
@@ -127,13 +145,57 @@ public sealed partial class QueryViewModel : ObservableObject
         _cts?.Cancel();
     }
 
+    [RelayCommand(CanExecute = nameof(CanRun))]
+    private Task ExplainAsync() => RunExplainAsync(analyze: false);
+
+    [RelayCommand(CanExecute = nameof(CanRun))]
+    private Task ExplainAnalyzeAsync() => RunExplainAsync(analyze: true);
+
+    [RelayCommand]
+    private void ShowResults() => IsShowingPlan = false;
+
+    private async Task RunExplainAsync(bool analyze)
+    {
+        IsRunning = true;
+        Status = analyze ? "Running EXPLAIN ANALYZE..." : "Running EXPLAIN...";
+
+        try
+        {
+            var result = await _explainService.ExplainAsync(Sql, analyze, CancellationToken.None);
+            ExplainRoot = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
+            ExplainSummary = result.ExecutionTimeMs is { } execMs
+                ? $"Planning: {result.PlanningTimeMs:F3} ms   Execution: {execMs:F3} ms"
+                : $"Planning: {result.PlanningTimeMs:F3} ms";
+            IsShowingPlan = true;
+            Status = "Plan ready";
+        }
+        catch (PostgresException ex)
+        {
+            Status = $"Explain failed: {ex.MessageText}";
+        }
+        catch (Exception ex)
+        {
+            Status = $"Explain failed: {ex.Message}";
+        }
+        finally
+        {
+            IsRunning = false;
+        }
+    }
+
     partial void OnIsRunningChanged(bool value)
     {
         RunCommand.NotifyCanExecuteChanged();
         CancelCommand.NotifyCanExecuteChanged();
+        ExplainCommand.NotifyCanExecuteChanged();
+        ExplainAnalyzeCommand.NotifyCanExecuteChanged();
     }
 
-    partial void OnSqlChanged(string value) => EditContext = null;
+    partial void OnSqlChanged(string value)
+    {
+        EditContext = null;
+        IsShowingPlan = false;
+    }
 
     partial void OnEditContextChanged(EditableTableContext? value) => OnPropertyChanged(nameof(IsEditable));
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -139,6 +139,10 @@
             <StackPanel Orientation="Horizontal" Grid.Row="1" Spacing="8" Margin="0,0,0,8">
                 <Button Content="Run" Command="{Binding ActiveTab.RunCommand}" ToolTip.Tip="Ctrl+Enter" />
                 <Button Content="Cancel" Command="{Binding ActiveTab.CancelCommand}" ToolTip.Tip="Esc" />
+                <Button Content="Explain" Command="{Binding ActiveTab.ExplainCommand}" />
+                <Button Content="Explain Analyze" Command="{Binding ActiveTab.ExplainAnalyzeCommand}" />
+                <Button Content="Show results" Command="{Binding ActiveTab.ShowResultsCommand}"
+                        IsVisible="{Binding ActiveTab.IsShowingPlan}" />
                 <Button Name="ExportButton" Content="Export">
                     <Button.Flyout>
                         <MenuFlyout>
@@ -157,11 +161,34 @@
             </Border>
 
             <Border Grid.Row="3" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Margin="0,8,0,8">
-                <DataGrid Name="ResultsGrid"
-                          IsReadOnly="{Binding !ActiveTab.IsEditable}"
-                          CanUserReorderColumns="False"
-                          GridLinesVisibility="All"
-                          AutoGenerateColumns="False" />
+                <Grid>
+                    <DataGrid Name="ResultsGrid"
+                              IsVisible="{Binding !ActiveTab.IsShowingPlan}"
+                              IsReadOnly="{Binding !ActiveTab.IsEditable}"
+                              CanUserReorderColumns="False"
+                              GridLinesVisibility="All"
+                              AutoGenerateColumns="False" />
+                    <Grid RowDefinitions="Auto,*" IsVisible="{Binding ActiveTab.IsShowingPlan}">
+                        <TextBlock Grid.Row="0" Text="{Binding ActiveTab.ExplainSummary}" Margin="4" FontSize="12" Opacity="0.8" />
+                        <ScrollViewer Grid.Row="1">
+                            <TreeView ItemsSource="{Binding ActiveTab.ExplainRoots}" Margin="4">
+                                <TreeView.ItemTemplate>
+                                    <TreeDataTemplate DataType="vm:ExplainNodeViewModel" ItemsSource="{Binding Children}">
+                                        <StackPanel Margin="0,2">
+                                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                                <Rectangle Width="{Binding BarWidth}" Height="10" Fill="#4C8BF5" VerticalAlignment="Center" />
+                                                <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
+                                            </StackPanel>
+                                            <TextBlock Text="{Binding CostLabel}" FontSize="11" Opacity="0.7" Margin="16,0,0,0" />
+                                            <TextBlock Text="{Binding ActualLabel}" FontSize="11" Opacity="0.7" Margin="16,0,0,0"
+                                                       IsVisible="{Binding ActualLabel, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
+                                        </StackPanel>
+                                    </TreeDataTemplate>
+                                </TreeView.ItemTemplate>
+                            </TreeView>
+                        </ScrollViewer>
+                    </Grid>
+                </Grid>
             </Border>
 
             <Border Grid.Row="4" Padding="4">

--- a/PgNimbus.Core/Query/ExplainService.cs
+++ b/PgNimbus.Core/Query/ExplainService.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using Npgsql;
+
+namespace PgNimbus.Core.Query;
+
+/// <summary>A single node in a Postgres query plan tree, as parsed from `EXPLAIN (FORMAT JSON)`.</summary>
+public sealed record ExplainNode(
+    string NodeType,
+    string? RelationName,
+    string? IndexName,
+    double StartupCost,
+    double TotalCost,
+    long PlanRows,
+    int PlanWidth,
+    double? ActualStartupTimeMs,
+    double? ActualTotalTimeMs,
+    long? ActualRows,
+    long? ActualLoops,
+    IReadOnlyList<ExplainNode> Children);
+
+public sealed record ExplainResult(ExplainNode Root, double? PlanningTimeMs, double? ExecutionTimeMs);
+
+/// <summary>
+/// Runs `EXPLAIN (FORMAT JSON [, ANALYZE])` and parses the resulting plan
+/// into a navigable tree, rather than leaving callers to parse Postgres's
+/// raw JSON shape themselves.
+/// </summary>
+public sealed class ExplainService
+{
+    private readonly NpgsqlDataSource _dataSource;
+
+    public ExplainService(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    public async Task<ExplainResult> ExplainAsync(string sql, bool analyze, CancellationToken ct)
+    {
+        var options = analyze ? "ANALYZE, FORMAT JSON, BUFFERS false, TIMING true" : "FORMAT JSON";
+        var explainSql = $"EXPLAIN ({options}) {sql}";
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(explainSql, connection);
+        var json = (string)(await command.ExecuteScalarAsync(ct))!;
+
+        using var document = JsonDocument.Parse(json);
+        var planEntry = document.RootElement[0];
+        var planningTime = planEntry.TryGetProperty("Planning Time", out var pt) ? pt.GetDouble() : (double?)null;
+        var executionTime = planEntry.TryGetProperty("Execution Time", out var et) ? et.GetDouble() : (double?)null;
+
+        return new ExplainResult(ParseNode(planEntry.GetProperty("Plan")), planningTime, executionTime);
+    }
+
+    private static ExplainNode ParseNode(JsonElement element)
+    {
+        var children = new List<ExplainNode>();
+        if (element.TryGetProperty("Plans", out var childPlans))
+        {
+            foreach (var child in childPlans.EnumerateArray())
+            {
+                children.Add(ParseNode(child));
+            }
+        }
+
+        return new ExplainNode(
+            element.GetProperty("Node Type").GetString()!,
+            element.TryGetProperty("Relation Name", out var rel) ? rel.GetString() : null,
+            element.TryGetProperty("Index Name", out var idx) ? idx.GetString() : null,
+            element.GetProperty("Startup Cost").GetDouble(),
+            element.GetProperty("Total Cost").GetDouble(),
+            element.GetProperty("Plan Rows").GetInt64(),
+            element.GetProperty("Plan Width").GetInt32(),
+            element.TryGetProperty("Actual Startup Time", out var ast) ? ast.GetDouble() : null,
+            element.TryGetProperty("Actual Total Time", out var att) ? att.GetDouble() : null,
+            element.TryGetProperty("Actual Rows", out var ar) ? ar.GetInt64() : null,
+            element.TryGetProperty("Actual Loops", out var al) ? al.GetInt64() : null,
+            children);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ExplainService` (`PgNimbus.Core.Query`) which runs `EXPLAIN (FORMAT JSON[, ANALYZE, TIMING true])` and parses Postgres's JSON plan into a navigable `ExplainNode` tree (node type, relation/index name, cost, plan rows/width, and — for ANALYZE — actual timing/rows/loops).
- Adds `ExplainNodeViewModel` (App layer) which formats those figures for display and derives a bar width relative to the plan's total cost, so the tree reads as a rough visual cost profile.
- Adds "Explain" and "Explain Analyze" buttons to the query toolbar, and a "Show results" button to switch back. The plan tree renders in the same panel as the results grid (toggled by `QueryViewModel.IsShowingPlan`), using a recursive `TreeDataTemplate`.
- Running a query, or editing its SQL, always resets back to the results view, since a stale plan next to edited SQL would be misleading.

## Test plan
Verified end-to-end against a local Postgres instance (headless Xvfb + xdotool):
- [x] `Explain` on a simple indexed lookup renders a single-node plan (`Index Scan on demo`) with correct cost/actual-time figures
- [x] `Explain Analyze` on a join renders a nested tree (`Hash Join` → `Seq Scan` / `Hash`), expandable/collapsible, with bars scaled relative to total cost
- [x] `Show results` switches back to the grid
- [x] `Run` after viewing a plan automatically switches back to the results view
- [x] An invalid relation reports `Explain failed: relation "..." does not exist` in the status bar without disturbing the previous grid contents
- [x] `dotnet build` — 0 warnings, 0 errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_