### PR TITLE
Mark generated releases as pre-release until signed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,3 +192,6 @@ jobs:
             artifacts/*.zip
             artifacts/SHA256SUMS.txt
           generate_release_notes: true
+          # Every build is unsigned until a code-signing cert / Apple
+          # Developer account is added — flip this off once that lands.
+          prerelease: true


### PR DESCRIPTION
Small follow-up to #37: flag every GitHub Release this pipeline creates as a pre-release, since all artifacts are unsigned until code-signing certs / an Apple Developer account are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)