### PR TITLE
Add a command palette (Ctrl+K / Ctrl+P) for fuzzy jump-to

### DIFF
--- a/PgNimbus.App/FuzzyMatcher.cs
+++ b/PgNimbus.App/FuzzyMatcher.cs
@@ -1,0 +1,68 @@
+namespace PgNimbus.App;
+
+/// <summary>
+/// Lightweight subsequence fuzzy matcher for the command palette. Returns a
+/// score (higher is better) when every character of the query appears in order
+/// in the target, or <c>null</c> when it doesn't match at all. Rewards a prefix
+/// hit, word-boundary hits, and consecutive runs so that, e.g., typing
+/// "cust" ranks "customers" above "created_at_customs".
+/// </summary>
+public static class FuzzyMatcher
+{
+    public static int? Score(string target, string query)
+    {
+        if (query.Length == 0)
+        {
+            return 0;
+        }
+
+        if (query.Length > target.Length)
+        {
+            return null;
+        }
+
+        var score = 0;
+        var targetIndex = 0;
+        var consecutive = 0;
+
+        foreach (var qc in query)
+        {
+            var lowerQuery = char.ToLowerInvariant(qc);
+            var matched = false;
+
+            while (targetIndex < target.Length)
+            {
+                var tc = target[targetIndex];
+                if (char.ToLowerInvariant(tc) == lowerQuery)
+                {
+                    var bonus = 1;
+                    if (targetIndex == 0)
+                    {
+                        bonus += 8; // prefix match — the strongest signal
+                    }
+                    else if (!char.IsLetterOrDigit(target[targetIndex - 1]))
+                    {
+                        bonus += 4; // start of a word (after '.', '_', space, ...)
+                    }
+
+                    bonus += consecutive * 2; // adjacency run
+                    score += bonus;
+                    consecutive++;
+                    targetIndex++;
+                    matched = true;
+                    break;
+                }
+
+                consecutive = 0;
+                targetIndex++;
+            }
+
+            if (!matched)
+            {
+                return null;
+            }
+        }
+
+        return score;
+    }
+}

--- a/PgNimbus.App/ViewModels/CommandPaletteViewModel.cs
+++ b/PgNimbus.App/ViewModels/CommandPaletteViewModel.cs
@@ -1,0 +1,117 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace PgNimbus.App.ViewModels;
+
+/// <summary>One selectable entry in the command palette.</summary>
+/// <param name="Title">The primary, fuzzy-matched label (e.g. "sales.orders", "Run query").</param>
+/// <param name="Category">A quiet right-aligned tag ("Table", "Saved query", "Action").</param>
+/// <param name="Glyph">A single-character icon shown at the leading edge.</param>
+/// <param name="InvokeAsync">Runs the entry's effect; awaited after the palette closes.</param>
+public sealed record PaletteItem(string Title, string Category, string Glyph, Func<Task> InvokeAsync);
+
+/// <summary>
+/// The command palette (Ctrl+K / Ctrl+P): one keyboard-first control to
+/// fuzzy-jump to any table, saved query, or action. The full candidate set is
+/// supplied by <see cref="MainViewModel"/> when the palette opens; this
+/// view-model owns filtering, selection, and invocation.
+/// </summary>
+public sealed partial class CommandPaletteViewModel : ObservableObject
+{
+    // The full candidate set for the current open. Tables arrive asynchronously,
+    // so this can be replaced while the palette is already open (see SetItems).
+    private IReadOnlyList<PaletteItem> _all = [];
+
+    [ObservableProperty]
+    private bool _isOpen;
+
+    [ObservableProperty]
+    private string _searchText = string.Empty;
+
+    [ObservableProperty]
+    private PaletteItem? _selectedItem;
+
+    public ObservableCollection<PaletteItem> Results { get; } = [];
+
+    /// <summary>Opens the palette over the given candidates, resetting the query.</summary>
+    public void Open(IReadOnlyList<PaletteItem> items)
+    {
+        _all = items;
+        SearchText = string.Empty;
+        RebuildResults();
+        IsOpen = true;
+    }
+
+    /// <summary>Swaps in a fuller candidate set (e.g. once tables have loaded), preserving the typed query.</summary>
+    public void SetItems(IReadOnlyList<PaletteItem> items)
+    {
+        _all = items;
+        if (IsOpen)
+        {
+            RebuildResults();
+        }
+    }
+
+    [RelayCommand]
+    private void Close()
+    {
+        IsOpen = false;
+        SearchText = string.Empty;
+    }
+
+    partial void OnSearchTextChanged(string value) => RebuildResults();
+
+    private void RebuildResults()
+    {
+        Results.Clear();
+
+        var query = SearchText.Trim();
+        IEnumerable<PaletteItem> matches;
+        if (query.Length == 0)
+        {
+            matches = _all;
+        }
+        else
+        {
+            matches = _all
+                .Select(item => (item, score: FuzzyMatcher.Score($"{item.Title} {item.Category}", query)))
+                .Where(x => x.score is not null)
+                .OrderByDescending(x => x.score!.Value)
+                .Select(x => x.item);
+        }
+
+        foreach (var item in matches)
+        {
+            Results.Add(item);
+        }
+
+        SelectedItem = Results.Count > 0 ? Results[0] : null;
+    }
+
+    /// <summary>Moves the highlighted row by <paramref name="delta"/>, wrapping around the list.</summary>
+    public void MoveSelection(int delta)
+    {
+        if (Results.Count == 0)
+        {
+            return;
+        }
+
+        var index = SelectedItem is null ? -1 : Results.IndexOf(SelectedItem);
+        index = (index + delta + Results.Count) % Results.Count;
+        SelectedItem = Results[index];
+    }
+
+    /// <summary>Closes the palette and runs the highlighted entry, if any.</summary>
+    public async Task AcceptAsync()
+    {
+        var item = SelectedItem;
+        if (item is null)
+        {
+            return;
+        }
+
+        Close();
+        await item.InvokeAsync();
+    }
+}

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -22,6 +22,17 @@ public sealed partial class MainViewModel : ObservableObject
 
     public NotifyMonitorViewModel NotifyMonitor { get; }
 
