### PR TITLE
Add LISTEN/NOTIFY monitor

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -6,6 +6,7 @@ using PgNimbus.App.Completion;
 using PgNimbus.App.ViewModels;
 using PgNimbus.App.Views;
 using PgNimbus.Core.Connections;
+using PgNimbus.Core.Notifications;
 using PgNimbus.Core.Query;
 using PgNimbus.Core.Schema;
 
@@ -60,16 +61,18 @@ public partial class App : Application
         var schemaService = new SchemaService(dataSource);
         var schemaTree = new SchemaTreeViewModel(schemaService);
         var completionProvider = new SqlCompletionProvider(schemaService);
+        var notifyMonitor = new NotifyMonitorViewModel(new NotificationListener(dataSource));
 
         var window = new MainWindow
         {
-            DataContext = new MainViewModel(engine, explainService, schemaTree, schemaService, completionProvider),
+            DataContext = new MainViewModel(engine, explainService, schemaTree, schemaService, completionProvider, notifyMonitor),
         };
 
-        if (tunnel is not null)
+        window.Closed += (_, _) =>
         {
-            window.Closed += (_, _) => tunnel.Dispose();
-        }
+            _ = notifyMonitor.DisposeAsync();
+            tunnel?.Dispose();
+        };
 
         _ = schemaTree.RefreshCommand.ExecuteAsync(null);
         _ = completionProvider.RefreshAsync(CancellationToken.None);

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -19,6 +19,8 @@ public sealed partial class MainViewModel : ObservableObject
 
     public SavedQueriesViewModel SavedQueries { get; }
 
+    public NotifyMonitorViewModel NotifyMonitor { get; }
+
     public ObservableCollection<QueryViewModel> Tabs { get; } = [];
 
     [ObservableProperty]
@@ -29,7 +31,8 @@ public sealed partial class MainViewModel : ObservableObject
         ExplainService explainService,
         SchemaTreeViewModel schemaTree,
         SchemaService schemaService,
-        SqlCompletionProvider completionProvider)
+        SqlCompletionProvider completionProvider,
+        NotifyMonitorViewModel notifyMonitor)
     {
         _engine = engine;
         _explainService = explainService;
@@ -37,6 +40,7 @@ public sealed partial class MainViewModel : ObservableObject
         _schemaService = schemaService;
         CompletionProvider = completionProvider;
         SavedQueries = new SavedQueriesViewModel(new SavedQueryStore(), new QueryHistoryStore(), () => ActiveTab);
+        NotifyMonitor = notifyMonitor;
 
         AddTab();
     }

