### PR TITLE
Drop macOS x64: GitHub retired the Intel runner image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,19 +92,15 @@ jobs:
       msi_sha256: ${{ steps.sha.outputs.sha256 }}
 
   build-macos:
+    # Apple Silicon only: GitHub retired the last Intel macOS runner image
+    # (macos-13) in December 2025, and has said x86_64 macOS support ends
+    # entirely after the macos-15 image retires (Fall 2027). There's no
+    # GitHub-hosted way to build osx-x64 anymore, and virtually all Macs
+    # sold since 2020 are Apple Silicon anyway.
     needs: prepare
+    runs-on: macos-14
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
-    strategy:
-      matrix:
-        include:
-          - rid: osx-x64
-            arch: x64
-            runner: macos-13
-          - rid: osx-arm64
-            arch: arm64
-            runner: macos-14
-    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
 
@@ -143,24 +139,24 @@ jobs:
           fi
           xcodebuild -version
 
-      - name: Publish NativeAOT (${{ matrix.rid }})
+      - name: Publish NativeAOT (osx-arm64)
         run: >
-          dotnet publish PgNimbus.App -c Release -r ${{ matrix.rid }}
+          dotnet publish PgNimbus.App -c Release -r osx-arm64
           --self-contained true
           -p:PublishAot=true
           -p:Version=${{ env.VERSION }}
           -p:FileVersion=${{ env.VERSION }}
           -p:InformationalVersion=${{ env.VERSION }}
-          -o publish/${{ matrix.rid }}
+          -o publish/osx-arm64
 
       - name: Build .app bundle + .dmg
         run: |
           chmod +x scripts/macos/build-app-bundle.sh
-          ./scripts/macos/build-app-bundle.sh publish/${{ matrix.rid }} "$VERSION" ${{ matrix.rid }} dist
+          ./scripts/macos/build-app-bundle.sh publish/osx-arm64 "$VERSION" osx-arm64 dist
 
       - uses: actions/upload-artifact@v4
         with:
-          name: macos-dmg-${{ matrix.arch }}
+          name: macos-dmg-arm64
           path: dist/*.dmg
 
   winget-manifest:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,11 +164,19 @@ job so it never publishes). It produces, per tag:
   The `UpgradeCode` GUID in `Product.wxs` is fixed forever — never
   regenerate it, that's what makes installing a newer tag upgrade in place
   instead of side-by-side.
-- **macOS** — built as *two separate native jobs*, not a cross-compiled or
-  universal binary: `osx-x64` on a `macos-13` (Intel) runner, `osx-arm64` on
-  a `macos-14` (Apple Silicon) runner. Each publish output is wrapped into
-  an unsigned/unnotarized `.app` + `.dmg` by
-  [`scripts/macos/build-app-bundle.sh`](scripts/macos/build-app-bundle.sh),
+- **macOS** — `osx-arm64` only, built on a `macos-14` runner. GitHub retired
+  the last Intel macOS runner image (`macos-13`) in December 2025 and has
+  said x86_64 macOS support ends entirely once the `macos-15` image retires
+  (Fall 2027) — there's no GitHub-hosted way to build `osx-x64` anymore, so
+  don't re-add an Intel matrix leg without a self-hosted Intel Mac runner.
+  Also pins to the newest pre-installed Xcode below major version 26:
+  Xcode 26 changed Swift auto-linking in a way that breaks NativeAOT's
+  static link of `libSystem.Security.Cryptography.Native.Apple.a`
+  ("symbol(s) not found for architecture arm64" / `pal_swiftbindings`),
+  closed "not planned" upstream
+  ([dotnet/runtime#116448](https://github.com/dotnet/runtime/issues/116448)).
+  The publish output is wrapped into an unsigned/unnotarized `.app` + `.dmg`
+  by [`scripts/macos/build-app-bundle.sh`](scripts/macos/build-app-bundle.sh),
   which also generates `.icns` from `PgNimbus.App/Assets/icon-256.png` via
   `sips`/`iconutil` (stock macOS tools, no extra dependency).
 - **winget** — the workflow renders (via

--- a/PgNimbus.App/PgNimbus.App.csproj
+++ b/PgNimbus.App/PgNimbus.App.csproj
@@ -21,7 +21,7 @@
     -->
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
-    <RuntimeIdentifiers>win-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Grab the latest build from [Releases](https://github.com/Shman4ik/pgNimbus/relea
 - **Windows** — `pgNimbus-<version>-win-x64.msi`, a per-user installer (no
   admin rights needed). It's unsigned for now, so Windows SmartScreen will
   warn on first run — click "More info" → "Run anyway".
-- **macOS** — `pgNimbus-<version>-macos-x64.dmg` (Intel) or
-  `pgNimbus-<version>-macos-arm64.dmg` (Apple Silicon). Also unsigned/
-  unnotarized: right-click the app → "Open" the first time to bypass
-  Gatekeeper.
+- **macOS** — `pgNimbus-<version>-macos-arm64.dmg` (Apple Silicon only;
+  GitHub retired hosted Intel macOS runners in December 2025, and Apple
+  hasn't sold an Intel Mac since 2023). Unsigned/unnotarized: right-click
+  the app → "Open" the first time to bypass Gatekeeper.
 - **winget** — a manifest is generated per release but not yet submitted to
   the community `winget-pkgs` repo; `winget install` support is coming once
   that's done.


### PR DESCRIPTION
The v0.1.0 run'\''s `build-macos (osx-x64, x64, macos-13)` job sat queued indefinitely and was cancelled. Confirmed why: GitHub fully retired the `macos-13` (last Intel) runner image in December 2025, and has said x86_64 macOS support ends entirely once `macos-15` retires (Fall 2027) - there'\''s no GitHub-hosted way to build `osx-x64` anymore.

- `build-macos` is now a single arm64-only job on `macos-14` (dropped the matrix, only one target left).
- `RuntimeIdentifiers` in the App csproj, README download instructions, and CLAUDE.md updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)