+    public CommandPaletteViewModel CommandPalette { get; } = new();
+
+    // Palette actions that need the window (theme, dialogs) live in the view;
+    // MainWindow subscribes to these so the palette can trigger them.
+    public event Action? ThemeToggleRequested;
+    public event Action? ShortcutsRequested;
+
+    // Relations rarely change mid-session, so the palette's "jump to a table"
+    // list is fetched once and reused across opens.
+    private IReadOnlyList<RelationInfo>? _relationCache;
+
     /// <summary>The connected profile's accent color ("#RRGGBB"), or null. Lets the window chrome show at a glance which environment (e.g. prod vs. dev) is connected.</summary>
     public string? AccentColor { get; }
 
@@ -126,16 +137,97 @@ public sealed partial class MainViewModel : ObservableObject
         ActiveTab = Tabs[(index + direction + Tabs.Count) % Tabs.Count];
     }
 
-    public async Task PreviewTableAsync(TableNode table)
-    {
-        ActiveTab.Sql = $"SELECT * FROM {SqlIdentifier.Quote(table.Schema)}.{SqlIdentifier.Quote(table.Name)} LIMIT 100;";
+    public Task PreviewTableAsync(TableNode table) => PreviewTableAsync(table.Schema, table.Name);
 
-        var columns = await _schemaService.GetColumnsAsync(table.Schema, table.Name, CancellationToken.None);
+    public async Task PreviewTableAsync(string schema, string name)
+    {
+        ActiveTab.Sql = $"SELECT * FROM {SqlIdentifier.Quote(schema)}.{SqlIdentifier.Quote(name)} LIMIT 100;";
+
+        var columns = await _schemaService.GetColumnsAsync(schema, name, CancellationToken.None);
         var primaryKeyColumns = columns.Where(c => c.IsPrimaryKey).Select(c => c.Name).ToList();
 
         if (primaryKeyColumns.Count > 0)
         {
-            ActiveTab.EditContext = new EditableTableContext(table.Schema, table.Name, primaryKeyColumns);
+            ActiveTab.EditContext = new EditableTableContext(schema, name, primaryKeyColumns);
         }
     }
+
+    /// <summary>
+    /// Opens the command palette. Actions and saved queries are available
+    /// instantly; the (potentially larger) table list is fetched in the
+    /// background and merged in without blocking the palette from showing.
+    /// </summary>
+    public async Task OpenCommandPaletteAsync()
+    {
+        var baseItems = BuildActionItems().Concat(BuildSavedQueryItems()).ToList();
+        CommandPalette.Open(baseItems);
+
+        try
+        {
+            _relationCache ??= await _schemaService.GetAllRelationsAsync(CancellationToken.None);
+        }
+        catch
+        {
+            // No connection / query failure: the palette still works for
+            // actions and saved queries, just without table jumps.
+            return;
+        }
+
+        if (!CommandPalette.IsOpen)
+        {
+            return; // dismissed before the tables arrived
+        }
+
+        CommandPalette.SetItems(baseItems.Concat(BuildTableItems(_relationCache)).ToList());
+    }
+
+    private IEnumerable<PaletteItem> BuildActionItems()
+    {
+        yield return new PaletteItem("Run query", "Action", "▶", Invoke(() => ActiveTab.RunCommand));
+        yield return new PaletteItem("Cancel query", "Action", "■", Invoke(() => ActiveTab.CancelCommand));
+        yield return new PaletteItem("Explain", "Action", "⚡", Invoke(() => ActiveTab.ExplainCommand));
+        yield return new PaletteItem("Explain Analyze", "Action", "⚡", Invoke(() => ActiveTab.ExplainAnalyzeCommand));
+        yield return new PaletteItem("New query tab", "Action", "＋", Invoke(() => AddTabCommand));
+        yield return new PaletteItem("Close tab", "Action", "✕", Invoke(() => CloseTabCommand));
+        yield return new PaletteItem("Next tab", "Action", "›", Invoke(() => NextTabCommand));
+        yield return new PaletteItem("Previous tab", "Action", "‹", Invoke(() => PreviousTabCommand));
+        yield return new PaletteItem("Toggle light/dark theme", "Action", "◐", () => { ThemeToggleRequested?.Invoke(); return Task.CompletedTask; });
+        yield return new PaletteItem("Keyboard shortcuts", "Action", "?", () => { ShortcutsRequested?.Invoke(); return Task.CompletedTask; });
+    }
+
+    private IEnumerable<PaletteItem> BuildSavedQueryItems() =>
+        SavedQueries.SavedQueries.Select(q => new PaletteItem(
+            q.Name,
+            "Saved query",
+            "★",
+            () => { SavedQueries.LoadSavedQueryCommand.Execute(q); return Task.CompletedTask; }));
+
+    private IEnumerable<PaletteItem> BuildTableItems(IReadOnlyList<RelationInfo> relations) =>
+        relations.Select(r => new PaletteItem(
+            $"{r.Schema}.{r.Name}",
+            "Table",
+            GlyphFor(r.Kind),
+            () => PreviewTableAsync(r.Schema, r.Name)));
+
+    private static string GlyphFor(RelationKind kind) => kind switch
+    {
+        RelationKind.Table => "▤",
+        RelationKind.View => "▥",
+        RelationKind.MaterializedView => "▦",
+        RelationKind.PartitionedTable => "▧",
+        _ => "▤",
+    };
+
+    // A command may be null at build time (ActiveTab settles later); resolve it
+    // lazily at invoke time and only fire when it can execute.
+    private static Func<Task> Invoke(Func<System.Windows.Input.ICommand?> resolve) => () =>
+    {
+        var command = resolve();
+        if (command?.CanExecute(null) == true)
+        {
+            command.Execute(null);
+        }
+
+        return Task.CompletedTask;
+    };
 }

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -64,6 +64,9 @@
         <KeyBinding Gesture="Ctrl+PageUp" Command="{Binding PreviousTabCommand}" />
     </Window.KeyBindings>
 