--- a/PgNimbus.App/ViewModels/NotifyMonitorViewModel.cs
+++ b/PgNimbus.App/ViewModels/NotifyMonitorViewModel.cs
@@ -1,0 +1,104 @@
+using System.Collections.ObjectModel;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core.Notifications;
+
+namespace PgNimbus.App.ViewModels;
+
+/// <summary>
+/// Drives a <see cref="NotificationListener"/> from the UI: lets the user
+/// build up a channel list, start/stop listening, and see incoming
+/// notifications as they arrive. Notifications come in on Npgsql's own
+/// background wait loop, not the UI thread, so they're marshalled via
+/// <see cref="Dispatcher.UIThread"/> before touching the observable collection.
+/// </summary>
+public sealed partial class NotifyMonitorViewModel : ObservableObject, IAsyncDisposable
+{
+    private readonly NotificationListener _listener;
+
+    [ObservableProperty]
+    private string _channelName = string.Empty;
+
+    [ObservableProperty]
+    private bool _isListening;
+
+    [ObservableProperty]
+    private string? _errorMessage;
+
+    public ObservableCollection<string> Channels { get; } = [];
+
+    public ObservableCollection<DatabaseNotification> Notifications { get; } = [];
+
+    public NotifyMonitorViewModel(NotificationListener listener)
+    {
+        _listener = listener;
+        _listener.NotificationReceived += OnNotificationReceived;
+    }
+
+    private void OnNotificationReceived(DatabaseNotification notification) =>
+        Dispatcher.UIThread.Post(() => Notifications.Insert(0, notification));
+
+    private bool CanAddChannel() => !string.IsNullOrWhiteSpace(ChannelName) && !Channels.Contains(ChannelName.Trim());
+
+    [RelayCommand(CanExecute = nameof(CanAddChannel))]
+    private void AddChannel()
+    {
+        Channels.Add(ChannelName.Trim());
+        ChannelName = string.Empty;
+        StartListeningCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand]
+    private void RemoveChannel(string? channel)
+    {
+        if (channel is not null)
+        {
+            Channels.Remove(channel);
+            StartListeningCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    private bool CanStartListening() => Channels.Count > 0 && !IsListening;
+
+    [RelayCommand(CanExecute = nameof(CanStartListening))]
+    private async Task StartListeningAsync()
+    {
+        try
+        {
+            await _listener.StartAsync(Channels.ToList(), CancellationToken.None);
+            IsListening = true;
+            ErrorMessage = null;
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+    }
+
+    private bool CanStopListening() => IsListening;
+
+    [RelayCommand(CanExecute = nameof(CanStopListening))]
+    private async Task StopListeningAsync()
+    {
+        await _listener.StopAsync();
+        IsListening = false;
+    }
+
+    [RelayCommand]
+    private void ClearNotifications() => Notifications.Clear();
+
+    partial void OnChannelNameChanged(string value) => AddChannelCommand.NotifyCanExecuteChanged();
+
+    partial void OnIsListeningChanged(bool value)
+    {
+        StartListeningCommand.NotifyCanExecuteChanged();
+        StopListeningCommand.NotifyCanExecuteChanged();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _listener.NotificationReceived -= OnNotificationReceived;
+        await _listener.DisposeAsync();
+    }
+}

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -5,6 +5,8 @@
         xmlns:ae="using:AvaloniaEdit"
         xmlns:vm="using:PgNimbus.App.ViewModels"
         xmlns:query="using:PgNimbus.Core.Query"
+        xmlns:notify="using:PgNimbus.Core.Notifications"
+        xmlns:sys="using:System"
         xmlns:conv="using:Avalonia.Data.Converters"
         mc:Ignorable="d"
         d:DesignWidth="1000" d:DesignHeight="650"
@@ -47,9 +49,16 @@
         <KeyBinding Gesture="Escape" Command="{Binding ActiveTab.CancelCommand}" />
     </Window.KeyBindings>
 
-    <Grid ColumnDefinitions="260,Auto,*" Margin="8">
+    <Grid ColumnDefinitions="300,Auto,*" Margin="8">
 
         <TabControl Grid.Column="0">
+            <TabControl.Styles>
+                <Style Selector="TabItem">
+                    <Setter Property="Padding" Value="8,6" />
+                    <Setter Property="MinWidth" Value="0" />
+                    <Setter Property="FontSize" Value="13" />
+                </Style>
+            </TabControl.Styles>
             <TabItem Header="Schemas">
                 <Grid RowDefinitions="*,Auto">
                     <Border Grid.Row="0" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
@@ -108,6 +117,55 @@
                         <Button Content="Load selected" Command="{Binding LoadHistoryEntryCommand}" CommandParameter="{Binding #HistoryList.SelectedItem}" />
                         <Button Content="Clear history" Command="{Binding ClearHistoryCommand}" />
                     </StackPanel>
+                </Grid>
+            </TabItem>
+            <TabItem Header="Notify">
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto" x:DataType="vm:NotifyMonitorViewModel" DataContext="{Binding NotifyMonitor}">
+                    <TextBlock Grid.Row="0" Text="Channels" FontWeight="SemiBold" Margin="4" />
+                    <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="4" Margin="4">
+                        <TextBox Text="{Binding ChannelName}" Watermark="Channel name" Width="140" />
+                        <Button Content="Add" Command="{Binding AddChannelCommand}" />
+                    </StackPanel>
+                    <Border Grid.Row="2" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" MinHeight="60">
+                        <ListBox ItemsSource="{Binding Channels}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="sys:String">
+                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                        <TextBlock Text="{Binding}" VerticalAlignment="Center" />
+                                        <Button Content="✕" Padding="2,0" FontSize="10" Tag="{Binding}" Click="OnRemoveChannelClick" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Border>
+                    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="4" Margin="4">
+                        <Button Content="Start listening" Command="{Binding StartListeningCommand}" />
+                        <Button Content="Stop" Command="{Binding StopListeningCommand}" />
+                    </StackPanel>
+                    <StackPanel Grid.Row="4" Margin="4">
+                        <TextBlock Text="{Binding IsListening, StringFormat='Listening: {0}'}" FontSize="11" Opacity="0.7" />
+                        <TextBlock Text="{Binding ErrorMessage}" Foreground="IndianRed" TextWrapping="Wrap" FontSize="11"
+                                   IsVisible="{Binding ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
+                    </StackPanel>
+                    <Grid Grid.Row="5" RowDefinitions="Auto,*">
+                        <TextBlock Grid.Row="0" Text="Notifications" FontWeight="SemiBold" Margin="4" />
+                        <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" MinHeight="80">
+                            <ListBox ItemsSource="{Binding Notifications}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate x:DataType="notify:DatabaseNotification">
+                                        <StackPanel>
+                                            <TextBlock FontSize="12">
+                                                <Run Text="{Binding Channel}" FontWeight="SemiBold" />
+                                                <Run Text="{Binding Payload}" />
+                                            </TextBlock>
+                                            <TextBlock Text="{Binding ReceivedAt}" Opacity="0.6" FontSize="10" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </Border>
+                    </Grid>
+                    <Button Grid.Row="6" Content="Clear" Command="{Binding ClearNotificationsCommand}" Margin="4" />
                 </Grid>
             </TabItem>
         </TabControl>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -109,6 +109,14 @@ public partial class MainWindow : Window
         }
     }
 
+    private void OnRemoveChannelClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Button { Tag: string channel })
+        {
+            _viewModel?.NotifyMonitor.RemoveChannelCommand.Execute(channel);
+        }
+    }
+
     private void OnSchemaTreeDoubleTapped(object? sender, TappedEventArgs e)
     {
         // Read the node off the tapped TreeViewItem's DataContext rather than

--- a/PgNimbus.Core/Notifications/NotificationListener.cs
+++ b/PgNimbus.Core/Notifications/NotificationListener.cs
@@ -1,0 +1,89 @@
+using Npgsql;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Notifications;
+
+public sealed record DatabaseNotification(string Channel, string Payload, int ProcessId, DateTimeOffset ReceivedAt);
+
+/// <summary>
+/// Keeps a dedicated connection open, `LISTEN`ing on a set of channels, and
+/// surfaces every `NOTIFY` as an event. Npgsql only delivers notifications
+/// while something is actively waiting on the connection, so a background
+/// loop repeatedly calls <see cref="NpgsqlConnection.WaitAsync"/> for as long
+/// as listening is active.
+/// </summary>
+public sealed class NotificationListener : IAsyncDisposable
+{
+    private readonly NpgsqlDataSource _dataSource;
+    private NpgsqlConnection? _connection;
+    private CancellationTokenSource? _cts;
+    private Task? _listenLoop;
+
+    public event Action<DatabaseNotification>? NotificationReceived;
+
+    public NotificationListener(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    public bool IsListening => _connection is not null;
+
+    public async Task StartAsync(IReadOnlyList<string> channels, CancellationToken ct)
+    {
+        await StopAsync();
+
+        var connection = await _dataSource.OpenConnectionAsync(ct);
+        connection.Notification += OnNotification;
+
+        foreach (var channel in channels)
+        {
+            await using var command = new NpgsqlCommand($"LISTEN {SqlIdentifier.Quote(channel)}", connection);
+            await command.ExecuteNonQueryAsync(ct);
+        }
+
+        _connection = connection;
+        _cts = new CancellationTokenSource();
+        _listenLoop = ListenLoopAsync(connection, _cts.Token);
+    }
+
+    public async Task StopAsync()
+    {
+        _cts?.Cancel();
+
+        if (_listenLoop is not null)
+        {
+            try
+            {
+                await _listenLoop;
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected: cancelling the wait loop on stop.
+            }
+        }
+
+        if (_connection is not null)
+        {
+            _connection.Notification -= OnNotification;
+            await _connection.DisposeAsync();
+        }
+
+        _connection = null;
+        _cts?.Dispose();
+        _cts = null;
+        _listenLoop = null;
+    }
+
+    private void OnNotification(object sender, NpgsqlNotificationEventArgs e) =>
+        NotificationReceived?.Invoke(new DatabaseNotification(e.Channel, e.Payload, e.PID, DateTimeOffset.UtcNow));
+
+    private static async Task ListenLoopAsync(NpgsqlConnection connection, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            await connection.WaitAsync(ct);
+        }
+    }
+
+    public async ValueTask DisposeAsync() => await StopAsync();
+}


### PR DESCRIPTION
## Summary
- Adds `NotificationListener` (`PgNimbus.Core.Notifications`), which keeps a dedicated connection `LISTEN`ing on a configurable set of channels. Npgsql only delivers notifications while something is actively waiting on the connection, so a background loop repeatedly calls `NpgsqlConnection.WaitAsync` for as long as listening is active.
- Adds `NotifyMonitorViewModel` (App layer), which drives the listener from the UI and marshals incoming notifications onto the UI thread via `Dispatcher.UIThread` before touching the observable collection (they arrive on Npgsql's own background thread, not the UI thread).
- Adds a "Notify" sidebar tab: add/remove channels, Start/Stop listening, and a live list of received notifications (channel, payload, timestamp, newest first), with a Clear button.
- Fixes a layout bug the new third tab exposed: three tab headers no longer fit the 260px sidebar and wrapped onto a second line, overlapping the content underneath. Fixed by trimming `TabItem` padding/min-width and widening the sidebar column slightly (260px → 300px).

## Test plan
Verified end-to-end against a local Postgres instance (headless Xvfb + xdotool, plus a separate `psql` session issuing `NOTIFY`):
- [x] Adding a channel and clicking "Start listening" executes `LISTEN` and flips status to "Listening: True"
- [x] A `NOTIFY` sent from a separate `psql` session appears live with correct channel/payload/timestamp
- [x] A second notification appears above the first (newest first)
- [x] "Stop" flips status to "Listening: False", and a `NOTIFY` sent afterward is correctly *not* received
- [x] "Clear" empties the notification list
- [x] Existing "Schemas" and "Queries" tabs still render correctly with the widened sidebar (no regression)
- [x] `dotnet build` — 0 warnings, 0 errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_