### PR TITLE
UI review: fix clipping/readability issues found by driving the app

### DIFF
--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -168,7 +168,7 @@
                             <ListBox Name="SavedQueriesList" ItemsSource="{Binding SavedQueries}">
                                 <ListBox.ItemTemplate>
                                     <DataTemplate x:DataType="query:SavedQuery">
-                                        <TextBlock Text="{Binding Name}" ToolTip.Tip="{Binding Sql}" />
+                                        <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Sql}" />
                                     </DataTemplate>
                                 </ListBox.ItemTemplate>
                             </ListBox>
@@ -254,7 +254,9 @@
                                 <ListBox.ItemTemplate>
                                     <DataTemplate x:DataType="notify:DatabaseNotification">
                                         <StackPanel>
-                                            <TextBlock FontSize="12">
+                                            <!-- Long payloads wrap (capped) instead of clipping at the panel edge -->
+                                            <TextBlock FontSize="12" TextWrapping="Wrap" MaxLines="4"
+                                                       TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Payload}">
                                                 <Run Text="{Binding Channel}" FontWeight="SemiBold" />
                                                 <Run Text="{Binding Payload}" />
                                             </TextBlock>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -106,6 +106,16 @@ public partial class MainWindow : Window
         BrowseFilterBox.TextChanged += OnBrowseFilterTextChanged;
         BrowseFilterBox.LostFocus += (_, _) => CloseFilterCompletion();
 
+        // On Windows, popups are native always-on-top windows, and one left
+        // open while the user Alt+Tabs (or clicks) into another program keeps
+        // floating above that program. Close every popup we own the moment
+        // this window stops being the foreground one.
+        Deactivated += (_, _) =>
+        {
+            _completionWindow?.Close();
+            CloseFilterCompletion();
+        };
+
         DataContextChanged += (_, _) =>
         {
             if (DataContext is MainViewModel vm)

--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ bar (the Files community app remains the visual north star):
 - [ ] **Empty state for the connection dialog** — the Saved Connections list
   is a bare grey panel when empty; give it the same friendly hint the
   saved-queries and history lists already have.
+- [ ] **Persist the theme choice** — the in-app light/dark toggle resets to
+  the OS default on every launch; remember it alongside the other persisted
+  app state.
 - [ ] **Drag-and-drop from the schema tree** — drag a table, column, or other
   object from the sidebar tree into the SQL editor and drop a valid, quoted
   identifier at the cursor (e.g. `"CreatedAt"`).


### PR DESCRIPTION
## What

Three interactive UI review passes on a live instance (Xvfb + seeded Postgres, light and dark themes, down to minimum window sizes), fixing every clipping/readability issue found and updating the README's production-ready backlog.

### Fixes

- **Tab strip overflow** — with ~8+ tabs the strip clipped mid-tab, the `+` button overlapped the last tab, and a newly opened (active!) tab could sit fully off-screen with no way to reach it. The tab list now scrolls horizontally and auto-scrolls the selected tab into view.
- **Results-grid column width** — auto width sizes a column to its widest cell, so one long `text` value pushed every other column out of the viewport. Columns now cap at 560 px; the cell inspector carries the full value.
- **Cell inspector sizing** — the card stretched to its 520 px max height even for a one-line value; it now sizes to content, centered.
- **Window minimum size** — at ~760 px wide the command bar clipped the Export button; 940×560 floor keeps every control reachable.
- **F1 shortcuts window** — fixed 600×800 and non-resizable clipped the bottom section on 1366×768 laptops; now 600×700 and resizable.
- **Saved-query names** — long names clipped flat at the panel edge; now ellipsized (SQL tooltip unchanged).
- **NOTIFY payloads** — long payloads rendered as one unwrapped line; now wrap up to 4 lines with an ellipsis and full payload in a tooltip.
- **Popups above other applications (reported on Windows)** — the IntelliSense list stayed painted over whatever app took focus (e.g. the browser). Both the SQL completion window and the WHERE-filter column popup are now closed explicitly on `Window.Deactivated`.

### README backlog updates

- Installer/CI marked shipped; remaining production-ready gaps sharpened: **code signing** (the biggest first-impression blocker — SmartScreen/Gatekeeper), **winget-pkgs first submission**, tab-bar scroll arrows/dropdown, connection-dialog empty state, and **theme persistence** (the light/dark toggle resets on relaunch).

## Verification

Every fix was verified by rebuilding and driving the running app (screenshots at each step): 13 tabs scroll with the active tab visible, the notes column caps and truncates, the inspector opens compact, the window refuses to shrink below 940×560 with nothing clipped, long saved names/payloads ellipsize/wrap, and the completion popup disappears the moment another window takes focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iqDASXrBYmuoqGYCiEKT4

---
_Generated by [Claude Code](https://claude.ai/code/session_017iqDASXrBYmuoqGYCiEKT4)_