### PR TITLE
Persist the light/dark theme choice across launches

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Styling;
 using Npgsql;
 using PgNimbus.App.Completion;
 using PgNimbus.App.ViewModels;
@@ -10,11 +11,35 @@ using PgNimbus.Core.Connections;
 using PgNimbus.Core.Notifications;
 using PgNimbus.Core.Query;
 using PgNimbus.Core.Schema;
+using PgNimbus.Core.Settings;
 
 namespace PgNimbus.App;
 
 public partial class App : Application
 {
+    private static readonly AppSettingsStore SettingsStore = new();
+
+    /// <summary>
+    /// Applies the theme the user last chose (see <see cref="PersistTheme"/>).
+    /// A fresh install has no saved theme, which maps to <see cref="ThemeVariant.Default"/>
+    /// — i.e. follow the OS, the pre-persistence behaviour.
+    /// </summary>
+    private void ApplyPersistedTheme() =>
+        RequestedThemeVariant = ThemeFromString(SettingsStore.Load().Theme);
+
+    /// <summary>Remembers an explicit light/dark choice so it survives a restart.</summary>
+    internal static void PersistTheme(ThemeVariant variant) =>
+        SettingsStore.Save(new AppSettings { Theme = ThemeToString(variant) });
+
+    private static ThemeVariant ThemeFromString(string? theme) => theme?.ToLowerInvariant() switch
+    {
+        "light" => ThemeVariant.Light,
+        "dark" => ThemeVariant.Dark,
+        _ => ThemeVariant.Default,
+    };
+
+    private static string ThemeToString(ThemeVariant variant) =>
+        variant == ThemeVariant.Dark ? "dark" : variant == ThemeVariant.Light ? "light" : "system";
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
@@ -26,6 +51,10 @@ public partial class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        // Restore the saved light/dark choice before any window resolves its
+        // ActualThemeVariant, so the first frame already paints in the right theme.
+        ApplyPersistedTheme();
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             var envConnectionString = Environment.GetEnvironmentVariable("PGNIMBUS_CONN");

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -299,6 +299,9 @@ public partial class MainWindow : Window
         app.RequestedThemeVariant = ActualThemeVariant == ThemeVariant.Dark
             ? ThemeVariant.Light
             : ThemeVariant.Dark;
+
+        // Remember the choice so the next launch doesn't snap back to the OS default.
+        App.PersistTheme(app.RequestedThemeVariant);
     }
 
     // Show the glyph for where a click will take you: a sun while dark (click

--- a/PgNimbus.Core/Settings/AppSettings.cs
+++ b/PgNimbus.Core/Settings/AppSettings.cs
@@ -1,0 +1,17 @@
+namespace PgNimbus.Core.Settings;
+
+/// <summary>
+/// Small bag of persisted, cross-session app preferences (currently just the
+/// theme). A record with defaulted <c>init</c> properties so a settings file
+/// written by an older build — missing a field added later — still loads, with
+/// the new field falling back to its default.
+/// </summary>
+public sealed record AppSettings
+{
+    /// <summary>
+    /// The chosen theme: <c>"light"</c>, <c>"dark"</c>, or <c>"system"</c> (follow
+    /// the OS). Kept as a plain string so <c>PgNimbus.Core</c> stays free of any
+    /// UI-framework types; the App maps it to/from Avalonia's ThemeVariant.
+    /// </summary>
+    public string Theme { get; init; } = "system";
+}

