### PR TITLE
Switch connection, cell-inspector word wrap, Unicode-readable JSON

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Npgsql;
@@ -44,7 +45,16 @@ public partial class App : Application
         base.OnFrameworkInitializationCompleted();
     }
 
-    private static ConnectionDialog BuildConnectionDialog(IClassicDesktopStyleApplicationLifetime desktop)
+    /// <summary>
+    /// Builds the connection-profile picker. Used both at startup (as
+    /// <see cref="IClassicDesktopStyleApplicationLifetime.MainWindow"/>, no
+    /// <paramref name="previousWindow"/>) and for "switch connection" from an
+    /// already-open <see cref="MainWindow"/> — in that case, connecting closes
+    /// <paramref name="previousWindow"/> after the new one is up, so its
+    /// resources (notify-listen connection, SSH tunnel) tear down via its own
+    /// <c>Closed</c> handler exactly as they would on a normal window close.
+    /// </summary>
+    internal static ConnectionDialog BuildConnectionDialog(IClassicDesktopStyleApplicationLifetime desktop, Window? previousWindow = null)
     {
         var viewModel = new ConnectionDialogViewModel(new ConnectionProfileStore(), CredentialStore.Create());
         var dialog = new ConnectionDialog { DataContext = viewModel };
@@ -55,12 +65,13 @@ public partial class App : Application
             desktop.MainWindow = mainWindow;
             mainWindow.Show();
             dialog.Close();
+            previousWindow?.Close();
         };
 
         return dialog;
     }
 
