### PR TITLE
pgNimbus: PostgreSQL GUI client (.NET 10 + Avalonia 12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What this is
 
-A fast, open-source PostgreSQL GUI client (.NET 10 + Avalonia 11), MIT
+A fast, open-source PostgreSQL GUI client (.NET 10 + Avalonia 12), MIT
 licensed. Windows is the primary target; the core engine stays
 cross-platform-capable. The thesis: **truly fast + open source + modern UI** —
 a gap none of pgAdmin/DBeaver (heavy), TablePlus (fast but paid/closed), or
@@ -53,3 +53,51 @@ speed with TablePlus's polish, PostgreSQL-first.
   Two-way sync with the ViewModel is done manually in `MainWindow.axaml.cs`
   (via `TextChanged` + `PropertyChanged`, with a re-entrancy guard), not via
   XAML `Binding`.
+
+## Bootstrapping a fresh Linux/CI sandbox (no .NET, no display, no Postgres)
+
+A bare container has none of this preinstalled. All of it installs cleanly
+via `apt-get` (no external downloads needed — `dotnet-install.sh` /
+`dot.net` are typically blocked by sandboxed network policies, but the
+Ubuntu `dotnet-sdk-10.0` apt package works and is the reliable path):
+
+```bash
+apt-get update -qq
+apt-get install -y dotnet-sdk-10.0          # build/run the app
+apt-get install -y xvfb imagemagick xdotool # headless display + screenshot + input
+apt-get install -y postgresql               # a real DB to click through, not just mocks
+```
+
+Then, to actually see and drive the UI:
+
+```bash
+# 1. A virtual display, once per sandbox lifetime:
+Xvfb :99 -screen 0 1280x800x24 &
+
+# 2. A local Postgres with seed data:
+service postgresql start
+su - postgres -c "psql -c \"ALTER USER postgres PASSWORD 'postgres';\""
+su - postgres -c "createdb demo"
+PGPASSWORD=postgres psql -h localhost -U postgres -d demo -c "CREATE TABLE ..."
+
+# 3. Build once, then run against DISPLAY=:99. Set PGNIMBUS_CONN so the
+#    app opens straight to MainWindow instead of the connection dialog —
+#    App.axaml.cs reads this env var and skips ConnectionDialog entirely:
+dotnet build
+DISPLAY=:99 PGNIMBUS_CONN="Host=localhost;Port=5432;Database=demo;Username=postgres;Password=postgres" \
+    timeout 15 dotnet run --project PgNimbus.App --no-build &
+
+# 4. Drive it (optional) and capture a screenshot:
+DISPLAY=:99 xdotool mousemove <x> <y> click 1   # click/expand/select
+DISPLAY=:99 xdotool key ctrl+a; xdotool type "SELECT * FROM t;"
+DISPLAY=:99 import -window root screenshot.png  # ImageMagick, captures the whole root window
+```
+
+Notes:
+- `dotnet run` under `timeout` is normal — the app has no natural exit, so
+  screenshot then let the timeout reap it.
+- Test both themes by toggling `RequestedThemeVariant` in `App.axaml`
+  (`Default`/`Dark`) between runs — revert it before committing.
+- This is how the Avalonia 11→12 upgrade and the PowerToys-style UI polish
+  were actually verified (not just built) in a Claude Code sandbox with no
+  prior .NET/GUI tooling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,3 @@ speed with TablePlus's polish, PostgreSQL-first.
   Two-way sync with the ViewModel is done manually in `MainWindow.axaml.cs`
   (via `TextChanged` + `PropertyChanged`, with a re-entrancy guard), not via
   XAML `Binding`.
-- Known accepted warning: Avalonia's Linux X11 backend transitively pulls
-  `Tmds.DBus.Protocol` 0.20.0, which has an open low-relevance advisory
-  (GHSA-xrw6-gwf8-vvr9). The only fixed line (0.90.0+) is a breaking rewrite
-  that Avalonia 11.2.3 can't load (TypeLoadException at startup). Don't try to
-  force-bump this package without confirming Avalonia has moved first.

--- a/PgNimbus.App/App.axaml
+++ b/PgNimbus.App/App.axaml
@@ -7,6 +7,7 @@
         <FluentTheme />
         <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
         <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml" />
+        <StyleInclude Source="avares://PgNimbus.App/Styles/Theme.axaml" />
     </Application.Styles>
 
 </Application>

--- a/PgNimbus.App/PgNimbus.App.csproj
+++ b/PgNimbus.App/PgNimbus.App.csproj
@@ -14,26 +14,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.3" />
-    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.1.0" />
+    <PackageReference Include="Avalonia" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.1" />
+    <PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.3" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.18" />
   </ItemGroup>
-
-  <!--
-    NU1903: Avalonia's X11 backend transitively pulls Tmds.DBus.Protocol 0.20.0,
-    which carries a known DoS advisory (GHSA-xrw6-gwf8-vvr9). The only fixed
-    releases (0.90.0+) are a breaking rewrite that Avalonia 11.2.3 cannot load
-    (TypeLoadException at startup on Linux), so this is accepted until Avalonia
-    itself bumps the dependency. Not reachable on the Windows-primary target.
-  -->
-  <PropertyGroup>
-    <NoWarn>$(NoWarn);NU1903</NoWarn>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\PgNimbus.Core\PgNimbus.Core.csproj" />

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -1,0 +1,124 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        PowerToys-inspired design tokens: soft rounded cards, pill-shaped nav
+        selection, accent-colored primary actions. Keep everything driven off
+        FluentTheme's DynamicResource brushes so light/dark and accent-color
+        changes keep working automatically.
+    -->
+    <Styles.Resources>
+        <CornerRadius x:Key="CardCornerRadius">8</CornerRadius>
+        <CornerRadius x:Key="ControlCornerRadius">6</CornerRadius>
+        <CornerRadius x:Key="PillCornerRadius">16</CornerRadius>
+
+        <!-- Fixed-alpha neutral grey so cards read the same, subtle weight in light and dark -->
+        <SolidColorBrush x:Key="CardBackgroundBrush" Color="#80808080" Opacity="0.06" />
+        <SolidColorBrush x:Key="CardBorderBrush" Color="#80808080" Opacity="0.16" />
+        <SolidColorBrush x:Key="HoverBackgroundBrush" Color="#80808080" Opacity="0.1" />
+    </Styles.Resources>
+
+    <!-- Card container: Border Classes="card" wraps a grouped panel -->
+    <Style Selector="Border.card">
+        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="{StaticResource CardCornerRadius}" />
+    </Style>
+
+    <!-- Buttons -->
+    <Style Selector="Button">
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="14,7" />
+    </Style>
+
+    <Style Selector="Button.accent">
+        <Setter Property="Background" Value="{DynamicResource SystemAccentColor}" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="BorderThickness" Value="0" />
+    </Style>
+    <Style Selector="Button.accent:pointerover">
+        <Setter Property="Background" Value="{DynamicResource SystemAccentColorLight1}" />
+    </Style>
+    <Style Selector="Button.accent:pressed">
+        <Setter Property="Background" Value="{DynamicResource SystemAccentColorDark1}" />
+    </Style>
+    <Style Selector="Button.accent:disabled">
+        <Setter Property="Background" Value="{DynamicResource SystemControlDisabledBaseLowBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlDisabledBaseMediumLowBrush}" />
+    </Style>
+
+    <!-- Round "close chip" buttons used for tab/channel close (✕) -->
+    <Style Selector="Button.chip">
+        <Setter Property="CornerRadius" Value="10" />
+        <Setter Property="Padding" Value="4,0" />
+        <Setter Property="MinWidth" Value="18" />
+        <Setter Property="MinHeight" Value="18" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Opacity" Value="0.6" />
+    </Style>
+    <Style Selector="Button.chip:pointerover">
+        <Setter Property="Background" Value="{StaticResource HoverBackgroundBrush}" />
+        <Setter Property="Opacity" Value="1" />
+    </Style>
+
+    <!-- Left-nav style TabItem: pill highlight instead of the classic underline tab strip -->
+    <Style Selector="TabControl">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Padding" Value="0" />
+    </Style>
+    <Style Selector="TabItem">
+        <Setter Property="Padding" Value="12,9" />
+        <Setter Property="Margin" Value="3,2" />
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="MinWidth" Value="0" />
+    </Style>
+    <Style Selector="TabItem:pointerover">
+        <Setter Property="Background" Value="{StaticResource HoverBackgroundBrush}" />
+    </Style>
+    <Style Selector="TabItem:selected">
+        <Setter Property="Background" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SystemAccentColor}" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+
+    <!-- Lists / trees: rounded row selection instead of edge-to-edge highlight bars -->
+    <Style Selector="ListBox, TreeView">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="4" />
+    </Style>
+    <Style Selector="ListBoxItem">
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="8,6" />
+        <Setter Property="Margin" Value="0,1" />
+    </Style>
+    <Style Selector="ListBoxItem:selected">
+        <Setter Property="Background" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}" />
+    </Style>
+    <Style Selector="TreeViewItem">
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="4,4" />
+    </Style>
+    <Style Selector="TreeViewItem:selected /template/ Border#PART_LayoutRoot">
+        <Setter Property="Background" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}" />
+    </Style>
+
+    <!-- Inputs: rounded to match the rest of the surface -->
+    <Style Selector="TextBox, ComboBox, NumericUpDown">
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+    </Style>
+
+    <!-- Results grid: soft horizontal rules instead of a full grid -->
+    <Style Selector="DataGrid">
+        <Setter Property="GridLinesVisibility" Value="Horizontal" />
+        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}" />
+        <Setter Property="RowBackground" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+    </Style>
+
+</Styles>

