### PR TITLE
Files-style segmented status bar, keyboard navigation, close-tab fix

### DIFF
--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -76,6 +76,45 @@
         <Setter Property="Padding" Value="12" />
     </Style>
 
+    <!--
+        Files-style segmented status bar: a quiet strip flush along the
+        layer's bottom edge, segments divided by hairline separators.
+    -->
+    <Style Selector="Border.statusBar">
+        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderThickness" Value="0,1,0,0" />
+        <Setter Property="Padding" Value="12,6" />
+    </Style>
+    <Style Selector="TextBlock.statusText">
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="Opacity" Value="0.85" />
+    </Style>
+    <Style Selector="TextBlock.statusText.dim">
+        <Setter Property="Opacity" Value="0.6" />
+    </Style>
+    <Style Selector="TextBlock.statusText.error">
+        <Setter Property="Foreground" Value="IndianRed" />
+    </Style>
+    <!-- Fixed amber that stays legible on both light and dark surfaces -->
+    <Style Selector="TextBlock.statusText.warn">
+        <Setter Property="Foreground" Value="#D9822B" />
+        <Setter Property="Opacity" Value="1" />
+    </Style>
+    <Style Selector="Rectangle.statusSeparator">
+        <Setter Property="Width" Value="1" />
+        <Setter Property="Height" Value="12" />
+        <Setter Property="Fill" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+
+    <!-- Compact sidebar section headers (Files-style micro-headers) -->
+    <Style Selector="TextBlock.sectionHeader">
+        <Setter Property="FontSize" Value="11" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Opacity" Value="0.55" />
+        <Setter Property="LetterSpacing" Value="0.8" />
+    </Style>
+
     <!-- Buttons -->
     <Style Selector="Button">
         <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -93,15 +93,37 @@ public sealed partial class MainViewModel : ObservableObject
             return;
         }
 
+        // Decide before the removal: when the removed item is the ListBox's
+        // selection, RemoveAt makes the two-way SelectedItem binding push
+        // ActiveTab = null synchronously, so comparing afterwards misses.
+        var wasActive = ReferenceEquals(ActiveTab, tab);
+
         tab.Executed -= SavedQueries.RecordExecution;
         Tabs.RemoveAt(index);
 
-        if (ReferenceEquals(ActiveTab, tab))
+        if (wasActive || ActiveTab is null)
         {
             ActiveTab = Tabs[Math.Min(index, Tabs.Count - 1)];
         }
 
         CloseTabCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand]
+    private void NextTab() => CycleTab(+1);
+
+    [RelayCommand]
+    private void PreviousTab() => CycleTab(-1);
+
+    private void CycleTab(int direction)
+    {
+        if (Tabs.Count < 2)
+        {
+            return;
+        }
+
+        var index = Tabs.IndexOf(ActiveTab);
+        ActiveTab = Tabs[(index + direction + Tabs.Count) % Tabs.Count];
     }
 
     public async Task PreviewTableAsync(TableNode table)

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -175,7 +175,7 @@ public sealed partial class QueryViewModel : ObservableObject
                                 }
 
                                 allRows.AddRange(rows);
-                                var rowText = $"{allRows.Count:N0} rows";
+                                var rowText = RowLabel(allRows.Count);
                                 var timeText = $"{resultSet.Elapsed.TotalMilliseconds:F0} ms · first byte {firstByteMs} ms";
 
                                 if (!firstScreenShown)
@@ -210,7 +210,7 @@ public sealed partial class QueryViewModel : ObservableObject
                     }
 
                     Status = "Done";
-                    RowCountText = $"{allRows.Count:N0} rows";
+                    RowCountText = RowLabel(allRows.Count);
                     TimingText = $"{stopwatch.Elapsed.TotalMilliseconds:F0} ms · first byte {firstByteMs} ms";
                     CapText = truncated
                         ? $"capped at {MaxDisplayRows:N0} rows — refine the query for the full set"
@@ -219,7 +219,7 @@ public sealed partial class QueryViewModel : ObservableObject
 
                 case CommandResult commandResult:
                     Status = commandResult.CommandTag;
