### PR TITLE
UX polish + performance: 30× faster large results, working NativeAOT (~100 ms cold start), Files-style UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,18 @@ apt-get update -qq
 apt-get install -y dotnet-sdk-10.0          # build/run the app
 apt-get install -y xvfb imagemagick xdotool # headless display + screenshot + input
 apt-get install -y postgresql               # a real DB to click through, not just mocks
+apt-get install -y clang zlib1g-dev         # only for NativeAOT publish (linux-x64)
 ```
+
+The linux-x64 NativeAOT publish works and is the build to use for
+startup-time claims (`dotnet publish PgNimbus.App -c Release -r linux-x64
+-p:PublishAot=true`, ~100 ms launch-to-window vs ~700 ms JIT). Two
+AOT-specific landmines are already handled in the codebase — keep them
+that way: `SatelliteResourceLanguages=en` in the App csproj (a
+culture-named satellite assembly + InvariantGlobalization crashes
+Avalonia's asset resolver at startup under AOT, surfacing as a bogus
+"avares://... not found") and no reflection binding paths (the results
+grid binds columns via `RowIndexConverter`, not `"[i]"` indexer paths).
 
 Then, to actually see and drive the UI:
 

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -64,9 +64,15 @@ public partial class App : Application
         var completionProvider = new SqlCompletionProvider(schemaService);
         var notifyMonitor = new NotifyMonitorViewModel(new NotificationListener(dataSource));
 
+        var csb = new NpgsqlConnectionStringBuilder(connectionString);
+
         var window = new MainWindow
         {
-            DataContext = new MainViewModel(engine, explainService, schemaTree, schemaService, schemaEditor, completionProvider, notifyMonitor, accentColor),
+            DataContext = new MainViewModel(
+                engine, explainService, schemaTree, schemaService, schemaEditor, completionProvider, notifyMonitor,
+                accentColor,
+                connectionHost: csb.Host ?? "",
+                connectionDatabase: csb.Database ?? ""),
         };
 
         window.Closed += (_, _) =>

--- a/PgNimbus.App/Converters/ListeningDotBrushConverter.cs
+++ b/PgNimbus.App/Converters/ListeningDotBrushConverter.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace PgNimbus.App.Converters;
+
+/// <summary>Status-dot fill for the LISTEN/NOTIFY monitor: green while listening, grey while idle.</summary>
+public sealed class ListeningDotBrushConverter : IValueConverter
+{
+    public static readonly ListeningDotBrushConverter Instance = new();
+
+    private static readonly SolidColorBrush Listening = new(Color.Parse("#3FB950"));
+    private static readonly SolidColorBrush Idle = new(Color.Parse("#80808080"));
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is true ? Listening : Idle;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/PgNimbus.App/Converters/RowIndexConverter.cs
+++ b/PgNimbus.App/Converters/RowIndexConverter.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace PgNimbus.App.Converters;
+
+/// <summary>
+/// Extracts one cell from an <c>object?[]</c> result row. The results grid
+/// binds each column to the row itself (empty path) with one of these instead
+/// of a reflection path like "[3]": indexer-path bindings need dynamic code,
+/// which breaks under NativeAOT/trimming (IL2026/IL3050), while an empty-path
+/// binding plus converter is reflection-free.
+/// </summary>
+public sealed class RowIndexConverter : IValueConverter
+{
+    private readonly int _index;
+
+    public RowIndexConverter(int index) => _index = index;
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is object?[] row && _index < row.Length ? row[_index] : null;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/PgNimbus.App/Converters/RowIndexConverter.cs
+++ b/PgNimbus.App/Converters/RowIndexConverter.cs
@@ -9,15 +9,35 @@ namespace PgNimbus.App.Converters;
 /// of a reflection path like "[3]": indexer-path bindings need dynamic code,
 /// which breaks under NativeAOT/trimming (IL2026/IL3050), while an empty-path
 /// binding plus converter is reflection-free.
+/// SQL NULL converts to a "NULL" placeholder (dimmed via
+/// <see cref="NullCellOpacityConverter"/>) so it's distinguishable from an
+/// empty string; MainWindow's cell-edit preparation clears the placeholder
+/// out of the editor so it can't be committed back as a literal string.
 /// </summary>
 public sealed class RowIndexConverter : IValueConverter
 {
+    public const string NullPlaceholder = "NULL";
+
     private readonly int _index;
 
     public RowIndexConverter(int index) => _index = index;
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is object?[] row && _index < row.Length ? row[_index] : null;
+        value is object?[] row && _index < row.Length ? row[_index] ?? NullPlaceholder : null;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// <summary>Dims cells whose underlying value is SQL NULL, so the "NULL" placeholder reads as a marker, not data.</summary>
+public sealed class NullCellOpacityConverter : IValueConverter
+{
+    private readonly int _index;
+
+    public NullCellOpacityConverter(int index) => _index = index;
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is object?[] row && _index < row.Length && row[_index] is null ? 0.4 : 1.0;
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/PgNimbus.App/PgNimbus.App.csproj
+++ b/PgNimbus.App/PgNimbus.App.csproj
@@ -11,6 +11,15 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <!--
+        English-only: don't ship localized satellite assemblies (the DataGrid
+        pulls in zh-Hans). Under NativeAOT the satellites are bundled into the
+        binary and enumerated by AppDomain.GetAssemblies() - with invariant
+        globalization, AssemblyName construction for a culture-named satellite
+        throws CultureNotFoundException inside Avalonia's asset resolver,
+        which surfaces as a bogus "avares://... not found" crash at startup.
+    -->
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/PgNimbus.App/ResultTextColumn.cs
+++ b/PgNimbus.App/ResultTextColumn.cs
@@ -1,0 +1,31 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using PgNimbus.App.Converters;
+
+namespace PgNimbus.App;
+
+/// <summary>
+/// A results-grid text column that dims cells whose underlying value is SQL
+/// NULL, so the "NULL" placeholder text (see <see cref="RowIndexConverter"/>)
+/// reads as a marker rather than data. The display element's DataContext is
+/// the row array, so a plain style can't see the cell value - the opacity
+/// binding has to be attached per generated element.
+/// </summary>
+public sealed class ResultTextColumn : DataGridTextColumn
+{
+    private readonly int _index;
+
+    public ResultTextColumn(int index) => _index = index;
+
+    protected override Control GenerateElement(DataGridCell cell, object dataItem)
+    {
+        var element = base.GenerateElement(cell, dataItem);
+        element.Bind(Visual.OpacityProperty, new Binding
+        {
+            Converter = new NullCellOpacityConverter(_index),
+        });
+
+        return element;
+    }
+}

--- a/PgNimbus.App/RowCellComparer.cs
+++ b/PgNimbus.App/RowCellComparer.cs
@@ -1,0 +1,47 @@
+using System.Collections;
+
+namespace PgNimbus.App;
+
+/// <summary>
+/// Orders result rows (<c>object?[]</c>) by one cell for DataGrid
+/// header-click sorting. The grid's columns bind to the whole row through a
+/// converter (no reflection path), so the stock path-based sort has nothing
+/// to work with - each column supplies one of these instead. NULLs sort
+/// last; same-type <see cref="IComparable"/> values (ints, timestamps,
+/// strings...) compare natively, anything else falls back to an ordinal
+/// string comparison.
+/// </summary>
+public sealed class RowCellComparer : IComparer
+{
+    private readonly int _index;
+
+    public RowCellComparer(int index) => _index = index;
+
+    public int Compare(object? x, object? y)
+    {
+        var a = (x as object?[])?[_index];
+        var b = (y as object?[])?[_index];
+
+        if (ReferenceEquals(a, b))
+        {
+            return 0;
+        }
+
+        if (a is null)
+        {
+            return 1;
+        }
+
+        if (b is null)
+        {
+            return -1;
+        }
+
+        if (a.GetType() == b.GetType() && a is IComparable comparable)
+        {
+            return comparable.CompareTo(b);
+        }
+
+        return string.CompareOrdinal(a.ToString(), b.ToString());
+    }
+}

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -62,6 +62,20 @@
         <Setter Property="CornerRadius" Value="{StaticResource CardCornerRadius}" />
     </Style>
 
+    <!--
+        Files-style two-tone shell: the window base carries a chrome tint
+        (the sidebar sits directly on it), and the main content pane is a
+        raised "layer" - page-background fill, hairline border, rounded
+        corners - like Files' content area on its Mica base.
+    -->
+    <Style Selector="Border.layer">
+        <Setter Property="Background" Value="{DynamicResource SystemControlPageBackgroundAltHighBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="{StaticResource CardCornerRadius}" />
+        <Setter Property="Padding" Value="12" />
+    </Style>
+
     <!-- Buttons -->
     <Style Selector="Button">
         <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -16,6 +16,25 @@
         <SolidColorBrush x:Key="CardBackgroundBrush" Color="#80808080" Opacity="0.06" />
         <SolidColorBrush x:Key="CardBorderBrush" Color="#80808080" Opacity="0.16" />
         <SolidColorBrush x:Key="HoverBackgroundBrush" Color="#80808080" Opacity="0.1" />
+
+        <!--
+            Nav pill highlight. FluentTheme's TabItem ControlTheme repaints
+            PART_LayoutRoot's background from TabItemHeaderBackground*
+            resources on :pointerover/:pressed (transparent by default), which
+            erases any background set on the TabItem itself as soon as the
+            pointer touches the selected tab. Those inner ControlTheme styles
+            also win the precedence fight against app-level /template/ styles,
+            so the reliable override point is the DynamicResource values they
+            paint with. This StyleInclude loads after FluentTheme, so these
+            take priority in resource lookup.
+        -->
+        <StaticResource x:Key="TabItemHeaderBackgroundSelected" ResourceKey="SystemControlHighlightListAccentLowBrush" />
+        <StaticResource x:Key="TabItemHeaderBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightListAccentLowBrush" />
+        <StaticResource x:Key="TabItemHeaderBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListAccentLowBrush" />
+        <StaticResource x:Key="TabItemHeaderBackgroundUnselectedPointerOver" ResourceKey="HoverBackgroundBrush" />
+        <StaticResource x:Key="TabItemHeaderBackgroundUnselectedPressed" ResourceKey="HoverBackgroundBrush" />
+        <!-- The pill *is* the selection indicator - hide the stock underline pipe -->
+        <SolidColorBrush x:Key="TabItemHeaderSelectedPipeFill" Color="Transparent" />
     </Styles.Resources>
 
     <!-- Card container: Border Classes="card" wraps a grouped panel -->
@@ -77,11 +96,7 @@
         <Setter Property="FontSize" Value="13" />
         <Setter Property="MinWidth" Value="0" />
     </Style>
-    <Style Selector="TabItem:pointerover">
-        <Setter Property="Background" Value="{StaticResource HoverBackgroundBrush}" />
-    </Style>
     <Style Selector="TabItem:selected">
-        <Setter Property="Background" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource SystemAccentColor}" />
         <Setter Property="FontWeight" Value="SemiBold" />
     </Style>

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -46,6 +46,12 @@
         <StreamGeometry x:Key="QueriesIconGeometry">M5,3C3.89,3 3,3.89 3,5V19C3,20.11 3.89,21 5,21H19C20.11,21 21,20.11 21,19V5C21,3.89 20.11,3 19,3H5M7,7H17V9H7V7M7,11H17V13H7V11M7,15H14V17H7V15Z</StreamGeometry>
         <StreamGeometry x:Key="BellIconGeometry">M21,19V20H3V19L5,17V11C5,7.9 7.03,5.17 10,4.29C10,4.19 10,4.1 10,4A2,2 0 0,1 12,2A2,2 0 0,1 14,4C14,4.1 14,4.19 14,4.29C16.97,5.17 19,7.9 19,11V17L21,19M14,21A2,2 0 0,1 12,23A2,2 0 0,1 10,21</StreamGeometry>
         <StreamGeometry x:Key="KeyIconGeometry">M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z</StreamGeometry>
+        <StreamGeometry x:Key="PlayIconGeometry">M8,5.14V19.14L19,12.14L8,5.14Z</StreamGeometry>
+        <StreamGeometry x:Key="StopIconGeometry">M18,18H6V6H18V18Z</StreamGeometry>
+        <StreamGeometry x:Key="FlashIconGeometry">M7,2V13H10V22L17,10H13L17,2H7Z</StreamGeometry>
+        <StreamGeometry x:Key="GaugeIconGeometry">M12,16A3,3 0 0,1 9,13C9,11.88 9.61,10.9 10.5,10.39L20.21,4.77L14.68,14.35C14.18,15.33 13.17,16 12,16M12,3C13.81,3 15.5,3.5 16.97,4.32L14.87,5.53C14,5.19 13,5 12,5A8,8 0 0,0 4,13C4,15.21 4.89,17.21 6.34,18.65H6.35C6.74,19.04 6.74,19.67 6.35,20.06C5.96,20.45 5.32,20.45 4.93,20.07V20.07C3.12,18.26 2,15.76 2,13A10,10 0 0,1 12,3M22,13C22,15.76 20.88,18.26 19.07,20.07V20.07C18.68,20.45 18.05,20.45 17.66,20.06C17.27,19.67 17.27,19.04 17.66,18.65V18.65C19.11,17.2 20,15.21 20,13C20,12 19.81,11 19.46,10.1L20.67,8C21.5,9.5 22,11.18 22,13Z</StreamGeometry>
+        <StreamGeometry x:Key="ExportIconGeometry">M2,12H4V17H20V12H22V17A2,2 0 0,1 20,19H4A2,2 0 0,1 2,17V12M12,15L17.55,9.54L16.13,8.13L13,11.25V2H11V11.25L7.88,8.13L6.46,9.54L12,15Z</StreamGeometry>
+        <StreamGeometry x:Key="TableIconGeometry">M5,4H19A2,2 0 0,1 21,6V17A2,2 0 0,1 19,19H5A2,2 0 0,1 3,17V6A2,2 0 0,1 5,4M5,8V12H11V8H5M13,8V12H19V8H13M5,14V17H11V14H5M13,14V17H19V14H13Z</StreamGeometry>
     </Styles.Resources>
 
     <!-- Card container: Border Classes="card" wraps a grouped panel -->
@@ -77,6 +83,18 @@
     <Style Selector="Button.accent:disabled">
         <Setter Property="Background" Value="{DynamicResource SystemControlDisabledBaseLowBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource SystemControlDisabledBaseMediumLowBrush}" />
+    </Style>
+
+    <!--
+        Quiet command-bar buttons (Files-style toolbar): transparent at rest,
+        FluentTheme's own pointerover/pressed washes provide the hover state -
+        the ControlTheme repaints the ContentPresenter on hover anyway, and
+        its default is exactly the subtle grey a quiet toolbar wants.
+    -->
+    <Style Selector="Button.toolbar">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="10,7" />
     </Style>
 
     <!-- Round "close chip" buttons used for tab/channel close (✕) -->

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -35,6 +35,17 @@
         <StaticResource x:Key="TabItemHeaderBackgroundUnselectedPressed" ResourceKey="HoverBackgroundBrush" />
         <!-- The pill *is* the selection indicator - hide the stock underline pipe -->
         <SolidColorBrush x:Key="TabItemHeaderSelectedPipeFill" Color="Transparent" />
+
+        <!--
+            Vector icons (Material Design Icons, Apache-2.0, pictogrammers.com).
+            Emoji glyphs render as tofu boxes on Linux without a color emoji
+            font; PathIcon fills with the inherited Foreground, so these also
+            pick up the accent color inside a selected nav pill for free.
+        -->
+        <StreamGeometry x:Key="DatabaseIconGeometry">M12,3C7.58,3 4,4.79 4,7C4,9.21 7.58,11 12,11C16.42,11 20,9.21 20,7C20,4.79 16.42,3 12,3M4,9V12C4,14.21 7.58,16 12,16C16.42,16 20,14.21 20,12V9C20,11.21 16.42,13 12,13C7.58,13 4,11.21 4,9M4,14V17C4,19.21 7.58,21 12,21C16.42,21 20,19.21 20,17V14C20,16.21 16.42,18 12,18C7.58,18 4,16.21 4,14Z</StreamGeometry>
+        <StreamGeometry x:Key="QueriesIconGeometry">M5,3C3.89,3 3,3.89 3,5V19C3,20.11 3.89,21 5,21H19C20.11,21 21,20.11 21,19V5C21,3.89 20.11,3 19,3H5M7,7H17V9H7V7M7,11H17V13H7V11M7,15H14V17H7V15Z</StreamGeometry>
+        <StreamGeometry x:Key="BellIconGeometry">M21,19V20H3V19L5,17V11C5,7.9 7.03,5.17 10,4.29C10,4.19 10,4.1 10,4A2,2 0 0,1 12,2A2,2 0 0,1 14,4C14,4.1 14,4.19 14,4.29C16.97,5.17 19,7.9 19,11V17L21,19M14,21A2,2 0 0,1 12,23A2,2 0 0,1 10,21</StreamGeometry>
+        <StreamGeometry x:Key="KeyIconGeometry">M22,18V22H18V19H15V16H12L9.74,13.74C9.19,13.91 8.61,14 8,14A6,6 0 0,1 2,8A6,6 0 0,1 8,2A6,6 0 0,1 14,8C14,8.61 13.91,9.19 13.74,9.74L22,18M7,5A2,2 0 0,0 5,7A2,2 0 0,0 7,9A2,2 0 0,0 9,7A2,2 0 0,0 7,5Z</StreamGeometry>
     </Styles.Resources>
 
     <!-- Card container: Border Classes="card" wraps a grouped panel -->

--- a/PgNimbus.App/ViewModels/ColumnNode.cs
+++ b/PgNimbus.App/ViewModels/ColumnNode.cs
@@ -17,6 +17,4 @@ public sealed class ColumnNode : SchemaTreeNode
     public bool NotNull { get; }
 
     public bool IsPrimaryKey { get; }
-
-    public string PrimaryKeyGlyph => IsPrimaryKey ? "🔑" : string.Empty;
 }

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -25,6 +25,12 @@ public sealed partial class MainViewModel : ObservableObject
     /// <summary>The connected profile's accent color ("#RRGGBB"), or null. Lets the window chrome show at a glance which environment (e.g. prod vs. dev) is connected.</summary>
     public string? AccentColor { get; }
 
+    /// <summary>Server host for the title-bar breadcrumb (host › database).</summary>
+    public string ConnectionHost { get; }
+
+    /// <summary>Database name for the title-bar breadcrumb (host › database).</summary>
+    public string ConnectionDatabase { get; }
+
     public ObservableCollection<QueryViewModel> Tabs { get; } = [];
 
     [ObservableProperty]
@@ -38,8 +44,12 @@ public sealed partial class MainViewModel : ObservableObject
         SchemaEditor schemaEditor,
         SqlCompletionProvider completionProvider,
         NotifyMonitorViewModel notifyMonitor,
-        string? accentColor = null)
+        string? accentColor = null,
+        string connectionHost = "",
+        string connectionDatabase = "")
     {
+        ConnectionHost = connectionHost;
+        ConnectionDatabase = connectionDatabase;
         _engine = engine;
         _explainService = explainService;
         SchemaTree = schemaTree;

--- a/PgNimbus.App/ViewModels/NotifyMonitorViewModel.cs
+++ b/PgNimbus.App/ViewModels/NotifyMonitorViewModel.cs
@@ -30,6 +30,11 @@ public sealed partial class NotifyMonitorViewModel : ObservableObject, IAsyncDis
 
     public ObservableCollection<DatabaseNotification> Notifications { get; } = [];
 
+    /// <summary>Human status line ("Listening on 2 channels" / "Not listening") instead of a raw bool.</summary>
+    public string ListeningStatus => IsListening
+        ? $"Listening on {Channels.Count} channel{(Channels.Count == 1 ? "" : "s")}"
+        : "Not listening";
+
     public NotifyMonitorViewModel(NotificationListener listener)
     {
         _listener = listener;
@@ -94,6 +99,7 @@ public sealed partial class NotifyMonitorViewModel : ObservableObject, IAsyncDis
     {
         StartListeningCommand.NotifyCanExecuteChanged();
         StopListeningCommand.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(ListeningStatus));
     }
 
     public async ValueTask DisposeAsync()

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -13,6 +13,15 @@ namespace PgNimbus.App.ViewModels;
 
 public sealed partial class QueryViewModel : ObservableObject
 {
+    /// <summary>
+    /// Ceiling on rows kept in memory per result set. Streaming keeps the UI
+    /// responsive during a huge SELECT, but every fetched row still lives on
+    /// the client - without a cap an unbounded scan of a big table (or a
+    /// runaway join) eventually exhausts memory. Past the cap the query is
+    /// cancelled server-side via the same path as the Cancel button.
+    /// </summary>
+    public const int MaxDisplayRows = 100_000;
+
     private readonly QueryEngine _engine;
     private readonly ExplainService _explainService;
     private CancellationTokenSource? _cts;
@@ -89,7 +98,10 @@ public sealed partial class QueryViewModel : ObservableObject
 
         try
         {
-            var result = await _engine.ExecuteAsync(executedSql, ct);
+            // Ask for one row past the cap: receiving it proves the result was
+            // actually cut short, so an exactly-at-the-cap result isn't
+            // mislabeled as truncated.
+            var result = await _engine.ExecuteAsync(executedSql, ct, MaxDisplayRows + 1);
 
             switch (result)
             {
@@ -102,6 +114,7 @@ public sealed partial class QueryViewModel : ObservableObject
 
                     var rowCount = 0;
                     var firstByteMs = -1L;
+                    var truncated = false;
 
                     // Read and materialize batches on a background thread. NpgsqlDataReader.ReadAsync
                     // frequently completes synchronously once data is already buffered, so consuming
@@ -118,18 +131,29 @@ public sealed partial class QueryViewModel : ObservableObject
                                 firstByteMs = stopwatch.ElapsedMilliseconds;
                             }
 
-                            rowCount += batch.Rows.Count;
+                            // The engine streams at most MaxDisplayRows + 1 rows;
+                            // the sentinel row past the cap is dropped, not shown.
+                            var rows = batch.Rows;
+                            if (rowCount + rows.Count > MaxDisplayRows)
+                            {
+                                rows = rows.Take(MaxDisplayRows - rowCount).ToList();
+                                truncated = true;
+                            }
+
+                            rowCount += rows.Count;
                             var statusText = $"{rowCount} rows ({firstByteMs} ms to first byte, {resultSet.Elapsed.TotalMilliseconds:F0} ms elapsed)";
 
                             await Dispatcher.UIThread.InvokeAsync(() =>
                             {
-                                Rows.AddRange(batch.Rows);
+                                Rows.AddRange(rows);
                                 Status = statusText;
                             });
                         }
                     }, ct);
 
-                    Status = $"{rowCount} rows in {stopwatch.Elapsed.TotalMilliseconds:F0} ms ({firstByteMs} ms to first byte)";
+                    Status = truncated
+                        ? $"Showing first {rowCount:N0} rows (capped at {MaxDisplayRows:N0} — refine the query for the full set) in {stopwatch.Elapsed.TotalMilliseconds:F0} ms"
+                        : $"{rowCount} rows in {stopwatch.Elapsed.TotalMilliseconds:F0} ms ({firstByteMs} ms to first byte)";
                     break;
 
                 case CommandResult commandResult:

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -61,13 +61,18 @@ public sealed partial class QueryViewModel : ObservableObject
     public ObservableCollection<string> ColumnNames { get; } = [];
 
     /// <summary>
-    /// AvaloniaList instead of ObservableCollection: a big unbounded result set
-    /// arrives as thousands of 200-row batches, and AddRange raises one
-    /// collection-changed notification per batch instead of one per row —
-    /// with a plain ObservableCollection the DataGrid's per-item handling
-    /// made large results appear to hang the UI.
+    /// The grid's rows. Replaced wholesale (a fresh list instance) rather than
+    /// mutated in bulk: the DataGrid's CollectionChanged handling costs
+    /// ~200 µs per row whether the change arrives as per-item Adds, a range
+    /// Add, or a Reset (~20 s for a capped 100k result, measured), while
+    /// assigning a pre-populated ItemsSource costs ~10 ms because
+    /// virtualization only ever realizes a viewport. The view watches this
+    /// property and re-points DataGrid.ItemsSource at the new instance.
+    /// Single-item mutations (inline cell edits) still notify normally and
+    /// stay cheap.
     /// </summary>
-    public AvaloniaList<object?[]> Rows { get; } = [];
+    [ObservableProperty]
+    private AvaloniaList<object?[]> _rows = [];
 
     /// <summary>Raised once per <see cref="RunAsync"/> completion (success, command, error, or cancellation) so a history tracker can record it without RunAsync knowing about persistence.</summary>
     public event Action<QueryHistoryEntry>? Executed;
@@ -91,7 +96,7 @@ public sealed partial class QueryViewModel : ObservableObject
         Status = "Running...";
         IsShowingPlan = false;
         ColumnNames.Clear();
-        Rows.Clear();
+        Rows = [];
         _columns = [];
 
         var stopwatch = Stopwatch.StartNew();
@@ -112,7 +117,7 @@ public sealed partial class QueryViewModel : ObservableObject
                         ColumnNames.Add(column.Name);
                     }
 
-                    var rowCount = 0;
+                    var allRows = new List<object?[]>();
                     var firstByteMs = -1L;
                     var truncated = false;
 
@@ -120,40 +125,68 @@ public sealed partial class QueryViewModel : ObservableObject
                     // frequently completes synchronously once data is already buffered, so consuming
                     // the async enumerable directly on the UI thread lets `await foreach` run many
                     // batches back-to-back without ever yielding — a big unbounded result set freezes
-                    // the UI and makes Cancel unresponsive until the whole query finishes. Only the
-                    // (cheap) Rows/Status mutation needs to happen on the UI thread.
-                    await Task.Run(async () =>
+                    // the UI and makes Cancel unresponsive until the whole query finishes.
+                    //
+                    // The grid gets exactly two row deliveries: the first batch immediately (the
+                    // "first screenful renders before the query finishes" promise), and the full
+                    // list swapped in at the end (see the Rows doc comment for why bulk mutation
+                    // of a bound collection is ruinously slow). In between, only the status line
+                    // ticks — appended rows would land below the fold anyway.
+                    try
                     {
-                        await foreach (var batch in resultSet.Batches.WithCancellation(ct))
+                        await Task.Run(async () =>
                         {
-                            if (firstByteMs < 0)
+                            var firstScreenShown = false;
+                            var lastStatusMs = 0L;
+
+                            await foreach (var batch in resultSet.Batches.WithCancellation(ct))
                             {
-                                firstByteMs = stopwatch.ElapsedMilliseconds;
+                                if (firstByteMs < 0)
+                                {
+                                    firstByteMs = stopwatch.ElapsedMilliseconds;
+                                }
+
+                                // The engine streams at most MaxDisplayRows + 1 rows;
+                                // the sentinel row past the cap is dropped, not shown.
+                                var rows = batch.Rows;
+                                if (allRows.Count + rows.Count > MaxDisplayRows)
+                                {
+                                    rows = rows.Take(MaxDisplayRows - allRows.Count).ToList();
+                                    truncated = true;
+                                }
+
+                                allRows.AddRange(rows);
+                                var statusText = $"{allRows.Count} rows ({firstByteMs} ms to first byte, {resultSet.Elapsed.TotalMilliseconds:F0} ms elapsed)";
+
+                                if (!firstScreenShown)
+                                {
+                                    firstScreenShown = true;
+                                    var firstScreen = new AvaloniaList<object?[]>(allRows);
+                                    await Dispatcher.UIThread.InvokeAsync(() =>
+                                    {
+                                        Rows = firstScreen;
+                                        Status = statusText;
+                                    });
+                                }
+                                else if (stopwatch.ElapsedMilliseconds - lastStatusMs >= 100)
+                                {
+                                    lastStatusMs = stopwatch.ElapsedMilliseconds;
+                                    Dispatcher.UIThread.Post(() => Status = statusText);
+                                }
                             }
-
-                            // The engine streams at most MaxDisplayRows + 1 rows;
-                            // the sentinel row past the cap is dropped, not shown.
-                            var rows = batch.Rows;
-                            if (rowCount + rows.Count > MaxDisplayRows)
-                            {
-                                rows = rows.Take(MaxDisplayRows - rowCount).ToList();
-                                truncated = true;
-                            }
-
-                            rowCount += rows.Count;
-                            var statusText = $"{rowCount} rows ({firstByteMs} ms to first byte, {resultSet.Elapsed.TotalMilliseconds:F0} ms elapsed)";
-
-                            await Dispatcher.UIThread.InvokeAsync(() =>
-                            {
-                                Rows.AddRange(rows);
-                                Status = statusText;
-                            });
-                        }
-                    }, ct);
+                        }, ct);
+                    }
+                    finally
+                    {
+                        // Runs on the UI thread (the awaiter resumed here) for
+                        // success, cancellation, and failure alike, so whatever
+                        // was streamed is always what the grid shows.
+                        Rows = new AvaloniaList<object?[]>(allRows);
+                    }
 
                     Status = truncated
-                        ? $"Showing first {rowCount:N0} rows (capped at {MaxDisplayRows:N0} — refine the query for the full set) in {stopwatch.Elapsed.TotalMilliseconds:F0} ms"
-                        : $"{rowCount} rows in {stopwatch.Elapsed.TotalMilliseconds:F0} ms ({firstByteMs} ms to first byte)";
+                        ? $"Showing first {allRows.Count:N0} rows (capped at {MaxDisplayRows:N0} — refine the query for the full set) in {stopwatch.Elapsed.TotalMilliseconds:F0} ms"
+                        : $"{allRows.Count} rows in {stopwatch.Elapsed.TotalMilliseconds:F0} ms ({firstByteMs} ms to first byte)";
                     break;
 
                 case CommandResult commandResult:

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -239,9 +239,9 @@ public sealed partial class QueryViewModel : ObservableObject
         {
             var result = await _explainService.ExplainAsync(Sql, analyze, CancellationToken.None);
             ExplainRoot = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
-            ExplainSummary = result.ExecutionTimeMs is { } execMs
-                ? $"Planning: {result.PlanningTimeMs:F3} ms   Execution: {execMs:F3} ms"
-                : $"Planning: {result.PlanningTimeMs:F3} ms";
+            var planningFragment = result.PlanningTimeMs is { } planMs ? $"Planning: {planMs:F3} ms" : null;
+            var executionFragment = result.ExecutionTimeMs is { } execMs ? $"Execution: {execMs:F3} ms" : null;
+            ExplainSummary = string.Join("   ", new[] { planningFragment, executionFragment }.Where(f => f is not null));
             IsShowingPlan = true;
             Status = "Plan ready";
         }

--- a/PgNimbus.App/Views/ConnectionDialog.axaml
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml
@@ -9,7 +9,7 @@
         x:DataType="vm:ConnectionDialogViewModel"
         Title="pgNimbus — Connect"
         Icon="avares://PgNimbus.App/Assets/icon-256.png"
-        Width="640" Height="620"
+        Width="640" Height="680"
         CanResize="False"
         WindowStartupLocation="CenterScreen">
 
@@ -38,7 +38,8 @@
 
         <Grid Grid.Column="1" Margin="20,0,0,0" RowDefinitions="*,Auto">
         <ScrollViewer Grid.Row="0" HorizontalScrollBarVisibility="Disabled">
-        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+        <!-- Right margin keeps the scrollbar (shown once the SSH section expands) off the field edges -->
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,0,14,0">
 
             <TextBlock Grid.Row="0" Text="Name" />
             <TextBox Grid.Row="1" Text="{Binding Name}" Margin="0,0,0,8" />

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -168,11 +168,15 @@
                         </ListBox>
                     </Border>
                     <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
-                        <Button Content="Start listening" Command="{Binding StartListeningCommand}" />
+                        <Button Classes="accent" Content="Start listening" Command="{Binding StartListeningCommand}" />
                         <Button Content="Stop" Command="{Binding StopListeningCommand}" />
                     </StackPanel>
                     <StackPanel Grid.Row="4" Margin="4,8,4,0">
-                        <TextBlock Text="{Binding IsListening, StringFormat='Listening: {0}'}" FontSize="11" Opacity="0.7" />
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <Ellipse Width="8" Height="8" VerticalAlignment="Center"
+                                     Fill="{Binding IsListening, Converter={x:Static conv2:ListeningDotBrushConverter.Instance}}" />
+                            <TextBlock Text="{Binding ListeningStatus}" FontSize="11" Opacity="0.8" />
+                        </StackPanel>
                         <TextBlock Text="{Binding ErrorMessage}" Foreground="IndianRed" TextWrapping="Wrap" FontSize="11"
                                    IsVisible="{Binding ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
                     </StackPanel>

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -21,7 +21,7 @@
     <Window.DataTemplates>
         <DataTemplate DataType="vm:SchemaNode">
             <StackPanel Orientation="Horizontal" Spacing="6">
-                <TextBlock Text="🗄" />
+                <PathIcon Data="{StaticResource DatabaseIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
                 <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
             </StackPanel>
         </DataTemplate>
@@ -38,7 +38,9 @@
         </DataTemplate>
         <DataTemplate DataType="vm:ColumnNode">
             <StackPanel Orientation="Horizontal" Spacing="6">
-                <TextBlock Text="{Binding PrimaryKeyGlyph}" Width="14" />
+                <Panel Width="14" VerticalAlignment="Center">
+                    <PathIcon Data="{StaticResource KeyIconGeometry}" Width="12" Height="12" IsVisible="{Binding IsPrimaryKey}" />
+                </Panel>
                 <TextBlock Text="{Binding Name}" />
                 <TextBlock Text="{Binding DataType}" Opacity="0.6" FontSize="11" VerticalAlignment="Center" />
             </StackPanel>
@@ -73,7 +75,7 @@
             <TabItem>
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock Text="🗄" />
+                        <PathIcon Data="{StaticResource DatabaseIconGeometry}" Width="14" Height="14" VerticalAlignment="Center" />
                         <TextBlock Text="Schemas" />
                     </StackPanel>
                 </TabItem.Header>
@@ -100,7 +102,7 @@
             <TabItem>
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock Text="📝" />
+                        <PathIcon Data="{StaticResource QueriesIconGeometry}" Width="14" Height="14" VerticalAlignment="Center" />
                         <TextBlock Text="Queries" />
                     </StackPanel>
                 </TabItem.Header>
@@ -143,7 +145,7 @@
             <TabItem>
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock Text="🔔" />
+                        <PathIcon Data="{StaticResource BellIconGeometry}" Width="14" Height="14" VerticalAlignment="Center" />
                         <TextBlock Text="Notify" />
                     </StackPanel>
                 </TabItem.Header>

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -66,7 +66,13 @@
                 <Border DockPanel.Dock="Left" Width="10" Height="10" CornerRadius="5" Margin="0,0,10,0"
                         VerticalAlignment="Center"
                         Background="{Binding AccentColor, Converter={x:Static conv2:HexToBrushConverter.Instance}}" />
-                <TextBlock Text="pgNimbus" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
+                <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+                    <TextBlock Text="pgNimbus" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
+                    <!-- Files-style breadcrumb: where am I connected -->
+                    <TextBlock Text="{Binding ConnectionHost}" FontSize="12" Opacity="0.65" VerticalAlignment="Center" Margin="10,0,0,0" />
+                    <TextBlock Text="›" FontSize="12" Opacity="0.45" VerticalAlignment="Center" />
+                    <TextBlock Text="{Binding ConnectionDatabase}" FontSize="12" Opacity="0.65" VerticalAlignment="Center" />
+                </StackPanel>
             </DockPanel>
         </Border>
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -58,7 +58,8 @@
         <KeyBinding Gesture="Escape" Command="{Binding ActiveTab.CancelCommand}" />
     </Window.KeyBindings>
 
-    <DockPanel Background="{DynamicResource SystemControlPageBackgroundAltHighBrush}">
+    <!-- Two-tone shell (Files-style): chrome-tinted base; the content pane is a raised layer -->
+    <DockPanel Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}">
         <Border DockPanel.Dock="Top" Height="40" Padding="16,0"
                 BorderThickness="0,0,0,1" BorderBrush="{StaticResource CardBorderBrush}">
             <DockPanel>
@@ -80,7 +81,8 @@
                     </StackPanel>
                 </TabItem.Header>
                 <Grid RowDefinitions="*,Auto" Margin="0,8,0,0">
-                    <Border Grid.Row="0" Classes="card">
+                    <!-- Sidebar content sits directly on the shell tone, Files-style - no card chrome -->
+                    <Border Grid.Row="0">
                         <TreeView Name="SchemaTreeView" ItemsSource="{Binding SchemaTree.Schemas}">
                             <TreeView.Styles>
                                 <Style Selector="TreeViewItem">
@@ -205,7 +207,8 @@
 
         <GridSplitter Grid.Column="1" Width="12" Background="Transparent" />
 
-        <Grid Grid.Column="2" RowDefinitions="Auto,Auto,*,*,Auto">
+        <Border Grid.Column="2" Classes="layer">
+        <Grid RowDefinitions="Auto,Auto,*,*,Auto">
 
             <DockPanel Grid.Row="0" Margin="0,0,0,8">
                 <Button DockPanel.Dock="Right" Classes="chip" Content="+" FontSize="14" Command="{Binding AddTabCommand}" ToolTip.Tip="New query tab" />
@@ -330,6 +333,7 @@
             </Border>
 
         </Grid>
+        </Border>
 
     </Grid>
     </DockPanel>

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -227,22 +227,64 @@
                 </ListBox>
             </DockPanel>
 
-            <StackPanel Orientation="Horizontal" Grid.Row="1" Spacing="8" Margin="0,0,0,12">
-                <Button Classes="accent" Content="Run" Command="{Binding ActiveTab.RunCommand}" ToolTip.Tip="Ctrl+Enter" />
-                <Button Content="Cancel" Command="{Binding ActiveTab.CancelCommand}" ToolTip.Tip="Esc" />
-                <Button Content="Explain" Command="{Binding ActiveTab.ExplainCommand}" />
-                <Button Content="Explain Analyze" Command="{Binding ActiveTab.ExplainAnalyzeCommand}" />
-                <Button Content="Show results" Command="{Binding ActiveTab.ShowResultsCommand}"
-                        IsVisible="{Binding ActiveTab.IsShowingPlan}" />
-                <Button Name="ExportButton" Content="Export">
-                    <Button.Flyout>
-                        <MenuFlyout>
-                            <MenuItem Header="Export as CSV..." Click="OnExportCsvClick" />
-                            <MenuItem Header="Export as JSON..." Click="OnExportJsonClick" />
-                        </MenuFlyout>
-                    </Button.Flyout>
-                </Button>
-            </StackPanel>
+            <!-- Files-style command bar: accent primary action, quiet icon+label secondaries -->
+            <Border Grid.Row="1" Classes="card" Padding="4" Margin="0,0,0,12" HorizontalAlignment="Left">
+                <Border.Resources>
+                    <!--
+                        Disabled buttons inside the command bar stay transparent
+                        (dim text only) instead of Fluent's grey fill - the
+                        ControlTheme paints the ContentPresenter from this
+                        resource, and a container-scoped override is the one
+                        reliable way to restyle it per-area.
+                    -->
+                    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="Transparent" />
+                </Border.Resources>
+                <StackPanel Orientation="Horizontal" Spacing="2">
+                    <Button Classes="accent" Command="{Binding ActiveTab.RunCommand}" ToolTip.Tip="Run (Ctrl+Enter)">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <PathIcon Data="{StaticResource PlayIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                            <TextBlock Text="Run" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="toolbar" Command="{Binding ActiveTab.CancelCommand}" ToolTip.Tip="Cancel (Esc)">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <PathIcon Data="{StaticResource StopIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                            <TextBlock Text="Cancel" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="toolbar" Command="{Binding ActiveTab.ExplainCommand}">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <PathIcon Data="{StaticResource FlashIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                            <TextBlock Text="Explain" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="toolbar" Command="{Binding ActiveTab.ExplainAnalyzeCommand}">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <PathIcon Data="{StaticResource GaugeIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                            <TextBlock Text="Explain Analyze" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="toolbar" Command="{Binding ActiveTab.ShowResultsCommand}"
+                            IsVisible="{Binding ActiveTab.IsShowingPlan}">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <PathIcon Data="{StaticResource TableIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                            <TextBlock Text="Show results" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="toolbar" Name="ExportButton">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <PathIcon Data="{StaticResource ExportIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                            <TextBlock Text="Export" VerticalAlignment="Center" />
+                        </StackPanel>
+                        <Button.Flyout>
+                            <MenuFlyout>
+                                <MenuItem Header="Export as CSV..." Click="OnExportCsvClick" />
+                                <MenuItem Header="Export as JSON..." Click="OnExportJsonClick" />
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+                </StackPanel>
+            </Border>
 
             <Border Grid.Row="2" Classes="card">
                 <ae:TextEditor Name="SqlEditor"

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -257,6 +257,7 @@
                               IsVisible="{Binding !ActiveTab.IsShowingPlan}"
                               IsReadOnly="{Binding !ActiveTab.IsEditable}"
                               CanUserReorderColumns="False"
+                              CanUserSortColumns="True"
                               AutoGenerateColumns="False" />
                     <Grid RowDefinitions="Auto,*" IsVisible="{Binding ActiveTab.IsShowingPlan}">
                         <TextBlock Grid.Row="0" Text="{Binding ActiveTab.ExplainSummary}" Margin="4" FontSize="12" Opacity="0.8" />

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -268,7 +268,21 @@ public partial class MainWindow : Window
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName != nameof(QueryViewModel.Sql) || _queryViewModel is null)
+        if (_queryViewModel is null)
+        {
+            return;
+        }
+
+        // Rows is swapped wholesale instead of mutated in place (bulk
+        // collection-change handling in the DataGrid costs ~200 µs/row; a
+        // fresh ItemsSource costs a viewport) - re-point the grid each time.
+        if (e.PropertyName == nameof(QueryViewModel.Rows))
+        {
+            ResultsGrid.ItemsSource = _queryViewModel.Rows;
+            return;
+        }
+
+        if (e.PropertyName != nameof(QueryViewModel.Sql))
         {
             return;
         }

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -42,6 +42,7 @@ public partial class MainWindow : Window
         SchemaTreeView.AddHandler(InputElement.DoubleTappedEvent, OnSchemaTreeDoubleTapped, RoutingStrategies.Bubble, handledEventsToo: true);
         ResultsGrid.CellEditEnding += OnCellEditEnding;
         ResultsGrid.CellEditEnded += OnCellEditEnded;
+        ResultsGrid.PreparingCellForEdit += OnPreparingCellForEdit;
 
         SqlEditor.TextArea.TextEntered += OnSqlTextEntered;
         SqlEditor.KeyDown += OnSqlEditorKeyDown;
@@ -143,6 +144,21 @@ public partial class MainWindow : Window
         if (_viewModel is not null && container?.DataContext is TableNode table)
         {
             _ = _viewModel.PreviewTableAsync(table);
+        }
+    }
+
+    private void OnPreparingCellForEdit(object? sender, DataGridPreparingCellForEditEventArgs e)
+    {
+        // NULL cells display a "NULL" placeholder through the column's
+        // converter - which also pre-fills the cell editor. Clear it so
+        // committing an untouched editor can't turn SQL NULL into the
+        // literal string "NULL".
+        if (e.EditingElement is TextBox textBox
+            && e.Row.DataContext is object?[] row
+            && e.Column.DisplayIndex < row.Length
+            && row[e.Column.DisplayIndex] is null)
+        {
+            textBox.Text = string.Empty;
         }
     }
 
@@ -303,7 +319,7 @@ public partial class MainWindow : Window
 
         for (var i = 0; i < query.ColumnNames.Count; i++)
         {
-            ResultsGrid.Columns.Add(new DataGridTextColumn
+            ResultsGrid.Columns.Add(new ResultTextColumn(i)
             {
                 Header = query.ColumnNames[i],
                 // Empty path + converter instead of "[i]": indexer paths

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -313,6 +313,11 @@ public partial class MainWindow : Window
                     Converter = new Converters.RowIndexConverter(i),
                     Mode = BindingMode.OneWay,
                 },
+                // No binding path also means no stock sort key - header-click
+                // sorting needs an explicit comparer, and with no path to
+                // infer sortability from, CanUserSort must be set by hand.
+                CustomSortComparer = new RowCellComparer(i),
+                CanUserSort = true,
             });
         }
     }

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -303,11 +303,16 @@ public partial class MainWindow : Window
 
         for (var i = 0; i < query.ColumnNames.Count; i++)
         {
-            var index = i;
             ResultsGrid.Columns.Add(new DataGridTextColumn
             {
-                Header = query.ColumnNames[index],
-                Binding = new Binding($"[{index}]") { Mode = BindingMode.OneWay },
+                Header = query.ColumnNames[i],
+                // Empty path + converter instead of "[i]": indexer paths
+                // resolve via reflection, which trips NativeAOT/trimming.
+                Binding = new Binding
+                {
+                    Converter = new Converters.RowIndexConverter(i),
+                    Mode = BindingMode.OneWay,
+                },
             });
         }
     }

--- a/PgNimbus.Core/Query/ExplainService.cs
+++ b/PgNimbus.Core/Query/ExplainService.cs
@@ -36,7 +36,9 @@ public sealed class ExplainService
 
     public async Task<ExplainResult> ExplainAsync(string sql, bool analyze, CancellationToken ct)
     {
-        var options = analyze ? "ANALYZE, FORMAT JSON, BUFFERS false, TIMING true" : "FORMAT JSON";
+        // Plain EXPLAIN omits "Planning Time" unless SUMMARY is requested explicitly
+        // (ANALYZE defaults SUMMARY to true already, so it's fine either way there).
+        var options = analyze ? "ANALYZE, FORMAT JSON, BUFFERS false, TIMING true" : "FORMAT JSON, SUMMARY";
         var explainSql = $"EXPLAIN ({options}) {sql}";
 
         await using var connection = await _dataSource.OpenConnectionAsync(ct);

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -149,7 +149,12 @@ public sealed class QueryEngine
                 var row = new object?[fieldCount];
                 for (var i = 0; i < fieldCount; i++)
                 {
-                    row[i] = await reader.IsDBNullAsync(i, ct) ? null : reader.GetValue(i);
+                    // Non-sequential access: the row is fully buffered once
+                    // ReadAsync returns, so sync GetValue never blocks on I/O.
+                    // One call per cell instead of IsDBNullAsync + GetValue -
+                    // half a million awaits per 100k×5 result was measurable.
+                    var value = reader.GetValue(i);
+                    row[i] = value is DBNull ? null : value;
                 }
 
                 buffer.Add(row);

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -38,7 +38,17 @@ public sealed class QueryEngine
         await command.ExecuteNonQueryAsync(ct);
     }
 
-    public async Task<StatementResult> ExecuteAsync(string sql, CancellationToken ct)
+    /// <param name="sql">The statement to execute.</param>
+    /// <param name="ct">Cancels the execution mid-flight.</param>
+    /// <param name="maxRows">
+    /// If set, the result stream ends after this many rows and the query is
+    /// cancelled server-side. Merely abandoning the reader doesn't stop
+    /// anything: Npgsql's reader disposal drains the entire remaining result
+    /// set to leave the connection usable, so a bounded consumer of an
+    /// unbounded SELECT would still pull every row over the wire. An explicit
+    /// backend cancel makes the drain a no-op.
+    /// </param>
+    public async Task<StatementResult> ExecuteAsync(string sql, CancellationToken ct, int? maxRows = null)
     {
         var stopwatch = Stopwatch.StartNew();
 
@@ -77,7 +87,7 @@ public sealed class QueryEngine
             {
                 Elapsed = stopwatch.Elapsed,
                 Columns = columns,
-                Batches = StreamBatches(connection, command, reader, ct),
+                Batches = StreamBatches(connection, command, reader, maxRows, ct),
             };
         }
         catch (Exception ex)
@@ -123,12 +133,16 @@ public sealed class QueryEngine
         NpgsqlConnection connection,
         NpgsqlCommand command,
         NpgsqlDataReader reader,
+        int? maxRows,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
     {
+        var stoppedAtRowCap = false;
+
         try
         {
             var fieldCount = reader.FieldCount;
             var buffer = new List<object?[]>(BatchSize);
+            var produced = 0;
 
             while (await reader.ReadAsync(ct))
             {
@@ -139,6 +153,18 @@ public sealed class QueryEngine
                 }
 
                 buffer.Add(row);
+                produced++;
+
+                if (produced >= maxRows)
+                {
+                    stoppedAtRowCap = true;
+                    if (buffer.Count > 0)
+                    {
+                        yield return new RowBatch(buffer);
+                    }
+
+                    yield break;
+                }
 
                 if (buffer.Count >= BatchSize)
                 {
@@ -154,7 +180,24 @@ public sealed class QueryEngine
         }
         finally
         {
-            await reader.DisposeAsync();
+            // Only cancel when the cap cut the stream short. A cancel request
+            // after normal completion could race a pooled-connection reuse and
+            // kill an unrelated subsequent query on the same backend.
+            if (stoppedAtRowCap)
+            {
+                command.Cancel();
+            }
+
+            try
+            {
+                await reader.DisposeAsync();
+            }
+            catch (PostgresException ex) when (stoppedAtRowCap && ex.SqlState == PostgresErrorCodes.QueryCanceled)
+            {
+                // The backend acknowledged the row-cap cancel while the reader
+                // was draining; the rows already yielded are still valid.
+            }
+
             await command.DisposeAsync();
             await connection.DisposeAsync();
         }

--- a/README.md
+++ b/README.md
@@ -20,10 +20,8 @@ from the ground up.
 
 ### Differentiators
 
-1. **Native performance** — measured ~0.7 s from launch to window (JIT,
-   Release, Linux container); sub-500 ms is the target via NativeAOT, which
-   currently has known blockers (asset loading and DataGrid reflection
-   bindings under trimming/AOT).
+1. **Native performance** — measured launch-to-window: ~100 ms as a NativeAOT
+   binary, ~0.7 s under JIT (Release, Linux container, 5-run spread).
 2. **PostgreSQL-first** — deep `pg_catalog` introspection (materialized views,
    real types, primary-key flags, and EXPLAIN visualization); never the
    lowest-common-denominator SQL dialect.
@@ -107,11 +105,18 @@ export PGNIMBUS_CONN="Host=localhost;Port=5432;Database=mydb;Username=postgres;P
 dotnet run --project PgNimbus.App
 ```
 