--- a/PgNimbus.Core/Settings/AppSettingsStore.cs
+++ b/PgNimbus.Core/Settings/AppSettingsStore.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PgNimbus.Core.Connections;
+
+namespace PgNimbus.Core.Settings;
+
+/// <summary>Persists <see cref="AppSettings"/> to a single JSON file under the app data root.</summary>
+public sealed class AppSettingsStore
+{
+    private readonly string _filePath;
+
+    public AppSettingsStore(string? filePath = null)
+    {
+        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "settings.json");
+    }
+
+    /// <summary>
+    /// Reads the saved settings, or returns defaults when there is no file yet.
+    /// A missing/unreadable/corrupt file must never block startup, so any failure
+    /// here falls back to defaults rather than throwing.
+    /// </summary>
+    public AppSettings Load()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return new AppSettings();
+        }
+
+        try
+        {
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize(json, AppSettingsJsonContext.Default.AppSettings) ?? new AppSettings();
+        }
+        catch (Exception e) when (e is IOException or JsonException or UnauthorizedAccessException)
+        {
+            return new AppSettings();
+        }
+    }
+
+    public void Save(AppSettings settings)
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(settings, AppSettingsJsonContext.Default.AppSettings);
+        File.WriteAllText(_filePath, json);
+    }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(AppSettings))]
+internal sealed partial class AppSettingsJsonContext : JsonSerializerContext;

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Things a person needs before pgNimbus can be their only Postgres client:
   per-connection scoping and pinning.
 - [x] **In-app theme toggle** — light/dark switch in the title bar (sun/moon
   button) instead of following the OS only; the SQL syntax palette repaints
-  with it.
+  with it, and the choice is remembered across launches.
 
 ### Polish — UX/UI fit and finish
 
@@ -346,9 +346,10 @@ bar (the Files community app remains the visual north star):
 - [ ] **Empty state for the connection dialog** — the Saved Connections list
   is a bare grey panel when empty; give it the same friendly hint the
   saved-queries and history lists already have.
-- [ ] **Persist the theme choice** — the in-app light/dark toggle resets to
-  the OS default on every launch; remember it alongside the other persisted
-  app state.
+- [x] **Persist the theme choice** — the in-app light/dark toggle is now
+  remembered across launches (saved to `settings.json` alongside the other
+  persisted app state) instead of snapping back to the OS default; a fresh
+  install with no saved choice still follows the OS.
 - [ ] **Drag-and-drop from the schema tree** — drag a table, column, or other
   object from the sidebar tree into the SQL editor and drop a valid, quoted
   identifier at the cursor (e.g. `"CreatedAt"`).
@@ -385,7 +386,8 @@ bar (the Files community app remains the visual north star):
   (initially: custom result visualizers).
 - [ ] **Localization** — externalize UI strings; ship Russian and German first.
 
-Recently shipped: one-keystroke SQL formatting (Ctrl+Shift+F, block-style
+Recently shipped: a remembered-across-launches theme choice, one-keystroke SQL
+formatting (Ctrl+Shift+F, block-style
 pretty-print with a never-corrupt token round-trip check), FROM-scoped
 WHERE/ORDER BY column suggestions and
 schema-qualified table completion after FROM/JOIN, tab-strip overflow scrolling,


### PR DESCRIPTION
Implements the **Persist the theme choice** backlog item (Polish section).

The in-app light/dark toggle previously reset to the OS default on every launch. Now the choice is remembered.

## Changes
- **`PgNimbus.Core/Settings/AppSettings.cs` + `AppSettingsStore.cs`** — a new settings record and JSON store, written to `settings.json` under the app-data root using the same source-generated-JSON pattern as the existing saved-query and history stores. The theme is kept as a plain string so `PgNimbus.Core` stays free of any UI-framework types (respecting the zero-UI-deps boundary). A missing/unreadable/corrupt file falls back to defaults, so it can never block startup.
- **`App.axaml.cs`** — applies the saved theme before any window resolves its `ActualThemeVariant`, so the first frame already paints in the right theme; a fresh install with no saved choice maps to `ThemeVariant.Default` (follow the OS), preserving prior behaviour.
- **`MainWindow.axaml.cs`** — persists the new variant whenever the title-bar toggle flips it.

## Verification
Driven end-to-end in the running app:
- Fresh launch → follows the OS, no settings file present.
- Toggle to dark → `settings.json` becomes `{"Theme":"dark"}`.
- Relaunch → **opens directly in dark** (restored on startup).

Also unit-checked the store: round-trips light/dark/system, and a corrupt/`{}` file degrades to the follow-OS default without throwing.

README backlog checkbox ticked; the theme-toggle feature bullet and "Recently shipped" updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUEDP544EnyAYXeaEGN6x4)_