--- a/PgNimbus.App/Views/AlterTableDialog.axaml
+++ b/PgNimbus.App/Views/AlterTableDialog.axaml
@@ -36,7 +36,7 @@
             <StackPanel>
                 <TextBlock Text="Add column" FontWeight="SemiBold" Margin="0,0,0,6" />
                 <Grid ColumnDefinitions="*,120,Auto" Margin="0,0,0,8">
-                    <TextBox Grid.Column="0" Text="{Binding NewColumnName}" Watermark="Column name" Margin="0,0,6,0" />
+                    <TextBox Grid.Column="0" Text="{Binding NewColumnName}" PlaceholderText="Column name" Margin="0,0,6,0" />
                     <ComboBox Grid.Column="1" ItemsSource="{Binding ColumnTypeOptions}" SelectedItem="{Binding NewColumnType}"
                               HorizontalAlignment="Stretch" Margin="0,0,6,0" />
                     <CheckBox Grid.Column="2" Content="Nullable" IsChecked="{Binding NewColumnNullable}" VerticalAlignment="Center" />
@@ -49,7 +49,7 @@
             <StackPanel>
                 <TextBlock Text="Rename selected column" FontWeight="SemiBold" Margin="0,0,0,6" />
                 <Grid ColumnDefinitions="*,Auto">
