### PR TITLE
Name query tabs from their SQL, with a dirty-state dot

### DIFF
--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -71,7 +71,7 @@ public sealed partial class MainViewModel : ObservableObject
     [RelayCommand]
     private void AddTab()
     {
-        var tab = new QueryViewModel(_engine, _explainService) { TabTitle = $"Query {Tabs.Count + 1}" };
+        var tab = new QueryViewModel(_engine, _explainService) { DefaultTitle = $"Query {Tabs.Count + 1}" };
         tab.Executed += SavedQueries.RecordExecution;
         Tabs.Add(tab);
         ActiveTab = tab;

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.Text.RegularExpressions;
 using Avalonia.Collections;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -57,6 +58,17 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private string _tabTitle = "Query";
 
+    /// <summary>Fallback tab label ("Query N") used when the SQL names no table to derive a title from.</summary>
+    [ObservableProperty]
+    private string _defaultTitle = "Query";
+
+    /// <summary>True when the SQL has been edited since it was last run — surfaced as a dot on the tab.</summary>
+    [ObservableProperty]
+    private bool _isDirty;
+
+    // The SQL as of the last run; edits away from it mark the tab dirty.
+    private string _lastRunSql;
+
     [ObservableProperty]
     private ExplainNodeViewModel? _explainRoot;
 
@@ -103,6 +115,8 @@ public sealed partial class QueryViewModel : ObservableObject
     {
         _engine = engine;
         _explainService = explainService;
+        _lastRunSql = Sql;
+        UpdateTabTitle();
     }
 
     private bool CanRun() => !IsRunning;
@@ -113,6 +127,10 @@ public sealed partial class QueryViewModel : ObservableObject
         _cts = new CancellationTokenSource();
         var ct = _cts.Token;
         var executedSql = Sql;
+
+        // Running clears the dirty flag: the on-screen SQL is now what produced the result.
+        _lastRunSql = executedSql;
+        IsDirty = false;
 
         IsRunning = true;
         Status = "Running...";
@@ -323,7 +341,33 @@ public sealed partial class QueryViewModel : ObservableObject
     {
         EditContext = null;
         IsShowingPlan = false;
+        IsDirty = !string.Equals(value, _lastRunSql, StringComparison.Ordinal);
+        UpdateTabTitle();
     }
+
+    partial void OnDefaultTitleChanged(string value) => UpdateTabTitle();
+
+    // Name the tab after the first table the SQL references, falling back to "Query N".
+    private void UpdateTabTitle() => TabTitle = DeriveTableName(Sql) ?? DefaultTitle;
+
+    private static string? DeriveTableName(string sql)
+    {
+        var match = TableReferenceRegex().Match(sql);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        var raw = match.Groups[1].Value;
+        // Keep just the table part of a schema-qualified name, and drop any quoting.
+        var table = (raw.Contains('.') ? raw[(raw.LastIndexOf('.') + 1)..] : raw).Trim('"');
+        return string.IsNullOrEmpty(table) ? null : table;
+    }
+
+    // First identifier after FROM/JOIN/UPDATE/INTO (covers SELECT, DELETE FROM, UPDATE, INSERT INTO);
+    // captures an optionally-quoted, optionally schema-qualified name. Source-generated for AOT.
+    [GeneratedRegex(@"\b(?:from|join|update|into)\s+(""?[\w$]+""?(?:\.""?[\w$]+""?)?)", RegexOptions.IgnoreCase)]
+    private static partial Regex TableReferenceRegex();
 
     partial void OnEditContextChanged(EditableTableContext? value) => OnPropertyChanged(nameof(IsEditable));
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -275,6 +275,11 @@
                         <DataTemplate x:DataType="vm:QueryViewModel">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <TextBlock Text="{Binding TabTitle}" VerticalAlignment="Center" />
+                                <!-- Dirty-state dot: SQL edited since last run -->
+                                <Ellipse Width="6" Height="6" VerticalAlignment="Center"
+                                         Fill="{DynamicResource SystemAccentColor}"
+                                         IsVisible="{Binding IsDirty}"
+                                         ToolTip.Tip="Unsaved changes since last run" />
                                 <Button Classes="chip" Content="✕" FontSize="10" Tag="{Binding}" Click="OnCloseTabClick" />
                             </StackPanel>
                         </DataTemplate>

--- a/README.md
+++ b/README.md
@@ -219,8 +219,9 @@ bar (the Files community app remains the visual north star):
   <kbd>Ctrl</kbd>+<kbd>±</kbd>).
 - [ ] **Alias-aware autocomplete** — complete column names after
   `alias.`/`table.`, not just bare identifiers.
