### PR TITLE
Add empty-state hints for results, saved queries, and history

### DIFF
--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -68,6 +68,13 @@ public sealed partial class QueryViewModel : ObservableObject
 
     public bool IsEditable => EditContext is { PrimaryKeyColumns.Count: > 0 };
 
+    /// <summary>
+    /// True when the results grid has nothing to show and isn't mid-run or displaying a plan — drives the
+    /// empty-state hint ("Run a query"). Recomputed from the <see cref="Rows"/>, <see cref="IsShowingPlan"/>,
+    /// and <see cref="IsRunning"/> change hooks.
+    /// </summary>
+    public bool HasNoResults => Rows.Count == 0 && !IsShowingPlan && !IsRunning;
+
     /// <summary>Single-root wrapper so the plan tree's TreeView can bind an IEnumerable ItemsSource to one node.</summary>
     public IReadOnlyList<ExplainNodeViewModel> ExplainRoots => ExplainRoot is null ? [] : [ExplainRoot];
 
@@ -305,7 +312,12 @@ public sealed partial class QueryViewModel : ObservableObject
         CancelCommand.NotifyCanExecuteChanged();
         ExplainCommand.NotifyCanExecuteChanged();
         ExplainAnalyzeCommand.NotifyCanExecuteChanged();
+        OnPropertyChanged(nameof(HasNoResults));
     }
+
+    partial void OnRowsChanged(AvaloniaList<object?[]> value) => OnPropertyChanged(nameof(HasNoResults));
+
+    partial void OnIsShowingPlanChanged(bool value) => OnPropertyChanged(nameof(HasNoResults));
 
     partial void OnSqlChanged(string value)
     {

--- a/PgNimbus.App/ViewModels/SavedQueriesViewModel.cs
+++ b/PgNimbus.App/ViewModels/SavedQueriesViewModel.cs
@@ -25,6 +25,12 @@ public sealed partial class SavedQueriesViewModel : ObservableObject
 
     public ObservableCollection<QueryHistoryEntry> History { get; } = [];
 
+    /// <summary>Drives the empty-state hint under an empty saved-queries list.</summary>
+    public bool HasNoSavedQueries => SavedQueries.Count == 0;
+
+    /// <summary>Drives the empty-state hint under an empty history list.</summary>
+    public bool HasNoHistory => History.Count == 0;
+
     public SavedQueriesViewModel(SavedQueryStore savedQueryStore, QueryHistoryStore historyStore, Func<QueryViewModel?> getActiveQuery)
     {
         _savedQueryStore = savedQueryStore;
@@ -40,6 +46,9 @@ public sealed partial class SavedQueriesViewModel : ObservableObject
         {
             History.Add(entry);
         }
+
+        SavedQueries.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasNoSavedQueries));
+        History.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasNoHistory));
     }
 
     public void RecordExecution(QueryHistoryEntry entry)

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -149,13 +149,19 @@
                 <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0" x:DataType="vm:SavedQueriesViewModel" DataContext="{Binding SavedQueries}">
                     <TextBlock Grid.Row="0" Classes="sectionHeader" Text="SAVED QUERIES" Margin="4,0,4,6" />
                     <Border Grid.Row="1" Classes="card" MinHeight="80">
-                        <ListBox Name="SavedQueriesList" ItemsSource="{Binding SavedQueries}">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate x:DataType="query:SavedQuery">
-                                    <TextBlock Text="{Binding Name}" ToolTip.Tip="{Binding Sql}" />
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
+                        <Grid>
+                            <ListBox Name="SavedQueriesList" ItemsSource="{Binding SavedQueries}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate x:DataType="query:SavedQuery">
+                                        <TextBlock Text="{Binding Name}" ToolTip.Tip="{Binding Sql}" />
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                            <TextBlock IsVisible="{Binding HasNoSavedQueries}" IsHitTestVisible="False"
+                                       Text="Name a query above and Save to keep it here"
+                                       TextWrapping="Wrap" TextAlignment="Center" Opacity="0.4" FontSize="12"
+                                       Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Grid>
                     </Border>
                     <TextBox Grid.Row="2" Name="NewQueryNameBox" Text="{Binding NewQueryName}" PlaceholderText="Query name" Margin="0,8,0,0" />
                     <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
