### PR TITLE
Scope WHERE completion to FROM tables; schema-qualify table completion

### DIFF
--- a/PgNimbus.App/Completion/SqlCompletionContext.cs
+++ b/PgNimbus.App/Completion/SqlCompletionContext.cs
@@ -9,8 +9,10 @@ internal enum SqlClause
     None,
     /// <summary>A table/view name goes here (after FROM, JOIN, INTO, UPDATE, TABLE…).</summary>
     TableRef,
-    /// <summary>A column/expression goes here (after SELECT, WHERE, ON, SET, BY…).</summary>
+    /// <summary>A column/expression goes here (after SELECT, SET, RETURNING…) — the full catalog, current tables' columns floated up.</summary>
     ColumnRef,
+    /// <summary>A row-scoped column reference (after WHERE, ON, HAVING, GROUP/ORDER BY, USING) — only the FROM-clause tables' columns can go here, not the whole schema.</summary>
+    Predicate,
 }
 
 /// <summary>
@@ -179,6 +181,14 @@ internal static partial class SqlCompletionContext
             }
         }
 
+        foreach (var kw in PredicateClauseKeywords)
+        {
+            if (word.Equals(kw, StringComparison.OrdinalIgnoreCase))
+            {
+                return SqlClause.Predicate;
+            }
+        }
+
         foreach (var kw in ColumnClauseKeywords)
         {
             if (word.Equals(kw, StringComparison.OrdinalIgnoreCase))
@@ -194,8 +204,14 @@ internal static partial class SqlCompletionContext
     private static readonly string[] TableClauseKeywords =
         ["from", "join", "into", "update", "table", "truncate"];
 
+    // Row-scoped column contexts: a predicate (WHERE/ON/HAVING) or a
+    // GROUP/ORDER BY / USING list can only name columns of the tables already in
+    // the statement's FROM, so completion narrows to those instead of the catalog.
+    private static readonly string[] PredicateClauseKeywords =
+        ["where", "on", "having", "by", "using"];
+
     private static readonly string[] ColumnClauseKeywords =
-        ["select", "where", "on", "having", "by", "set", "returning", "using", "values", "when", "then", "else", "distinct"];
+        ["select", "set", "returning", "values", "when", "then", "else", "distinct"];
 
     // Skips a $$…$$ / $tag$…$tag$ literal starting at `start`. Returns false when
     // the '$' isn't a dollar-quote opener (e.g. a $1 parameter); on true, `i` is

--- a/PgNimbus.App/Completion/SqlCompletionProvider.cs
+++ b/PgNimbus.App/Completion/SqlCompletionProvider.cs
@@ -15,7 +15,12 @@ namespace PgNimbus.App.Completion;
 /// table's columns (or, after <c>schema.</c>, that schema's tables).</item>
 /// <item><b>Table position</b> — after FROM/JOIN/INTO/UPDATE, only what can
 /// legally go there: tables, schemas, the statement's CTE names, and keywords —
-/// no column noise.</item>
+/// no column noise. A table completes schema-qualified (<c>public.users</c>) so
+/// the reference resolves regardless of the search_path.</item>
+/// <item><b>Predicate position</b> — after WHERE/ON/HAVING/GROUP BY/ORDER BY,
+/// only the columns of the tables the statement pulls FROM (plus its aliases,
+/// CTEs, functions and keywords); the rest of the catalog's columns and tables
+/// are dropped, since nothing else is in scope for a row predicate.</item>
 /// <item><b>Anywhere else</b> — everything, but with the columns of the tables
 /// the statement touches (FROM/JOIN plus UPDATE/INSERT INTO targets) floated to
 /// the top and pre-selected, and the statement's aliases offered too. System
@@ -97,6 +102,9 @@ public sealed class SqlCompletionProvider
     private IReadOnlyList<SqlCompletionData> _baseItems = [];
     // Its table-position subset: keywords + schemas + tables, no columns/functions.
     private IReadOnlyList<SqlCompletionData> _tableRefItems = [];
+    // Its predicate subset: keywords + functions only, no catalog columns/tables —
+    // a WHERE/ON/BY caret gets these plus just the FROM tables' own columns.
+    private IReadOnlyList<SqlCompletionData> _predicateBaseItems = [];
 
     public SqlCompletionProvider(SchemaService schemaService)
     {
@@ -109,8 +117,9 @@ public sealed class SqlCompletionProvider
         var columnsByTable = new Dictionary<string, List<TableColumn>>(StringComparer.OrdinalIgnoreCase);
 
         var keywordItems = Keywords.Select(k => new SqlCompletionData(k, "keyword")).ToList();
+        var functionItems = Functions.Select(f => new SqlCompletionData(f, "function", $"{f}()", FunctionPriority)).ToList();
         var baseItems = new List<SqlCompletionData>(keywordItems);
-        baseItems.AddRange(Functions.Select(f => new SqlCompletionData(f, "function", $"{f}()", FunctionPriority)));
+        baseItems.AddRange(functionItems);
         // Keywords go *after* the catalog here: with nothing typed yet the list
         // renders in insertion order, and right after FROM/JOIN the point is the
         // tables, not SELECT/WHERE.
@@ -129,9 +138,12 @@ public sealed class SqlCompletionProvider
             foreach (var table in schemaTables)
             {
                 tables.Add((schema.Name, table.Name));
-                var tableItem = new SqlCompletionData(table.Name, $"table ({schema.Name})", SqlIdentifier.QuoteIfNeeded(table.Name), TablePriority);
-                baseItems.Add(tableItem);
-                tableRefItems.Add(tableItem);
+                // Elsewhere a table completes to its bare name; in table position
+                // (after FROM/JOIN) it completes schema-qualified ("public.users")
+                // so the reference is unambiguous whatever the search_path is.
+                var qualified = $"{SqlIdentifier.QuoteIfNeeded(schema.Name)}.{SqlIdentifier.QuoteIfNeeded(table.Name)}";
+                baseItems.Add(new SqlCompletionData(table.Name, $"table ({schema.Name})", SqlIdentifier.QuoteIfNeeded(table.Name), TablePriority));
+                tableRefItems.Add(new SqlCompletionData(table.Name, $"table ({schema.Name})", qualified, TablePriority));
             }
 
             var columns = await _schemaService.GetAllColumnsAsync(schema.Name, ct);
@@ -149,6 +161,9 @@ public sealed class SqlCompletionProvider
         _columnsByTable = columnsByTable;
         _baseItems = Dedupe(baseItems);
         _tableRefItems = Dedupe(tableRefItems);
+        // A predicate caret gets keywords + functions but no catalog columns/tables;
+        // GetPredicateCompletions prepends just the FROM tables' own columns.
+        _predicateBaseItems = Dedupe(keywordItems.Concat(functionItems));
     }
 
     /// <summary>
@@ -172,9 +187,12 @@ public sealed class SqlCompletionProvider
             return GetMemberCompletions(qualifier, sql);
         }
 
