### PR TITLE
Add explicit transaction control (BEGIN/COMMIT/ROLLBACK)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,14 @@ and wrong project memory is worse than none.
    returns result rows via `IAsyncEnumerable<RowBatch>` in ~200-row batches so
    the UI can render before the full result set arrives. Every execution
    takes a `CancellationToken` and must actually stop mid-flight, not just at
-   the start.
+   the start. The one deliberate exception: inside an explicit transaction
+   (`BeginTransactionAsync`), statements run on the single held session
+   connection and return a fully-materialized `MaterializedResultSet` instead —
+   a lazily-streaming reader would pin that connection open and block the next
+   statement in the transaction. A failed statement inside a transaction
+   auto-rolls-back the block (so the connection never lingers in Postgres's
+   aborted-transaction state), and `TransactionStateChanged` is how the App's
+   "in transaction" indicator stays in sync no matter which path changed it.
 3. **PostgreSQL-first, not lowest-common-denominator.** `SchemaService` reads
    `pg_catalog` directly (not `information_schema`) so it can see materialized
    views, partitioned tables, and real Postgres semantics (e.g. primary-key

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using PgNimbus.App.Completion;
@@ -63,6 +64,15 @@ public sealed partial class MainViewModel : ObservableObject
     [ObservableProperty]
     private QueryViewModel _activeTab = null!;
 
+    /// <summary>
+    /// True while an explicit BEGIN…COMMIT/ROLLBACK transaction is open — drives
+    /// the toolbar's "in transaction" indicator and which transaction buttons
+    /// show. Kept in sync with the engine (including auto-rollback on error) via
+    /// its <see cref="QueryEngine.TransactionStateChanged"/> event.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isInTransaction;
+
     public MainViewModel(
         QueryEngine engine,
         ExplainService explainService,
@@ -89,7 +99,74 @@ public sealed partial class MainViewModel : ObservableObject
         NotifyMonitor = notifyMonitor;
         AccentColor = accentColor;
 
+        // The engine owns the transaction state; mirror it here so the indicator
+        // and command availability follow every change — including an
+        // auto-rollback that fires from a background query thread.
+        _engine.TransactionStateChanged += OnEngineTransactionStateChanged;
+
         AddTab();
+    }
+
+    private void OnEngineTransactionStateChanged() =>
+        Dispatcher.UIThread.Post(() => IsInTransaction = _engine.IsInTransaction);
+
+    partial void OnIsInTransactionChanged(bool value)
+    {
+        BeginTransactionCommand.NotifyCanExecuteChanged();
+        CommitTransactionCommand.NotifyCanExecuteChanged();
+        RollbackTransactionCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool CanBeginTransaction() => !IsInTransaction;
+
+    private bool CanEndTransaction() => IsInTransaction;
+
+    /// <summary>Opens an explicit transaction (BEGIN); subsequent statements run inside it until commit or rollback.</summary>
+    [RelayCommand(CanExecute = nameof(CanBeginTransaction))]
+    private async Task BeginTransactionAsync()
+    {
+        try
+        {
+            await _engine.BeginTransactionAsync(CancellationToken.None);
+            ActiveTab.Status = "Transaction started — BEGIN";
+        }
+        catch (Exception ex)
+        {
+            ActiveTab.Status = $"Couldn't begin transaction: {ex.Message}";
+            ActiveTab.HasError = true;
+        }
+    }
+
+    /// <summary>Commits the open transaction (COMMIT).</summary>
+    [RelayCommand(CanExecute = nameof(CanEndTransaction))]
+    private async Task CommitTransactionAsync()
+    {
+        try
+        {
+            await _engine.CommitAsync(CancellationToken.None);
+            ActiveTab.Status = "Transaction committed — COMMIT";
+        }
+        catch (Exception ex)
+        {
+            ActiveTab.Status = $"Commit failed: {ex.Message}";
+            ActiveTab.HasError = true;
+        }
+    }
+
+    /// <summary>Rolls back the open transaction (ROLLBACK).</summary>
+    [RelayCommand(CanExecute = nameof(CanEndTransaction))]
+    private async Task RollbackTransactionAsync()
+    {
+        try
+        {
+            await _engine.RollbackAsync(CancellationToken.None);
+            ActiveTab.Status = "Transaction rolled back — ROLLBACK";
+        }
+        catch (Exception ex)
+        {
+            ActiveTab.Status = $"Rollback failed: {ex.Message}";
+            ActiveTab.HasError = true;
+        }
     }
 
     // Lazily builds (and caches) the reconciler each query tab uses to offer an
@@ -256,6 +333,9 @@ public sealed partial class MainViewModel : ObservableObject
         yield return new PaletteItem("Cancel query", "Action", "■", Invoke(() => ActiveTab.CancelCommand));
         yield return new PaletteItem("Explain", "Action", "⚡", Invoke(() => ActiveTab.ExplainCommand));
         yield return new PaletteItem("Explain Analyze", "Action", "⚡", Invoke(() => ActiveTab.ExplainAnalyzeCommand));
+        yield return new PaletteItem("Begin transaction", "Action", "⛃", Invoke(() => BeginTransactionCommand));
+        yield return new PaletteItem("Commit transaction", "Action", "✓", Invoke(() => CommitTransactionCommand));
+        yield return new PaletteItem("Rollback transaction", "Action", "↺", Invoke(() => RollbackTransactionCommand));
         yield return new PaletteItem("Refresh database & schema", "Action", "⟳", Invoke(() => RefreshSchemaCommand));
         yield return new PaletteItem("New query tab", "Action", "＋", Invoke(() => AddTabCommand));
         yield return new PaletteItem("Close tab", "Action", "✕", Invoke(() => CloseTabCommand));

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -341,6 +341,30 @@ public sealed partial class QueryViewModel : ObservableObject
                         : null;
                     break;
 
+                case MaterializedResultSet materialized:
+                    // Fully-materialized result of a statement run inside a
+                    // transaction (see QueryEngine): no streaming, the rows are
+                    // already in memory. Mirror the streaming path's cap handling.
+                    _columns = materialized.Columns;
+                    foreach (var column in materialized.Columns)
+                    {
+                        ColumnNames.Add(column.Name);
+                    }
+
+                    var overCap = materialized.Truncated || materialized.Rows.Count > MaxDisplayRows;
+                    var shown = overCap
+                        ? materialized.Rows.Take(MaxDisplayRows).ToList()
+                        : materialized.Rows;
+
+                    Rows = new AvaloniaList<object?[]>(shown);
+                    Status = "Done";
+                    RowCountText = RowLabel(shown.Count);
+                    TimingText = $"{materialized.Elapsed.TotalMilliseconds:F0} ms";
+                    CapText = overCap
+                        ? $"capped at {MaxDisplayRows:N0} rows — refine the query for the full set"
+                        : null;
+                    break;
+
                 case CommandResult commandResult:
                     Status = commandResult.CommandTag;
                     RowCountText = $"{RowLabel(commandResult.RowsAffected)} affected";
@@ -348,7 +372,9 @@ public sealed partial class QueryViewModel : ObservableObject
                     break;
 
                 case QueryError error:
-                    Status = $"Error: {error.Message}";
+                    Status = error.RolledBack
+                        ? $"Error: {error.Message} — transaction rolled back"
+                        : $"Error: {error.Message}";
                     HasError = true;
                     await TryOfferFixAsync(executedSql);
                     break;

--- a/PgNimbus.App/ViewModels/ScriptResultViewModel.cs
+++ b/PgNimbus.App/ViewModels/ScriptResultViewModel.cs
@@ -114,7 +114,9 @@ public sealed class ScriptResultViewModel
                     $"{index} · {keyword}",
                     "Error",
                     hasError: true,
-                    statusText: $"Error: {error.Message}",
+                    statusText: error.RolledBack
+                        ? $"Error: {error.Message} — transaction rolled back"
+                        : $"Error: {error.Message}",
                     columns: [],
                     columnNames: [],
                     rows: [],

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -378,6 +378,34 @@
                             </MenuFlyout>
                         </Button.Flyout>
                     </Button>
+
+                    <!-- Transaction control: Begin toggles to Commit/Rollback + an
+                         "in transaction" indicator while a block is open -->
+                    <Rectangle Classes="statusSeparator" Margin="6,0" />
+                    <Button Classes="toolbar" Command="{Binding BeginTransactionCommand}"
+                            IsVisible="{Binding !IsInTransaction}"
+                            ToolTip.Tip="Begin a transaction (BEGIN)">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <TextBlock Text="⛃" FontSize="13" VerticalAlignment="Center" />
+                            <TextBlock Text="Begin" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="toolbar" Command="{Binding CommitTransactionCommand}"
+                            IsVisible="{Binding IsInTransaction}"
+                            ToolTip.Tip="Commit the transaction (COMMIT)">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <TextBlock Text="✓" FontSize="13" VerticalAlignment="Center" />
+                            <TextBlock Text="Commit" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="toolbar" Command="{Binding RollbackTransactionCommand}"
+                            IsVisible="{Binding IsInTransaction}"
+                            ToolTip.Tip="Roll back the transaction (ROLLBACK)">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <TextBlock Text="↺" FontSize="13" VerticalAlignment="Center" />
+                            <TextBlock Text="Rollback" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
                 </StackPanel>
             </Border>
 
@@ -566,6 +594,15 @@
                     <TextBlock Text="{Binding ActiveTab.Status}"
                                Classes="statusText" Classes.error="{Binding ActiveTab.HasError}"
                                TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
+                    <!-- Persistent "in transaction" indicator: an explicit BEGIN block is open -->
+                    <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center"
+                                IsVisible="{Binding IsInTransaction}"
+                                ToolTip.Tip="A transaction is open — statements run inside it until you commit or roll back">
+                        <Rectangle Classes="statusSeparator" />
+                        <Ellipse Width="8" Height="8" Fill="#D9822B" VerticalAlignment="Center" />
+                        <TextBlock Text="In transaction" Classes="statusText" Foreground="#D9822B"
+                                   FontWeight="SemiBold" VerticalAlignment="Center" />
+                    </StackPanel>
                     <!-- "Did you mean the quoted form?" fix, offered after a failed unquoted-identifier run -->
                     <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center"
                                 IsVisible="{Binding ActiveTab.FixSuggestionSql, Converter={x:Static conv:ObjectConverters.IsNotNull}}">

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -15,9 +15,118 @@ public sealed class QueryEngine
 
     private readonly NpgsqlDataSource _dataSource;
 
+    // Non-null while an explicit user transaction is open. Every execution then
+    // runs on this one connection (instead of a fresh pooled one) so BEGIN and a
+    // later COMMIT/ROLLBACK bracket the same session. Cleared — and the
+    // connection disposed back to the pool — when the transaction ends.
+    private NpgsqlConnection? _transactionConnection;
+
     public QueryEngine(NpgsqlDataSource dataSource)
     {
         _dataSource = dataSource;
+    }
+
+    /// <summary>True while an explicit BEGIN…COMMIT/ROLLBACK transaction is open.</summary>
+    public bool IsInTransaction => _transactionConnection is not null;
+
+    /// <summary>
+    /// Raised whenever the explicit-transaction state changes — a BEGIN, a
+    /// COMMIT/ROLLBACK, or an auto-rollback after a statement failed. Lets the UI
+    /// keep its "in transaction" indicator in sync no matter which path changed
+    /// the state. May fire on a background thread, so subscribers that touch UI
+    /// must marshal to their UI thread.
+    /// </summary>
+    public event Action? TransactionStateChanged;
+
+    /// <summary>
+    /// Opens an explicit transaction: takes a dedicated connection and runs
+    /// <c>BEGIN</c> on it. Subsequent executions run on that connection until
+    /// <see cref="CommitAsync"/> or <see cref="RollbackAsync"/>. A no-op if a
+    /// transaction is already open.
+    /// </summary>
+    public async Task BeginTransactionAsync(CancellationToken ct)
+    {
+        if (_transactionConnection is not null)
+        {
+            return;
+        }
+
+        var connection = await _dataSource.OpenConnectionAsync(ct);
+        try
+        {
+            await using var command = new NpgsqlCommand("BEGIN", connection);
+            await command.ExecuteNonQueryAsync(ct);
+        }
+        catch
+        {
+            await connection.DisposeAsync();
+            throw;
+        }
+
+        _transactionConnection = connection;
+        TransactionStateChanged?.Invoke();
+    }
+
+    /// <summary>Commits the open transaction. A no-op if none is open.</summary>
+    public Task CommitAsync(CancellationToken ct) => EndTransactionAsync("COMMIT", ct);
+
+    /// <summary>Rolls back the open transaction. A no-op if none is open.</summary>
+    public Task RollbackAsync(CancellationToken ct) => EndTransactionAsync("ROLLBACK", ct);
+
+    // Ends the transaction with COMMIT or ROLLBACK. The session connection is
+    // always released and the state cleared (in the finally), even when the verb
+    // itself fails — a failed COMMIT still ends the transaction server-side, so
+    // leaving the connection marked "in transaction" would be a lie.
+    private async Task EndTransactionAsync(string verb, CancellationToken ct)
+    {
+        var connection = _transactionConnection;
+        if (connection is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await using var command = new NpgsqlCommand(verb, connection);
+            await command.ExecuteNonQueryAsync(ct);
+        }
+        finally
+        {
+            _transactionConnection = null;
+            await connection.DisposeAsync();
+            TransactionStateChanged?.Invoke();
+        }
+    }
+
+    // Auto-rollback after a statement failed inside a transaction. A failed
+    // statement puts Postgres in the "current transaction is aborted" state where
+    // every further statement errors until the block is rolled back, so rather
+    // than strand the user there, undo the whole transaction and release the
+    // connection. Best-effort: a rollback that itself fails still clears state.
+    private async Task AutoRollbackAsync()
+    {
+        var connection = _transactionConnection;
+        if (connection is null)
+        {
+            return;
+        }
+
+        _transactionConnection = null;
+        try
+        {
+            await using var command = new NpgsqlCommand("ROLLBACK", connection);
+            await command.ExecuteNonQueryAsync();
+        }
+        catch
+        {
+            // The connection is being discarded regardless; a rollback failure
+            // here changes nothing the caller can act on.
+        }
+        finally
+        {
+            await connection.DisposeAsync();
+            TransactionStateChanged?.Invoke();
+        }
     }
 
     /// <summary>
@@ -27,6 +136,30 @@ public sealed class QueryEngine
     /// </summary>
     public async Task ExecuteNonQueryAsync(string sql, IReadOnlyDictionary<string, object?> parameters, CancellationToken ct)
     {
+        // Inside a transaction the edit must run on the session connection so it's
+        // part of the same block; a failure there aborts the transaction, so
+        // auto-rollback before surfacing the error.
+        if (_transactionConnection is { } tx)
+        {
+            await using var txCommand = new NpgsqlCommand(sql, tx);
+            foreach (var (name, value) in parameters)
+            {
+                txCommand.Parameters.AddWithValue(name, value ?? DBNull.Value);
+            }
+
+            try
+            {
+                await txCommand.ExecuteNonQueryAsync(ct);
+            }
+            catch (PostgresException)
+            {
+                await AutoRollbackAsync();
+                throw;
+            }
+
+            return;
+        }
+
         await using var connection = await _dataSource.OpenConnectionAsync(ct);
         await using var command = new NpgsqlCommand(sql, connection);
 
@@ -50,6 +183,15 @@ public sealed class QueryEngine
     /// </param>
     public async Task<StatementResult> ExecuteAsync(string sql, CancellationToken ct, int? maxRows = null)
     {
+        // Inside a transaction the statement runs on the shared session
+        // connection and its result is fully materialized: a lazily-streaming
+        // reader would pin that one connection open, blocking the next statement
+        // in the transaction until the grid finished consuming it.
+        if (_transactionConnection is not null)
+        {
+            return await ExecuteInTransactionAsync(sql, maxRows, ct);
+        }
+
         var stopwatch = Stopwatch.StartNew();
 
         NpgsqlConnection? connection = null;
@@ -141,20 +283,88 @@ public sealed class QueryEngine
         int? maxRowsPerStatement,
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
     {
-        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        // In a transaction the whole script runs on the shared session connection
+        // (so it joins the open block); otherwise it gets its own pooled
+        // connection that's disposed when the script ends.
+        var inTransaction = _transactionConnection is not null;
+        var connection = inTransaction ? _transactionConnection! : await _dataSource.OpenConnectionAsync(ct);
 
-        foreach (var statement in statements)
+        try
         {
-            ct.ThrowIfCancellationRequested();
-
-            var result = await ExecuteOnConnectionAsync(connection, statement, maxRowsPerStatement, ct);
-            yield return result;
-
-            if (result is QueryError)
+            foreach (var statement in statements)
             {
-                yield break;
+                ct.ThrowIfCancellationRequested();
+
+                var result = await ExecuteOnConnectionAsync(connection, statement, maxRowsPerStatement, ct);
+
+                if (result is QueryError error)
+                {
+                    // A failed statement aborts the transaction; undo it and flag
+                    // the rollback so the last section can say so.
+                    if (inTransaction)
+                    {
+                        await AutoRollbackAsync();
+                        yield return error with { RolledBack = true };
+                    }
+                    else
+                    {
+                        yield return error;
+                    }
+
+                    yield break;
+                }
+
+                yield return result;
             }
         }
+        finally
+        {
+            // AutoRollbackAsync already disposed the session connection on the
+            // error path; only a pooled (non-transaction) connection is ours to
+            // release here.
+            if (!inTransaction)
+            {
+                await connection.DisposeAsync();
+            }
+        }
+    }
+
+    // Runs one statement on the open transaction's connection and materializes
+    // its result (see ExecuteAsync for why streaming is avoided here). A failure
+    // auto-rolls-back the transaction and comes back flagged so the UI can note
+    // that the block is gone.
+    private async Task<StatementResult> ExecuteInTransactionAsync(string sql, int? maxRows, CancellationToken ct)
+    {
+        var connection = _transactionConnection!;
+        var stopwatch = Stopwatch.StartNew();
+
+        StatementResult result;
+        try
+        {
+            // ExecuteOnConnectionAsync converts PostgresExceptions to QueryError
+            // but lets other failures (e.g. a dropped connection) escape; ExecuteAsync
+            // promises never to throw those, so translate them here too.
+            result = await ExecuteOnConnectionAsync(connection, sql, maxRows, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // A cancelled statement doesn't abort the transaction — leave the
+            // block open so the user can retry, commit, or roll back explicitly.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            await AutoRollbackAsync();
+            return new QueryError { Elapsed = stopwatch.Elapsed, Message = ex.Message, RolledBack = true };
+        }
+
+        if (result is QueryError error)
+        {
+            await AutoRollbackAsync();
+            return error with { RolledBack = true };
+        }
+
+        return result;
     }
 
     // Executes one statement on an already-open connection and materializes its

--- a/PgNimbus.Core/Query/QueryResult.cs
+++ b/PgNimbus.Core/Query/QueryResult.cs
@@ -55,4 +55,10 @@ public sealed record QueryError : StatementResult
 
     /// <summary>1-based character position into the submitted SQL, for editor error highlighting.</summary>
     public int? Position { get; init; }
+
+    /// <summary>
+    /// True when this failure happened inside an explicit transaction and the
+    /// engine auto-rolled it back — the block is gone, so the UI can say so.
+    /// </summary>
+    public bool RolledBack { get; init; }
 }

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   single connection (so `BEGIN…COMMIT`, `SET`, and temp tables carry across
   them); each statement gets its own selectable result section with per-statement
   timing, and the run stops at the first error (psql `ON_ERROR_STOP` style).
+- **Transaction control** — an explicit **Begin** toolbar button opens a
+  transaction that every statement (and inline grid edit) then runs inside on
+  one held connection; **Commit**/**Rollback** end it, a status-bar "in
+  transaction" indicator shows while it's open, and a failed statement
+  auto-rolls-back the block so you're never stranded in Postgres's
+  aborted-transaction state.
 - **Streaming, cancellable results** — the first screenful renders before the
   full result set arrives, backed by a virtualized grid with inline cell
   editing and CSV/JSON export.
@@ -270,7 +276,7 @@ Things a person needs before pgNimbus can be their only Postgres client:
 
 ### Next — depth on the Postgres-first promise
 
-- [ ] **Transaction control** — explicit BEGIN/COMMIT/ROLLBACK toolbar state,
+- [x] **Transaction control** — explicit BEGIN/COMMIT/ROLLBACK toolbar state,
   with a visible "in transaction" indicator and auto-rollback on error.
 - [x] **SQL formatting** — one-keystroke pretty-printing of the statement under
   the cursor (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd>, or "Format SQL" in the
@@ -390,7 +396,8 @@ bar (the Files community app remains the visual north star):
   (initially: custom result visualizers).
 - [ ] **Localization** — externalize UI strings; ship Russian and German first.
 
-Recently shipped: abbreviated column types in the schema tree
+Recently shipped: transaction control (Begin/Commit/Rollback toolbar state, an
+"in transaction" status-bar indicator, and auto-rollback on error), abbreviated column types in the schema tree
 (timestamptz/varchar…, full name on hover), a collapsible sidebar (Ctrl+B, 200px
 resize floor), a
 remembered-across-launches theme choice, one-keystroke SQL


### PR DESCRIPTION
Implements the **Transaction control** roadmap item: an explicit **Begin** toolbar button opens a transaction that every statement and inline grid edit then runs inside, on a single held connection; **Commit**/**Rollback** end it, a status-bar "in transaction" indicator shows while it's open, and a failed statement auto-rolls-back the block so the user is never stranded in Postgres's aborted-transaction state.

## Engine (`PgNimbus.Core`)
- `QueryEngine` holds an optional session connection while a transaction is open. `BeginTransactionAsync` / `CommitAsync` / `RollbackAsync` manage it, and a `TransactionStateChanged` event keeps the UI in sync no matter which path changed the state (including auto-rollback).
- While in a transaction, `ExecuteAsync` / `ExecuteScriptAsync` / `ExecuteNonQueryAsync` all run on that connection. Result-returning statements are fully materialized (`MaterializedResultSet`) rather than streamed, because a lazily-streaming reader would pin the single connection and block the next statement in the block.
- A failed statement inside a transaction auto-rolls-back and comes back as a `QueryError` flagged `RolledBack`.

## UI (`PgNimbus.App`)
- `MainViewModel` exposes `IsInTransaction` plus Begin/Commit/Rollback commands (also surfaced in the command palette), mirroring engine state via the event (marshaled to the UI thread).
- The toolbar shows **Begin**, swapping to **Commit**/**Rollback** while a transaction is open; the status bar carries a persistent amber "In transaction" indicator.
- `QueryViewModel` / `ScriptResultViewModel` render the materialized result and note the auto-rollback in the status message.

## Docs
- README roadmap item checked off, plus a feature bullet and a "recently shipped" note.
- CLAUDE.md documents the in-transaction materialization exception to the streaming rule.

## Verification
Built clean (0 warnings). Exercised against a real Postgres:
- Transaction isolation — an external session does not see uncommitted changes; the in-transaction session sees its own writes.
- **Commit** persists; **Rollback** undoes.
- **Auto-rollback on error** ends the block, undoes prior writes, and leaves the engine immediately usable again.
- `TransactionStateChanged` fires on every transition.
- UI drive: Begin toggles the toolbar + status-bar indicator; a failing statement flips the indicator off with an "…— transaction rolled back" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012PAcHmABj5CUFk94jbrswn)_