@@ -165,16 +171,22 @@
                     </StackPanel>
                     <TextBlock Grid.Row="4" Classes="sectionHeader" Text="HISTORY" Margin="4,16,4,6" />
                     <Border Grid.Row="5" Classes="card" MinHeight="80">
-                        <ListBox Name="HistoryList" ItemsSource="{Binding History}">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate x:DataType="query:QueryHistoryEntry">
-                                    <StackPanel>
-                                        <TextBlock Text="{Binding Sql}" TextTrimming="CharacterEllipsis" MaxLines="2" TextWrapping="Wrap" FontSize="12" />
-                                        <TextBlock Text="{Binding ExecutedAt}" Opacity="0.6" FontSize="10" />
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
+                        <Grid>
+                            <ListBox Name="HistoryList" ItemsSource="{Binding History}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate x:DataType="query:QueryHistoryEntry">
+                                        <StackPanel>
+                                            <TextBlock Text="{Binding Sql}" TextTrimming="CharacterEllipsis" MaxLines="2" TextWrapping="Wrap" FontSize="12" />
+                                            <TextBlock Text="{Binding ExecutedAt}" Opacity="0.6" FontSize="10" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                            <TextBlock IsVisible="{Binding HasNoHistory}" IsHitTestVisible="False"
+                                       Text="Queries you run will appear here"
+                                       TextWrapping="Wrap" TextAlignment="Center" Opacity="0.4" FontSize="12"
+                                       Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        </Grid>
                     </Border>
                     <StackPanel Grid.Row="6" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
                         <Button Content="Load selected" Command="{Binding LoadHistoryEntryCommand}" CommandParameter="{Binding #HistoryList.SelectedItem}" />
@@ -344,6 +356,18 @@
                               CanUserReorderColumns="False"
                               CanUserSortColumns="True"
                               AutoGenerateColumns="False" />
+                    <!-- Empty state: a friendly hint instead of a bare grid before any query has run -->
+                    <StackPanel IsVisible="{Binding ActiveTab.HasNoResults}"
+                                HorizontalAlignment="Center" VerticalAlignment="Center"
+                                Spacing="10" IsHitTestVisible="False">
+                        <PathIcon Data="{StaticResource TableIconGeometry}" Width="34" Height="34"
+                                  Opacity="0.28" HorizontalAlignment="Center" />
+                        <TextBlock Text="No results yet" FontSize="14" FontWeight="SemiBold"
+                                   Opacity="0.6" HorizontalAlignment="Center" />
+                        <TextBlock Opacity="0.45" FontSize="12" HorizontalAlignment="Center">
+                            Run a query with <Run FontWeight="SemiBold">Ctrl+Enter</Run> or <Run FontWeight="SemiBold">F5</Run>
+                        </TextBlock>
+                    </StackPanel>
                     <Grid RowDefinitions="Auto,*" IsVisible="{Binding ActiveTab.IsShowingPlan}">
                         <TextBlock Grid.Row="0" Text="{Binding ActiveTab.ExplainSummary}" Margin="4" FontSize="12" Opacity="0.8" />
                         <ScrollViewer Grid.Row="1">

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ bar (the Files community app remains the visual north star):
 - [ ] **Running-query feedback** — an indeterminate progress bar in the
   status bar and a live elapsed-time tick while a query runs (the row/timing
   segments only update per batch today).