+    <!-- Root grid layers the command-palette overlay above the whole shell -->
+    <Grid>
+
     <!-- Two-tone shell (Files-style): chrome-tinted base; the content pane is a raised layer -->
     <DockPanel Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}">
         <Border DockPanel.Dock="Top" Height="40" Padding="16,0"
@@ -443,5 +446,65 @@
 
     </Grid>
     </DockPanel>
+
+    <!--
+        Command palette (Ctrl+K / Ctrl+P): a centered overlay above everything.
+        The scrim closes it on an outside click; the card holds a search box and
+        a fuzzy-ranked list of tables, saved queries, and actions.
+    -->
+    <Border Name="PaletteOverlay"
+            IsVisible="{Binding CommandPalette.IsOpen}"
+            Background="#66000000"
+            PointerPressed="OnPaletteScrimPressed">
+        <Border Width="560" MaxHeight="440" Margin="0,90,0,0"
+                VerticalAlignment="Top" HorizontalAlignment="Center"
+                Background="{DynamicResource SystemControlPageBackgroundAltHighBrush}"
+                BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                CornerRadius="10" BoxShadow="0 12 32 0 #40000000"
+                PointerPressed="OnPaletteCardPressed"
+                x:DataType="vm:CommandPaletteViewModel" DataContext="{Binding CommandPalette}">
+            <Grid RowDefinitions="Auto,*">
+                <TextBox Grid.Row="0" Name="PaletteSearchBox" Margin="10"
+                         FontSize="15" BorderThickness="0"
+                         Background="Transparent"
+                         Text="{Binding SearchText, Mode=TwoWay}"
+                         KeyDown="OnPaletteSearchKeyDown"
+                         PlaceholderText="Jump to a table, saved query, or action…">
+                    <TextBox.InnerLeftContent>
+                        <PathIcon Data="{StaticResource MagnifyIconGeometry}" Width="15" Height="15"
+                                  Opacity="0.5" Margin="8,0,4,0" VerticalAlignment="Center" />
+                    </TextBox.InnerLeftContent>
+                </TextBox>
+                <Border Grid.Row="1" BorderThickness="0,1,0,0" BorderBrush="{StaticResource CardBorderBrush}">
+                    <Grid>
+                        <ListBox Name="PaletteList" ItemsSource="{Binding Results}"
+                                 SelectedItem="{Binding SelectedItem, Mode=TwoWay}"
+                                 SelectionMode="Single" Padding="6"
+                                 Tapped="OnPaletteListTapped"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="vm:PaletteItem">
+                                    <Grid ColumnDefinitions="Auto,*,Auto">
+                                        <TextBlock Grid.Column="0" Text="{Binding Glyph}" Width="20"
+                                                   Opacity="0.7" VerticalAlignment="Center" />
+                                        <TextBlock Grid.Column="1" Text="{Binding Title}"
+                                                   TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
+                                        <TextBlock Grid.Column="2" Text="{Binding Category}"
+                                                   FontSize="11" Opacity="0.45" VerticalAlignment="Center"
+                                                   Margin="12,0,0,0" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                        <TextBlock IsVisible="{Binding !Results.Count}" IsHitTestVisible="False"
+                                   Text="No matches" Opacity="0.4" FontSize="13"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center" Margin="16" />
+                    </Grid>
+                </Border>
+            </Grid>
+        </Border>
+    </Border>
+
+    </Grid>
 
 </Window>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -11,6 +11,7 @@ using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using AvaloniaEdit.CodeCompletion;
 using AvaloniaEdit.Highlighting;