-                    <TextBox Grid.Column="0" Text="{Binding RenameTo}" Watermark="New name" Margin="0,0,6,0" />
+                    <TextBox Grid.Column="0" Text="{Binding RenameTo}" PlaceholderText="New name" Margin="0,0,6,0" />
                     <Button Grid.Column="1" Content="Rename" Command="{Binding RenameColumnCommand}" />
                 </Grid>
             </StackPanel>

--- a/PgNimbus.App/Views/AlterTableDialog.axaml
+++ b/PgNimbus.App/Views/AlterTableDialog.axaml
@@ -9,15 +9,15 @@
         Width="520" Height="560"
         WindowStartupLocation="CenterOwner">
 
-    <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,Auto" Margin="12">
+    <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,Auto" Margin="16">
 
-        <TextBlock Grid.Row="0" FontWeight="SemiBold" Margin="0,0,0,8">
+        <TextBlock Grid.Row="0" FontWeight="SemiBold" FontSize="14" Margin="0,0,0,10">
             <Run Text="{Binding Schema}" />
             <Run Text="." />
             <Run Text="{Binding Table}" />
         </TextBlock>
 
-        <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Margin="0,0,0,8">
+        <Border Grid.Row="1" Classes="card" Margin="0,0,0,10">
             <ListBox Name="ColumnsList" ItemsSource="{Binding Columns}" SelectedItem="{Binding SelectedColumn, Mode=TwoWay}">
                 <ListBox.ItemTemplate>
                     <DataTemplate x:DataType="schema:ColumnDetail">
@@ -32,22 +32,22 @@
             </ListBox>
         </Border>
 
-        <Border Grid.Row="2" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Padding="8" Margin="0,0,0,8">
+        <Border Grid.Row="2" Classes="card" Padding="10" Margin="0,0,0,10">
             <StackPanel>
