### PR TITLE
Add per-connection accent color

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -42,9 +42,9 @@ public partial class App : Application
         var viewModel = new ConnectionDialogViewModel(new ConnectionProfileStore(), CredentialStore.Create());
         var dialog = new ConnectionDialog { DataContext = viewModel };
 
-        viewModel.Connected += (connectionString, tunnel) =>
+        viewModel.Connected += (connectionString, accentColor, tunnel) =>
         {
-            var mainWindow = BuildMainWindow(connectionString, tunnel);
+            var mainWindow = BuildMainWindow(connectionString, accentColor, tunnel);
             desktop.MainWindow = mainWindow;
             mainWindow.Show();
             dialog.Close();
@@ -53,7 +53,7 @@ public partial class App : Application
         return dialog;
     }
 
-    private static MainWindow BuildMainWindow(string connectionString, SshTunnel? tunnel = null)
+    private static MainWindow BuildMainWindow(string connectionString, string? accentColor = null, SshTunnel? tunnel = null)
     {
         var dataSource = NpgsqlDataSource.Create(connectionString);
         var engine = new QueryEngine(dataSource);
@@ -65,7 +65,7 @@ public partial class App : Application
 
         var window = new MainWindow
         {
-            DataContext = new MainViewModel(engine, explainService, schemaTree, schemaService, completionProvider, notifyMonitor),
+            DataContext = new MainViewModel(engine, explainService, schemaTree, schemaService, completionProvider, notifyMonitor, accentColor),
         };
 
         window.Closed += (_, _) =>

--- a/PgNimbus.App/Converters/HexToBrushConverter.cs
+++ b/PgNimbus.App/Converters/HexToBrushConverter.cs
@@ -1,0 +1,17 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace PgNimbus.App.Converters;
+
+/// <summary>Converts a "#RRGGBB" string (or null) into a brush, falling back to transparent for unset/invalid values.</summary>
+public sealed class HexToBrushConverter : IValueConverter
+{
+    public static readonly HexToBrushConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is string hex && Color.TryParse(hex, out var color) ? new SolidColorBrush(color) : Brushes.Transparent;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
+++ b/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
@@ -16,6 +16,10 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
 
     public IReadOnlyList<SshAuthMethod> SshAuthMethods { get; } = Enum.GetValues<SshAuthMethod>();
 
+    /// <summary>Preset swatches shown in the dialog; a per-connection accent color helps tell environments (prod vs. dev) apart at a glance.</summary>
+    public IReadOnlyList<string> AccentColorSwatches { get; } =
+        ["#E5484D", "#F76B15", "#FFB224", "#46A758", "#0091FF", "#8E4EC6", "#6B7280"];
+
     [ObservableProperty]
     private ConnectionProfile? _selectedProfile;
 
@@ -36,6 +40,9 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
 
     [ObservableProperty]
     private SslMode _sslMode = SslMode.Prefer;
+
+    [ObservableProperty]
+    private string? _accentColor;
 
     [ObservableProperty]
     private string _password = string.Empty;
@@ -67,8 +74,8 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
     [ObservableProperty]
     private bool _isConnecting;
 
-    /// <summary>Raised with the built connection string and, if a tunnel was used, the live SshTunnel to keep alive.</summary>
-    public event Action<string, SshTunnel?>? Connected;
+    /// <summary>Raised with the built connection string, the profile's accent color, and, if a tunnel was used, the live SshTunnel to keep alive.</summary>
+    public event Action<string, string?, SshTunnel?>? Connected;
 
     public ConnectionDialogViewModel(ConnectionProfileStore store, ICredentialStore credentialStore)
     {
@@ -94,6 +101,7 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         Database = value.Database;
         Username = value.Username;
         SslMode = value.SslMode;
+        AccentColor = value.AccentColor;
         Password = _credentialStore.LoadPassword(value.Id) ?? string.Empty;
 
         UseSshTunnel = value.SshTunnel is not null;
@@ -115,6 +123,7 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         Database = "postgres";
         Username = "postgres";
         SslMode = SslMode.Prefer;
+        AccentColor = null;
         Password = string.Empty;
         UseSshTunnel = false;
         SshHost = string.Empty;
@@ -161,6 +170,9 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void SelectAccentColor(string? color) => AccentColor = color;
+
+    [RelayCommand]
     private void Delete()
     {
         if (SelectedProfile is null)
@@ -196,12 +208,12 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
                 var connectionString = profile.BuildConnectionString(
                     string.IsNullOrEmpty(Password) ? null : Password,
                     (tunnel.LocalHost, tunnel.LocalPort));
-                Connected?.Invoke(connectionString, tunnel);
+                Connected?.Invoke(connectionString, profile.AccentColor, tunnel);
             }
             else
             {
                 var connectionString = profile.BuildConnectionString(string.IsNullOrEmpty(Password) ? null : Password);
-                Connected?.Invoke(connectionString, null);
+                Connected?.Invoke(connectionString, profile.AccentColor, null);
             }
         }
         catch (Exception ex)
@@ -242,7 +254,8 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
             Database,
             Username,
             SslMode,
-            SshTunnel: sshTunnel);
+            AccentColor,
+            sshTunnel);
         error = null;
         return true;
     }

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -21,6 +21,9 @@ public sealed partial class MainViewModel : ObservableObject
 
     public NotifyMonitorViewModel NotifyMonitor { get; }
 
