### PR TITLE
Add a collapsible sidebar (Ctrl+B) with a 200px resize floor

### DIFF
--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -76,6 +76,9 @@
         <Border DockPanel.Dock="Top" Height="40" Padding="16,0"
                 BorderThickness="0,0,0,1" BorderBrush="{StaticResource CardBorderBrush}">
             <DockPanel>
+                <Button Name="SidebarToggleButton" DockPanel.Dock="Left" Classes="chip" Content="☰"
+                        FontSize="13" Padding="7,3" Margin="0,0,10,0" VerticalAlignment="Center"
+                        Click="OnToggleSidebarClick" ToolTip.Tip="Toggle sidebar (Ctrl+B)" />
                 <Border DockPanel.Dock="Left" Width="10" Height="10" CornerRadius="5" Margin="0,0,10,0"
                         VerticalAlignment="Center"
                         Background="{Binding AccentColor, Converter={x:Static conv2:HexToBrushConverter.Instance}}" />
@@ -98,9 +101,15 @@
             </DockPanel>
         </Border>
 
-    <Grid ColumnDefinitions="300,Auto,*" Margin="16">
+    <Grid Name="ContentGrid" Margin="16">
+        <Grid.ColumnDefinitions>
+            <!-- 200px floor so a manual splitter drag can't shrink the sidebar to a sliver -->
+            <ColumnDefinition Width="300" MinWidth="200" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
 
-        <TabControl Grid.Column="0">
+        <TabControl Name="SidebarTabs" Grid.Column="0">
             <TabItem>
                 <TabItem.Header>
                     <StackPanel Orientation="Horizontal" Spacing="8">
@@ -274,7 +283,7 @@
             </TabItem>
         </TabControl>
 
-        <GridSplitter Grid.Column="1" Width="12" Background="Transparent" />
+        <GridSplitter Name="SidebarSplitter" Grid.Column="1" Width="12" Background="Transparent" />
 
         <!-- Padding moves to the inner grid so the status bar can run flush along the layer's bottom edge -->
         <Border Grid.Column="2" Classes="layer" Padding="0">

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -49,6 +49,11 @@ public partial class MainWindow : Window
     private const double MaxEditorFontSize = 32;
     private const double DefaultEditorFontSize = 14;
 
+    // Sidebar collapse (Ctrl+B): the width to restore to, and whether it's hidden.
+    private const double SidebarMinWidth = 200;
+    private GridLength _savedSidebarWidth = new(300);
+    private bool _sidebarCollapsed;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -200,6 +205,13 @@ public partial class MainWindow : Window
             return;
         }
 
+        if (e.Key == Key.B && e.KeyModifiers == KeyModifiers.Control)
+        {
+            ToggleSidebar();
+            e.Handled = true;
+            return;
+        }
+
         if (e.Key == Key.F6 && e.KeyModifiers == KeyModifiers.None)
         {
             if (SqlEditor.IsKeyboardFocusWithin)
@@ -280,6 +292,35 @@ public partial class MainWindow : Window
         if (sender is Button { Tag: QueryViewModel tab })
         {
             _viewModel?.CloseTabCommand.Execute(tab);
+        }
+    }
+
+    private void OnToggleSidebarClick(object? sender, RoutedEventArgs e) => ToggleSidebar();
+
+    // Fully hides the schema/queries/notify sidebar (and its splitter) to give the
+    // editor and results the whole width, or restores it. The last manual width is
+    // remembered so re-showing returns to where the user had dragged it. Collapsing
+    // also drops the column's 200px floor (it's the manual-resize guard, not a
+    // collapse guard) so the column can actually reach zero.
+    private void ToggleSidebar()
+    {
+        var column = ContentGrid.ColumnDefinitions[0];
+        _sidebarCollapsed = !_sidebarCollapsed;
+
+        if (_sidebarCollapsed)
+        {
+            _savedSidebarWidth = column.Width is { IsAbsolute: true, Value: > 0 } w ? w : new GridLength(300);
+            column.MinWidth = 0;
+            column.Width = new GridLength(0);
+            SidebarTabs.IsVisible = false;
+            SidebarSplitter.IsVisible = false;
+        }
+        else
+        {
+            column.MinWidth = SidebarMinWidth;
+            column.Width = _savedSidebarWidth;
+            SidebarTabs.IsVisible = true;
+            SidebarSplitter.IsVisible = true;
         }
     }
 