@@ -125,6 +126,13 @@ public partial class MainWindow : Window
     // focus currently is - a KeyBinding can't express a toggle.
     protected override void OnKeyDown(KeyEventArgs e)
     {
+        if ((e.Key == Key.K || e.Key == Key.P) && e.KeyModifiers.HasFlag(KeyModifiers.Control))
+        {
+            OpenCommandPalette();
+            e.Handled = true;
+            return;
+        }
+
         if (e.Key == Key.F1 && e.KeyModifiers == KeyModifiers.None)
         {
             ShowShortcutsWindow();
@@ -155,10 +163,15 @@ public partial class MainWindow : Window
         if (_viewModel is not null)
         {
             _viewModel.PropertyChanged -= OnMainViewModelPropertyChanged;
+            _viewModel.ThemeToggleRequested -= ToggleTheme;
+            _viewModel.ShortcutsRequested -= ShowShortcutsWindow;
         }
 
         _viewModel = vm;
         _viewModel.PropertyChanged += OnMainViewModelPropertyChanged;
+        // Palette actions that touch the window are handled here.
+        _viewModel.ThemeToggleRequested += ToggleTheme;
+        _viewModel.ShortcutsRequested += ShowShortcutsWindow;
 
         AttachQuery(vm.ActiveTab);
     }
@@ -210,7 +223,9 @@ public partial class MainWindow : Window
     // follow the OS. Setting the application variant flips ActualThemeVariant on
     // the window, which the ActualThemeVariantChanged handler above picks up to
     // repaint the SQL palette and swap this button's glyph.
-    private void OnToggleThemeClick(object? sender, RoutedEventArgs e)
+    private void OnToggleThemeClick(object? sender, RoutedEventArgs e) => ToggleTheme();
+
+    private void ToggleTheme()
     {
         if (Application.Current is not { } app)
         {
@@ -496,6 +511,82 @@ public partial class MainWindow : Window
         SqlEditor.Text = _queryViewModel.Sql;
         _suppressEditorSync = false;
     }
+
+    // Opens the command palette and moves keyboard focus straight to its search
+    // box, so typing filters immediately without a mouse.
+    private void OpenCommandPalette()
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        _ = _viewModel.OpenCommandPaletteAsync();
+        // Focus after the overlay has been laid out (IsVisible flips this frame).
+        Dispatcher.UIThread.Post(() =>
+        {
+            PaletteSearchBox.Focus();
+            PaletteSearchBox.SelectAll();
+        }, DispatcherPriority.Input);
+    }
+
+    // Arrow keys move the highlight, Enter runs it, Esc dismisses - all while the
+    // caret stays in the search box, so the palette is fully keyboard-driven.
+    private void OnPaletteSearchKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        var palette = _viewModel.CommandPalette;
+        switch (e.Key)
+        {
+            case Key.Down:
+                palette.MoveSelection(+1);
+                ScrollPaletteSelectionIntoView();
+                e.Handled = true;
+                break;
+            case Key.Up:
+                palette.MoveSelection(-1);
+                ScrollPaletteSelectionIntoView();
+                e.Handled = true;
+                break;
+            case Key.Enter:
+                _ = palette.AcceptAsync();
+                e.Handled = true;
+                break;
+            case Key.Escape:
+                palette.CloseCommand.Execute(null);
+                e.Handled = true;
+                break;
+        }
+    }
+
+    private void ScrollPaletteSelectionIntoView()
+    {
+        if (_viewModel?.CommandPalette.SelectedItem is { } item)
+        {
+            PaletteList.ScrollIntoView(item);
+        }
+    }
+
+    // A click on a result row accepts it immediately (the binding has already
+    // updated SelectedItem by the time this fires).
+    private void OnPaletteListTapped(object? sender, TappedEventArgs e)
+    {
+        if (_viewModel is not null && _viewModel.CommandPalette.SelectedItem is not null)
+        {
+            _ = _viewModel.CommandPalette.AcceptAsync();
+        }
+    }
+
+    // A press on the scrim (but not the card) dismisses the palette.
+    private void OnPaletteScrimPressed(object? sender, PointerPressedEventArgs e) =>
+        _viewModel?.CommandPalette.CloseCommand.Execute(null);
+
+    // Swallow presses on the card so they don't bubble to the scrim and close it.
+    private void OnPaletteCardPressed(object? sender, PointerPressedEventArgs e) => e.Handled = true;
 
     private void RebuildColumns(QueryViewModel query)
     {

--- a/PgNimbus.App/Views/ShortcutsWindow.axaml
+++ b/PgNimbus.App/Views/ShortcutsWindow.axaml
@@ -163,6 +163,16 @@
             <Border Classes="card" Padding="4">
                 <StackPanel>
                     <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
+                        <TextBlock Classes="what" Text="Command palette (jump to table / query / action)" />
+                        <StackPanel Grid.Column="1" Classes="keys">
+                            <Border Classes="kbd"><TextBlock Text="Ctrl" /></Border>
+                            <Border Classes="kbd"><TextBlock Text="K" /></Border>
+                            <TextBlock Classes="combo" Text="or" />
+                            <Border Classes="kbd"><TextBlock Text="Ctrl" /></Border>
+                            <Border Classes="kbd"><TextBlock Text="P" /></Border>
+                        </StackPanel>
+                    </Grid>
+                    <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
                         <TextBlock Classes="what" Text="Switch focus: editor ↔ results grid" />
                         <StackPanel Grid.Column="1" Classes="keys">
                             <Border Classes="kbd"><TextBlock Text="F6" /></Border>

--- a/PgNimbus.Core/Schema/SchemaService.cs
+++ b/PgNimbus.Core/Schema/SchemaService.cs
@@ -14,6 +14,8 @@ public enum RelationKind
 
 public sealed record TableInfo(string Name, RelationKind Kind);
 
+public sealed record RelationInfo(string Schema, string Name, RelationKind Kind);
+
 public sealed record ColumnDetail(string Name, string DataType, bool NotNull, bool IsPrimaryKey);
 
 public sealed record TableColumn(string Table, string Column);
@@ -85,6 +87,45 @@ public sealed class SchemaService
             };
 
             results.Add(new TableInfo(reader.GetString(0), kind));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Every relation (table/view/matview/partitioned table) across all
