### PR TITLE
Add no-SQL schema editing (alter table via UI)

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -59,13 +59,14 @@ public partial class App : Application
         var engine = new QueryEngine(dataSource);
         var explainService = new ExplainService(dataSource);
         var schemaService = new SchemaService(dataSource);
+        var schemaEditor = new SchemaEditor(dataSource);
         var schemaTree = new SchemaTreeViewModel(schemaService);
         var completionProvider = new SqlCompletionProvider(schemaService);
         var notifyMonitor = new NotifyMonitorViewModel(new NotificationListener(dataSource));
 
         var window = new MainWindow
         {
-            DataContext = new MainViewModel(engine, explainService, schemaTree, schemaService, completionProvider, notifyMonitor, accentColor),
+            DataContext = new MainViewModel(engine, explainService, schemaTree, schemaService, schemaEditor, completionProvider, notifyMonitor, accentColor),
         };
 
         window.Closed += (_, _) =>

--- a/PgNimbus.App/ViewModels/AlterTableViewModel.cs
+++ b/PgNimbus.App/ViewModels/AlterTableViewModel.cs
@@ -1,0 +1,177 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.App.ViewModels;
+
+/// <summary>Drives the no-SQL "alter table" dialog: lists a table's columns and lets the user add/drop/rename one without writing DDL by hand.</summary>
+public sealed partial class AlterTableViewModel : ObservableObject
+{
+    private readonly SchemaEditor _schemaEditor;
+    private readonly SchemaService _schemaService;
+
+    public string Schema { get; }
+
+    public string Table { get; }
+
+    public ObservableCollection<ColumnDetail> Columns { get; } = [];
+
+    public IReadOnlyList<string> ColumnTypeOptions { get; } = ColumnTypes.All;
+
+    [ObservableProperty]
+    private ColumnDetail? _selectedColumn;
+
+    [ObservableProperty]
+    private string _newColumnName = string.Empty;
+
+    [ObservableProperty]
+    private string _newColumnType = ColumnTypes.All[0];
+
+    [ObservableProperty]
+    private bool _newColumnNullable = true;
+
+    [ObservableProperty]
+    private string _renameTo = string.Empty;
+
+    [ObservableProperty]
+    private string? _statusMessage;
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    /// <summary>Raised after a successful ALTER TABLE so the schema tree node for this table can refresh.</summary>
+    public event Action? SchemaChanged;
+
+    public AlterTableViewModel(SchemaEditor schemaEditor, SchemaService schemaService, string schema, string table)
+    {
+        _schemaEditor = schemaEditor;
+        _schemaService = schemaService;
+        Schema = schema;
+        Table = table;
+    }
+
+    public async Task LoadAsync()
+    {
+        IsBusy = true;
+        try
+        {
+            var columns = await _schemaService.GetColumnsAsync(Schema, Table, CancellationToken.None);
+            Columns.Clear();
+            foreach (var column in columns)
+            {
+                Columns.Add(column);
+            }
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Failed to load columns: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private bool CanAddColumn() => !string.IsNullOrWhiteSpace(NewColumnName) && !IsBusy;
+
+    [RelayCommand(CanExecute = nameof(CanAddColumn))]
+    private async Task AddColumnAsync()
+    {
+        var name = NewColumnName.Trim();
+        IsBusy = true;
+        try
+        {
+            await _schemaEditor.AddColumnAsync(Schema, Table, name, NewColumnType, NewColumnNullable, CancellationToken.None);
+            StatusMessage = $"Added column \"{name}\".";
+            NewColumnName = string.Empty;
+            await LoadAsync();
+            SchemaChanged?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Failed to add column: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private bool CanDropColumn() => SelectedColumn is not null && !IsBusy;
+
+    [RelayCommand(CanExecute = nameof(CanDropColumn))]
+    private async Task DropColumnAsync()
+    {
+        if (SelectedColumn is not { } column)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        try
+        {
+            await _schemaEditor.DropColumnAsync(Schema, Table, column.Name, CancellationToken.None);
+            StatusMessage = $"Dropped column \"{column.Name}\".";
+            SelectedColumn = null;
+            await LoadAsync();
+            SchemaChanged?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Failed to drop column: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private bool CanRenameColumn() => SelectedColumn is not null && !string.IsNullOrWhiteSpace(RenameTo) && !IsBusy;
+
+    [RelayCommand(CanExecute = nameof(CanRenameColumn))]
+    private async Task RenameColumnAsync()
+    {
+        if (SelectedColumn is not { } column)
+        {
+            return;
+        }
+
+        var newName = RenameTo.Trim();
+        IsBusy = true;
+        try
+        {
+            await _schemaEditor.RenameColumnAsync(Schema, Table, column.Name, newName, CancellationToken.None);
+            StatusMessage = $"Renamed \"{column.Name}\" to \"{newName}\".";
+            RenameTo = string.Empty;
+            SelectedColumn = null;
+            await LoadAsync();
+            SchemaChanged?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Failed to rename column: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    partial void OnNewColumnNameChanged(string value) => AddColumnCommand.NotifyCanExecuteChanged();
+
+    partial void OnRenameToChanged(string value) => RenameColumnCommand.NotifyCanExecuteChanged();
+
+    partial void OnSelectedColumnChanged(ColumnDetail? value)
+    {
+        DropColumnCommand.NotifyCanExecuteChanged();
+        RenameColumnCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnIsBusyChanged(bool value)
+    {
+        AddColumnCommand.NotifyCanExecuteChanged();
+        DropColumnCommand.NotifyCanExecuteChanged();
+        RenameColumnCommand.NotifyCanExecuteChanged();
+    }
+}

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -12,6 +12,7 @@ public sealed partial class MainViewModel : ObservableObject
     private readonly QueryEngine _engine;
     private readonly ExplainService _explainService;
     private readonly SchemaService _schemaService;
+    private readonly SchemaEditor _schemaEditor;
 
     public SchemaTreeViewModel SchemaTree { get; }
 
@@ -34,6 +35,7 @@ public sealed partial class MainViewModel : ObservableObject
         ExplainService explainService,
         SchemaTreeViewModel schemaTree,
         SchemaService schemaService,
+        SchemaEditor schemaEditor,
         SqlCompletionProvider completionProvider,
         NotifyMonitorViewModel notifyMonitor,
         string? accentColor = null)
@@ -42,6 +44,7 @@ public sealed partial class MainViewModel : ObservableObject
         _explainService = explainService;
         SchemaTree = schemaTree;
         _schemaService = schemaService;
+        _schemaEditor = schemaEditor;
         CompletionProvider = completionProvider;
         SavedQueries = new SavedQueriesViewModel(new SavedQueryStore(), new QueryHistoryStore(), () => ActiveTab);
         NotifyMonitor = notifyMonitor;
@@ -49,6 +52,9 @@ public sealed partial class MainViewModel : ObservableObject
 
         AddTab();
     }
+
+    public AlterTableViewModel CreateAlterTableViewModel(TableNode table) =>
+        new(_schemaEditor, _schemaService, table.Schema, table.Name);
 
     private bool CanCloseTab() => Tabs.Count > 1;
 

--- a/PgNimbus.App/ViewModels/SchemaTreeNode.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeNode.cs
@@ -24,6 +24,9 @@ public abstract partial class SchemaTreeNode : ObservableObject
     /// <summary>Seeds a placeholder child so an as-yet-unloaded expandable node still shows an expand arrow.</summary>
     protected void MarkExpandable() => Children.Add(new PlaceholderNode());
 
+    /// <summary>Re-fetches this node's children immediately, bypassing the lazy-load-once gate (used after schema-changing operations like ALTER TABLE).</summary>
+    public Task RefreshAsync() => LoadChildrenAsync();
+
     partial void OnIsExpandedChanged(bool value)
     {
         if (!value || _loaded)

--- a/PgNimbus.App/Views/AlterTableDialog.axaml
+++ b/PgNimbus.App/Views/AlterTableDialog.axaml
@@ -1,0 +1,68 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:PgNimbus.App.ViewModels"
+        xmlns:schema="using:PgNimbus.Core.Schema"
+        xmlns:conv="using:Avalonia.Data.Converters"
+        x:Class="PgNimbus.App.Views.AlterTableDialog"
+        x:DataType="vm:AlterTableViewModel"
+        Title="pgNimbus — Alter Table"
+        Width="520" Height="560"
+        WindowStartupLocation="CenterOwner">
+
+    <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,Auto" Margin="12">
+
+        <TextBlock Grid.Row="0" FontWeight="SemiBold" Margin="0,0,0,8">
+            <Run Text="{Binding Schema}" />
+            <Run Text="." />
+            <Run Text="{Binding Table}" />
+        </TextBlock>
+
+        <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Margin="0,0,0,8">
+            <ListBox Name="ColumnsList" ItemsSource="{Binding Columns}" SelectedItem="{Binding SelectedColumn, Mode=TwoWay}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="schema:ColumnDetail">
+                        <Grid ColumnDefinitions="*,Auto,Auto">
+                            <TextBlock Grid.Column="0" Text="{Binding Name}" />
+                            <TextBlock Grid.Column="1" Text="{Binding DataType}" Opacity="0.7" FontSize="11" Margin="8,0" />
+                            <TextBlock Grid.Column="2" Text="PK" FontSize="10" Opacity="0.7"
+                                       IsVisible="{Binding IsPrimaryKey}" />
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Border>
+
+        <Border Grid.Row="2" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Padding="8" Margin="0,0,0,8">
+            <StackPanel>
+                <TextBlock Text="Add column" FontWeight="SemiBold" Margin="0,0,0,4" />
+                <Grid ColumnDefinitions="*,120,Auto" Margin="0,0,0,6">
+                    <TextBox Grid.Column="0" Text="{Binding NewColumnName}" Watermark="Column name" Margin="0,0,6,0" />
+                    <ComboBox Grid.Column="1" ItemsSource="{Binding ColumnTypeOptions}" SelectedItem="{Binding NewColumnType}"
+                              HorizontalAlignment="Stretch" Margin="0,0,6,0" />
+                    <CheckBox Grid.Column="2" Content="Nullable" IsChecked="{Binding NewColumnNullable}" VerticalAlignment="Center" />
+                </Grid>
+                <Button Content="Add Column" Command="{Binding AddColumnCommand}" HorizontalAlignment="Right" />
+            </StackPanel>
+        </Border>
+
+        <Border Grid.Row="3" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Padding="8" Margin="0,0,0,8">
+            <StackPanel>
+                <TextBlock Text="Rename selected column" FontWeight="SemiBold" Margin="0,0,0,4" />
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBox Grid.Column="0" Text="{Binding RenameTo}" Watermark="New name" Margin="0,0,6,0" />
+                    <Button Grid.Column="1" Content="Rename" Command="{Binding RenameColumnCommand}" />
+                </Grid>
+            </StackPanel>
+        </Border>
+
+        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" TextWrapping="Wrap" Margin="0,0,0,8"
+                   IsVisible="{Binding StatusMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
+
+        <StackPanel Grid.Row="5" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">
+            <Button Content="Drop Selected Column" Command="{Binding DropColumnCommand}" />
+            <Button Content="Close" Click="OnCloseClick" />
+        </StackPanel>
+
+    </Grid>
+
+</Window>

--- a/PgNimbus.App/Views/AlterTableDialog.axaml.cs
+++ b/PgNimbus.App/Views/AlterTableDialog.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using PgNimbus.App.ViewModels;
+
+namespace PgNimbus.App.Views;
+
+public partial class AlterTableDialog : Window
+{
+    public AlterTableDialog()
+    {
+        InitializeComponent();
+
+        Opened += async (_, _) =>
+        {
+            if (DataContext is AlterTableViewModel vm)
+            {
+                await vm.LoadAsync();
+            }
+        };
+    }
+
+    private void OnCloseClick(object? sender, RoutedEventArgs e) => Close();
+}

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -26,6 +26,11 @@
         </DataTemplate>
         <DataTemplate DataType="vm:TableNode">
             <StackPanel Orientation="Horizontal" Spacing="6">
+                <StackPanel.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="Alter Table..." Tag="{Binding}" Click="OnAlterTableClick" />
+                    </ContextMenu>
+                </StackPanel.ContextMenu>
                 <TextBlock Text="{Binding Glyph}" />
                 <TextBlock Text="{Binding Name}" />
             </StackPanel>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -117,6 +117,22 @@ public partial class MainWindow : Window
         }
     }
 
+    private void OnAlterTableClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem { Tag: TableNode table } || _viewModel is null)
+        {
+            return;
+        }
+
+        var alterTableViewModel = _viewModel.CreateAlterTableViewModel(table);
+        // Same TableNode instance the schema tree displays, so reloading its
+        // children in place picks up the ALTER TABLE without a full tree refresh.
+        alterTableViewModel.SchemaChanged += () => _ = table.RefreshAsync();
+
+        var dialog = new AlterTableDialog { DataContext = alterTableViewModel };
+        dialog.ShowDialog(this);
+    }
+
     private void OnSchemaTreeDoubleTapped(object? sender, TappedEventArgs e)
     {
         // Read the node off the tapped TreeViewItem's DataContext rather than

--- a/PgNimbus.Core/Schema/SchemaEditor.cs
+++ b/PgNimbus.Core/Schema/SchemaEditor.cs
@@ -1,0 +1,70 @@
+using Npgsql;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Schema;
+
+/// <summary>Postgres column types offered by the no-SQL "alter table" UI - a fixed allow-list, not free text, since it's concatenated directly into DDL.</summary>
+public static class ColumnTypes
+{
+    public static readonly IReadOnlyList<string> All =
+        ["text", "integer", "bigint", "boolean", "numeric", "double precision", "date", "timestamptz", "uuid", "jsonb"];
+}
+
+/// <summary>
+/// Applies schema changes (ALTER TABLE ADD/DROP/RENAME COLUMN) so the UI can
+/// offer no-SQL table editing. Column/table/schema names come from
+/// SqlIdentifier.Quote (never string-concatenated raw), and column types are
+/// restricted to <see cref="ColumnTypes.All"/> rather than accepting free text.
+/// </summary>
+public sealed class SchemaEditor
+{
+    private readonly NpgsqlDataSource _dataSource;
+
+    public SchemaEditor(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    public Task AddColumnAsync(string schema, string table, string column, string dataType, bool isNullable, CancellationToken ct)
+    {
+        if (!ColumnTypes.All.Contains(dataType))
+        {
+            throw new ArgumentException($"Unsupported column type: {dataType}", nameof(dataType));
+        }
+
+        var nullability = isNullable ? "" : " NOT NULL";
+        var sql = $"""
+            ALTER TABLE {SqlIdentifier.Quote(schema)}.{SqlIdentifier.Quote(table)}
+            ADD COLUMN {SqlIdentifier.Quote(column)} {dataType}{nullability}
+            """;
+
+        return ExecuteAsync(sql, ct);
+    }
+
+    public Task DropColumnAsync(string schema, string table, string column, CancellationToken ct)
+    {
+        var sql = $"""
+            ALTER TABLE {SqlIdentifier.Quote(schema)}.{SqlIdentifier.Quote(table)}
+            DROP COLUMN {SqlIdentifier.Quote(column)}
+            """;
+
+        return ExecuteAsync(sql, ct);
+    }
+
+    public Task RenameColumnAsync(string schema, string table, string oldName, string newName, CancellationToken ct)
+    {
+        var sql = $"""
+            ALTER TABLE {SqlIdentifier.Quote(schema)}.{SqlIdentifier.Quote(table)}
+            RENAME COLUMN {SqlIdentifier.Quote(oldName)} TO {SqlIdentifier.Quote(newName)}
+            """;
+
+        return ExecuteAsync(sql, ct);
+    }
+
+    private async Task ExecuteAsync(string sql, CancellationToken ct)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync(ct);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an "Alter Table..." context menu item on tables in the schema tree, opening a dialog to add, rename, or drop a column without hand-writing DDL.
- `SchemaEditor` (`PgNimbus.Core.Schema`) builds the `ALTER TABLE ... ADD/DROP/RENAME COLUMN` statements from `SqlIdentifier`-quoted schema/table/column names. Column types are restricted to a fixed allow-list (`ColumnTypes.All`) rather than accepted as free text, since the type is concatenated directly into the statement.
- `AlterTableViewModel` (App layer) drives the dialog against the table's real column list (via `SchemaService`) and re-fetches it after every successful change.
- `SchemaTreeNode` gained a public `RefreshAsync()` so the specific `TableNode` the context menu was opened from can reload its children in place afterwards, without a full schema-tree refresh.

## Test plan
Verified end-to-end against a local Postgres instance (headless Xvfb + xdotool, cross-checked with `psql`):
- [x] Right-clicking a table → "Alter Table..." opens a dialog listing its current columns
- [x] Adding a column shows up immediately in the dialog's column list and is confirmed via `\d <table>` in `psql`
- [x] Renaming a column updates the dialog and persists
- [x] Dropping a column updates the dialog and persists
- [x] Closing the dialog leaves the schema tree showing the table's current (not stale) column list, without a full tree refresh
- [x] `dotnet build` — 0 warnings, 0 errors


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUXn2rRsY9wuyvenz4tRQ1)_