+    /// <summary>The connected profile's accent color ("#RRGGBB"), or null. Lets the window chrome show at a glance which environment (e.g. prod vs. dev) is connected.</summary>
+    public string? AccentColor { get; }
+
     public ObservableCollection<QueryViewModel> Tabs { get; } = [];
 
     [ObservableProperty]
@@ -32,7 +35,8 @@ public sealed partial class MainViewModel : ObservableObject
         SchemaTreeViewModel schemaTree,
         SchemaService schemaService,
         SqlCompletionProvider completionProvider,
-        NotifyMonitorViewModel notifyMonitor)
+        NotifyMonitorViewModel notifyMonitor,
+        string? accentColor = null)
     {
         _engine = engine;
         _explainService = explainService;
@@ -41,6 +45,7 @@ public sealed partial class MainViewModel : ObservableObject
         CompletionProvider = completionProvider;
         SavedQueries = new SavedQueriesViewModel(new SavedQueryStore(), new QueryHistoryStore(), () => ActiveTab);
         NotifyMonitor = notifyMonitor;
+        AccentColor = accentColor;
 
         AddTab();
     }

--- a/PgNimbus.App/Views/ConnectionDialog.axaml
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml
@@ -3,6 +3,8 @@
         xmlns:vm="using:PgNimbus.App.ViewModels"
         xmlns:conn="using:PgNimbus.Core.Connections"
         xmlns:conv="using:Avalonia.Data.Converters"
+        xmlns:converters="using:PgNimbus.App.Converters"
+        xmlns:sys="using:System"
         x:Class="PgNimbus.App.Views.ConnectionDialog"
         x:DataType="vm:ConnectionDialogViewModel"
         Title="pgNimbus — Connect"
@@ -19,8 +21,12 @@
                     <ListBox.ItemTemplate>
                         <DataTemplate DataType="conn:ConnectionProfile">
                             <StackPanel>
-                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
-                                <TextBlock Text="{Binding Host}" FontSize="11" Opacity="0.7" />
+                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                    <Ellipse Width="8" Height="8" VerticalAlignment="Center"
+                                             Fill="{Binding AccentColor, Converter={x:Static converters:HexToBrushConverter.Instance}}" />
+                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
+                                </StackPanel>
+                                <TextBlock Text="{Binding Host}" FontSize="11" Opacity="0.7" Margin="14,0,0,0" />
                             </StackPanel>
                         </DataTemplate>
                     </ListBox.ItemTemplate>
