### PR TITLE
Theme-aware PostgreSQL syntax highlighting in the query editor

### DIFF
--- a/PgNimbus.App/Assets/PostgreSql.xshd
+++ b/PgNimbus.App/Assets/PostgreSql.xshd
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    PostgreSQL syntax highlighting for the query editor. The foreground
+    values baked in here are the dark-theme palette; MainWindow recolors
+    the named colors at runtime for the light theme (and back), so keep
+    the color names in sync with ApplySqlHighlightingTheme.
+-->
+<SyntaxDefinition name="PostgreSQL" extensions=".sql" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
+    <Color name="Comment" foreground="#6A9955" />
+    <Color name="String" foreground="#CE9178" />
+    <Color name="Number" foreground="#B5CEA8" />
+    <Color name="Keyword" foreground="#569CD6" fontWeight="bold" />
+    <Color name="Type" foreground="#4EC9B0" />
+
+    <RuleSet ignoreCase="true">
+        <Span color="Comment" begin="--" />
+        <Span color="Comment" multiline="true" begin="/\*" end="\*/" />
+        <Span color="String" begin="'" end="'" />
+
+        <Keywords color="Keyword">
+            <Word>SELECT</Word>
+            <Word>INSERT</Word>
+            <Word>UPDATE</Word>
+            <Word>DELETE</Word>
+            <Word>TRUNCATE</Word>
+            <Word>FROM</Word>
+            <Word>WHERE</Word>
+            <Word>JOIN</Word>
+            <Word>INNER</Word>
+            <Word>LEFT</Word>
+            <Word>RIGHT</Word>
+            <Word>FULL</Word>
+            <Word>OUTER</Word>
+            <Word>CROSS</Word>
+            <Word>LATERAL</Word>
+            <Word>ON</Word>
+            <Word>USING</Word>
+            <Word>GROUP</Word>
+            <Word>BY</Word>
+            <Word>ORDER</Word>
+            <Word>HAVING</Word>
+            <Word>LIMIT</Word>
+            <Word>OFFSET</Word>
+            <Word>AS</Word>
+            <Word>AND</Word>
+            <Word>OR</Word>
+            <Word>NOT</Word>
+            <Word>IN</Word>
+            <Word>IS</Word>
+            <Word>NULL</Word>
+            <Word>DISTINCT</Word>
+            <Word>UNION</Word>
+            <Word>ALL</Word>
+            <Word>EXCEPT</Word>
+            <Word>INTERSECT</Word>
+            <Word>CASE</Word>
+            <Word>WHEN</Word>
+            <Word>THEN</Word>
+            <Word>ELSE</Word>
+            <Word>END</Word>
+            <Word>BETWEEN</Word>
+            <Word>LIKE</Word>
+            <Word>ILIKE</Word>
+            <Word>SIMILAR</Word>
+            <Word>EXISTS</Word>
+            <Word>ANY</Word>
+            <Word>SOME</Word>
+            <Word>CREATE</Word>
+            <Word>ALTER</Word>
+            <Word>DROP</Word>
+            <Word>TABLE</Word>
+            <Word>VIEW</Word>
+            <Word>MATERIALIZED</Word>
+            <Word>INDEX</Word>
+            <Word>SCHEMA</Word>
+            <Word>DATABASE</Word>
+            <Word>SEQUENCE</Word>
+            <Word>FUNCTION</Word>
+            <Word>PROCEDURE</Word>
+            <Word>TRIGGER</Word>
+            <Word>EXTENSION</Word>
+            <Word>PRIMARY</Word>
+            <Word>FOREIGN</Word>
+            <Word>KEY</Word>
+            <Word>REFERENCES</Word>
+            <Word>UNIQUE</Word>
+            <Word>CHECK</Word>
+            <Word>DEFAULT</Word>
+            <Word>CONSTRAINT</Word>
+            <Word>INTO</Word>
+            <Word>VALUES</Word>
+            <Word>SET</Word>
+            <Word>RETURNING</Word>
+            <Word>WITH</Word>
+            <Word>RECURSIVE</Word>
+            <Word>ASC</Word>
+            <Word>DESC</Word>
+            <Word>NULLS</Word>
+            <Word>FIRST</Word>
+            <Word>LAST</Word>
+            <Word>TRUE</Word>
+            <Word>FALSE</Word>
+            <Word>BEGIN</Word>
+            <Word>COMMIT</Word>
+            <Word>ROLLBACK</Word>
+            <Word>TRANSACTION</Word>
+            <Word>SAVEPOINT</Word>
+            <Word>EXPLAIN</Word>
+            <Word>ANALYZE</Word>
+            <Word>VERBOSE</Word>
+            <Word>VACUUM</Word>
+            <Word>REINDEX</Word>
+            <Word>CLUSTER</Word>
+            <Word>GRANT</Word>
+            <Word>REVOKE</Word>
+            <Word>CAST</Word>
+            <Word>COALESCE</Word>
+            <Word>NULLIF</Word>
+            <Word>GREATEST</Word>
+            <Word>LEAST</Word>
+            <Word>EXTRACT</Word>
+            <Word>ADD</Word>
+            <Word>COLUMN</Word>
+            <Word>RENAME</Word>
+            <Word>TO</Word>
+            <Word>OWNER</Word>
+            <Word>IF</Word>
+            <Word>CASCADE</Word>
+            <Word>RESTRICT</Word>
+            <Word>LISTEN</Word>
+            <Word>NOTIFY</Word>
+            <Word>UNLISTEN</Word>
+            <Word>PARTITION</Word>
+            <Word>OVER</Word>
+            <Word>WINDOW</Word>
+            <Word>FILTER</Word>
+            <Word>RETURNS</Word>
+            <Word>LANGUAGE</Word>
+            <Word>DECLARE</Word>
+            <Word>CURSOR</Word>
+            <Word>FETCH</Word>
+            <Word>TEMP</Word>
+            <Word>TEMPORARY</Word>
+            <Word>UNLOGGED</Word>
+            <Word>CONCURRENTLY</Word>
+            <Word>ONLY</Word>
+            <Word>CONFLICT</Word>
+            <Word>DO</Word>
+            <Word>NOTHING</Word>
+        </Keywords>
+
+        <Keywords color="Type">
+            <Word>SMALLINT</Word>
+            <Word>INT</Word>
+            <Word>INTEGER</Word>
+            <Word>BIGINT</Word>
+            <Word>DECIMAL</Word>
+            <Word>NUMERIC</Word>
+            <Word>REAL</Word>
+            <Word>DOUBLE</Word>
+            <Word>PRECISION</Word>
+            <Word>SMALLSERIAL</Word>
+            <Word>SERIAL</Word>
+            <Word>BIGSERIAL</Word>
+            <Word>MONEY</Word>
+            <Word>TEXT</Word>
+            <Word>VARCHAR</Word>
+            <Word>CHAR</Word>
+            <Word>CHARACTER</Word>
+            <Word>VARYING</Word>
+            <Word>BYTEA</Word>
+            <Word>TIMESTAMP</Word>
+            <Word>TIMESTAMPTZ</Word>
+            <Word>DATE</Word>
+            <Word>TIME</Word>
+            <Word>TIMETZ</Word>
+            <Word>INTERVAL</Word>
+            <Word>BOOLEAN</Word>
+            <Word>BOOL</Word>
+            <Word>INET</Word>
+            <Word>CIDR</Word>
+            <Word>MACADDR</Word>
+            <Word>UUID</Word>
+            <Word>XML</Word>
+            <Word>JSON</Word>
+            <Word>JSONB</Word>
+            <Word>ARRAY</Word>
+            <Word>TSVECTOR</Word>
+            <Word>TSQUERY</Word>
+            <Word>REGCLASS</Word>
+            <Word>OID</Word>
+        </Keywords>
+
+        <Rule color="Number">\b\d+(\.\d+)?\b</Rule>
+    </RuleSet>
+</SyntaxDefinition>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1,13 +1,19 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Xml;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Media;
+using Avalonia.Platform;
 using Avalonia.Platform.Storage;
