### PR TITLE
Fix four UI clipping/readability issues found by driving the app

### DIFF
--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -17,6 +17,7 @@
         Icon="avares://PgNimbus.App/Assets/icon-256.png"
         WindowStartupLocation="CenterOwner"
         Width="1100" Height="800"
+        MinWidth="940" MinHeight="560"
         FontFamily="{StaticResource InterFont}">
 
     <Window.DataTemplates>
@@ -278,8 +279,13 @@
 
             <DockPanel Grid.Row="0" Margin="0,0,0,8">
                 <Button DockPanel.Dock="Right" Classes="chip" Content="+" FontSize="14" Command="{Binding AddTabCommand}" ToolTip.Tip="New query tab" />
+                <!-- Horizontal scroll (not clipping): with many tabs the strip
+                     used to cut off mid-tab and hide the active tab entirely;
+                     AutoScrollToSelectedItem keeps a newly added tab in view. -->
                 <ListBox Name="TabsList" ItemsSource="{Binding Tabs}" SelectedItem="{Binding ActiveTab, Mode=TwoWay}"
-                          SelectionMode="Single">
+                          SelectionMode="Single" AutoScrollToSelectedItem="True"
+                          ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                          ScrollViewer.VerticalScrollBarVisibility="Disabled">
                     <ListBox.ItemsPanel>
                         <ItemsPanelTemplate>
                             <StackPanel Orientation="Horizontal" Spacing="2" />
@@ -646,7 +652,7 @@
             IsVisible="{Binding CellInspector.IsOpen}"
             Background="#66000000"
             PointerPressed="OnCellInspectorScrimPressed">
-        <Border Width="640" MaxHeight="520" MinHeight="200"
+        <Border Width="640" MaxHeight="520" MinHeight="120" VerticalAlignment="Center"
                 Background="{DynamicResource SystemControlPageBackgroundAltHighBrush}"
                 BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
                 CornerRadius="10" BoxShadow="0 12 32 0 #40000000"

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1036,6 +1036,10 @@ public partial class MainWindow : Window
                 // infer sortability from, CanUserSort must be set by hand.
                 CustomSortComparer = new RowCellComparer(i),
                 CanUserSort = true,
+                // Auto width sizes to the widest cell, so one long text value
+                // used to blow the column past the viewport; cap it and let
+                // the cell inspector carry the full value.
+                MaxWidth = 560,
             });
         }
     }

--- a/PgNimbus.App/Views/ShortcutsWindow.axaml
+++ b/PgNimbus.App/Views/ShortcutsWindow.axaml
@@ -3,8 +3,9 @@
         x:Class="PgNimbus.App.Views.ShortcutsWindow"
         Title="pgNimbus — Keyboard Shortcuts"
         Icon="avares://PgNimbus.App/Assets/icon-256.png"
-        Width="600" Height="800"
-        CanResize="False"
+        Width="600" Height="700"
+        MinWidth="480" MinHeight="400"
+        CanResize="True"
         WindowStartupLocation="CenterOwner"
         FontFamily="{StaticResource InterFont}">
 

--- a/README.md
+++ b/README.md
@@ -226,8 +226,16 @@ Things a person needs before pgNimbus can be their only Postgres client:
   gets its own result tab/section, with per-statement timings.
 - [x] **DDL view** — a "Source" tab per object: reconstructed
   `CREATE TABLE`/`CREATE VIEW`/index definitions from `pg_catalog`.
-- [ ] **Windows installer + releases** — signed MSI/winget package and a CI
-  pipeline that publishes NativeAOT builds per tag.
+- [x] **Windows installer + releases** — a per-user MSI and a macOS `.dmg`
+  built and published by CI on every tag, plus generated winget manifests.
+- [ ] **Code signing** — Authenticode for the MSI, Developer ID +
+  notarization for the `.dmg`. Both ship unsigned today, so SmartScreen and
+  Gatekeeper warn on first run — the single biggest first-impression blocker
+  for a production release. The pipeline already has the slot for it; needs
+  a cert and an Apple developer account.
+- [ ] **winget submission** — manifests are generated and validated per
+  release, but the first manual `winget-pkgs` PR (which registers the
+  `pgNimbus.pgNimbus` identifier) hasn't been made yet.
 
 ### Next — depth on the Postgres-first promise
 
