### PR TITLE
Add cell inspector and Shift+Enter statement execution

### DIFF
--- a/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
+++ b/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace PgNimbus.App.ViewModels;
+
+/// <summary>
+/// Backs the results-grid cell inspector overlay: a read-only, copyable detail
+/// view of one cell's full value, opened when a <c>text</c>/<c>jsonb</c> value
+/// is too long to read inline. <c>jsonb</c>/<c>json</c> values are
+/// pretty-printed; everything else is shown as its plain string form.
+/// </summary>
+public sealed partial class CellInspectorViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool _isOpen;
+
+    [ObservableProperty]
+    private string _columnName = string.Empty;
+
+    [ObservableProperty]
+    private string _displayText = string.Empty;
+
+    /// <summary>True when <see cref="DisplayText"/> is pretty-printed JSON - drives monospace display in the view.</summary>
+    [ObservableProperty]
+    private bool _isJson;
+
+    public void Open(string columnName, object? value)
+    {
+        ColumnName = columnName;
+        (DisplayText, IsJson) = Format(value);
+        IsOpen = true;
+    }
+
+    [RelayCommand]
+    private void Close() => IsOpen = false;
+
+    private static (string Text, bool IsJson) Format(object? value)
+    {
+        var text = value switch
+        {
+            null => "NULL",
+            byte[] bytes => $"\\x{Convert.ToHexString(bytes)}",
+            _ => value.ToString() ?? string.Empty,
+        };
+
+        return TryPrettyPrintJson(text, out var pretty) ? (pretty, true) : (text, false);
+    }
+
+    // Npgsql returns json/jsonb columns as their raw text by default, so the
+    // only signal that a value is JSON (rather than, say, a plain string that
+    // happens to start with '{') is that it actually parses as one.
+    private static bool TryPrettyPrintJson(string text, out string pretty)
+    {
+        pretty = text;
+
+        var trimmed = text.AsSpan().Trim();
+        if (trimmed.Length == 0 || (trimmed[0] != '{' && trimmed[0] != '['))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(text);
+            pretty = JsonSerializer.Serialize(document, new JsonSerializerOptions { WriteIndented = true });
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -25,6 +25,8 @@ public sealed partial class MainViewModel : ObservableObject
 
     public CommandPaletteViewModel CommandPalette { get; } = new();
 
+    public CellInspectorViewModel CellInspector { get; } = new();
+
     // Palette actions that need the window (theme, dialogs) live in the view;
     // MainWindow subscribes to these so the palette can trigger them.
     public event Action? ThemeToggleRequested;

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -180,15 +180,30 @@ public sealed partial class QueryViewModel : ObservableObject
     private bool CanRun() => !IsRunning;
 
     [RelayCommand(CanExecute = nameof(CanRun))]
-    private async Task RunAsync()
+    private Task RunAsync() => RunCoreAsync(Sql, isEntireScript: true);
+
+    /// <summary>
+    /// Runs a single statement in isolation - e.g. the one the caret sits in,
+    /// for <c>Shift</c>+<c>Enter</c> "smart execution" - without touching
+    /// <see cref="Sql"/>, the dirty flag, or the multi-statement script/section
+    /// machinery. The tab's on-screen script is left exactly as it was; only
+    /// the grid and status bar reflect this one statement's outcome. A no-op
+    /// while a run is already in flight, same as <see cref="RunCommand"/>.
+    /// </summary>
+    public Task RunStatementAsync(string statementSql) =>
+        CanRun() ? RunCoreAsync(statementSql, isEntireScript: false) : Task.CompletedTask;
+
+    private async Task RunCoreAsync(string executedSql, bool isEntireScript)
     {
         _cts = new CancellationTokenSource();
         var ct = _cts.Token;
-        var executedSql = Sql;
 
-        // Running clears the dirty flag: the on-screen SQL is now what produced the result.
-        _lastRunSql = executedSql;
-        IsDirty = false;
+        if (isEntireScript)
+        {
+            // Running clears the dirty flag: the on-screen SQL is now what produced the result.
+            _lastRunSql = executedSql;
+            IsDirty = false;
+        }
 
         IsRunning = true;
         Status = "Running...";
@@ -208,24 +223,27 @@ public sealed partial class QueryViewModel : ObservableObject
 
         var stopwatch = Stopwatch.StartNew();
 
-        // Split off the multi-statement script path. A single statement keeps the
-        // streaming/editing/browse path below untouched; only a genuine script
-        // (two or more statements) runs on one shared connection with per-statement
-        // result sections.
-        var statements = SqlScriptSplitter.Split(executedSql);
-
         try
         {
-            if (statements.Count > 1)
+            if (isEntireScript)
             {
-                await RunScriptAsync(statements, stopwatch, ct);
-                if (HasError)
+                // Split off the multi-statement script path. A single statement keeps the
+                // streaming/editing/browse path below untouched; only a genuine script
+                // (two or more statements) runs on one shared connection with per-statement
+                // result sections. A statement run in isolation (RunStatementAsync) is
+                // already exactly one statement, so it always takes the path below.
+                var statements = SqlScriptSplitter.Split(executedSql);
+                if (statements.Count > 1)
                 {
-                    await TryOfferFixAsync(executedSql);
-                }
+                    await RunScriptAsync(statements, stopwatch, ct);
+                    if (HasError)
+                    {
+                        await TryOfferFixAsync(executedSql);
+                    }
 
-                Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, StatusSummary()));
-                return;
+                    Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, StatusSummary()));
+                    return;
+                }
             }
 
             // Ask for one row past the cap: receiving it proves the result was

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -476,7 +476,8 @@
                               CanUserSortColumns="True"
                               SelectionMode="Extended"
                               ClipboardCopyMode="None"
