### PR TITLE
Add copy from the results grid (Ctrl+C and Copy as CSV/JSON/Markdown/INSERT)

### DIFF
--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -447,4 +447,57 @@ public sealed partial class QueryViewModel : ObservableObject
     }
 
     public void ExportJson(Stream stream) => ResultExporter.WriteJson(stream, ColumnNames, Rows);
+
+    /// <summary>The clipboard "Copy as" shapes the results grid offers.</summary>
+    public enum CopyFormat
+    {
+        Tsv,
+        Csv,
+        Json,
+        Markdown,
+        Insert,
+    }
+
+    /// <summary>
+    /// Renders the given rows (or the whole result set when <paramref name="selectedRows"/> is empty) in
+    /// <paramref name="format"/> for the clipboard. Returns null when there's nothing to copy. INSERT statements
+    /// target the edited table when the result set maps to one, otherwise a <c>table_name</c> placeholder.
+    /// </summary>
+    public string? CopyRows(CopyFormat format, IReadOnlyList<object?[]> selectedRows)
+    {
+        var rows = selectedRows.Count > 0 ? selectedRows : (IReadOnlyList<object?[]>)Rows;
+        if (rows.Count == 0 || ColumnNames.Count == 0)
+        {
+            return null;
+        }
+
+        using var writer = new StringWriter();
+        switch (format)
+        {
+            case CopyFormat.Tsv:
+                ResultExporter.WriteTsv(writer, ColumnNames, rows);
+                break;
+            case CopyFormat.Csv:
+                ResultExporter.WriteCsv(writer, ColumnNames, rows);
+                break;
+            case CopyFormat.Markdown:
+                ResultExporter.WriteMarkdown(writer, ColumnNames, rows);
+                break;
+            case CopyFormat.Insert:
+                ResultExporter.WriteInsert(writer, InsertTargetTable, ColumnNames, rows);
+                break;
+            case CopyFormat.Json:
+                using (var stream = new MemoryStream())
+                {
+                    ResultExporter.WriteJson(stream, ColumnNames, rows);
+                    return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+                }
+        }
+
+        return writer.ToString();
+    }
+
+    private string InsertTargetTable => EditContext is { } ctx
+        ? $"{ResultExporter.QuoteIdentifier(ctx.Schema)}.{ResultExporter.QuoteIdentifier(ctx.Table)}"
+        : "table_name";
 }

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -355,7 +355,22 @@
                               IsReadOnly="{Binding !ActiveTab.IsEditable}"
                               CanUserReorderColumns="False"
                               CanUserSortColumns="True"
-                              AutoGenerateColumns="False" />
+                              SelectionMode="Extended"
+                              ClipboardCopyMode="None"
+                              AutoGenerateColumns="False">
+                        <DataGrid.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="Copy" InputGesture="Ctrl+C" Click="OnCopyCells" />
+                                <Separator />
+                                <MenuItem Header="Copy as">
+                                    <MenuItem Header="CSV" Click="OnCopyAsCsv" />
+                                    <MenuItem Header="JSON" Click="OnCopyAsJson" />
+                                    <MenuItem Header="Markdown table" Click="OnCopyAsMarkdown" />
+                                    <MenuItem Header="INSERT statements" Click="OnCopyAsInsert" />
+                                </MenuItem>
+                            </ContextMenu>
+                        </DataGrid.ContextMenu>
+                    </DataGrid>
                     <!-- Empty state: a friendly hint instead of a bare grid before any query has run -->
                     <StackPanel IsVisible="{Binding ActiveTab.HasNoResults}"
                                 HorizontalAlignment="Center" VerticalAlignment="Center"

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform;
@@ -66,6 +67,7 @@ public partial class MainWindow : Window
         ResultsGrid.CellEditEnding += OnCellEditEnding;
         ResultsGrid.CellEditEnded += OnCellEditEnded;
         ResultsGrid.PreparingCellForEdit += OnPreparingCellForEdit;
+        ResultsGrid.KeyDown += OnResultsGridKeyDown;
 
         SqlEditor.TextArea.TextEntered += OnSqlTextEntered;
         SqlEditor.KeyDown += OnSqlEditorKeyDown;