-- [ ] **Empty states** — friendly hints in the blank results area ("Run a
-  query — Ctrl+Enter") and empty saved-queries/history lists instead of bare
-  cards.
+- [x] **Empty states** — friendly hints in the blank results area ("No results
+  yet — run a query with Ctrl+Enter or F5") and in empty saved-queries/history
+  lists instead of bare cards.
 - [ ] **Mica/acrylic backdrop on Windows** — the two-tone shell is ready for
   it; deliberately deferred until it can be verified on a real Windows
   desktop (transparency fallbacks can't be seen headless).
@@ -245,7 +245,8 @@ bar (the Files community app remains the visual north star):
   (initially: custom result visualizers).
 - [ ] **Localization** — externalize UI strings; ship Russian and German first.
 
-Recently shipped: the in-app light/dark theme toggle, the schema-tree filter
+Recently shipped: empty-state hints, the in-app light/dark theme toggle, the
+schema-tree filter
 box, paste-anything connection
 string parsing (URI / JDBC /
 ADO.NET / libpq / psql), the F1 shortcuts cheat sheet, theme-aware SQL

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -109,6 +109,12 @@ means for pgNimbus. Adopting its language where Avalonia allows.
 | --- | --- | --- |
 | In-app theme toggle | Title-bar sun/moon `chip` button (left of the `?`) flips `Application.Current.RequestedThemeVariant` between Light and Dark, so the app no longer only follows the OS. The window's existing `ActualThemeVariantChanged` hook — already there for the SQL highlighter — now also swaps the button glyph (`UpdateThemeIcon`: sun while dark = "click for light", moon while light), so the SQL palette and the toggle icon stay in lockstep however the variant changes. Verified under Xvfb: light→dark→light round-trip, whole shell + editor + syntax colors repaint each way and the glyph tracks. | (this commit) |
 
+## Iteration 14
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Empty states | Blank areas now guide instead of sitting bare. A centered dimmed table-icon hint ("No results yet — run a query with Ctrl+Enter or F5") overlays the results grid, driven by a new `QueryViewModel.HasNoResults` (`Rows.Count == 0 && !IsShowingPlan && !IsRunning`, recomputed from the Rows/IsShowingPlan/IsRunning change hooks). The saved-queries and history cards get their own centered hints via `SavedQueriesViewModel.HasNoSavedQueries`/`HasNoHistory` (notified on each collection change). All overlays are `IsHitTestVisible=False` so they never eat clicks. Verified under Xvfb: the results hint shows at startup and vanishes when `SELECT 1` returns a row; both list hints render on a fresh profile. | (this commit) |
+
 ## Open / candidate items
 - [ ] Mica/acrylic backdrop remains blocked on safe verification (a headless
       sandbox can't see transparency failures).


### PR DESCRIPTION
Ships the **Empty states** item from the README Polish backlog. Blank areas rendered as bare cards with no guidance; this fills all three with friendly, dimmed hints.

## What changed

- **Results grid:** a centered table-icon empty state — *"No results yet — run a query with Ctrl+Enter or F5"* — driven by a new `QueryViewModel.HasNoResults` (`Rows.Count == 0 && !IsShowingPlan && !IsRunning`), recomputed from the `Rows` / `IsShowingPlan` / `IsRunning` change hooks. It clears the moment a result arrives.
- **Saved queries / history cards:** centered hints backed by `SavedQueriesViewModel.HasNoSavedQueries` / `HasNoHistory`, notified on each collection change.
- All overlays are `IsHitTestVisible="False"` so they never intercept clicks on the underlying list/grid.

## Verification

Built clean (0 warnings) and driven under Xvfb:

- Results hint shows at startup, then **vanishes** when `SELECT 1;` returns a row (grid shows `?column? = 1`, status `Done · 1 row`).
- Both list hints render on a fresh profile ("Name a query above and Save to keep it here", "Queries you run will appear here").

Docs updated: README backlog item checked off and added to "Recently shipped"; `docs/PROGRESS.md` iteration 14 entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jn6BLPstk7at5cqx3XFAyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jn6BLPstk7at5cqx3XFAyU)_