-                              AutoGenerateColumns="False">
+                              AutoGenerateColumns="False"
+                              CellPointerPressed="OnResultsGridCellPointerPressed">
                         <DataGrid.ContextMenu>
                             <ContextMenu x:DataType="vm:MainViewModel">
                                 <MenuItem Header="Copy" InputGesture="Ctrl+C" Click="OnCopyCells" />
@@ -487,6 +488,8 @@
                                     <MenuItem Header="Markdown table" Click="OnCopyAsMarkdown" />
                                     <MenuItem Header="INSERT statements" Click="OnCopyAsInsert" />
                                 </MenuItem>
+                                <Separator />
+                                <MenuItem Header="Inspect cell…" Click="OnInspectCellClick" />
                                 <Separator />
                                 <MenuItem Header="Add row…" Click="OnAddRowClick"
                                           IsEnabled="{Binding ActiveTab.IsEditable}" />
@@ -627,6 +630,39 @@
                                    HorizontalAlignment="Center" VerticalAlignment="Center" Margin="16" />
                     </Grid>
                 </Border>
+            </Grid>
+        </Border>
+    </Border>
+
+    <!--
+        Cell inspector: double-click a results-grid cell (or its context menu)
+        to see the full value - readable and copyable without inline-edit
+        tricks, with jsonb/json pretty-printed. Same centered-overlay-over-scrim
+        shape as the command palette, closed by the scrim, the × button, or Esc.
+    -->
+    <Border Name="CellInspectorOverlay"
+            IsVisible="{Binding CellInspector.IsOpen}"
+            Background="#66000000"
+            PointerPressed="OnCellInspectorScrimPressed">
+        <Border Width="640" MaxHeight="520" MinHeight="200"
+                Background="{DynamicResource SystemControlPageBackgroundAltHighBrush}"
+                BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                CornerRadius="10" BoxShadow="0 12 32 0 #40000000"
+                PointerPressed="OnCellInspectorCardPressed"
+                x:DataType="vm:CellInspectorViewModel" DataContext="{Binding CellInspector}">
+            <Grid RowDefinitions="Auto,*" Margin="14">
+                <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto" Margin="0,0,0,10">
+                    <TextBlock Grid.Column="0" Text="{Binding ColumnName}" FontWeight="SemiBold" FontSize="14"
+                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                    <Button Grid.Column="1" Content="Copy" Classes="chip" Margin="6,0,0,0"
+                            Click="OnCellInspectorCopyClick" />
+                    <Button Grid.Column="2" Content="✕" Classes="chip" Margin="6,0,0,0"
+                            Command="{Binding CloseCommand}" />
+                </Grid>
+                <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                    <SelectableTextBlock Text="{Binding DisplayText}" TextWrapping="NoWrap"
+                                          FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="13" />
+                </ScrollViewer>
             </Grid>
         </Border>
     </Border>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -37,6 +37,11 @@ public partial class MainWindow : Window
     private bool _suppressFilterCompletion;
     private ShortcutsWindow? _shortcutsWindow;
     private IHighlightingDefinition? _sqlHighlighting;