+    /// non-system schemas in one query, schema-qualified — feeds the command
+    /// palette's fuzzy "jump to a table" list without an N+1 per-schema walk.
+    /// </summary>
+    public async Task<IReadOnlyList<RelationInfo>> GetAllRelationsAsync(CancellationToken ct)
+    {
+        const string sql = """
+            SELECT n.nspname, c.relname, c.relkind::text
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname NOT LIKE 'pg\_%'
+              AND n.nspname <> 'information_schema'
+              AND c.relkind IN ('r', 'v', 'm', 'p')
+            ORDER BY n.nspname, c.relname
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<RelationInfo>();
+        while (await reader.ReadAsync(ct))
+        {
+            var kind = reader.GetString(2) switch
+            {
+                "r" => RelationKind.Table,
+                "v" => RelationKind.View,
+                "m" => RelationKind.MaterializedView,
+                "p" => RelationKind.PartitionedTable,
+                _ => RelationKind.Table,
+            };
+
+            results.Add(new RelationInfo(reader.GetString(0), reader.GetString(1), kind));
         }
 
         return results;

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ from the ground up.
   (Heroku/Supabase/Neon-style), `jdbc:postgresql://` URLs, ADO.NET/Npgsql
   `Key=Value;` strings, libpq `host=… dbname=…` keyword strings, and even
   full `psql` command lines (including `PGPASSWORD=… psql -h …` prefixes).
+- **Command palette** — press <kbd>Ctrl</kbd>+<kbd>K</kbd> (or
+  <kbd>Ctrl</kbd>+<kbd>P</kbd>) to fuzzy-jump to any table, saved query, or
+  action from one keyboard-driven control.
 - **Keyboard shortcuts cheat sheet** — press <kbd>F1</kbd> (or the `?`
   title-bar button) for an overview of every binding.
 - **Multi-tab query editor** — schema-aware SQL autocomplete, saved queries,
@@ -71,6 +74,7 @@ Press <kbd>F1</kbd> in the app for the full cheat sheet. The highlights:
 
 | Action | Shortcut |
 | --- | --- |
+| Command palette (jump to table / query / action) | <kbd>Ctrl</kbd>+<kbd>K</kbd> or <kbd>Ctrl</kbd>+<kbd>P</kbd> |
 | Run query | <kbd>Ctrl</kbd>+<kbd>Enter</kbd> or <kbd>F5</kbd> |
 | Cancel running query | <kbd>Esc</kbd> |
 | New / close query tab | <kbd>Ctrl</kbd>+<kbd>T</kbd> / <kbd>Ctrl</kbd>+<kbd>W</kbd> |
@@ -163,7 +167,7 @@ individually shippable pieces.
 
 Things a person needs before pgNimbus can be their only Postgres client:
 
-- [ ] **Command palette** (`Ctrl+K`/`Ctrl+P`) — fuzzy-jump to any table, saved
+- [x] **Command palette** (`Ctrl+K`/`Ctrl+P`) — fuzzy-jump to any table, saved
   query, or action; the keyboard-first differentiator in one control.
 - [ ] **Data browsing without SQL** — filter bar, ORDER BY on header click, and
   paging when previewing a table, pushed down to the server (`WHERE`/`LIMIT`/
@@ -246,7 +250,8 @@ bar (the Files community app remains the visual north star):
   (initially: custom result visualizers).
 - [ ] **Localization** — externalize UI strings; ship Russian and German first.
 
-Recently shipped: SQL-derived tab titles with a dirty dot, results-grid copy
+Recently shipped: the Ctrl+K/Ctrl+P command palette (fuzzy-jump to any table,
+saved query, or action), SQL-derived tab titles with a dirty dot, results-grid copy
 (Ctrl+C / Copy as CSV·JSON·Markdown·INSERT),
 empty-state hints, the in-app light/dark theme toggle, the
 schema-tree filter

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -127,8 +127,14 @@ means for pgNimbus. Adopting its language where Avalonia allows.
 | --- | --- | --- |
 | Smarter tab titles | Tabs are named from the first table the SQL references (a source-generated `[GeneratedRegex]` grabs the identifier after FROM/JOIN/UPDATE/INTO, keeps the table part of a schema-qualified name, strips quotes), falling back to a `DefaultTitle` ("Query N") when none. A dirty-state accent dot (`IsDirty`) shows when the SQL differs from `_lastRunSql` — set as the baseline at the start of each run — so the dot appears on edit and clears on run. Regex is source-generated to stay AOT-clean. Verified under Xvfb: `SELECT 1` stayed "Query 1"; pasting `SELECT * FROM public.customers …` retitled the tab to "customers" with the dot; F5 cleared the dot. | (this commit) |
 
+## Iteration 17
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Command palette (`Ctrl+K` / `Ctrl+P`) | A centered overlay above the whole shell that fuzzy-jumps to any table, saved query, or action — the keyboard-first differentiator in one control. `CommandPaletteViewModel` owns the query/selection/invocation; `MainViewModel.OpenCommandPaletteAsync` builds the candidate set (actions + saved queries instantly, then merges in tables once `SchemaService.GetAllRelationsAsync` — a new single `pg_catalog` query returning schema-qualified relations — returns, so the palette shows without blocking on the DB). A `PaletteItem` carries a `Func<Task>` effect: table entries call `PreviewTableAsync(schema, name)` (refactored to a schema/name overload), actions resolve `ICommand`s lazily and fire only when `CanExecute`, and window-level actions (theme toggle, shortcuts) route through `ThemeToggleRequested`/`ShortcutsRequested` events the view subscribes to. Ranking is a subsequence `FuzzyMatcher` (prefix / word-boundary / adjacency bonuses) over "Title Category". Fully keyboard-driven from the search box: ↑/↓ move the highlight, Enter accepts, Esc / outside-click dismiss. Verified under Xvfb: Ctrl+K listed 10 actions + tables; typing "order" narrowed to `sales.order_summary` + `sales.orders`; Enter jumped the editor to `SELECT * FROM "sales"."order_summary" LIMIT 100;` and closed; Ctrl+P + "theme" ran the toggle. README (feature bullet, shortcut row) + F1 cheat sheet updated. | (this commit) |
+
 ## Open / candidate items
 - [ ] Mica/acrylic backdrop remains blocked on safe verification (a headless
       sandbox can't see transparency failures).
-- [ ] Roadmap features (command palette, extension manager) — out of polish
+- [ ] Roadmap features (extension manager, plugin API) — out of polish
       scope


### PR DESCRIPTION
Implements the **Command palette** backlog item (Now section): a keyboard-first control to fuzzy-jump to any table, saved query, or action.

## What's new

- **`Ctrl+K` / `Ctrl+P`** opens a centered overlay above the whole shell. A search box (auto-focused) fuzzy-filters a ranked list; ↑/↓ move the highlight, **Enter** accepts, **Esc** / outside-click dismisses.
- **Three entry kinds:**
  - **Tables** → jump straight to `SELECT * FROM schema.table LIMIT 100;` (with edit context wired up when the table has a PK).
  - **Saved queries** → load into the active tab.
  - **Actions** → Run / Cancel / Explain / Explain Analyze / New·Close·Next·Previous tab / Toggle theme / Keyboard shortcuts.

## How it's built

- `CommandPaletteViewModel` owns query, selection, and invocation. A `PaletteItem` carries a `Func<Task>` effect.
- `MainViewModel.OpenCommandPaletteAsync` shows actions + saved queries **instantly**, then merges tables in once `SchemaService.GetAllRelationsAsync` returns — a new single `pg_catalog` query for schema-qualified relations — so the palette never blocks on the DB (and still works for actions with no connection).
- Window-level actions (theme toggle, shortcuts window) route through `ThemeToggleRequested` / `ShortcutsRequested` events the view subscribes to, keeping `Core`/VM free of UI concerns.
- `FuzzyMatcher` is a subsequence matcher with prefix / word-boundary / adjacency bonuses. Actions resolve their `ICommand` lazily and fire only when `CanExecute`.

## Verification

Built clean (0 warnings) and driven under Xvfb against a seeded `demo` DB:
- `Ctrl+K` listed 10 actions + all tables with category tags and glyphs.
- Typing `order` narrowed to `sales.order_summary` + `sales.orders`.
- **Enter** jumped the editor to `SELECT * FROM "sales"."order_summary" LIMIT 100;` and closed the palette (tab retitled `order_summary`).
- `Ctrl+P` + `theme` ran the theme-toggle action.

Docs updated: README feature bullet + shortcut row, and the F1 cheat sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RXb4Xkfgs8RW1kDEHxbeP

---
_Generated by [Claude Code](https://claude.ai/code/session_016RXb4Xkfgs8RW1kDEHxbeP)_