-        return context.Clause == SqlClause.TableRef
-            ? GetTableRefCompletions(sql)
-            : GetGeneralCompletions(sql);
+        return context.Clause switch
+        {
+            SqlClause.TableRef => GetTableRefCompletions(sql),
+            SqlClause.Predicate => GetPredicateCompletions(sql),
+            _ => GetGeneralCompletions(sql),
+        };
     }
 
     // After "qualifier.": the columns of the table the qualifier names (directly
@@ -223,8 +241,38 @@ public sealed class SqlCompletionProvider
     // columns win, plus its aliases and CTE names.
     private IReadOnlyList<SqlCompletionData> GetGeneralCompletions(string sql)
     {
+        var items = CollectStatementItems(sql, out _);
+        items.AddRange(_baseItems);
+        return Dedupe(items);
+    }
+
+    // Predicate/row position (WHERE, ON, HAVING, GROUP/ORDER BY, USING): only the
+    // columns of the FROM tables can be named here, so we offer those (plus the
+    // statement's aliases, CTE names, functions and keywords) and drop the rest of
+    // the catalog's columns/tables/schemas. If nothing in FROM resolves to known
+    // columns yet, fall back to the full catalog rather than a near-empty list.
+    private IReadOnlyList<SqlCompletionData> GetPredicateCompletions(string sql)
+    {
+        var items = CollectStatementItems(sql, out var resolvedColumns);
+        if (!resolvedColumns)
+        {
+            items.AddRange(_baseItems);
+            return Dedupe(items);
+        }
+
+        items.AddRange(_predicateBaseItems);
+        return Dedupe(items);
+    }
+
+    // The current statement's own contributions — every FROM/UPDATE/INTO table's
+    // columns (top priority) and aliases, plus CTE names. Sets
+    // <paramref name="resolvedColumns"/> when at least one table resolved to real
+    // catalog columns, so a predicate caret knows whether it can safely narrow.
+    private List<SqlCompletionData> CollectStatementItems(string sql, out bool resolvedColumns)
+    {
         var items = new List<SqlCompletionData>();
         var added = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        resolvedColumns = false;
 
         foreach (var table in SqlCompletionContext.ExtractTables(sql))
         {
@@ -238,6 +286,7 @@ public sealed class SqlCompletionProvider
                 continue;
             }
 
+            resolvedColumns = true;
             foreach (var column in columns)
             {
                 items.Add(ColumnItem(column, CurrentColumnPriority));
@@ -249,8 +298,7 @@ public sealed class SqlCompletionProvider
             items.Add(new SqlCompletionData(cte, "CTE", SqlIdentifier.QuoteIfNeeded(cte), CtePriority));
         }
 
-        items.AddRange(_baseItems);
-        return Dedupe(items);
+        return items;
     }
 
     private IReadOnlyList<TableColumn>? ColumnsFor(string schema, string table)

--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   action from one keyboard-driven control.
 - **Keyboard shortcuts cheat sheet** — press <kbd>F1</kbd> (or the `?`
   title-bar button) for an overview of every binding.