-                    RowCountText = $"{commandResult.RowsAffected} row(s) affected";
+                    RowCountText = $"{RowLabel(commandResult.RowsAffected)} affected";
                     TimingText = $"{commandResult.Elapsed.TotalMilliseconds:F0} ms";
                     break;
 
@@ -243,6 +243,8 @@ public sealed partial class QueryViewModel : ObservableObject
             _cts = null;
         }
     }
+
+    private static string RowLabel(long count) => count == 1 ? "1 row" : $"{count:N0} rows";
 
     /// <summary>Flattens the segmented status back into one line for query-history entries.</summary>
     private string StatusSummary() =>

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -33,6 +33,21 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private string _status = "Ready";
 
+    /// <summary>Paints the status-bar message red for error outcomes.</summary>
+    [ObservableProperty]
+    private bool _hasError;
+
+    // Structured status-bar segments (Files-style): each renders as its own
+    // divided segment in the bottom bar; null collapses the segment.
+    [ObservableProperty]
+    private string? _rowCountText;
+
+    [ObservableProperty]
+    private string? _timingText;
+
+    [ObservableProperty]
+    private string? _capText;
+
     [ObservableProperty]
     private bool _isRunning;
 
@@ -94,6 +109,10 @@ public sealed partial class QueryViewModel : ObservableObject
 
         IsRunning = true;
         Status = "Running...";
+        HasError = false;
+        RowCountText = null;
+        TimingText = null;
+        CapText = null;
         IsShowingPlan = false;
         ColumnNames.Clear();
         Rows = [];
@@ -156,7 +175,8 @@ public sealed partial class QueryViewModel : ObservableObject
                                 }
 
                                 allRows.AddRange(rows);
-                                var statusText = $"{allRows.Count} rows ({firstByteMs} ms to first byte, {resultSet.Elapsed.TotalMilliseconds:F0} ms elapsed)";
+                                var rowText = $"{allRows.Count:N0} rows";
+                                var timeText = $"{resultSet.Elapsed.TotalMilliseconds:F0} ms · first byte {firstByteMs} ms";
 
                                 if (!firstScreenShown)
                                 {
@@ -165,13 +185,18 @@ public sealed partial class QueryViewModel : ObservableObject
                                     await Dispatcher.UIThread.InvokeAsync(() =>
                                     {
                                         Rows = firstScreen;
-                                        Status = statusText;
+                                        RowCountText = rowText;
+                                        TimingText = timeText;
                                     });
                                 }
                                 else if (stopwatch.ElapsedMilliseconds - lastStatusMs >= 100)
                                 {
                                     lastStatusMs = stopwatch.ElapsedMilliseconds;
-                                    Dispatcher.UIThread.Post(() => Status = statusText);
+                                    Dispatcher.UIThread.Post(() =>
+                                    {
+                                        RowCountText = rowText;
+                                        TimingText = timeText;
+                                    });
                                 }
                             }
                         }, ct);
@@ -184,26 +209,32 @@ public sealed partial class QueryViewModel : ObservableObject
                         Rows = new AvaloniaList<object?[]>(allRows);
                     }
 
-                    Status = truncated
-                        ? $"Showing first {allRows.Count:N0} rows (capped at {MaxDisplayRows:N0} — refine the query for the full set) in {stopwatch.Elapsed.TotalMilliseconds:F0} ms"
-                        : $"{allRows.Count} rows in {stopwatch.Elapsed.TotalMilliseconds:F0} ms ({firstByteMs} ms to first byte)";
+                    Status = "Done";
+                    RowCountText = $"{allRows.Count:N0} rows";
+                    TimingText = $"{stopwatch.Elapsed.TotalMilliseconds:F0} ms · first byte {firstByteMs} ms";
+                    CapText = truncated
+                        ? $"capped at {MaxDisplayRows:N0} rows — refine the query for the full set"
+                        : null;
                     break;
 
                 case CommandResult commandResult:
-                    Status = $"{commandResult.CommandTag} — {commandResult.RowsAffected} row(s) affected in {commandResult.Elapsed.TotalMilliseconds:F0} ms";
+                    Status = commandResult.CommandTag;
+                    RowCountText = $"{commandResult.RowsAffected} row(s) affected";
+                    TimingText = $"{commandResult.Elapsed.TotalMilliseconds:F0} ms";
                     break;
 
                 case QueryError error:
                     Status = $"Error: {error.Message}";
+                    HasError = true;
                     break;
             }
 
-            Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, Status));
+            Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, StatusSummary()));
         }
         catch (OperationCanceledException)
         {
             Status = "Cancelled";
-            Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, Status));
+            Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, StatusSummary()));
         }
         finally
         {
@@ -212,6 +243,10 @@ public sealed partial class QueryViewModel : ObservableObject
             _cts = null;
         }
     }
+
+    /// <summary>Flattens the segmented status back into one line for query-history entries.</summary>
+    private string StatusSummary() =>
+        string.Join(" · ", new[] { Status, RowCountText, TimingText, CapText }.Where(s => !string.IsNullOrEmpty(s)));
 
     private bool CanCancel() => IsRunning;
 
@@ -234,6 +269,7 @@ public sealed partial class QueryViewModel : ObservableObject
     {
         IsRunning = true;
         Status = analyze ? "Running EXPLAIN ANALYZE..." : "Running EXPLAIN...";
+        HasError = false;
 
         try
         {
@@ -248,10 +284,12 @@ public sealed partial class QueryViewModel : ObservableObject
         catch (PostgresException ex)
         {
             Status = $"Explain failed: {ex.MessageText}";
+            HasError = true;
         }
         catch (Exception ex)
         {
             Status = $"Explain failed: {ex.Message}";
+            HasError = true;
         }
         finally
         {
@@ -286,6 +324,8 @@ public sealed partial class QueryViewModel : ObservableObject
     /// </summary>
     public async Task CommitCellEditAsync(object?[] row, int columnIndex, string newValueText)
     {
+        HasError = false;
+
         if (EditContext is not { } context)
         {
             Status = "Editing isn't available for this result set.";
@@ -325,6 +365,7 @@ public sealed partial class QueryViewModel : ObservableObject
         catch (Exception ex)
         {
             Status = $"Invalid value for {columnName}: {ex.Message}";
+            HasError = true;
             return;
         }
 
@@ -351,6 +392,7 @@ public sealed partial class QueryViewModel : ObservableObject
         catch (Exception ex)
         {
             Status = $"Update failed: {ex.Message}";
+            HasError = true;
         }
     }
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -115,7 +115,7 @@
                     </StackPanel>
                 </TabItem.Header>
                 <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0" x:DataType="vm:SavedQueriesViewModel" DataContext="{Binding SavedQueries}">
-                    <TextBlock Grid.Row="0" Text="Saved queries" FontWeight="SemiBold" Margin="4,0,4,6" />
+                    <TextBlock Grid.Row="0" Classes="sectionHeader" Text="SAVED QUERIES" Margin="4,0,4,6" />
                     <Border Grid.Row="1" Classes="card" MinHeight="80">
                         <ListBox Name="SavedQueriesList" ItemsSource="{Binding SavedQueries}">
                             <ListBox.ItemTemplate>
@@ -131,7 +131,7 @@
                         <Button Content="Load" Command="{Binding LoadSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}" />
                         <Button Content="Delete" Command="{Binding DeleteSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}" />
                     </StackPanel>
-                    <TextBlock Grid.Row="4" Text="History" FontWeight="SemiBold" Margin="4,16,4,6" />
+                    <TextBlock Grid.Row="4" Classes="sectionHeader" Text="HISTORY" Margin="4,16,4,6" />
                     <Border Grid.Row="5" Classes="card" MinHeight="80">
                         <ListBox Name="HistoryList" ItemsSource="{Binding History}">
                             <ListBox.ItemTemplate>
@@ -158,7 +158,7 @@
                     </StackPanel>
                 </TabItem.Header>
                 <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0" x:DataType="vm:NotifyMonitorViewModel" DataContext="{Binding NotifyMonitor}">
-                    <TextBlock Grid.Row="0" Text="Channels" FontWeight="SemiBold" Margin="4,0,4,6" />
+                    <TextBlock Grid.Row="0" Classes="sectionHeader" Text="CHANNELS" Margin="4,0,4,6" />
                     <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="6">
                         <TextBox Text="{Binding ChannelName}" PlaceholderText="Channel name" Width="140" />
                         <Button Content="Add" Command="{Binding AddChannelCommand}" />
@@ -189,7 +189,7 @@
                                    IsVisible="{Binding ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
                     </StackPanel>
                     <Grid Grid.Row="5" RowDefinitions="Auto,*" Margin="0,8,0,0">
-                        <TextBlock Grid.Row="0" Text="Notifications" FontWeight="SemiBold" Margin="4,0,4,6" />
+                        <TextBlock Grid.Row="0" Classes="sectionHeader" Text="NOTIFICATIONS" Margin="4,0,4,6" />
                         <Border Grid.Row="1" Classes="card" MinHeight="80">
                             <ListBox ItemsSource="{Binding Notifications}">
                                 <ListBox.ItemTemplate>
@@ -213,8 +213,10 @@
 
         <GridSplitter Grid.Column="1" Width="12" Background="Transparent" />
 
-        <Border Grid.Column="2" Classes="layer">
-        <Grid RowDefinitions="Auto,Auto,*,*,Auto">
+        <!-- Padding moves to the inner grid so the status bar can run flush along the layer's bottom edge -->
+        <Border Grid.Column="2" Classes="layer" Padding="0">
+        <Grid RowDefinitions="*,Auto">
+        <Grid Grid.Row="0" Margin="12,12,12,0" RowDefinitions="Auto,Auto,*,*">
 
             <DockPanel Grid.Row="0" Margin="0,0,0,8">
                 <Button DockPanel.Dock="Right" Classes="chip" Content="+" FontSize="14" Command="{Binding AddTabCommand}" ToolTip.Tip="New query tab" />
@@ -334,8 +336,30 @@
                 </Grid>
             </Border>
 
-            <Border Grid.Row="4" Padding="4,0">
-                <TextBlock Text="{Binding ActiveTab.Status}" Opacity="0.8" FontSize="12" />
+        </Grid>
+
+            <!-- Files-style segmented status bar: message · rows · timing · cap warning -->
+            <Border Grid.Row="1" Classes="statusBar">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <TextBlock Text="{Binding ActiveTab.Status}"
+                               Classes="statusText" Classes.error="{Binding ActiveTab.HasError}"
+                               TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
+                    <StackPanel Orientation="Horizontal" Spacing="10"
+                                IsVisible="{Binding ActiveTab.RowCountText, Converter={x:Static conv:ObjectConverters.IsNotNull}}">
+                        <Rectangle Classes="statusSeparator" />
+                        <TextBlock Classes="statusText dim" Text="{Binding ActiveTab.RowCountText}" VerticalAlignment="Center" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="10"
+                                IsVisible="{Binding ActiveTab.TimingText, Converter={x:Static conv:ObjectConverters.IsNotNull}}">
+                        <Rectangle Classes="statusSeparator" />
+                        <TextBlock Classes="statusText dim" Text="{Binding ActiveTab.TimingText}" VerticalAlignment="Center" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="10"
+                                IsVisible="{Binding ActiveTab.CapText, Converter={x:Static conv:ObjectConverters.IsNotNull}}">
+                        <Rectangle Classes="statusSeparator" />
+                        <TextBlock Classes="statusText warn" Text="{Binding ActiveTab.CapText}" VerticalAlignment="Center" />
+                    </StackPanel>
+                </StackPanel>
             </Border>
 
         </Grid>

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -55,7 +55,13 @@
 
     <Window.KeyBindings>
         <KeyBinding Gesture="Ctrl+Enter" Command="{Binding ActiveTab.RunCommand}" />
+        <KeyBinding Gesture="F5" Command="{Binding ActiveTab.RunCommand}" />
         <KeyBinding Gesture="Escape" Command="{Binding ActiveTab.CancelCommand}" />
+        <KeyBinding Gesture="Ctrl+T" Command="{Binding AddTabCommand}" />
+        <!-- No parameter: CloseTab falls back to the active tab -->
+        <KeyBinding Gesture="Ctrl+W" Command="{Binding CloseTabCommand}" />
+        <KeyBinding Gesture="Ctrl+PageDown" Command="{Binding NextTabCommand}" />
+        <KeyBinding Gesture="Ctrl+PageUp" Command="{Binding PreviousTabCommand}" />
     </Window.KeyBindings>
 
     <!-- Two-tone shell (Files-style): chrome-tinted base; the content pane is a raised layer -->

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -56,6 +56,29 @@ public partial class MainWindow : Window
         };
     }
 
+    // F6 hops focus between the SQL editor and the results grid (the two
+    // keyboard workspaces). Done in code because the target depends on where
+    // focus currently is - a KeyBinding can't express a toggle.
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.F6 && e.KeyModifiers == KeyModifiers.None)
+        {
+            if (SqlEditor.IsKeyboardFocusWithin)
+            {
+                ResultsGrid.Focus();
+            }
+            else
+            {
+                SqlEditor.TextArea.Focus();
+            }
+
+            e.Handled = true;
+            return;
+        }
+
+        base.OnKeyDown(e);
+    }
+
     private void Attach(MainViewModel vm)
     {
         if (_viewModel is not null)
@@ -71,7 +94,9 @@ public partial class MainWindow : Window
 
     private void OnMainViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(MainViewModel.ActiveTab) && _viewModel is not null)