@@ -372,6 +374,50 @@ public partial class MainWindow : Window
         completionWindow.Show();
         completionWindow.Closed += (_, _) => _completionWindow = null;
         _completionWindow = completionWindow;
+    }
+
+    // Ctrl+C copies the selection as TSV (spreadsheet-friendly). ClipboardCopyMode
+    // is None on the grid because our columns bind through a converter with no
+    // path, so the stock copy has no cell text to read - we build it ourselves.
+    private void OnResultsGridKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.C && e.KeyModifiers.HasFlag(KeyModifiers.Control))
+        {
+            _ = CopySelectionAsync(QueryViewModel.CopyFormat.Tsv);
+            e.Handled = true;
+        }
+    }
+
+    private void OnCopyCells(object? sender, RoutedEventArgs e) => _ = CopySelectionAsync(QueryViewModel.CopyFormat.Tsv);
+
+    private void OnCopyAsCsv(object? sender, RoutedEventArgs e) => _ = CopySelectionAsync(QueryViewModel.CopyFormat.Csv);
+
+    private void OnCopyAsJson(object? sender, RoutedEventArgs e) => _ = CopySelectionAsync(QueryViewModel.CopyFormat.Json);
+
+    private void OnCopyAsMarkdown(object? sender, RoutedEventArgs e) => _ = CopySelectionAsync(QueryViewModel.CopyFormat.Markdown);
+
+    private void OnCopyAsInsert(object? sender, RoutedEventArgs e) => _ = CopySelectionAsync(QueryViewModel.CopyFormat.Insert);
+
+    // Copies the selected rows (or the whole result set when nothing is selected)
+    // in the chosen shape.
+    private async Task CopySelectionAsync(QueryViewModel.CopyFormat format)
+    {
+        if (_queryViewModel is null)
+        {
+            return;
+        }
+
+        var selected = ResultsGrid.SelectedItems.OfType<object?[]>().ToList();
+        var text = _queryViewModel.CopyRows(format, selected);
+        if (string.IsNullOrEmpty(text))
+        {
+            return;
+        }
+
+        if (TopLevel.GetTopLevel(this)?.Clipboard is { } clipboard)
+        {
+            await clipboard.SetTextAsync(text);
+        }
     }
 
     private async void OnExportCsvClick(object? sender, RoutedEventArgs e)

--- a/PgNimbus.Core/Export/ResultExporter.cs
+++ b/PgNimbus.Core/Export/ResultExporter.cs
@@ -24,6 +24,59 @@ public static class ResultExporter
         }
     }
 
+    /// <summary>
+    /// Tab-separated rows with a header line — the spreadsheet-friendly shape for a plain clipboard copy.
+    /// Tabs and newlines inside a value are collapsed to spaces so the row/column grid stays intact on paste.
+    /// </summary>
+    public static void WriteTsv(TextWriter writer, IReadOnlyList<string> columns, IEnumerable<object?[]> rows)
+    {
+        writer.Write(string.Join('\t', columns.Select(SanitizeTsv)));
+        writer.Write('\n');
+
+        foreach (var row in rows)
+        {
+            writer.Write(string.Join('\t', row.Select(v => SanitizeTsv(FormatCsvValue(v)))));
+            writer.Write('\n');
+        }
+    }
+
+    /// <summary>A GitHub-flavored Markdown table (header, separator row, then data), pipes and newlines escaped.</summary>
+    public static void WriteMarkdown(TextWriter writer, IReadOnlyList<string> columns, IEnumerable<object?[]> rows)
+    {
+        writer.Write("| ");
+        writer.Write(string.Join(" | ", columns.Select(EscapeMarkdown)));
+        writer.Write(" |\n| ");
+        writer.Write(string.Join(" | ", columns.Select(_ => "---")));
+        writer.Write(" |\n");
+
+        foreach (var row in rows)
+        {
+            writer.Write("| ");
+            writer.Write(string.Join(" | ", row.Select(v => EscapeMarkdown(FormatCsvValue(v)))));
+            writer.Write(" |\n");
+        }
+    }
+
+    /// <summary>
+    /// One <c>INSERT INTO table (cols) VALUES (...);</c> per row, with proper SQL literal quoting (NULL,
+    /// unquoted numbers/booleans, single-quoted and '-escaped text, <c>\x…</c> bytea).
+    /// </summary>
+    public static void WriteInsert(TextWriter writer, string table, IReadOnlyList<string> columns, IEnumerable<object?[]> rows)
+    {
+        var columnList = string.Join(", ", columns.Select(QuoteIdentifier));
+
+        foreach (var row in rows)
+        {
+            writer.Write("INSERT INTO ");
+            writer.Write(table);
+            writer.Write(" (");
+            writer.Write(columnList);
+            writer.Write(") VALUES (");
+            writer.Write(string.Join(", ", row.Select(FormatSqlLiteral)));
+            writer.Write(");\n");
+        }
+    }
+
     public static void WriteJson(Stream stream, IReadOnlyList<string> columns, IEnumerable<object?[]> rows)
     {
         using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
@@ -57,6 +110,33 @@ public static class ResultExporter
 
     private static string EscapeCsvField(string value) =>
         value.IndexOfAny([',', '"', '\n', '\r']) < 0 ? value : $"\"{value.Replace("\"", "\"\"")}\"";