+using Avalonia.Styling;
 using Avalonia.VisualTree;
 using AvaloniaEdit.CodeCompletion;
+using AvaloniaEdit.Highlighting;
+using AvaloniaEdit.Highlighting.Xshd;
 using PgNimbus.App.ViewModels;
 
 namespace PgNimbus.App.Views;
@@ -21,10 +27,17 @@ public partial class MainWindow : Window
     private int _pendingEditColumnIndex;
     private string? _pendingEditText;
     private CompletionWindow? _completionWindow;
+    private IHighlightingDefinition? _sqlHighlighting;
 
     public MainWindow()
     {
         InitializeComponent();
+
+        LoadSqlHighlighting();
+        // ActualThemeVariant isn't final at construction time - re-resolve the
+        // palette once the window opens, and again on any live theme switch.
+        Opened += (_, _) => ApplySqlHighlightingTheme();
+        ActualThemeVariantChanged += (_, _) => ApplySqlHighlightingTheme();
 
         SqlEditor.TextChanged += (_, _) =>
         {
@@ -54,6 +67,45 @@ public partial class MainWindow : Window
                 Attach(vm);
             }
         };
+    }
+
+    private void LoadSqlHighlighting()
+    {
+        using var stream = AssetLoader.Open(new Uri("avares://PgNimbus.App/Assets/PostgreSql.xshd"));
+        using var reader = XmlReader.Create(stream);
+        _sqlHighlighting = HighlightingLoader.Load(reader, HighlightingManager.Instance);
+        ApplySqlHighlightingTheme();
+    }
+
+    // The XSHD bakes in the dark palette; the highlighter has no theme
+    // awareness of its own, so the named colors are rewritten whenever the
+    // actual theme variant resolves or changes.
+    private void ApplySqlHighlightingTheme()
+    {
+        if (_sqlHighlighting is null)
+        {
+            return;
+        }
+
+        var dark = ActualThemeVariant == ThemeVariant.Dark;
+        SetHighlightColor("Comment", dark ? "#6A9955" : "#008000");
+        SetHighlightColor("String", dark ? "#CE9178" : "#A31515");
+        SetHighlightColor("Number", dark ? "#B5CEA8" : "#098658");
+        SetHighlightColor("Keyword", dark ? "#569CD6" : "#0000E0");
+        SetHighlightColor("Type", dark ? "#4EC9B0" : "#267F99");
+
+        // Reassigning is what makes the TextView drop its cached line
+        // visuals and re-run the highlighter with the new brushes.
+        SqlEditor.SyntaxHighlighting = null;
+        SqlEditor.SyntaxHighlighting = _sqlHighlighting;
+    }
+
+    private void SetHighlightColor(string name, string hex)
+    {
+        if (_sqlHighlighting!.GetNamedColor(name) is { } color)
+        {
+            color.Foreground = new SimpleHighlightingBrush(Color.Parse(hex));
+        }
     }
 
     // F6 hops focus between the SQL editor and the results grid (the two

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -91,7 +91,14 @@ means for pgNimbus. Adopting its language where Avalonia allows.
 | Close-tab selection bug (pre-existing, ✕ button too) | Closing the active tab left no tab selected and the editor/grid showing the dead tab's content: `Tabs.RemoveAt` makes the two-way-bound tab ListBox push `SelectedItem = null` into `ActiveTab` synchronously, so `CloseTab`'s "was it active" check compared against null (and the swallowed NRE in `AttachQuery` hid it). Fixed by deciding before the removal + guarding the transient null in the view. Verified: close via Ctrl+W lands on the neighbor tab, pill highlighted, its own SQL/results restored. | (this commit) |
 | Status-bar pluralization | "1 rows" → "1 row"; "N row(s) affected" → real singular/plural. | (this commit) |
 