--- a/PgNimbus.App/Views/ShortcutsWindow.axaml
+++ b/PgNimbus.App/Views/ShortcutsWindow.axaml
@@ -237,6 +237,13 @@
                         </StackPanel>
                     </Grid>
                     <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
+                        <TextBlock Classes="what" Text="Collapse / show the sidebar" />
+                        <StackPanel Grid.Column="1" Classes="keys">
+                            <Border Classes="kbd"><TextBlock Text="Ctrl" /></Border>
+                            <Border Classes="kbd"><TextBlock Text="B" /></Border>
+                        </StackPanel>
+                    </Grid>
+                    <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
                         <TextBlock Classes="what" Text="Preview a table (in the schema tree)" />
                         <StackPanel Grid.Column="1" Classes="keys">
                             <TextBlock Classes="combo" Text="Double-click" />

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Press <kbd>F1</kbd> in the app for the full cheat sheet. The highlights:
 | --- | --- |
 | Command palette (jump to table / query / action) | <kbd>Ctrl</kbd>+<kbd>K</kbd> or <kbd>Ctrl</kbd>+<kbd>P</kbd> |
 | Refresh database & schema | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> |
+| Collapse / show the sidebar | <kbd>Ctrl</kbd>+<kbd>B</kbd> |
 | Run query | <kbd>Ctrl</kbd>+<kbd>Enter</kbd> or <kbd>F5</kbd> |
 | Run just the statement under the cursor | <kbd>Shift</kbd>+<kbd>Enter</kbd> |
 | Format the statement under the cursor | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> |
@@ -353,9 +354,10 @@ bar (the Files community app remains the visual north star):
 - [ ] **Drag-and-drop from the schema tree** — drag a table, column, or other
   object from the sidebar tree into the SQL editor and drop a valid, quoted
   identifier at the cursor (e.g. `"CreatedAt"`).
-- [ ] **Collapsible sidebar** — a 200px minimum width on manual resize (so it
-  can't shrink to an unreadable sliver) plus a collapse button / <kbd>Ctrl</kbd>+<kbd>B</kbd>
-  that fully hides the sidebar and gives the editor and results the full width.
+- [x] **Collapsible sidebar** — a 200px minimum width on manual resize (so it
+  can't shrink to an unreadable sliver) plus a collapse button (the ☰ in the
+  title bar) / <kbd>Ctrl</kbd>+<kbd>B</kbd> that fully hides the sidebar and gives
+  the editor and results the full width, restoring to the last dragged width.
 - [ ] **Abbreviated column types in the tree** — show long types compactly
   (e.g. `timestamp with time zone` → `timestamptz`), with the full type name in
   a tooltip on a ~150 ms hover delay.
@@ -386,7 +388,8 @@ bar (the Files community app remains the visual north star):
   (initially: custom result visualizers).
 - [ ] **Localization** — externalize UI strings; ship Russian and German first.
 
-Recently shipped: a remembered-across-launches theme choice, one-keystroke SQL
+Recently shipped: a collapsible sidebar (Ctrl+B, 200px resize floor), a
+remembered-across-launches theme choice, one-keystroke SQL
 formatting (Ctrl+Shift+F, block-style
 pretty-print with a never-corrupt token round-trip check), FROM-scoped
 WHERE/ORDER BY column suggestions and


### PR DESCRIPTION
Implements the **Collapsible sidebar** backlog item (Polish section).

The schema/queries/notify sidebar could be dragged down to an unreadable sliver and had no way to get fully out of the way.

## Changes
- **200px resize floor** — the sidebar column now declares `MinWidth="200"`, so a manual splitter drag can't shrink it below a usable width.
- **Collapse toggle** — a ☰ button in the title bar and <kbd>Ctrl</kbd>+<kbd>B</kbd> hide the sidebar and its splitter, giving the editor + results the full width; toggling again restores the last dragged width. Collapsing temporarily drops the column's `MinWidth` so it can actually reach zero, then restores it on show.
- Added a row to the F1 shortcuts cheat sheet and the README keyboard table.

## Verification
Driven end-to-end in the running app: <kbd>Ctrl</kbd>+<kbd>B</kbd> collapses the sidebar to a full-width editor, and again restores it to its previous 300px width with the schema tree back.

README backlog checkbox ticked; keyboard-shortcuts table and "Recently shipped" updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUEDP544EnyAYXeaEGN6x4)_