-    private static MainWindow BuildMainWindow(string connectionString, string? accentColor = null, SshTunnel? tunnel = null)
+    internal static MainWindow BuildMainWindow(string connectionString, string? accentColor = null, SshTunnel? tunnel = null)
     {
         var dataSource = NpgsqlDataSource.Create(connectionString);
         var engine = new QueryEngine(dataSource);

--- a/PgNimbus.App/Converters/BoolToTextWrappingConverter.cs
+++ b/PgNimbus.App/Converters/BoolToTextWrappingConverter.cs
@@ -1,0 +1,17 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace PgNimbus.App.Converters;
+
+/// <summary>Converts a word-wrap toggle (bool) into a <see cref="TextWrapping"/> value.</summary>
+public sealed class BoolToTextWrappingConverter : IValueConverter
+{
+    public static readonly BoolToTextWrappingConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is true ? TextWrapping.Wrap : TextWrapping.NoWrap;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -169,6 +169,11 @@
         <Setter Property="Background" Value="{StaticResource HoverBackgroundBrush}" />
         <Setter Property="Opacity" Value="1" />
     </Style>
+    <!-- Checked state for chip-styled ToggleButtons (e.g. cell inspector's Wrap toggle) -->
+    <Style Selector="ToggleButton.chip:checked">
+        <Setter Property="Background" Value="{StaticResource HoverBackgroundBrush}" />
+        <Setter Property="Opacity" Value="1" />
+    </Style>
 
     <!-- Left-nav style TabItem: pill highlight instead of the classic underline tab strip -->
     <Style Selector="TabControl">

--- a/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
+++ b/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
@@ -1,4 +1,6 @@
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Unicode;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
@@ -24,6 +26,19 @@ public sealed partial class CellInspectorViewModel : ObservableObject
     /// <summary>True when <see cref="DisplayText"/> is pretty-printed JSON - drives monospace display in the view.</summary>
     [ObservableProperty]
     private bool _isJson;
+
+    /// <summary>Whether the inspector wraps long lines, Notepad++-style. On by default so a long text/jsonb value never scrolls off-screen horizontally.</summary>
+    [ObservableProperty]
+    private bool _wordWrap = true;
+
+    private static readonly JsonSerializerOptions PrettyPrintOptions = new()
+    {
+        WriteIndented = true,
+        // Default JsonSerializer escaping is ASCII-only (everything else
+        // becomes \uXXXX) - relax to all Unicode so e.g. Cyrillic values
+        // show as themselves, not escape sequences.
+        Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+    };
 
     public void Open(string columnName, object? value)
     {
@@ -63,7 +78,7 @@ public sealed partial class CellInspectorViewModel : ObservableObject
         try
         {
             using var document = JsonDocument.Parse(text);
-            pretty = JsonSerializer.Serialize(document, new JsonSerializerOptions { WriteIndented = true });
+            pretty = JsonSerializer.Serialize(document, PrettyPrintOptions);
             return true;
         }
         catch (JsonException)

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -31,6 +31,12 @@ public sealed partial class MainViewModel : ObservableObject
     // MainWindow subscribes to these so the palette can trigger them.
     public event Action? ThemeToggleRequested;
     public event Action? ShortcutsRequested;
+    // Raised when the user asks to connect to a different server/database;
+    // MainWindow reopens the connection dialog (App.BuildConnectionDialog).
+    public event Action? SwitchConnectionRequested;
+
+    [RelayCommand]
+    private void SwitchConnection() => SwitchConnectionRequested?.Invoke();
 
     // Relations rarely change mid-session, so the palette's "jump to a table"
     // list is fetched once and reused across opens.
@@ -252,6 +258,7 @@ public sealed partial class MainViewModel : ObservableObject
         yield return new PaletteItem("Close tab", "Action", "✕", Invoke(() => CloseTabCommand));
         yield return new PaletteItem("Next tab", "Action", "›", Invoke(() => NextTabCommand));
         yield return new PaletteItem("Previous tab", "Action", "‹", Invoke(() => PreviousTabCommand));
+        yield return new PaletteItem("Switch connection…", "Action", "⇄", () => { SwitchConnectionRequested?.Invoke(); return Task.CompletedTask; });
         yield return new PaletteItem("Toggle light/dark theme", "Action", "◐", () => { ThemeToggleRequested?.Invoke(); return Task.CompletedTask; });
         yield return new PaletteItem("Keyboard shortcuts", "Action", "?", () => { ShortcutsRequested?.Invoke(); return Task.CompletedTask; });
     }

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -92,6 +92,8 @@
                     <TextBlock Text="{Binding ConnectionHost}" FontSize="12" Opacity="0.65" VerticalAlignment="Center" Margin="10,0,0,0" />
                     <TextBlock Text="›" FontSize="12" Opacity="0.45" VerticalAlignment="Center" />
                     <TextBlock Text="{Binding ConnectionDatabase}" FontSize="12" Opacity="0.65" VerticalAlignment="Center" />
+                    <Button Classes="chip" Content="⇄" FontSize="12" VerticalAlignment="Center" Margin="4,0,0,0"
+                            Click="OnSwitchConnectionClick" ToolTip.Tip="Switch connection" />
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -661,16 +663,19 @@
                 PointerPressed="OnCellInspectorCardPressed"
                 x:DataType="vm:CellInspectorViewModel" DataContext="{Binding CellInspector}">
             <Grid RowDefinitions="Auto,*" Margin="14">
-                <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto" Margin="0,0,0,10">
+                <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto,Auto" Margin="0,0,0,10">
                     <TextBlock Grid.Column="0" Text="{Binding ColumnName}" FontWeight="SemiBold" FontSize="14"
                                VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
-                    <Button Grid.Column="1" Content="Copy" Classes="chip" Margin="6,0,0,0"
+                    <ToggleButton Grid.Column="1" Content="Wrap" Classes="chip" Margin="6,0,0,0"
+                                  IsChecked="{Binding WordWrap}" ToolTip.Tip="Toggle word wrap" />
+                    <Button Grid.Column="2" Content="Copy" Classes="chip" Margin="6,0,0,0"
                             Click="OnCellInspectorCopyClick" />
-                    <Button Grid.Column="2" Content="✕" Classes="chip" Margin="6,0,0,0"
+                    <Button Grid.Column="3" Content="✕" Classes="chip" Margin="6,0,0,0"
                             Command="{Binding CloseCommand}" />
                 </Grid>
                 <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
-                    <SelectableTextBlock Text="{Binding DisplayText}" TextWrapping="NoWrap"
+                    <SelectableTextBlock Text="{Binding DisplayText}"
+                                          TextWrapping="{Binding WordWrap, Converter={x:Static conv2:BoolToTextWrappingConverter.Instance}}"
                                           FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="13" />
                 </ScrollViewer>
             </Grid>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Xml;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
@@ -224,6 +225,7 @@ public partial class MainWindow : Window
             _viewModel.PropertyChanged -= OnMainViewModelPropertyChanged;
             _viewModel.ThemeToggleRequested -= ToggleTheme;
             _viewModel.ShortcutsRequested -= ShowShortcutsWindow;
+            _viewModel.SwitchConnectionRequested -= SwitchConnection;
         }
 
         _viewModel = vm;
@@ -231,6 +233,7 @@ public partial class MainWindow : Window
         // Palette actions that touch the window are handled here.
         _viewModel.ThemeToggleRequested += ToggleTheme;
         _viewModel.ShortcutsRequested += ShowShortcutsWindow;
+        _viewModel.SwitchConnectionRequested += SwitchConnection;
 
         AttachQuery(vm.ActiveTab);
     }
@@ -308,6 +311,25 @@ public partial class MainWindow : Window
     }
 
     private void OnShowShortcutsClick(object? sender, RoutedEventArgs e) => ShowShortcutsWindow();