-                <TextBlock Text="Add column" FontWeight="SemiBold" Margin="0,0,0,4" />
-                <Grid ColumnDefinitions="*,120,Auto" Margin="0,0,0,6">
+                <TextBlock Text="Add column" FontWeight="SemiBold" Margin="0,0,0,6" />
+                <Grid ColumnDefinitions="*,120,Auto" Margin="0,0,0,8">
                     <TextBox Grid.Column="0" Text="{Binding NewColumnName}" Watermark="Column name" Margin="0,0,6,0" />
                     <ComboBox Grid.Column="1" ItemsSource="{Binding ColumnTypeOptions}" SelectedItem="{Binding NewColumnType}"
                               HorizontalAlignment="Stretch" Margin="0,0,6,0" />
                     <CheckBox Grid.Column="2" Content="Nullable" IsChecked="{Binding NewColumnNullable}" VerticalAlignment="Center" />
                 </Grid>
-                <Button Content="Add Column" Command="{Binding AddColumnCommand}" HorizontalAlignment="Right" />
+                <Button Classes="accent" Content="Add Column" Command="{Binding AddColumnCommand}" HorizontalAlignment="Right" />
             </StackPanel>
         </Border>
 
-        <Border Grid.Row="3" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Padding="8" Margin="0,0,0,8">
+        <Border Grid.Row="3" Classes="card" Padding="10" Margin="0,0,0,10">
             <StackPanel>
-                <TextBlock Text="Rename selected column" FontWeight="SemiBold" Margin="0,0,0,4" />
+                <TextBlock Text="Rename selected column" FontWeight="SemiBold" Margin="0,0,0,6" />
                 <Grid ColumnDefinitions="*,Auto">
                     <TextBox Grid.Column="0" Text="{Binding RenameTo}" Watermark="New name" Margin="0,0,6,0" />
                     <Button Grid.Column="1" Content="Rename" Command="{Binding RenameColumnCommand}" />
@@ -55,7 +55,7 @@
             </StackPanel>
         </Border>
 
-        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" TextWrapping="Wrap" Margin="0,0,0,8"
+        <TextBlock Grid.Row="4" Text="{Binding StatusMessage}" TextWrapping="Wrap" Margin="0,0,0,10"
                    IsVisible="{Binding StatusMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
 
         <StackPanel Grid.Row="5" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right">

--- a/PgNimbus.App/Views/ConnectionDialog.axaml
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml
@@ -12,11 +12,11 @@
         CanResize="False"
         WindowStartupLocation="CenterScreen">
 
-    <Grid ColumnDefinitions="220,*" Margin="12">
+    <Grid ColumnDefinitions="220,*" Margin="16">
 
         <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto">
-            <TextBlock Grid.Row="0" Text="Saved Connections" FontWeight="SemiBold" Margin="0,0,0,6" />
-            <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+            <TextBlock Grid.Row="0" Text="Saved Connections" FontWeight="SemiBold" Margin="0,0,0,8" />
+            <Border Grid.Row="1" Classes="card">
                 <ListBox ItemsSource="{Binding Profiles}" SelectedItem="{Binding SelectedProfile}">
                     <ListBox.ItemTemplate>
                         <DataTemplate DataType="conn:ConnectionProfile">
@@ -32,10 +32,10 @@
                     </ListBox.ItemTemplate>
                 </ListBox>
             </Border>
-            <Button Grid.Row="2" Content="New" Command="{Binding NewCommand}" Margin="0,6,0,0" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" />
+            <Button Grid.Row="2" Content="New" Command="{Binding NewCommand}" Margin="0,8,0,0" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" />
         </Grid>
 
-        <ScrollViewer Grid.Column="1" Margin="16,0,0,0" HorizontalScrollBarVisibility="Disabled">
+        <ScrollViewer Grid.Column="1" Margin="20,0,0,0" HorizontalScrollBarVisibility="Disabled">
         <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
 
             <TextBlock Grid.Row="0" Text="Name" />
@@ -69,8 +69,8 @@
             <CheckBox Grid.Row="8" Content="Connect through an SSH tunnel" IsChecked="{Binding UseSshTunnel}" Margin="0,0,0,8" />
 
             <Border Grid.Row="9" IsVisible="{Binding UseSshTunnel}"
-                    BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1"
-                    Padding="8" Margin="0,0,0,8">
+                    Classes="card"
+                    Padding="10" Margin="0,0,0,8">
                 <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
                     <TextBlock Grid.Row="0" Text="SSH Host / Port" />
                     <Grid Grid.Row="1" ColumnDefinitions="*,100" Margin="0,0,0,8">
@@ -135,7 +135,7 @@
             <StackPanel Grid.Row="12" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="0,8,0,0">
                 <Button Content="Delete" Command="{Binding DeleteCommand}" />
                 <Button Content="Save" Command="{Binding SaveCommand}" />