+    // The row/column the pointer last pressed in the results grid, so "Inspect
+    // cell…" on the context menu (which carries no cell of its own) knows what
+    // to open - kept in sync by every press, not just the one that opens it.
+    private object?[]? _lastPressedRow;
+    private int _lastPressedColumnIndex;
 
     public MainWindow()
     {
@@ -137,6 +142,13 @@ public partial class MainWindow : Window
     // focus currently is - a KeyBinding can't express a toggle.
     protected override void OnKeyDown(KeyEventArgs e)
     {
+        if (e.Key == Key.Escape && _viewModel?.CellInspector.IsOpen == true)
+        {
+            _viewModel.CellInspector.CloseCommand.Execute(null);
+            e.Handled = true;
+            return;
+        }
+
         if ((e.Key == Key.K || e.Key == Key.P) && e.KeyModifiers.HasFlag(KeyModifiers.Control))
         {
             OpenCommandPalette();
@@ -401,6 +413,21 @@ public partial class MainWindow : Window
         {
             ShowCompletion(includeTypedChar: false);
             e.Handled = true;
+            return;
+        }
+
+        // Smart execution: runs just the statement the caret sits in (between
+        // ;s) rather than the whole tab, so trying one statement out of a
+        // multi-statement script doesn't require selecting it by hand first.
+        if (e.Key == Key.Enter && e.KeyModifiers == KeyModifiers.Shift)
+        {
+            if (_queryViewModel is { } query
+                && SqlScriptSplitter.StatementAt(SqlEditor.Text, SqlEditor.CaretOffset) is { } statement)
+            {
+                _ = query.RunStatementAsync(statement);
+            }
+
+            e.Handled = true;
         }
     }
 
@@ -451,6 +478,60 @@ public partial class MainWindow : Window
             }
         }
     }
+
+    // Tracks the last-pressed cell for "Inspect cell…" (the context menu click
+    // carries no cell of its own), and opens the inspector immediately on a
+    // double-click - the discoverable, no-menu path to the same place.
+    private void OnResultsGridCellPointerPressed(object? sender, DataGridCellPointerPressedEventArgs e)
+    {
+        if (e.Row.DataContext is not object?[] row)
+        {
+            return;
+        }
+
+        _lastPressedRow = row;
+        _lastPressedColumnIndex = e.Column.DisplayIndex;
+
+        if (e.PointerPressedEventArgs.ClickCount == 2)
+        {
+            OpenCellInspector(row, e.Column.DisplayIndex);
+        }
+    }
+
+    private void OnInspectCellClick(object? sender, RoutedEventArgs e)
+    {
+        if (_lastPressedRow is { } row)
+        {
+            OpenCellInspector(row, _lastPressedColumnIndex);
+        }
+    }
+
+    private void OpenCellInspector(object?[] row, int columnIndex)
+    {
+        if (_viewModel is null || _queryViewModel is null || columnIndex >= row.Length
+            || columnIndex >= _queryViewModel.ColumnNames.Count)
+        {
+            return;
+        }
+
+        _viewModel.CellInspector.Open(_queryViewModel.ColumnNames[columnIndex], row[columnIndex]);
+    }
+
+    private async void OnCellInspectorCopyClick(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel is null || TopLevel.GetTopLevel(this)?.Clipboard is not { } clipboard)
+        {
+            return;
+        }
+
+        await clipboard.SetTextAsync(_viewModel.CellInspector.DisplayText);
+    }
+
+    private void OnCellInspectorScrimPressed(object? sender, PointerPressedEventArgs e) =>
+        _viewModel?.CellInspector.CloseCommand.Execute(null);
+
+    // Swallow presses on the card so they don't bubble to the scrim and close it.
+    private void OnCellInspectorCardPressed(object? sender, PointerPressedEventArgs e) => e.Handled = true;
 
     // In browse mode a header click sorts server-side (ORDER BY + reload page 1)
     // instead of the client-side comparer sort - cancel the default and re-query.

--- a/PgNimbus.App/Views/ShortcutsWindow.axaml
+++ b/PgNimbus.App/Views/ShortcutsWindow.axaml
@@ -57,6 +57,13 @@
                         </StackPanel>
                     </Grid>
                     <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
+                        <TextBlock Classes="what" Text="Run just the statement under the cursor" />
+                        <StackPanel Grid.Column="1" Classes="keys">
+                            <Border Classes="kbd"><TextBlock Text="Shift" /></Border>
+                            <Border Classes="kbd"><TextBlock Text="Enter" /></Border>
+                        </StackPanel>
+                    </Grid>
+                    <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
                         <TextBlock Classes="what" Text="Cancel running query" />
                         <StackPanel Grid.Column="1" Classes="keys">
                             <Border Classes="kbd"><TextBlock Text="Esc" /></Border>