+
+    private void OnSwitchConnectionClick(object? sender, RoutedEventArgs e) => SwitchConnection();
+
+    // Reopens the connection dialog so a different profile (or an ad-hoc
+    // connection) can be chosen without restarting the app. This window stays
+    // usable until the new connection succeeds; only then does the dialog's
+    // Connected handler close it (tearing down its notify listener/tunnel via
+    // the Closed hook in App.BuildMainWindow). Cancelling the dialog leaves
+    // everything as it was.
+    private void SwitchConnection()
+    {
+        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            return;
+        }
+
+        var dialog = App.BuildConnectionDialog(desktop, previousWindow: this);
+        dialog.Show(this);
+    }
 
     private void ShowShortcutsWindow()
     {

--- a/PgNimbus.Core/Export/ResultExporter.cs
+++ b/PgNimbus.Core/Export/ResultExporter.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Unicode;
 
 namespace PgNimbus.Core.Export;
 
@@ -77,9 +79,19 @@ public static class ResultExporter
         }
     }
 
+    // Escaping is relaxed to all Unicode ranges instead of the JsonSerializer
+    // default (ASCII-only, everything else \uXXXX-escaped) - non-Latin text
+    // (e.g. Cyrillic) should read as itself in an exported/copied JSON file,
+    // not as escape sequences.
+    private static readonly JsonWriterOptions JsonOptions = new()
+    {
+        Indented = true,
+        Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+    };
+
     public static void WriteJson(Stream stream, IReadOnlyList<string> columns, IEnumerable<object?[]> rows)
     {
-        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+        using var writer = new Utf8JsonWriter(stream, JsonOptions);
 
         writer.WriteStartArray();
         foreach (var row in rows)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   (so production doesn't look like staging), SSH tunnel support, and
   passwords held by the OS credential store (DPAPI on Windows) instead of
   being written to disk with the profile.
+- **Switch connection without restarting** — the ⇄ button next to the
+  title-bar breadcrumb (or "Switch connection…" in the command palette)
+  reopens the connection dialog; the current window stays fully usable until
+  the new connection succeeds, then hands over cleanly (LISTEN subscriptions
+  and SSH tunnels for the old connection are torn down).
 - **Paste-anything connection strings** — drop whatever is on your clipboard
   into the connection dialog and it fills the form: `postgres://` URIs
   (Heroku/Supabase/Neon-style), `jdbc:postgresql://` URLs, ADO.NET/Npgsql
@@ -104,6 +109,10 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   cast to its real type server-side, blanks fall back to defaults),
   "Delete selected row(s)" with a confirmation, and "Set cell to NULL" (the
   gesture inline editing can't express), all keyed on the primary key.
+- **Cell inspector** — double-click a cell (or "Inspect cell…" on the grid
+  context menu) to read the full value of a long `text`/`jsonb` cell in an
+  overlay: JSON pretty-printed, word wrap on by default with a toggle, and a
+  one-click copy.
 - **EXPLAIN visualization** — a graphical plan tree for `EXPLAIN` and
   `EXPLAIN ANALYZE`, not just raw text output.
 - **LISTEN/NOTIFY monitor** — subscribe to channels and watch notifications
@@ -227,7 +236,9 @@ Things a person needs before pgNimbus can be their only Postgres client:
 - [x] **DDL view** — a "Source" tab per object: reconstructed
   `CREATE TABLE`/`CREATE VIEW`/index definitions from `pg_catalog`.
 - [x] **Windows installer + releases** — a per-user MSI and a macOS `.dmg`
-  built and published by CI on every tag, plus generated winget manifests.
+  built and published by CI on every tag
+  ([`release.yml`](.github/workflows/release.yml)), plus generated winget
+  manifests.
 - [ ] **Code signing** — Authenticode for the MSI, Developer ID +
   notarization for the `.dmg`. Both ship unsigned today, so SmartScreen and
   Gatekeeper warn on first run — the single biggest first-impression blocker
@@ -269,7 +280,9 @@ bar (the Files community app remains the visual north star):
   `INSERT` statements) on the grid context menu.
 - [x] **Cell inspector** — a detail pane (or popover) for the selected cell so
   long `text`/`jsonb` values are readable and copyable without inline-edit
-  tricks; pretty-print JSON.
+  tricks; pretty-print JSON. Word wrap is on by default (Notepad++-style),
+  with a "Wrap" toggle in the header, and non-ASCII text (e.g. Cyrillic)
+  displays as itself rather than `\uXXXX` escapes.
 - [x] **Set a cell to NULL from the grid** — inline editing can't express
   "make it NULL" (empty string ≠ NULL); a "Set cell to NULL" context-menu
   action on the results grid issues the targeted UPDATE.


### PR DESCRIPTION
## What

Three user-facing improvements plus a README refresh:

- **Switch connection without restarting** — a ⇄ chip next to the title-bar breadcrumb (and a "Switch connection…" command-palette action) reopens the connection dialog. The current window stays fully usable until the new connection succeeds; only then does it close, tearing down its LISTEN monitor and SSH tunnel via the existing `Closed` hook. Cancelling the dialog leaves everything untouched.
- **Cell inspector word wrap** — long `text`/`jsonb` values wrap by default (Notepad++-style) instead of scrolling horizontally, with a "Wrap" toggle chip in the inspector header (new `BoolToTextWrappingConverter` + a checked style for chip `ToggleButton`s).
- **Readable non-ASCII JSON** — the cell inspector's pretty-printer and `ResultExporter.WriteJson` (JSON export + "Copy as JSON") now emit non-Latin text as-is instead of `\uXXXX` escapes, e.g. `"Name": "Выживание"` instead of `"Name": "Выжи..."` (`JavaScriptEncoder.Create(UnicodeRanges.All)`).
- **README** — the release pipeline is done: link `release.yml` from the shipped backlog item, and document the new features above.

## Testing

- `dotnet build` clean (0 warnings / 0 errors) after rebasing onto main.
- Rebased over #42–#45; README conflicts resolved keeping mains updated backlog entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)