-                <Button Content="Connect" Command="{Binding ConnectCommand}" IsEnabled="{Binding !IsConnecting}" />
+                <Button Classes="accent" Content="Connect" Command="{Binding ConnectCommand}" IsEnabled="{Binding !IsConnecting}" />
             </StackPanel>
 
         </Grid>

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -114,7 +114,7 @@
                             </ListBox.ItemTemplate>
                         </ListBox>
                     </Border>
-                    <TextBox Grid.Row="2" Name="NewQueryNameBox" Text="{Binding NewQueryName}" Watermark="Query name" Margin="0,8,0,0" />
+                    <TextBox Grid.Row="2" Name="NewQueryNameBox" Text="{Binding NewQueryName}" PlaceholderText="Query name" Margin="0,8,0,0" />
                     <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
                         <Button Content="Save" Command="{Binding SaveCurrentQueryCommand}" />
                         <Button Content="Load" Command="{Binding LoadSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}" />
@@ -149,7 +149,7 @@
                 <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0" x:DataType="vm:NotifyMonitorViewModel" DataContext="{Binding NotifyMonitor}">
                     <TextBlock Grid.Row="0" Text="Channels" FontWeight="SemiBold" Margin="4,0,4,6" />
                     <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="6">
-                        <TextBox Text="{Binding ChannelName}" Watermark="Channel name" Width="140" />
+                        <TextBox Text="{Binding ChannelName}" PlaceholderText="Channel name" Width="140" />
                         <Button Content="Add" Command="{Binding AddChannelCommand}" />
                     </StackPanel>
                     <Border Grid.Row="2" Classes="card" MinHeight="60" Margin="0,8,0,0">

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -55,23 +55,29 @@
         <KeyBinding Gesture="Escape" Command="{Binding ActiveTab.CancelCommand}" />
     </Window.KeyBindings>
 
-    <DockPanel>
-        <Border DockPanel.Dock="Top" Height="4"
-                Background="{Binding AccentColor, Converter={x:Static conv2:HexToBrushConverter.Instance}}" />
+    <DockPanel Background="{DynamicResource SystemControlPageBackgroundAltHighBrush}">
+        <Border DockPanel.Dock="Top" Height="40" Padding="16,0"
+                BorderThickness="0,0,0,1" BorderBrush="{StaticResource CardBorderBrush}">
+            <DockPanel>
+                <Border DockPanel.Dock="Left" Width="10" Height="10" CornerRadius="5" Margin="0,0,10,0"
+                        VerticalAlignment="Center"
+                        Background="{Binding AccentColor, Converter={x:Static conv2:HexToBrushConverter.Instance}}" />
+                <TextBlock Text="pgNimbus" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
+            </DockPanel>
+        </Border>
 
-    <Grid ColumnDefinitions="300,Auto,*" Margin="8">
+    <Grid ColumnDefinitions="300,Auto,*" Margin="16">
 
         <TabControl Grid.Column="0">
-            <TabControl.Styles>
-                <Style Selector="TabItem">
-                    <Setter Property="Padding" Value="8,6" />
-                    <Setter Property="MinWidth" Value="0" />
-                    <Setter Property="FontSize" Value="13" />
-                </Style>
-            </TabControl.Styles>
-            <TabItem Header="Schemas">
-                <Grid RowDefinitions="*,Auto">
-                    <Border Grid.Row="0" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+            <TabItem>
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Text="🗄" />
+                        <TextBlock Text="Schemas" />
+                    </StackPanel>
+                </TabItem.Header>
+                <Grid RowDefinitions="*,Auto" Margin="0,8,0,0">
+                    <Border Grid.Row="0" Classes="card">
                         <TreeView Name="SchemaTreeView" ItemsSource="{Binding SchemaTree.Schemas}">
                             <TreeView.Styles>
                                 <Style Selector="TreeViewItem">
@@ -90,10 +96,16 @@
                                Foreground="IndianRed" TextWrapping="Wrap" Margin="4" FontSize="11" />
                 </Grid>
             </TabItem>