@@ -283,9 +291,24 @@ bar (the Files community app remains the visual north star):
 - [x] **`Shift`+`Enter` smart execution** — run with <kbd>Shift</kbd>+<kbd>Enter</kbd>
   (alongside <kbd>Ctrl</kbd>+<kbd>Enter</kbd>/<kbd>F5</kbd>), executing just the
   statement the cursor sits in (between `;`s) without having to select it first.
-- [ ] **Overflowing tab bar navigation** — once many tabs are open, stop
-  squeezing them unreadably; add `<`/`>` scroll arrows and a dropdown listing
-  all open tabs with type-to-search.
+- [x] **Tab bar overflow scrolling** — with many tabs open, the strip now
+  scrolls horizontally and keeps the active tab in view. (It used to clip:
+  the "+" button overlapped the last visible tab and a newly opened tab
+  could sit fully off-screen with no way to reach it.)
+- [ ] **Tab bar navigation extras** — `<`/`>` scroll arrows and a dropdown
+  listing all open tabs with type-to-search, on top of the basic scrolling.
+- [x] **Capped results-grid column width** — auto column width sizes to the
+  widest cell, so a single long `text` value used to push every other column
+  out of view; columns now cap at 560 px, with the cell inspector
+  (double-click) carrying the full value.
+- [x] **Content-sized cell inspector** — the inspector card sizes to its
+  value (small values get a small card) instead of always opening at full
+  height.
+- [x] **Window minimum size** — a 940×560 floor, below which the command bar
+  and browse bar used to clip into unreadability.
+- [ ] **Empty state for the connection dialog** — the Saved Connections list
+  is a bare grey panel when empty; give it the same friendly hint the
+  saved-queries and history lists already have.
 - [ ] **Drag-and-drop from the schema tree** — drag a table, column, or other
   object from the sidebar tree into the SQL editor and drop a valid, quoted
   identifier at the cursor (e.g. `"CreatedAt"`).
@@ -322,7 +345,9 @@ bar (the Files community app remains the visual north star):
   (initially: custom result visualizers).
 - [ ] **Localization** — externalize UI strings; ship Russian and German first.
 
-Recently shipped: clause-aware SQL IntelliSense (tables after FROM/JOIN,
+Recently shipped: tab-strip overflow scrolling, capped results-grid column
+widths, a content-sized cell inspector, a window minimum size,
+clause-aware SQL IntelliSense (tables after FROM/JOIN,
 typed columns, aliases, CTEs, function-call insertion, auto-popup, no popups
 inside strings/comments), editor niceties (current-line highlight,
 matching-bracket highlight, Ctrl+wheel / Ctrl+± font zoom), "Set cell to


### PR DESCRIPTION
Interactive review on a live instance (Xvfb + seeded Postgres, light and
dark, down to small window sizes) surfaced four places where content
clipped or became unreadable; all are small, targeted fixes:

- Tab strip: horizontal StackPanel clipped mid-tab once ~8 tabs were
  open - the "+" button overlapped the last tab and a newly added tab
  (the active one) could sit fully off-screen. The tab ListBox now
  scrolls horizontally and auto-scrolls the selected tab into view.
- Results grid: auto column width sizes to the widest cell, so one long
  text value made its column wider than the whole viewport. Columns now
  cap at 560px; the cell inspector still shows the full value.
- Cell inspector: the card stretched to its 520px MaxHeight even for a
  one-line value (it was missing VerticalAlignment, so it filled the
  scrim). It now sizes to content, centered.
- Window: at ~760px wide the command bar clipped the Export button.
  MinWidth/MinHeight 940x560 keeps every control reachable.

README backlog updated to match: tab-bar scrolling and the installer/CI
items marked shipped, remaining production-ready gaps sharpened (code
signing, winget submission, tab-bar arrows/dropdown, connection-dialog
empty state).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017iqDASXrBYmuoqGYCiEKT4