@@ -154,6 +161,14 @@
                             <Border Classes="kbd"><TextBlock Text="Enter" /></Border>
                             <TextBlock Classes="combo" Text="/" />
                             <Border Classes="kbd"><TextBlock Text="Esc" /></Border>
+                        </StackPanel>
+                    </Grid>
+                    <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
+                        <TextBlock Classes="what" Text="Inspect cell (full value, pretty-printed JSON)" />
+                        <StackPanel Grid.Column="1" Classes="keys">
+                            <TextBlock Classes="combo" Text="Double-click" />
+                            <TextBlock Classes="combo" Text="or" />
+                            <TextBlock Classes="combo" Text="context menu" />
                         </StackPanel>
                     </Grid>
                 </StackPanel>

--- a/PgNimbus.Core/Query/SqlScriptSplitter.cs
+++ b/PgNimbus.Core/Query/SqlScriptSplitter.cs
@@ -21,9 +21,72 @@ public static class SqlScriptSplitter
     public static IReadOnlyList<string> Split(string sql)
     {
         var statements = new List<string>();
+        foreach (var (start, end) in RawSpans(sql))
+        {
+            var text = sql[start..end].Trim();
+            if (text.Length > 0)
+            {
+                statements.Add(text);
+            }
+        }
+
+        return statements;
+    }
+
+    /// <summary>
+    /// Finds the statement that <paramref name="offset"/> (a caret position
+    /// into <paramref name="sql"/>) sits in - the same semicolon-delimited
+    /// unit <see cref="Split"/> would produce for it - so "run just this
+    /// statement" execution doesn't require selecting it first. An offset
+    /// sitting in a blank/comment-only gap between statements resolves to the
+    /// next statement, or the previous one if there is none after it. Returns
+    /// null only when <paramref name="sql"/> has no statement at all.
+    /// </summary>
+    public static string? StatementAt(string sql, int offset)
+    {
         if (string.IsNullOrEmpty(sql))
         {
-            return statements;
+            return null;
+        }
+
+        offset = Math.Clamp(offset, 0, sql.Length);
+
+        string? before = null;
+        foreach (var (start, end) in RawSpans(sql))
+        {
+            var text = sql[start..end].Trim();
+            if (text.Length == 0)
+            {
+                continue;
+            }
+
+            if (offset >= start && offset <= end)
+            {
+                return text;
+            }
+
+            if (start > offset)
+            {
+                return text;
+            }
+
+            before = text;
+        }
+
+        return before;
+    }
+
+    // Raw, untrimmed [start, end) spans between semicolons - the lexical scan
+    // both Split and StatementAt key off. Respects single-quoted string
+    // literals ('' escapes), double-quoted identifiers, dollar-quoted strings
+    // ($tag$...$tag$), line comments (-- to end of line), and (nestable)
+    // block comments, per the type-level remarks.
+    private static List<(int Start, int End)> RawSpans(string sql)
+    {
+        var spans = new List<(int, int)>();
+        if (string.IsNullOrEmpty(sql))
+        {
+            return spans;
         }
 
         var n = sql.Length;
@@ -52,7 +115,7 @@ public static class SqlScriptSplitter
                     i = afterDollar > i ? afterDollar : i + 1;
                     break;
                 case ';':
-                    AddStatement(statements, sql, start, i);
+                    spans.Add((start, i));
                     start = i + 1;
                     i = start;
                     break;
@@ -63,17 +126,8 @@ public static class SqlScriptSplitter
         }
 
         // Trailing statement with no closing semicolon.
-        AddStatement(statements, sql, start, n);
-        return statements;
-    }
-
-    private static void AddStatement(List<string> statements, string sql, int start, int end)
-    {
-        var text = sql[start..end].Trim();
-        if (text.Length > 0)
-        {
-            statements.Add(text);
-        }
+        spans.Add((start, n));
+        return spans;
     }
 
     // Returns the index just past the closing quote (or end-of-string if the

--- a/README.md
+++ b/README.md
@@ -114,12 +114,14 @@ Press <kbd>F1</kbd> in the app for the full cheat sheet. The highlights:
 | Command palette (jump to table / query / action) | <kbd>Ctrl</kbd>+<kbd>K</kbd> or <kbd>Ctrl</kbd>+<kbd>P</kbd> |
 | Refresh database & schema | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> |
 | Run query | <kbd>Ctrl</kbd>+<kbd>Enter</kbd> or <kbd>F5</kbd> |