+
+    private static string SanitizeTsv(string value) =>
+        value.IndexOfAny(['\t', '\n', '\r']) < 0
+            ? value
+            : value.Replace('\t', ' ').Replace('\r', ' ').Replace('\n', ' ');
+
+    private static string EscapeMarkdown(string value) =>
+        value.Replace("\\", "\\\\").Replace("|", "\\|").Replace("\r", string.Empty).Replace("\n", "<br>");
+
+    /// <summary>
+    /// Quote a Postgres identifier only when needed: a bare lowercase identifier is left as-is, anything
+    /// else is double-quoted (with <c>"</c>-doubling) so mixed-case/reserved names round-trip.
+    /// </summary>
+    public static string QuoteIdentifier(string name) =>
+        name.Length > 0 && (char.IsLower(name[0]) || name[0] == '_') && name.All(c => char.IsLower(c) || char.IsDigit(c) || c == '_')
+            ? name
+            : $"\"{name.Replace("\"", "\"\"")}\"";
+
+    private static string FormatSqlLiteral(object? value) => value switch
+    {
+        null or DBNull => "NULL",
+        bool b => b ? "TRUE" : "FALSE",
+        byte or sbyte or short or ushort or int or uint or long or ulong => Convert.ToString(value, CultureInfo.InvariantCulture) ?? "NULL",
+        float or double or decimal => ((IFormattable)value).ToString(null, CultureInfo.InvariantCulture),
+        byte[] bytes => $"'\\x{Convert.ToHexString(bytes)}'",
+        _ => $"'{FormatCsvValue(value).Replace("'", "''")}'",
+    };
 
     private static void WriteJsonValue(Utf8JsonWriter writer, object? value)
     {

--- a/README.md
+++ b/README.md
@@ -205,9 +205,9 @@ bar (the Files community app remains the visual north star):
   (schemas and loaded tables, case-insensitive substring); a schema stays
   when its name matches or a loaded table inside it does, auto-expanding to
   reveal the match, with a clear (✕) button.
-- [ ] **Copy from the results grid** — <kbd>Ctrl</kbd>+<kbd>C</kbd> for the
-  selected cell/rows, plus "Copy as" (CSV, JSON, Markdown table, `INSERT`
-  statements) on the grid context menu.
+- [x] **Copy from the results grid** — <kbd>Ctrl</kbd>+<kbd>C</kbd> copies the
+  selected rows (or all rows) as TSV, plus "Copy as" (CSV, JSON, Markdown table,
+  `INSERT` statements) on the grid context menu.
 - [ ] **Cell inspector** — a detail pane (or popover) for the selected cell so
   long `text`/`jsonb` values are readable and copyable without inline-edit
   tricks; pretty-print JSON.
@@ -245,7 +245,8 @@ bar (the Files community app remains the visual north star):
   (initially: custom result visualizers).
 - [ ] **Localization** — externalize UI strings; ship Russian and German first.
 
-Recently shipped: empty-state hints, the in-app light/dark theme toggle, the
+Recently shipped: results-grid copy (Ctrl+C / Copy as CSV·JSON·Markdown·INSERT),
+empty-state hints, the in-app light/dark theme toggle, the
 schema-tree filter
 box, paste-anything connection
 string parsing (URI / JDBC /

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -115,6 +115,12 @@ means for pgNimbus. Adopting its language where Avalonia allows.
 | --- | --- | --- |
 | Empty states | Blank areas now guide instead of sitting bare. A centered dimmed table-icon hint ("No results yet — run a query with Ctrl+Enter or F5") overlays the results grid, driven by a new `QueryViewModel.HasNoResults` (`Rows.Count == 0 && !IsShowingPlan && !IsRunning`, recomputed from the Rows/IsShowingPlan/IsRunning change hooks). The saved-queries and history cards get their own centered hints via `SavedQueriesViewModel.HasNoSavedQueries`/`HasNoHistory` (notified on each collection change). All overlays are `IsHitTestVisible=False` so they never eat clicks. Verified under Xvfb: the results hint shows at startup and vanishes when `SELECT 1` returns a row; both list hints render on a fresh profile. | (this commit) |
 
+## Iteration 15
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Copy from the results grid | `Ctrl+C` copies the selected rows (or the whole result set when nothing is selected) as TSV; a grid context menu adds **Copy** and **Copy as ▸ CSV / JSON / Markdown table / INSERT statements**. Formatting lives in `Core`'s `ResultExporter` (new `WriteTsv`/`WriteMarkdown`/`WriteInsert` beside the existing CSV/JSON, plus public `QuoteIdentifier` and SQL-literal quoting — NULL, unquoted numbers/booleans, `''`-escaped text, `\x…` bytea), so it stays UI-free and reuses one value formatter. `QueryViewModel.CopyRows` renders to a string; the grid is `SelectionMode=Extended` with `ClipboardCopyMode=None` (our columns bind through a path-less converter, so the stock copy has no cell text — the view builds it and writes via `IClipboard.SetTextAsync`). INSERT targets the edited table when the result maps to one, else a `table_name` placeholder. Verified under Xvfb against `SELECT id,name,email FROM customers LIMIT 3`: Ctrl+C produced tab-separated header+rows, and the context menu produced valid INSERTs (numeric id unquoted, text quoted) and a GitHub Markdown table. | (this commit) |
+
 ## Open / candidate items
 - [ ] Mica/acrylic backdrop remains blocked on safe verification (a headless
       sandbox can't see transparency failures).


### PR DESCRIPTION
Ships the **Copy from the results grid** item from the README Polish backlog. The grid had file export but no clipboard copy.

## What changed

- **`Ctrl+C`** copies the selected rows — or the whole result set when nothing is selected — as **TSV** (spreadsheet-friendly).
- A grid **context menu**: `Copy`, and `Copy as ▸ CSV / JSON / Markdown table / INSERT statements`.
- Formatting lives in **`Core`'s `ResultExporter`** — new `WriteTsv` / `WriteMarkdown` / `WriteInsert` beside the existing CSV/JSON, plus a public `QuoteIdentifier` and SQL-literal quoting (NULL, unquoted numbers/booleans, `''`-escaped text, `\x…` bytea). This keeps it UI-free and reuses one value formatter.
- `QueryViewModel.CopyRows` renders the chosen shape to a string. The grid is `SelectionMode=Extended` with `ClipboardCopyMode=None` — its columns bind through a path-less converter, so the stock DataGrid copy has no cell text to read; the view builds the text itself and writes via `IClipboard.SetTextAsync`.
- INSERT targets the edited table when the result set maps to one, else a `table_name` placeholder.

## Verification

Built clean (0 warnings) and driven under Xvfb against `SELECT id, name, email FROM public.customers ORDER BY id LIMIT 3` (verified by reading the X clipboard):

- **Ctrl+C** → `id⇥name⇥email` header + three tab-separated rows.
- **Copy as → INSERT** → `INSERT INTO table_name (id, name, email) VALUES (1, 'c1', 'c1@x.io');` … (numeric `id` unquoted, text single-quoted).
- **Copy as → Markdown table** → a valid GitHub-flavored pipe table with the `| --- |` separator row.

CSV and JSON reuse the already-tested `ResultExporter` writers.

Docs updated: README backlog item checked off and added to "Recently shipped"; `docs/PROGRESS.md` iteration 15 entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jn6BLPstk7at5cqx3XFAyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jn6BLPstk7at5cqx3XFAyU)_