+        // ActiveTab is transiently null while the tab ListBox reacts to the
+        // removal of its selected item (see MainViewModel.CloseTab).
+        if (e.PropertyName == nameof(MainViewModel.ActiveTab) && _viewModel is { ActiveTab: not null })
         {
             AttachQuery(_viewModel.ActiveTab);
         }

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -83,10 +83,16 @@ means for pgNimbus. Adopting its language where Avalonia allows.
 | Compact sidebar section headers | SAVED QUERIES / HISTORY / CHANNELS / NOTIFICATIONS as Files-style micro-headers: 11 px semibold, 0.55 opacity, letter-spaced uppercase (`TextBlock.sectionHeader`). Verified both themes. | (this commit) |
 | AOT re-check | New compiled bindings only; publish clean (known DataGrid warnings), AOT binary runs the new status bar (500 rows in 31 ms, first byte 4 ms). | (this commit) |
 
+## Iteration 10
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Keyboard navigation | New shortcuts alongside Ctrl+Enter/Escape: **F5** run (DB-tool convention), **Ctrl+T** new tab, **Ctrl+W** close tab (parameterless → active tab), **Ctrl+PageDown/PageUp** cycle tabs (`NextTab`/`PreviousTab` on `MainViewModel`), **F6** hops focus editor ↔ results grid (code-behind — the target depends on where focus is). All exercised via xdotool from editor focus; AOT publish + shortcut smoke re-checked. | (this commit) |
+| Close-tab selection bug (pre-existing, ✕ button too) | Closing the active tab left no tab selected and the editor/grid showing the dead tab's content: `Tabs.RemoveAt` makes the two-way-bound tab ListBox push `SelectedItem = null` into `ActiveTab` synchronously, so `CloseTab`'s "was it active" check compared against null (and the swallowed NRE in `AttachQuery` hid it). Fixed by deciding before the removal + guarding the transient null in the view. Verified: close via Ctrl+W lands on the neighbor tab, pill highlighted, its own SQL/results restored. | (this commit) |
+| Status-bar pluralization | "1 rows" → "1 row"; "N row(s) affected" → real singular/plural. | (this commit) |
+
 ## Open / candidate items
 - [ ] Mica/acrylic backdrop remains blocked on safe verification (a headless
       sandbox can't see transparency failures).
-- [ ] Keyboard navigation audit (tab order, editor ↔ grid focus, Ctrl+W
-      close tab?)
 - [ ] Roadmap features (command palette, extension manager) — out of polish
       scope

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -75,10 +75,17 @@ means for pgNimbus. Adopting its language where Avalonia allows.
 | --- | --- | --- |
 | Title-bar connection breadcrumb | Files-style context in the chrome: "pgNimbus  host › database", parsed from the connection string (`NpgsqlConnectionStringBuilder`) and exposed as `ConnectionHost`/`ConnectionDatabase` on `MainViewModel`. Quiet 65 %-opacity text next to the accent environment dot. | (this commit) |
 
+## Iteration 9
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Files-style segmented status bar | The single concatenated `Status` string became structured segments — message · row count · timing · amber cap warning — divided by hairline separators in a strip flush along the layer's bottom edge (layer padding moved inward so the bar and its top hairline run edge-to-edge). New `RowCountText`/`TimingText`/`CapText`/`HasError` observables on `QueryViewModel`; streaming ticks update the row/timing segments while the message stays "Running..."; errors paint the message IndianRed; history entries get the segments flattened back into one line (`StatusSummary`). Verified live: success, 100k cap (backend `idle` after, 415 ms JIT / capped display intact), error, both themes. | (this commit) |
+| Compact sidebar section headers | SAVED QUERIES / HISTORY / CHANNELS / NOTIFICATIONS as Files-style micro-headers: 11 px semibold, 0.55 opacity, letter-spaced uppercase (`TextBlock.sectionHeader`). Verified both themes. | (this commit) |
+| AOT re-check | New compiled bindings only; publish clean (known DataGrid warnings), AOT binary runs the new status bar (500 rows in 31 ms, first byte 4 ms). | (this commit) |
+
 ## Open / candidate items
-- [ ] More Files-language adoption: compact sidebar section headers,
-      segmented status bar. Mica/acrylic backdrop remains blocked on safe
-      verification (a headless sandbox can't see transparency failures).
+- [ ] Mica/acrylic backdrop remains blocked on safe verification (a headless
+      sandbox can't see transparency failures).
 - [ ] Keyboard navigation audit (tab order, editor ↔ grid focus, Ctrl+W
       close tab?)
 - [ ] Roadmap features (command palette, extension manager) — out of polish


### PR DESCRIPTION
Continues the Files-community UI polish arc (see `docs/PROGRESS.md`, iterations 9–10).

## Segmented status bar
The bottom status line was one concatenated string; it's now Files-style structured segments — **message · row count · timing · amber cap warning** — divided by hairline separators, in a strip that runs flush along the content layer's bottom edge. `QueryViewModel` exposes `RowCountText`/`TimingText`/`CapText` plus `HasError` (paints the message red); streaming ticks update the row/timing segments while the message stays "Running…", and history entries flatten the segments back into one summary line. Proper singular/plural ("1 row", "3 rows affected").

## Compact sidebar section headers
SAVED QUERIES / HISTORY / CHANNELS / NOTIFICATIONS become 11 px letter-spaced micro-headers (`TextBlock.sectionHeader`).

## Keyboard navigation
Alongside the existing Ctrl+Enter/Escape: **F5** run, **Ctrl+T** new tab, **Ctrl+W** close active tab, **Ctrl+PageDown/PageUp** cycle tabs, **F6** hops focus editor ↔ results grid.

## Bug fix: closing the active tab lost selection (pre-existing, ✕ button too)
`Tabs.RemoveAt` makes the two-way-bound tab ListBox push `SelectedItem = null` into `ActiveTab` synchronously, so `CloseTab`'s "was the closed tab active" check ran against null and the shared editor/grid kept showing the dead tab's content (the resulting NRE in `AttachQuery` was swallowed by the binding layer). The check now happens before the removal and the view guards the transient null.

## Verification
Everything driven live under Xvfb (xdotool) against seeded Postgres, in both themes: success / 100k-cap (backend `idle` after server-side cancel, capped display time intact at ~415 ms JIT) / error paths, every shortcut, and the close-tab repro before and after the fix. NativeAOT publish + launch re-checked after each binding change (500 rows in 31 ms, first byte 4 ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z99AzDaPnJZKJp2o49sLx

---
_Generated by [Claude Code](https://claude.ai/code/session_019z99AzDaPnJZKJp2o49sLx)_