@@ -98,6 +104,33 @@
 
             <TextBlock Grid.Row="10" Text="{Binding ErrorMessage}" Foreground="IndianRed" TextWrapping="Wrap"
                        IsVisible="{Binding ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" Margin="0,0,0,8" />
+
+            <StackPanel Grid.Row="11" Margin="0,0,0,8">
+                <TextBlock Text="Accent Color" />
+                <StackPanel Orientation="Horizontal" Spacing="6" Margin="0,4,0,0">
+                    <Button Command="{Binding SelectAccentColorCommand}" CommandParameter="{x:Null}"
+                            Width="24" Height="24" Padding="0" CornerRadius="12"
+                            Background="Transparent" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
+                            ToolTip.Tip="None" />
+                    <ItemsControl ItemsSource="{Binding AccentColorSwatches}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <StackPanel Orientation="Horizontal" Spacing="6" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="sys:String">
+                                <Button Command="{Binding $parent[ItemsControl].((vm:ConnectionDialogViewModel)DataContext).SelectAccentColorCommand}"
+                                        CommandParameter="{Binding}"
+                                        Width="24" Height="24" Padding="0" CornerRadius="12"
+                                        Background="{Binding Converter={x:Static converters:HexToBrushConverter.Instance}}"
+                                        BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
+                                        ToolTip.Tip="{Binding}" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </StackPanel>
 
             <StackPanel Grid.Row="12" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="0,8,0,0">
                 <Button Content="Delete" Command="{Binding DeleteCommand}" />

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -8,6 +8,7 @@
         xmlns:notify="using:PgNimbus.Core.Notifications"
         xmlns:sys="using:System"
         xmlns:conv="using:Avalonia.Data.Converters"
+        xmlns:conv2="using:PgNimbus.App.Converters"
         mc:Ignorable="d"
         d:DesignWidth="1000" d:DesignHeight="650"
         x:Class="PgNimbus.App.Views.MainWindow"
@@ -48,6 +49,10 @@
         <KeyBinding Gesture="Ctrl+Enter" Command="{Binding ActiveTab.RunCommand}" />
         <KeyBinding Gesture="Escape" Command="{Binding ActiveTab.CancelCommand}" />
     </Window.KeyBindings>
+
+    <DockPanel>
+        <Border DockPanel.Dock="Top" Height="4"
+                Background="{Binding AccentColor, Converter={x:Static conv2:HexToBrushConverter.Instance}}" />
 
     <Grid ColumnDefinitions="300,Auto,*" Margin="8">
 
@@ -256,5 +261,6 @@
         </Grid>
 
     </Grid>
+    </DockPanel>
 
 </Window>


### PR DESCRIPTION
## Summary
- Wires up the previously-unused `ConnectionProfile.AccentColor` field end to end.
- Adds a row of preset color swatches to the connection dialog so the user can pick an accent color per saved connection; the chosen color also shows as a small dot next to the entry in the saved-connections list.
- The color flows through `ConnectionDialogViewModel.Connected` → `App.BuildMainWindow` → `MainViewModel`, which exposes it for a thin colored strip along the top of the main window — a quick visual cue for telling environments (e.g. prod vs. dev) apart at a glance when multiple windows are open.
- Adds `HexToBrushConverter` (`PgNimbus.App.Converters`) to turn a `"#RRGGBB"` string into a brush, falling back to transparent for null/invalid values so connections without a chosen color render exactly as before.

## Test plan
Verified end-to-end against a local Postgres instance (headless Xvfb + xdotool):
- [x] Picking a swatch and saving a connection persists the hex value to `connections.json`
- [x] Connecting with an accent color shows the matching colored strip at the top of the main window
- [x] Connecting with no accent color set (both an unset saved profile and the `PGNIMBUS_CONN` env-var direct-connect path) renders no strip, with no visual regression
- [x] `dotnet build` — 0 warnings, 0 errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_