-### Publishing a NativeAOT build (Windows)
+### Publishing a NativeAOT build
 
 ```bash
-dotnet publish PgNimbus.App -c Release -r win-x64 -p:PublishAot=true
+dotnet publish PgNimbus.App -c Release -r win-x64 -p:PublishAot=true    # Windows
+dotnet publish PgNimbus.App -c Release -r linux-x64 -p:PublishAot=true  # Linux (needs clang + zlib1g-dev)
 ```
+
+The linux-x64 AOT binary is exercised as part of development: it launches to a
+window in ~100 ms and the query grid, EXPLAIN visualization, and profile
+stores all work (JSON persistence uses source-generated serializer contexts,
+and the results grid binds columns via converters instead of reflection
+paths, both of which trimming/AOT require).
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ from the ground up.
 
 ### Differentiators
 
-1. **Native performance** — NativeAOT-friendly code, cold start under 500 ms.
+1. **Native performance** — measured ~0.7 s from launch to window (JIT,
+   Release, Linux container); sub-500 ms is the target via NativeAOT, which
+   currently has known blockers (asset loading and DataGrid reflection
+   bindings under trimming/AOT).
 2. **PostgreSQL-first** — deep `pg_catalog` introspection (materialized views,
    real types, primary-key flags, and EXPLAIN visualization); never the
    lowest-common-denominator SQL dialect.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -63,12 +63,17 @@ means for pgNimbus. Adopting its language where Avalonia allows.
 | --- | --- | --- |
 | Files-style command bar | Query toolbar is now a rounded card containing an accent Run (play icon) and quiet icon+label secondaries (stop/flash/gauge/table/export MDI glyphs) that are transparent at rest with Fluent's own hover wash. Disabled buttons stay quiet (dim text, no grey fill) via a container-scoped `ButtonBackgroundDisabled` resource override — the reliable per-area escape from ControlTheme repainting. Verified rest/hover/disabled in light and dark. | (this commit) |
 