-            <TabItem Header="Queries">
-                <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,*,Auto" x:DataType="vm:SavedQueriesViewModel" DataContext="{Binding SavedQueries}">
-                    <TextBlock Grid.Row="0" Text="Saved queries" FontWeight="SemiBold" Margin="4" />
-                    <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" MinHeight="80">
+            <TabItem>
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Text="📝" />
+                        <TextBlock Text="Queries" />
+                    </StackPanel>
+                </TabItem.Header>
+                <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0" x:DataType="vm:SavedQueriesViewModel" DataContext="{Binding SavedQueries}">
+                    <TextBlock Grid.Row="0" Text="Saved queries" FontWeight="SemiBold" Margin="4,0,4,6" />
+                    <Border Grid.Row="1" Classes="card" MinHeight="80">
                         <ListBox Name="SavedQueriesList" ItemsSource="{Binding SavedQueries}">
                             <ListBox.ItemTemplate>
                                 <DataTemplate x:DataType="query:SavedQuery">
@@ -102,16 +114,14 @@
                             </ListBox.ItemTemplate>
                         </ListBox>
                     </Border>
-                    <TextBox Grid.Row="2" Name="NewQueryNameBox" Text="{Binding NewQueryName}" Watermark="Query name" Margin="4,4,4,0" />
-                    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="4" Margin="4">
+                    <TextBox Grid.Row="2" Name="NewQueryNameBox" Text="{Binding NewQueryName}" Watermark="Query name" Margin="0,8,0,0" />
+                    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
                         <Button Content="Save" Command="{Binding SaveCurrentQueryCommand}" />
                         <Button Content="Load" Command="{Binding LoadSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}" />
                         <Button Content="Delete" Command="{Binding DeleteSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}" />
                     </StackPanel>
-                    <Grid Grid.Row="4" RowDefinitions="Auto">
-                        <TextBlock Grid.Row="0" Text="History" FontWeight="SemiBold" Margin="4" />
-                    </Grid>
-                    <Border Grid.Row="5" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" MinHeight="80">
+                    <TextBlock Grid.Row="4" Text="History" FontWeight="SemiBold" Margin="4,16,4,6" />
+                    <Border Grid.Row="5" Classes="card" MinHeight="80">
                         <ListBox Name="HistoryList" ItemsSource="{Binding History}">
                             <ListBox.ItemTemplate>
                                 <DataTemplate x:DataType="query:QueryHistoryEntry">
@@ -123,43 +133,49 @@
                             </ListBox.ItemTemplate>
                         </ListBox>
                     </Border>
-                    <StackPanel Grid.Row="6" Orientation="Horizontal" Spacing="4" Margin="4">
+                    <StackPanel Grid.Row="6" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
                         <Button Content="Load selected" Command="{Binding LoadHistoryEntryCommand}" CommandParameter="{Binding #HistoryList.SelectedItem}" />
                         <Button Content="Clear history" Command="{Binding ClearHistoryCommand}" />
                     </StackPanel>
                 </Grid>
             </TabItem>
-            <TabItem Header="Notify">
-                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto" x:DataType="vm:NotifyMonitorViewModel" DataContext="{Binding NotifyMonitor}">
-                    <TextBlock Grid.Row="0" Text="Channels" FontWeight="SemiBold" Margin="4" />
-                    <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="4" Margin="4">
+            <TabItem>
+                <TabItem.Header>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock Text="🔔" />
+                        <TextBlock Text="Notify" />
+                    </StackPanel>
+                </TabItem.Header>
+                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0" x:DataType="vm:NotifyMonitorViewModel" DataContext="{Binding NotifyMonitor}">
+                    <TextBlock Grid.Row="0" Text="Channels" FontWeight="SemiBold" Margin="4,0,4,6" />
+                    <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="6">
                         <TextBox Text="{Binding ChannelName}" Watermark="Channel name" Width="140" />
                         <Button Content="Add" Command="{Binding AddChannelCommand}" />
                     </StackPanel>
-                    <Border Grid.Row="2" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" MinHeight="60">
+                    <Border Grid.Row="2" Classes="card" MinHeight="60" Margin="0,8,0,0">
                         <ListBox ItemsSource="{Binding Channels}">
                             <ListBox.ItemTemplate>
                                 <DataTemplate x:DataType="sys:String">
-                                    <StackPanel Orientation="Horizontal" Spacing="4">
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
                                         <TextBlock Text="{Binding}" VerticalAlignment="Center" />
-                                        <Button Content="✕" Padding="2,0" FontSize="10" Tag="{Binding}" Click="OnRemoveChannelClick" />
+                                        <Button Classes="chip" Content="✕" FontSize="10" Tag="{Binding}" Click="OnRemoveChannelClick" />
                                     </StackPanel>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
                         </ListBox>
                     </Border>
-                    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="4" Margin="4">
+                    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
                         <Button Content="Start listening" Command="{Binding StartListeningCommand}" />
                         <Button Content="Stop" Command="{Binding StopListeningCommand}" />
                     </StackPanel>