-- **Multi-tab query editor** — schema-aware SQL autocomplete (tables after
-  `FROM`/`JOIN`, columns with their data types elsewhere, `alias.` member
-  access, CTE names, common functions inserted as calls), saved queries,
+- **Multi-tab query editor** — schema-aware SQL autocomplete (schema-qualified
+  tables after `FROM`/`JOIN`, `FROM`-scoped columns in `WHERE`/`ON`/`ORDER BY`,
+  columns with their data types elsewhere, `alias.` member access, CTE names,
+  common functions inserted as calls), saved queries,
   run history, current-line and matching-bracket highlighting, and font-size
   zoom (<kbd>Ctrl</kbd>+wheel / <kbd>Ctrl</kbd>+<kbd>±</kbd>).
 - **Run a whole script** — execute several `;`-separated statements at once on a
@@ -239,8 +240,17 @@ Things a person needs before pgNimbus can be their only Postgres client:
   built and published by CI on every tag
   ([`release.yml`](.github/workflows/release.yml)), plus generated winget
   manifests.
-- [ ] **From-scoped WHERE suggestions** — restrict column autocomplete in the query editor's `WHERE` clause to only show fields from tables/collections specified in the `FROM` clause instead of the entire schema.
-- [ ] **Automatic schema completion** — automatically prepend the parent schema prefix when selecting a table name immediately after a `FROM` or `JOIN` keyword.
+- [x] **From-scoped WHERE suggestions** — column autocomplete in the query
+  editor's `WHERE`/`ON`/`HAVING`/`GROUP BY`/`ORDER BY` clauses now offers only the
+  columns of the tables in the statement's `FROM` (plus its aliases, CTEs,
+  functions and keywords) instead of the entire schema; it falls back to the full
+  catalog when no `FROM` table has resolved yet, so an incomplete query is never
+  left with a near-empty list.
+- [x] **Automatic schema completion** — accepting a table in table position
+  (after `FROM`/`JOIN`/`INTO`/`UPDATE`) inserts it schema-qualified
+  (`public.users`, `analytics.events`), so the reference resolves regardless of
+  the server's `search_path`; the bare name still filters the list, and a table
+  referenced elsewhere (or picked after typing `schema.`) stays unqualified.
 - [ ] **Code signing** — Authenticode for the MSI, Developer ID +
   notarization for the `.dmg`. Both ship unsigned today, so SmartScreen and
   Gatekeeper warn on first run — the single biggest first-impression blocker
@@ -363,7 +373,9 @@ bar (the Files community app remains the visual north star):
   (initially: custom result visualizers).
 - [ ] **Localization** — externalize UI strings; ship Russian and German first.
 
-Recently shipped: tab-strip overflow scrolling, capped results-grid column
+Recently shipped: FROM-scoped WHERE/ORDER BY column suggestions and
+schema-qualified table completion after FROM/JOIN, tab-strip overflow scrolling,
+capped results-grid column
 widths, a content-sized cell inspector, a window minimum size,
 clause-aware SQL IntelliSense (tables after FROM/JOIN,
 typed columns, aliases, CTEs, function-call insertion, auto-popup, no popups


### PR DESCRIPTION
Implements the two top actionable **Now** backlog items for the query-editor autocomplete.

## From-scoped WHERE suggestions
Column autocomplete after `WHERE` / `ON` / `HAVING` / `GROUP BY` / `ORDER BY` / `USING` now offers only the columns of the tables the statement pulls `FROM` (plus its aliases, CTE names, functions, and keywords), instead of the entire schema.

- New `SqlClause.Predicate` context routes these clauses to a scoped completion path.
- Falls back to the full catalog when no `FROM` table has resolved yet, so an incomplete query is never left with a near-empty list.
- `SELECT`-list completion is unchanged (full catalog, current table's columns floated to the top).

## Automatic schema completion
Accepting a table in table position (after `FROM` / `JOIN` / `INTO` / `UPDATE`) now inserts it schema-qualified (`public.users`, `analytics.events`), so the reference resolves regardless of the server's `search_path`.

- The bare name still filters the list.
- Tables referenced elsewhere, and tables picked after typing `schema.`, stay unqualified.

## Verification
Built cleanly (0 warnings) on the .NET 10 SDK. Exercised the real `SqlCompletionProvider` against a seeded local Postgres (schemas `public` + `analytics`, three tables) via a throwaway harness:

- `FROM ` → tables insert as `public.users` / `analytics.events`; schemas stay bare.
- `FROM users WHERE ` → only `id, email, created_at` + functions/keywords; no unrelated columns, tables, or schemas.
- Two-table join `WHERE` → both tables' columns + aliases.
- `SELECT 1 WHERE ` (no resolvable FROM) → full-catalog fallback.
- `SELECT | FROM users` control → unchanged full catalog.

README backlog checkboxes ticked and Features / "Recently shipped" sections updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUEDP544EnyAYXeaEGN6x4)_