-- [ ] **Smarter tab titles** — name query tabs from their SQL (first table
-  referenced) instead of "Query N", with a dirty-state dot.
+- [x] **Smarter tab titles** — query tabs are named from their SQL (first table
+  referenced) instead of "Query N", with a dirty-state dot when the SQL has
+  changed since the last run.
 - [ ] **Running-query feedback** — an indeterminate progress bar in the
   status bar and a live elapsed-time tick while a query runs (the row/timing
   segments only update per batch today).
@@ -245,7 +246,8 @@ bar (the Files community app remains the visual north star):
   (initially: custom result visualizers).
 - [ ] **Localization** — externalize UI strings; ship Russian and German first.
 
-Recently shipped: results-grid copy (Ctrl+C / Copy as CSV·JSON·Markdown·INSERT),
+Recently shipped: SQL-derived tab titles with a dirty dot, results-grid copy
+(Ctrl+C / Copy as CSV·JSON·Markdown·INSERT),
 empty-state hints, the in-app light/dark theme toggle, the
 schema-tree filter
 box, paste-anything connection

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -121,6 +121,12 @@ means for pgNimbus. Adopting its language where Avalonia allows.
 | --- | --- | --- |
 | Copy from the results grid | `Ctrl+C` copies the selected rows (or the whole result set when nothing is selected) as TSV; a grid context menu adds **Copy** and **Copy as ▸ CSV / JSON / Markdown table / INSERT statements**. Formatting lives in `Core`'s `ResultExporter` (new `WriteTsv`/`WriteMarkdown`/`WriteInsert` beside the existing CSV/JSON, plus public `QuoteIdentifier` and SQL-literal quoting — NULL, unquoted numbers/booleans, `''`-escaped text, `\x…` bytea), so it stays UI-free and reuses one value formatter. `QueryViewModel.CopyRows` renders to a string; the grid is `SelectionMode=Extended` with `ClipboardCopyMode=None` (our columns bind through a path-less converter, so the stock copy has no cell text — the view builds it and writes via `IClipboard.SetTextAsync`). INSERT targets the edited table when the result maps to one, else a `table_name` placeholder. Verified under Xvfb against `SELECT id,name,email FROM customers LIMIT 3`: Ctrl+C produced tab-separated header+rows, and the context menu produced valid INSERTs (numeric id unquoted, text quoted) and a GitHub Markdown table. | (this commit) |
 
+## Iteration 16
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Smarter tab titles | Tabs are named from the first table the SQL references (a source-generated `[GeneratedRegex]` grabs the identifier after FROM/JOIN/UPDATE/INTO, keeps the table part of a schema-qualified name, strips quotes), falling back to a `DefaultTitle` ("Query N") when none. A dirty-state accent dot (`IsDirty`) shows when the SQL differs from `_lastRunSql` — set as the baseline at the start of each run — so the dot appears on edit and clears on run. Regex is source-generated to stay AOT-clean. Verified under Xvfb: `SELECT 1` stayed "Query 1"; pasting `SELECT * FROM public.customers …` retitled the tab to "customers" with the dot; F5 cleared the dot. | (this commit) |
+
 ## Open / candidate items
 - [ ] Mica/acrylic backdrop remains blocked on safe verification (a headless
       sandbox can't see transparency failures).


### PR DESCRIPTION
Ships the **Smarter tab titles** item from the README Polish backlog. Tabs were all "Query N".

## What changed

- Each tab is named after the **first table its SQL references** — a source-generated `[GeneratedRegex]` grabs the identifier after `FROM`/`JOIN`/`UPDATE`/`INTO`, keeps the table part of a schema-qualified name, and strips quotes. Falls back to a `DefaultTitle` ("Query N") when the SQL names no table.
- A **dirty-state accent dot** (`IsDirty`) shows when the SQL differs from `_lastRunSql`, which is set as the baseline at the start of each run — so the dot appears on edit and clears on run.
- The regex is **source-generated** to stay AOT/trim-clean.

## Verification

Built clean (0 warnings) and driven under Xvfb:

- Default `SELECT 1;` (no table) → tab stays **"Query 1"**.
- Paste `SELECT * FROM public.customers ORDER BY id LIMIT 5;` → tab retitles to **"customers"** and the **dirty dot appears**.
- **F5** runs it → the dirty dot **clears**.

Docs updated: README backlog item checked off and added to "Recently shipped"; `docs/PROGRESS.md` iteration 16 entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jn6BLPstk7at5cqx3XFAyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jn6BLPstk7at5cqx3XFAyU)_