-                    <StackPanel Grid.Row="4" Margin="4">
+                    <StackPanel Grid.Row="4" Margin="4,8,4,0">
                         <TextBlock Text="{Binding IsListening, StringFormat='Listening: {0}'}" FontSize="11" Opacity="0.7" />
                         <TextBlock Text="{Binding ErrorMessage}" Foreground="IndianRed" TextWrapping="Wrap" FontSize="11"
                                    IsVisible="{Binding ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
                     </StackPanel>
-                    <Grid Grid.Row="5" RowDefinitions="Auto,*">
-                        <TextBlock Grid.Row="0" Text="Notifications" FontWeight="SemiBold" Margin="4" />
-                        <Border Grid.Row="1" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" MinHeight="80">
+                    <Grid Grid.Row="5" RowDefinitions="Auto,*" Margin="0,8,0,0">
+                        <TextBlock Grid.Row="0" Text="Notifications" FontWeight="SemiBold" Margin="4,0,4,6" />
+                        <Border Grid.Row="1" Classes="card" MinHeight="80">
                             <ListBox ItemsSource="{Binding Notifications}">
                                 <ListBox.ItemTemplate>
                                     <DataTemplate x:DataType="notify:DatabaseNotification">
@@ -175,37 +191,37 @@
                             </ListBox>
                         </Border>
                     </Grid>
-                    <Button Grid.Row="6" Content="Clear" Command="{Binding ClearNotificationsCommand}" Margin="4" />
+                    <Button Grid.Row="6" Content="Clear" Command="{Binding ClearNotificationsCommand}" Margin="0,8,0,0" />
                 </Grid>
             </TabItem>
         </TabControl>
 
-        <GridSplitter Grid.Column="1" Width="4" />
+        <GridSplitter Grid.Column="1" Width="12" Background="Transparent" />
 
         <Grid Grid.Column="2" RowDefinitions="Auto,Auto,*,*,Auto">
 
-            <DockPanel Grid.Row="0" Margin="0,0,0,4">
-                <Button DockPanel.Dock="Right" Content="+" Command="{Binding AddTabCommand}" ToolTip.Tip="New query tab" />
+            <DockPanel Grid.Row="0" Margin="0,0,0,8">
+                <Button DockPanel.Dock="Right" Classes="chip" Content="+" FontSize="14" Command="{Binding AddTabCommand}" ToolTip.Tip="New query tab" />
                 <ListBox Name="TabsList" ItemsSource="{Binding Tabs}" SelectedItem="{Binding ActiveTab, Mode=TwoWay}"
                           SelectionMode="Single">
                     <ListBox.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <StackPanel Orientation="Horizontal" />
+                            <StackPanel Orientation="Horizontal" Spacing="2" />
                         </ItemsPanelTemplate>
                     </ListBox.ItemsPanel>
                     <ListBox.ItemTemplate>
                         <DataTemplate x:DataType="vm:QueryViewModel">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <TextBlock Text="{Binding TabTitle}" VerticalAlignment="Center" />
-                                <Button Content="✕" Padding="2,0" FontSize="10" Tag="{Binding}" Click="OnCloseTabClick" />
+                                <Button Classes="chip" Content="✕" FontSize="10" Tag="{Binding}" Click="OnCloseTabClick" />
                             </StackPanel>
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
             </DockPanel>
 
-            <StackPanel Orientation="Horizontal" Grid.Row="1" Spacing="8" Margin="0,0,0,8">
-                <Button Content="Run" Command="{Binding ActiveTab.RunCommand}" ToolTip.Tip="Ctrl+Enter" />
+            <StackPanel Orientation="Horizontal" Grid.Row="1" Spacing="8" Margin="0,0,0,12">
+                <Button Classes="accent" Content="Run" Command="{Binding ActiveTab.RunCommand}" ToolTip.Tip="Ctrl+Enter" />
                 <Button Content="Cancel" Command="{Binding ActiveTab.CancelCommand}" ToolTip.Tip="Esc" />
                 <Button Content="Explain" Command="{Binding ActiveTab.ExplainCommand}" />
                 <Button Content="Explain Analyze" Command="{Binding ActiveTab.ExplainAnalyzeCommand}" />
@@ -221,20 +237,19 @@
                 </Button>
             </StackPanel>
 