+## Iteration 11
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| No SQL syntax highlighting (every query rendered plain) | Custom PostgreSQL XSHD (`Assets/PostgreSql.xshd`: keywords, types, strings, `--`/`/* */` comments, numbers; `ignoreCase`) loaded through AvaloniaEdit's `HighlightingLoader`. The highlighter has no theme awareness, so `MainWindow` rewrites the named colors on `Opened`/`ActualThemeVariantChanged` — VS-dark palette (#569CD6 keywords etc.) vs. saturated light palette — and reassigns `SyntaxHighlighting` to drop cached line visuals. Verified in both themes and under NativeAOT (the `AssetLoader.Open` path is the historical AOT landmine — publish + launch re-checked, highlighting renders). xdotool note: typed text gets garbled by the completion popup; paste via `xclip`/Ctrl+V for clean editor screenshots. | (this commit) |
+
 ## Open / candidate items
+- [ ] Schema-tree filter box (Files-style search; valuable with 30+ schemas)
 - [ ] Mica/acrylic backdrop remains blocked on safe verification (a headless
       sandbox can't see transparency failures).
 - [ ] Roadmap features (command palette, extension manager) — out of polish


### PR DESCRIPTION
Continues the polish loop (see `docs/PROGRESS.md`, iteration 11).

## What

Queries rendered as plain text — the most visible gap for a SQL tool. A custom PostgreSQL XSHD definition (`Assets/PostgreSql.xshd`: keywords, types, single-quoted strings, `--` and `/* */` comments, numbers, case-insensitive) now drives AvaloniaEdit's highlighter.

The highlighter has no theme awareness of its own, so `MainWindow` rewrites the definition's named colors whenever the actual theme variant resolves or changes — a VS-dark palette (light-blue keywords, green comments, salmon strings) on dark, a saturated palette on light — and reassigns `SyntaxHighlighting` so the TextView drops its cached line visuals and re-renders.

## Verification

Driven live under Xvfb in both themes (query pasted via clipboard, run with F5, results confirmed). NativeAOT publish + launch re-checked — the `AssetLoader.Open` path is the historical AOT landmine, and highlighting renders correctly in the AOT binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z99AzDaPnJZKJp2o49sLx

---
_Generated by [Claude Code](https://claude.ai/code/session_019z99AzDaPnJZKJp2o49sLx)_