+## Iteration 7
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Files two-tone shell | Window base now carries the chrome tint (`SystemControlBackgroundChromeMediumLowBrush`); the sidebar (nav pills + schema tree, card chrome removed) sits directly on it, and the whole right pane became a raised `Border.layer` — page-background fill, hairline border, 8 px radius — matching Files' content-on-Mica layering. Verified light + dark with results on screen. | (this commit) |
+
 ## Open / candidate items
-- [ ] More Files-language adoption: layered content tones (sidebar vs
-      content), compact left sidebar with section headers, breadcrumb-style
-      context (connection › database), segmented status bar. Mica/acrylic
-      backdrop remains blocked on safe verification (a headless sandbox
-      can't see transparency failures).
+- [ ] More Files-language adoption: compact sidebar section headers,
+      breadcrumb-style context (connection › database), segmented status
+      bar. Mica/acrylic backdrop remains blocked on safe verification (a
+      headless sandbox can't see transparency failures).
 - [ ] Keyboard navigation audit (tab order, editor ↔ grid focus, Ctrl+W
       close tab?)
 - [ ] Roadmap features (command palette, extension manager) — out of polish

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -69,11 +69,16 @@ means for pgNimbus. Adopting its language where Avalonia allows.
 | --- | --- | --- |
 | Files two-tone shell | Window base now carries the chrome tint (`SystemControlBackgroundChromeMediumLowBrush`); the sidebar (nav pills + schema tree, card chrome removed) sits directly on it, and the whole right pane became a raised `Border.layer` — page-background fill, hairline border, 8 px radius — matching Files' content-on-Mica layering. Verified light + dark with results on screen. | (this commit) |
 
+## Iteration 8
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Title-bar connection breadcrumb | Files-style context in the chrome: "pgNimbus  host › database", parsed from the connection string (`NpgsqlConnectionStringBuilder`) and exposed as `ConnectionHost`/`ConnectionDatabase` on `MainViewModel`. Quiet 65 %-opacity text next to the accent environment dot. | (this commit) |
+
 ## Open / candidate items
 - [ ] More Files-language adoption: compact sidebar section headers,
-      breadcrumb-style context (connection › database), segmented status
-      bar. Mica/acrylic backdrop remains blocked on safe verification (a
-      headless sandbox can't see transparency failures).
+      segmented status bar. Mica/acrylic backdrop remains blocked on safe
+      verification (a headless sandbox can't see transparency failures).
 - [ ] Keyboard navigation audit (tab order, editor ↔ grid focus, Ctrl+W
       close tab?)
 - [ ] Roadmap features (command palette, extension manager) — out of polish

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -41,10 +41,14 @@ current when landing work on this branch.
 | Memory on unbounded 5M-row scan | unbounded growth | capped (~30 MB data + runtime) |
 | Backend after cap/cancel | kept running | `idle` (explicit backend cancel) |
 
-## Open / candidate items
+## Iteration 4
 
-- [ ] Click-to-sort on result grid columns (needs `CustomSortComparer`;
-      columns have no sortable binding path by design) — in progress
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Progress log | This file. | `607e0fc` |
+| Header-click sorting on result columns | Columns bind through a converter (no path), so the stock sort has no key: each column gets a `RowCellComparer` (`CustomSortComparer`) comparing its cell — NULLs last, same-type `IComparable` natively, ordinal-string fallback — plus explicit `CanUserSort`/`CanUserSortColumns`. Verified: text asc/desc with arrows, numeric `id` sorts 1,2,3 (not 1,10,100), and a 100k-row result sorts in ~1 s. | (this commit) |
+
+## Open / candidate items
 - [ ] NULL cells indistinguishable from empty strings in the grid (dim
       "NULL" placeholder? needs care: display text feeds the inline cell
       editor, so a converter-only approach risks writing the string "NULL")

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -48,13 +48,19 @@ current when landing work on this branch.
 | Progress log | This file. | `607e0fc` |
 | Header-click sorting on result columns | Columns bind through a converter (no path), so the stock sort has no key: each column gets a `RowCellComparer` (`CustomSortComparer`) comparing its cell — NULLs last, same-type `IComparable` natively, ordinal-string fallback — plus explicit `CanUserSort`/`CanUserSortColumns`. Verified: text asc/desc with arrows, numeric `id` sorts 1,2,3 (not 1,10,100), and a 100k-row result sorts in ~1 s. | (this commit) |
 
+## Iteration 5
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| NULL cells indistinguishable from empty strings | `RowIndexConverter` renders SQL NULL as a "NULL" placeholder; `ResultTextColumn` dims those cells to 0.4 opacity via a per-element binding (a style can't see the cell value), so the marker reads as a marker while a literal `'NULL'` string stays full-contrast. `PreparingCellForEdit` clears the placeholder out of the cell editor so an untouched commit can't write the string "NULL". Verified with NULL / `''` / `'NULL'` side by side. | (this commit) |
+
 ## Open / candidate items
-- [ ] NULL cells indistinguishable from empty strings in the grid (dim
-      "NULL" placeholder? needs care: display text feeds the inline cell
-      editor, so a converter-only approach risks writing the string "NULL")
+- [ ] **UI north star: [Files](https://github.com/files-community/Files)** —
+      adopt its Windows design language where Avalonia allows: command-bar
+      toolbar (icon+label, transparent-until-hover), layered content tones,
+      8 px radii, compact sidebar. Mica/acrylic backdrop remains blocked on
+      safe verification (a headless sandbox can't see transparency failures).
 - [ ] Keyboard navigation audit (tab order, editor ↔ grid focus, Ctrl+W
       close tab?)
-- [ ] Mica/acrylic backdrop — still deliberately skipped: can't safely
-      verify transparency fallbacks headlessly
 - [ ] Roadmap features (command palette, extension manager) — out of polish
       scope

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -54,12 +54,21 @@ current when landing work on this branch.
 | --- | --- | --- |
 | NULL cells indistinguishable from empty strings | `RowIndexConverter` renders SQL NULL as a "NULL" placeholder; `ResultTextColumn` dims those cells to 0.4 opacity via a per-element binding (a style can't see the cell value), so the marker reads as a marker while a literal `'NULL'` string stays full-contrast. `PreparingCellForEdit` clears the placeholder out of the cell editor so an untouched commit can't write the string "NULL". Verified with NULL / `''` / `'NULL'` side by side. | (this commit) |
 
+## Iteration 6 — UI north star: [Files](https://github.com/files-community/Files)
+
+Per owner direction, Files is the reference for what "great Windows UI"
+means for pgNimbus. Adopting its language where Avalonia allows.
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Files-style command bar | Query toolbar is now a rounded card containing an accent Run (play icon) and quiet icon+label secondaries (stop/flash/gauge/table/export MDI glyphs) that are transparent at rest with Fluent's own hover wash. Disabled buttons stay quiet (dim text, no grey fill) via a container-scoped `ButtonBackgroundDisabled` resource override — the reliable per-area escape from ControlTheme repainting. Verified rest/hover/disabled in light and dark. | (this commit) |
+
 ## Open / candidate items
-- [ ] **UI north star: [Files](https://github.com/files-community/Files)** —
-      adopt its Windows design language where Avalonia allows: command-bar
-      toolbar (icon+label, transparent-until-hover), layered content tones,
-      8 px radii, compact sidebar. Mica/acrylic backdrop remains blocked on
-      safe verification (a headless sandbox can't see transparency failures).
+- [ ] More Files-language adoption: layered content tones (sidebar vs
+      content), compact left sidebar with section headers, breadcrumb-style
+      context (connection › database), segmented status bar. Mica/acrylic
+      backdrop remains blocked on safe verification (a headless sandbox
+      can't see transparency failures).
 - [ ] Keyboard navigation audit (tab order, editor ↔ grid focus, Ctrl+W
       close tab?)
 - [ ] Roadmap features (command palette, extension manager) — out of polish

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,56 @@
+# Polish & performance loop — progress log
+
+Working branch: `claude/loop-command-gjyq99`. Each entry was verified by
+building and driving the real app under Xvfb (screenshots / `pg_stat_activity`
+/ file traces), not just by code review. Newest iteration last; keep this file
+current when landing work on this branch.
+
+## Iteration 1
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Light-theme nav pill loses highlight on hover | Root-caused: FluentTheme's TabItem ControlTheme repaints `PART_LayoutRoot` from `TabItemHeaderBackground*` resources on `:pointerover`/`:pressed`, bypassing `TemplateBinding`; app-level `/template/` styles lose the precedence fight. Fixed by overriding the DynamicResource values FluentTheme paints with; stock underline pipe retired. Verified light + dark, all pointer states. | `3c68697` |
+| Unbounded memory growth on huge results | 100k-row display cap. Lives in `QueryEngine` (owns the `NpgsqlCommand`) because abandoning the reader drains the whole result set and a between-reads token cancel never reaches the backend — cap issues an explicit `command.Cancel()`. ViewModel requests cap+1 rows so an exactly-at-cap result isn't mislabeled truncated. Verified: backend goes `idle` in `pg_stat_activity`, bounded RSS, Cancel + small-result paths intact. | `c57fcea` |
+| Emoji icons render as tofu on Linux | Nav glyphs (🗄 📝 🔔) and the 🔑 primary-key marker replaced with Material Design Icons `PathIcon` geometries; they inherit `Foreground`, so accent-inside-pill and dark theme work for free. | `becf827` |
+| README "cold start under 500 ms" claim | Nobody had measured. JIT Release: ~700–720 ms launch-to-window (5 runs, 10 ms polling). NativeAOT (the intended route) crashed at startup at the time. README updated to measured figures. | `2798291` |
+
+## Iteration 2
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| 100k-row result took ~20 s to display | Engine streams 100k rows in ~0.2 s; the DataGrid burns ~200 µs/row of UI time on **any** bulk collection change (per-item Add, range Add, Reset all alike), while assigning a pre-populated `ItemsSource` costs ~10 ms (virtualization realizes only a viewport). `Rows` is now swapped wholesale: first batch immediately, accumulation off-UI, full list swapped at completion (success/cancel/cap). Also dropped per-cell `IsDBNullAsync` in the engine (~20% engine win). **21.8 s → 0.4–0.7 s.** | `f7c29bb` |
+| Wide-schema stress test | 30 schemas × 40 tables × 20 columns (1,200 tables) seeded (Sonnet subagent); lazy-loading schema tree renders instantly at every level. | — (test only) |
+| DataGrid scroll with 100k loaded rows | Ctrl+End jumps to the last row instantly; grid stays responsive. | — (test only) |
+| Notify tab polish | Accent "Start listening", green/grey status dot + "Listening on N channels" replacing `Listening: False`. Verified live: psql `NOTIFY` arrived and rendered. | `efaa123` |
+| SSH-tunnel section polish | Scrollbar no longer overlaps field edges; dialog height 680 so the SSH-expanded form fits with no scroll/clipping. | `efaa123` |
+
+## Iteration 3
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| NativeAOT publish crashed at startup | Bogus `avares://…/icon-256.png not found`. Real cause three layers down: NativeAOT bundles the DataGrid's `zh-Hans` satellite assembly into `AppDomain.GetAssemblies()`; with `InvariantGlobalization=true`, Avalonia's asset resolver calls `GetName()` on it → `CultureNotFoundException`, swallowed and re-surfaced as file-not-found. JIT never loads the satellite, hence JIT-only working. Fix: `SatelliteResourceLanguages=en`. Also replaced reflection `"[i]"` grid bindings with `RowIndexConverter` (clears IL2026/IL3050). | `af5473e` |
+| AOT verification & measurements | Published linux-x64 AOT binary: full UI, capped 100k query in 167 ms, EXPLAIN plan tree, launch-to-window **91–112 ms** (JIT ~710 ms). README + CLAUDE.md updated. | `af5473e`, `b5fb46d` |
+| Plain EXPLAIN showed "Planning:  ms" (no number) | Plain `EXPLAIN` omits Planning Time without `SUMMARY`; now requests `FORMAT JSON, SUMMARY`, and the summary line omits absent fragments. (Sonnet subagent, screenshot-verified.) | `48a01f7` |
+
+## Measurements (Linux container, 4 cores)
+
+| Metric | Before | After |
+| --- | --- | --- |
+| Capped 100k-row `SELECT *` display | 21.8 s | 0.4–0.7 s JIT / 167 ms AOT |
+| Launch-to-window (Release) | ~710 ms JIT | 91–112 ms NativeAOT |
+| Memory on unbounded 5M-row scan | unbounded growth | capped (~30 MB data + runtime) |
+| Backend after cap/cancel | kept running | `idle` (explicit backend cancel) |
+
+## Open / candidate items
+
+- [ ] Click-to-sort on result grid columns (needs `CustomSortComparer`;
+      columns have no sortable binding path by design) — in progress
+- [ ] NULL cells indistinguishable from empty strings in the grid (dim
+      "NULL" placeholder? needs care: display text feeds the inline cell
+      editor, so a converter-only approach risks writing the string "NULL")
+- [ ] Keyboard navigation audit (tab order, editor ↔ grid focus, Ctrl+W
+      close tab?)
+- [ ] Mica/acrylic backdrop — still deliberately skipped: can't safely
+      verify transparency fallbacks headlessly
+- [ ] Roadmap features (command palette, extension manager) — out of polish
+      scope


### PR DESCRIPTION
Iterative polish/performance pass, every change verified by building and driving the real app under Xvfb (screenshots, `pg_stat_activity`, file traces). Full per-iteration log with root causes and measurements in `docs/PROGRESS.md`.

## Performance

- **100k-row results: 21.8 s → 0.4–0.7 s (JIT), 167 ms (AOT).** The engine streams 100k rows in ~0.2 s; the DataGrid was burning ~200 µs/row on *any* bulk collection change while a pre-populated `ItemsSource` costs ~10 ms. `Rows` is now swapped wholesale: first batch immediately (streaming-first-screenful preserved), full list once at the end. Also removed ~500k per-cell `IsDBNullAsync` awaits per 100k×5 result.
- **Row cap (100k) with true server-side stop.** Abandoning the reader makes Npgsql drain the whole result set, and a between-reads token cancel never reaches the backend — the cap lives in `QueryEngine` and issues an explicit `command.Cancel()`. Verified: backend goes `idle`, RSS bounded, Cancel/small-result paths intact.
- **NativeAOT publish actually works now: 91–112 ms launch-to-window** (vs ~710 ms JIT). The startup crash was `CultureNotFoundException` from the DataGrid's `zh-Hans` satellite assembly under invariant globalization, surfacing as a bogus `avares://… not found`; fixed with `SatelliteResourceLanguages=en` plus converter-based grid bindings replacing reflection `"[i]"` paths (clears IL2026/IL3050). README's cold-start claim replaced with measured numbers.

## Fixes

- **Light-theme nav pill vanishing on hover** — FluentTheme's TabItem ControlTheme repaints `PART_LayoutRoot` on pointerover/pressed and outranks app-level template styles; fixed by overriding the resources it paints with.
- **Plain EXPLAIN showing "Planning:  ms"** — now requests `FORMAT JSON, SUMMARY`.

## UX (Files as the design reference, per owner)

- Vector icons (MDI `PathIcon`) replacing emoji tofu on Linux, including the primary-key marker.
- Header-click sorting on result columns (`CustomSortComparer` per column; typed comparisons, NULLs last) — needed because the AOT-safe bindings have no sort path.
- SQL NULL renders as a dimmed placeholder, distinct from `''` and from a literal `'NULL'`; cell editor is cleared of the placeholder so an untouched commit can't write the string "NULL".
- Files-style command bar (accent Run, quiet icon+label secondaries), two-tone shell (chrome base + raised content layer), title-bar `host › database` breadcrumb.
- Notify tab status dot + live-verified LISTEN/NOTIFY; connection dialog SSH-section layout fixes.

## Verification

Everything above was exercised end-to-end in a headless sandbox (Xvfb + seeded Postgres incl. a 5M-row table and a 1,200-table wide schema), in both light and dark themes; the AOT binary itself was launched and driven. `docs/PROGRESS.md` carries the before/after table and remaining candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S16mf1cmthrGPJi4yN4uev

---
_Generated by [Claude Code](https://claude.ai/code/session_01S16mf1cmthrGPJi4yN4uev)_