-            <Border Grid.Row="2" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1">
+            <Border Grid.Row="2" Classes="card">
                 <ae:TextEditor Name="SqlEditor"
                                ShowLineNumbers="True"
                                FontFamily="Cascadia Code,Consolas,Menlo,monospace"
                                FontSize="14" />
             </Border>
 
-            <Border Grid.Row="3" BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}" BorderThickness="1" Margin="0,8,0,8">
+            <Border Grid.Row="3" Classes="card" Margin="0,12,0,12">
                 <Grid>
                     <DataGrid Name="ResultsGrid"
                               IsVisible="{Binding !ActiveTab.IsShowingPlan}"
                               IsReadOnly="{Binding !ActiveTab.IsEditable}"
                               CanUserReorderColumns="False"
-                              GridLinesVisibility="All"
                               AutoGenerateColumns="False" />
                     <Grid RowDefinitions="Auto,*" IsVisible="{Binding ActiveTab.IsShowingPlan}">
                         <TextBlock Grid.Row="0" Text="{Binding ActiveTab.ExplainSummary}" Margin="4" FontSize="12" Opacity="0.8" />
@@ -244,7 +259,8 @@
                                     <TreeDataTemplate DataType="vm:ExplainNodeViewModel" ItemsSource="{Binding Children}">
                                         <StackPanel Margin="0,2">
                                             <StackPanel Orientation="Horizontal" Spacing="6">
-                                                <Rectangle Width="{Binding BarWidth}" Height="10" Fill="#4C8BF5" VerticalAlignment="Center" />
+                                                <Rectangle Width="{Binding BarWidth}" Height="10" RadiusX="2" RadiusY="2"
+                                                           Fill="{DynamicResource SystemAccentColor}" VerticalAlignment="Center" />
                                                 <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
                                             </StackPanel>
                                             <TextBlock Text="{Binding CostLabel}" FontSize="11" Opacity="0.7" Margin="16,0,0,0" />
@@ -259,8 +275,8 @@
                 </Grid>
             </Border>
 
-            <Border Grid.Row="4" Padding="4">
-                <TextBlock Text="{Binding ActiveTab.Status}" />
+            <Border Grid.Row="4" Padding="4,0">
+                <TextBlock Text="{Binding ActiveTab.Status}" Opacity="0.8" FontSize="12" />
             </Border>
 
         </Grid>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -39,7 +39,7 @@ public partial class MainWindow : Window
         // TreeViewItem's own DoubleTapped handling (toggling expand) marks the
         // event Handled, so it never reaches a plain `+=` subscription on the
         // parent TreeView. Use AddHandler with handledEventsToo to still see it.
-        SchemaTreeView.AddHandler(Gestures.DoubleTappedEvent, OnSchemaTreeDoubleTapped, RoutingStrategies.Bubble, handledEventsToo: true);
+        SchemaTreeView.AddHandler(InputElement.DoubleTappedEvent, OnSchemaTreeDoubleTapped, RoutingStrategies.Bubble, handledEventsToo: true);
         ResultsGrid.CellEditEnding += OnCellEditEnding;
         ResultsGrid.CellEditEnded += OnCellEditEnded;
 


### PR DESCRIPTION
## Summary

Brings the full pgNimbus application into `main` for the first time. `main` currently only has the README; all application code has been developed on this branch across a sequence of feature commits:

- Scaffold: .NET 10 + Avalonia solution (Core/App split, `Npgsql`-only core)
- Schema tree sidebar, connection manager + OS credential store, SSH tunnel support
- Inline data editing in the results grid, CSV/JSON export
- Schema-aware SQL autocomplete, saved queries + run history
- Multi-tab query editor, graphical EXPLAIN visualization, LISTEN/NOTIFY monitor
- Per-connection accent color, no-SQL schema editing (alter table via UI)
- UX polish pass toward a PowerToys-style look (rounded cards, pill nav selection, accent buttons)
- Upgrade to Avalonia 12 (from 11.2.3), fixing the breaking API changes that came with it

## Test plan

- [x] `dotnet build` succeeds clean (0 warnings, 0 errors) on .NET 10 SDK
- [x] App verified running under Xvfb against a real local Postgres instance: schema tree, query execution + results grid, EXPLAIN view, connection dialog, alter-table dialog — in both light and dark theme
- [ ] Manual smoke test on a real Windows machine (primary target platform) recommended before/after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NBZMoJdD1JoH4BVaqcGNy

---
_Generated by [Claude Code](https://claude.ai/code/session_013NBZMoJdD1JoH4BVaqcGNy)_