### PR TITLE
Fix UI freeze and unresponsive Cancel on large result sets

### DIFF
--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -1,6 +1,8 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
+using Avalonia.Collections;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Npgsql;
@@ -49,7 +51,14 @@ public sealed partial class QueryViewModel : ObservableObject
 
     public ObservableCollection<string> ColumnNames { get; } = [];
 
-    public ObservableCollection<object?[]> Rows { get; } = [];
+    /// <summary>
+    /// AvaloniaList instead of ObservableCollection: a big unbounded result set
+    /// arrives as thousands of 200-row batches, and AddRange raises one
+    /// collection-changed notification per batch instead of one per row —
+    /// with a plain ObservableCollection the DataGrid's per-item handling
+    /// made large results appear to hang the UI.
+    /// </summary>
+    public AvaloniaList<object?[]> Rows { get; } = [];
 
     /// <summary>Raised once per <see cref="RunAsync"/> completion (success, command, error, or cancellation) so a history tracker can record it without RunAsync knowing about persistence.</summary>
     public event Action<QueryHistoryEntry>? Executed;
@@ -94,21 +103,31 @@ public sealed partial class QueryViewModel : ObservableObject
                     var rowCount = 0;
                     var firstByteMs = -1L;
 
-                    await foreach (var batch in resultSet.Batches.WithCancellation(ct))
+                    // Read and materialize batches on a background thread. NpgsqlDataReader.ReadAsync
+                    // frequently completes synchronously once data is already buffered, so consuming
+                    // the async enumerable directly on the UI thread lets `await foreach` run many
+                    // batches back-to-back without ever yielding — a big unbounded result set freezes
+                    // the UI and makes Cancel unresponsive until the whole query finishes. Only the
+                    // (cheap) Rows/Status mutation needs to happen on the UI thread.
+                    await Task.Run(async () =>
                     {
-                        if (firstByteMs < 0)
+                        await foreach (var batch in resultSet.Batches.WithCancellation(ct))
                         {
-                            firstByteMs = stopwatch.ElapsedMilliseconds;
-                        }
+                            if (firstByteMs < 0)
+                            {
+                                firstByteMs = stopwatch.ElapsedMilliseconds;
+                            }
 
-                        foreach (var row in batch.Rows)
-                        {
-                            Rows.Add(row);
-                        }
+                            rowCount += batch.Rows.Count;
+                            var statusText = $"{rowCount} rows ({firstByteMs} ms to first byte, {resultSet.Elapsed.TotalMilliseconds:F0} ms elapsed)";
 
-                        rowCount += batch.Rows.Count;
-                        Status = $"{rowCount} rows ({firstByteMs} ms to first byte, {resultSet.Elapsed.TotalMilliseconds:F0} ms elapsed)";
-                    }
+                            await Dispatcher.UIThread.InvokeAsync(() =>
+                            {
+                                Rows.AddRange(batch.Rows);
+                                Status = statusText;
+                            });
+                        }
+                    }, ct);
 
                     Status = $"{rowCount} rows in {stopwatch.Elapsed.TotalMilliseconds:F0} ms ({firstByteMs} ms to first byte)";
                     break;


### PR DESCRIPTION
## Summary
- Seeded a local ~1GB / 5M-row test table (`bigdata.events`, 200K `bigdata.users`) to stress-test the app against large data and long-running queries per request
- Found a real violation of this project's own streaming/cancellation architectural rule: running an unbounded `SELECT * FROM bigdata.events` froze the UI (no rows rendered, status stuck on "Running...") and clicking **Cancel did nothing** until the query finished on its own
- Root cause was two compounding issues in `QueryViewModel.RunAsync`:
  1. `await foreach` over the batch stream ran directly on the UI thread — `NpgsqlDataReader.ReadAsync` frequently completes synchronously once data is buffered, so the loop could run thousands of iterations without ever yielding back to the dispatcher, starving it of any chance to repaint or process the Cancel click
  2. `Rows` was a plain `ObservableCollection<object?[]>` appended one row at a time (200 individual `Add` calls per batch), each firing its own `CollectionChanged` notification that the DataGrid has to handle — compounding badly at multi-million-row scale
- Fix: move the batch-reading loop to a background thread via `Task.Run`, marshal only the (cheap) `Rows`/`Status` mutation back to the UI thread per batch via `Dispatcher.UIThread.InvokeAsync`, and switch `Rows` to `AvaloniaList<object?[]>` so each batch applies as a single `AddRange` notification instead of 200 individual ones

## Test plan
- [x] `dotnet build` clean from scratch (0 warnings, 0 errors) on .NET 10 SDK
- [x] Verified under Xvfb against the real 5M-row table: grid now renders live during a big query, status updates in real time, Cancel reliably stops it mid-flight (confirmed via a temporary trace log to rule out input-automation flakiness, then re-verified cleanly without it)
- [x] Confirmed no regression on existing cases: small queries (3-row / 1000-row), `EXPLAIN ANALYZE` against the large table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NBZMoJdD1JoH4BVaqcGNy

---
_Generated by [Claude Code](https://claude.ai/code/session_013NBZMoJdD1JoH4BVaqcGNy)_