### PR TITLE
Add "Refresh database & schema" as top-priority backlog item

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ individually shippable pieces.
 
 Things a person needs before pgNimbus can be their only Postgres client:
 
+- [ ] **Refresh database & schema** — reload the schema tree and autocomplete
+  cache from the server on demand (toolbar button / shortcut), so newly created
+  or altered tables, columns, and other objects show up without reconnecting.
 - [x] **Command palette** (`Ctrl+K`/`Ctrl+P`) — fuzzy-jump to any table, saved
   query, or action; the keyboard-first differentiator in one control.
 - [x] **Data browsing without SQL** — filter bar, ORDER BY on header click, and


### PR DESCRIPTION
Per request, adds a top-priority backlog entry at the top of the **Now** section for an on-demand **Refresh database & schema** function: reload the schema tree and autocomplete cache from the server (toolbar button / shortcut) so newly created or altered tables, columns, and other objects show up without reconnecting.

Docs-only change (README backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RXb4Xkfgs8RW1kDEHxbeP

---
_Generated by [Claude Code](https://claude.ai/code/session_016RXb4Xkfgs8RW1kDEHxbeP)_