+| Run just the statement under the cursor | <kbd>Shift</kbd>+<kbd>Enter</kbd> |
 | Cancel running query | <kbd>Esc</kbd> |
 | New / close query tab | <kbd>Ctrl</kbd>+<kbd>T</kbd> / <kbd>Ctrl</kbd>+<kbd>W</kbd> |
 | Next / previous tab | <kbd>Ctrl</kbd>+<kbd>PageDown</kbd> / <kbd>Ctrl</kbd>+<kbd>PageUp</kbd> |
 | SQL autocomplete | <kbd>Ctrl</kbd>+<kbd>Space</kbd> (also triggers while typing) |
 | Switch focus: editor ↔ results grid | <kbd>F6</kbd> |
 | Edit selected result cell | <kbd>F2</kbd>, then <kbd>Enter</kbd> to commit / <kbd>Esc</kbd> to cancel |
+| Inspect a result cell (full value, pretty-printed JSON) | Double-click, or "Inspect cell…" on the grid context menu |
 | Keyboard shortcuts window | <kbd>F1</kbd> |
 
 ## Architecture
@@ -253,7 +255,7 @@ bar (the Files community app remains the visual north star):
 - [x] **Copy from the results grid** — <kbd>Ctrl</kbd>+<kbd>C</kbd> copies the
   selected rows (or all rows) as TSV, plus "Copy as" (CSV, JSON, Markdown table,
   `INSERT` statements) on the grid context menu.
-- [ ] **Cell inspector** — a detail pane (or popover) for the selected cell so
+- [x] **Cell inspector** — a detail pane (or popover) for the selected cell so
   long `text`/`jsonb` values are readable and copyable without inline-edit
   tricks; pretty-print JSON.
 - [ ] **Set a cell to NULL from the grid** — inline editing can't express
@@ -268,7 +270,7 @@ bar (the Files community app remains the visual north star):
   table's columns first and hide noise like `pg_catalog`; in the results-grid
   `WHERE` filter box, suggest *only* the current dataset's columns (no SQL
   functions or unrelated tables).
-- [ ] **`Shift`+`Enter` smart execution** — run with <kbd>Shift</kbd>+<kbd>Enter</kbd>
+- [x] **`Shift`+`Enter` smart execution** — run with <kbd>Shift</kbd>+<kbd>Enter</kbd>
   (alongside <kbd>Ctrl</kbd>+<kbd>Enter</kbd>/<kbd>F5</kbd>), executing just the
   statement the cursor sits in (between `;`s) without having to select it first.
 - [ ] **Overflowing tab bar navigation** — once many tabs are open, stop


### PR DESCRIPTION
## Summary
- **Cell inspector**: double-click a results-grid cell (or "Inspect cell…" on its context menu) to open a copyable detail overlay for the full value; `jsonb`/`json` values are pretty-printed, `bytea` is shown as hex.
- **Shift+Enter smart execution**: runs just the SQL statement the caret sits in (split on top-level `;`s) instead of the whole tab, without touching the tab's script text, dirty flag, or the multi-statement script/section UI.
- Refactored `SqlScriptSplitter`'s internal lexer scan into a shared span-producing helper so both the existing `Split()` (unchanged behavior) and the new `StatementAt(sql, offset)` reuse the same quote/comment/dollar-quote-aware logic.
- Updated `README.md` and the in-app Shortcuts window (`F1`) with the new shortcut and interaction.

## Test plan
- [x] `dotnet build` succeeds with 0 warnings/errors.
- [x] Live-verified via Avalonia DevTools MCP against a real Postgres: double-clicking a `notes` cell opened the inspector with the correct column name and full text; the ✕ button closed it.
- [x] Ran a two-statement script (`SELECT * FROM cell_test; SELECT count(*) FROM cell_test;`) and confirmed the existing multi-statement "Script: N statements OK" section-chip behavior is unaffected by the `SqlScriptSplitter` refactor.
- [x] Not independently verified live: the exact `Shift+Enter` keystroke and JSON pretty-printing in the popover (tooling in this session couldn't send modifier-key chords without resorting to raw OS-level input, which was intentionally stopped short). Both paths reuse logic already confirmed correct (statement splitting for scripts; the inspector's open/format/close pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)