### PR TITLE
Promote transaction controls in the command bar; add running-query feedback

### DIFF
--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -34,6 +34,12 @@ public sealed partial class QueryViewModel : ObservableObject
     private CancellationTokenSource? _cts;
     private IReadOnlyList<ColumnInfo> _columns = [];
 
+    // Live "still running" clock: a UI-thread timer ticks the elapsed time while a
+    // query (or EXPLAIN) is in flight, so a slow statement that hasn't produced a
+    // batch yet still shows visible progress instead of a frozen "Running…".
+    private readonly Stopwatch _runClock = new();
+    private DispatcherTimer? _runClockTimer;
+
     [ObservableProperty]
     private string _sql = "SELECT 1;";
 
@@ -57,6 +63,10 @@ public sealed partial class QueryViewModel : ObservableObject
 
     [ObservableProperty]
     private bool _isRunning;
+
+    /// <summary>Live elapsed time of the in-flight query ("1.2 s"), ticked while <see cref="IsRunning"/>; null when idle. Drives the status-bar running indicator alongside the indeterminate progress bar.</summary>
+    [ObservableProperty]
+    private string? _runningElapsedText;
 
     [ObservableProperty]
     private EditableTableContext? _editContext;
@@ -580,7 +590,40 @@ public sealed partial class QueryViewModel : ObservableObject
         ExplainAnalyzeCommand.NotifyCanExecuteChanged();
         ApplyFixCommand.NotifyCanExecuteChanged();
         OnPropertyChanged(nameof(HasNoResults));
+
+        if (value)
+        {
+            StartRunClock();
+        }
+        else
+        {
+            StopRunClock();
+        }
     }
+
+    // The live clock runs entirely on the UI thread: IsRunning flips on the UI
+    // thread (before the first await, and again in the run's finally, which
+    // resumes on the captured UI context), so timer create/start/stop are safe here.
+    private void StartRunClock()
+    {
+        _runClock.Restart();
+        RunningElapsedText = "0.0 s";
+
+        _runClockTimer ??= new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(100) };
+        _runClockTimer.Tick -= OnRunClockTick;
+        _runClockTimer.Tick += OnRunClockTick;
+        _runClockTimer.Start();
+    }
+
+    private void StopRunClock()
+    {
+        _runClockTimer?.Stop();
+        _runClock.Stop();
+        RunningElapsedText = null;
+    }
+
+    private void OnRunClockTick(object? sender, EventArgs e) =>
+        RunningElapsedText = $"{_runClock.Elapsed.TotalSeconds:F1} s";
 
     partial void OnRowsChanged(AvaloniaList<object?[]> value) => OnPropertyChanged(nameof(HasNoResults));
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -335,6 +335,7 @@
                     <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="Transparent" />
                 </Border.Resources>
                 <StackPanel Orientation="Horizontal" Spacing="2">
+                    <!-- Group 1 — execution: the primary Run + its Cancel -->
                     <Button Classes="accent" Command="{Binding ActiveTab.RunCommand}" ToolTip.Tip="Run (Ctrl+Enter)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource PlayIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
@@ -347,13 +348,49 @@
                             <TextBlock Text="Cancel" VerticalAlignment="Center" />
                         </StackPanel>
                     </Button>
-                    <Button Classes="toolbar" Command="{Binding ActiveTab.ExplainCommand}">
+
+                    <!-- Group 2 — transaction control (sits right after execution,
+                         ahead of the analysis tools: running inside a transaction
+                         is a core workflow, not a secondary one). Begin toggles to
+                         Commit/Rollback while a block is open; the amber tint on
+                         Commit/Rollback marks them as the state-changing pair. -->
+                    <Rectangle Classes="statusSeparator" Margin="7,0" />
+                    <Button Classes="toolbar" Command="{Binding BeginTransactionCommand}"
+                            IsVisible="{Binding !IsInTransaction}"
+                            ToolTip.Tip="Begin a transaction (BEGIN)">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <TextBlock Text="⛃" FontSize="13" VerticalAlignment="Center" />
+                            <TextBlock Text="Begin" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="toolbar" Command="{Binding CommitTransactionCommand}"
+                            IsVisible="{Binding IsInTransaction}"
+                            Foreground="#D9822B"
+                            ToolTip.Tip="Commit the transaction (COMMIT)">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <TextBlock Text="✓" FontSize="13" VerticalAlignment="Center" />
+                            <TextBlock Text="Commit" FontWeight="SemiBold" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="toolbar" Command="{Binding RollbackTransactionCommand}"
+                            IsVisible="{Binding IsInTransaction}"
+                            Foreground="#D9822B"
+                            ToolTip.Tip="Roll back the transaction (ROLLBACK)">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <TextBlock Text="↺" FontSize="13" VerticalAlignment="Center" />
+                            <TextBlock Text="Rollback" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+
+                    <!-- Group 3 — analysis: plan inspection (secondary to running) -->
+                    <Rectangle Classes="statusSeparator" Margin="7,0" />
+                    <Button Classes="toolbar" Command="{Binding ActiveTab.ExplainCommand}" ToolTip.Tip="Show the query plan (EXPLAIN)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource FlashIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
                             <TextBlock Text="Explain" VerticalAlignment="Center" />
                         </StackPanel>
                     </Button>
-                    <Button Classes="toolbar" Command="{Binding ActiveTab.ExplainAnalyzeCommand}">
+                    <Button Classes="toolbar" Command="{Binding ActiveTab.ExplainAnalyzeCommand}" ToolTip.Tip="Run and show the actual plan (EXPLAIN ANALYZE)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource GaugeIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
                             <TextBlock Text="Explain Analyze" VerticalAlignment="Center" />
@@ -366,7 +403,10 @@
                             <TextBlock Text="Show results" VerticalAlignment="Center" />
                         </StackPanel>
                     </Button>
-                    <Button Classes="toolbar" Name="ExportButton">
+
+                    <!-- Group 4 — data out: export -->
+                    <Rectangle Classes="statusSeparator" Margin="7,0" />
+                    <Button Classes="toolbar" Name="ExportButton" ToolTip.Tip="Export results (CSV / JSON)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource ExportIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
                             <TextBlock Text="Export" VerticalAlignment="Center" />
@@ -377,34 +417,6 @@
                                 <MenuItem Header="Export as JSON..." Click="OnExportJsonClick" />
                             </MenuFlyout>
                         </Button.Flyout>
-                    </Button>
-
-                    <!-- Transaction control: Begin toggles to Commit/Rollback + an
-                         "in transaction" indicator while a block is open -->
-                    <Rectangle Classes="statusSeparator" Margin="6,0" />
-                    <Button Classes="toolbar" Command="{Binding BeginTransactionCommand}"
-                            IsVisible="{Binding !IsInTransaction}"
-                            ToolTip.Tip="Begin a transaction (BEGIN)">
-                        <StackPanel Orientation="Horizontal" Spacing="7">
-                            <TextBlock Text="⛃" FontSize="13" VerticalAlignment="Center" />
-                            <TextBlock Text="Begin" VerticalAlignment="Center" />
-                        </StackPanel>
-                    </Button>
-                    <Button Classes="toolbar" Command="{Binding CommitTransactionCommand}"
-                            IsVisible="{Binding IsInTransaction}"
-                            ToolTip.Tip="Commit the transaction (COMMIT)">
-                        <StackPanel Orientation="Horizontal" Spacing="7">
-                            <TextBlock Text="✓" FontSize="13" VerticalAlignment="Center" />
-                            <TextBlock Text="Commit" VerticalAlignment="Center" />
-                        </StackPanel>
-                    </Button>
-                    <Button Classes="toolbar" Command="{Binding RollbackTransactionCommand}"
-                            IsVisible="{Binding IsInTransaction}"
-                            ToolTip.Tip="Roll back the transaction (ROLLBACK)">
-                        <StackPanel Orientation="Horizontal" Spacing="7">
-                            <TextBlock Text="↺" FontSize="13" VerticalAlignment="Center" />
-                            <TextBlock Text="Rollback" VerticalAlignment="Center" />
-                        </StackPanel>
                     </Button>
                 </StackPanel>
             </Border>
@@ -594,6 +606,14 @@
                     <TextBlock Text="{Binding ActiveTab.Status}"
                                Classes="statusText" Classes.error="{Binding ActiveTab.HasError}"
                                TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
+                    <!-- Running indicator: indeterminate bar + live elapsed tick while a query is in flight -->
+                    <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center"
+                                IsVisible="{Binding ActiveTab.IsRunning}">
+                        <Rectangle Classes="statusSeparator" />
+                        <ProgressBar IsIndeterminate="True" Width="90" Height="4"
+                                     VerticalAlignment="Center" ShowProgressText="False" />
+                        <TextBlock Classes="statusText dim" Text="{Binding ActiveTab.RunningElapsedText}" VerticalAlignment="Center" />
+                    </StackPanel>
                     <!-- Persistent "in transaction" indicator: an explicit BEGIN block is open -->
                     <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center"
                                 IsVisible="{Binding IsInTransaction}"


### PR DESCRIPTION
Two follow-ups on top of the transaction-control work (#53).

## Command-bar organisation
The transaction buttons were tacked onto the end of the command bar, behind Explain / Explain Analyze / Export. Running inside a transaction is a core workflow, not a secondary one, so the bar is now grouped into four divider-separated zones and the transaction controls move up ahead of the analysis tools:

`Run · Cancel │ Begin ⇄ Commit · Rollback │ Explain · Explain Analyze · Show results │ Export`

- Begin toggles to **Commit**/**Rollback** while a block is open (unchanged behaviour).
- **Commit**/**Rollback** get an amber tint marking them as the state-changing pair.
- Added tooltips to Explain / Explain Analyze / Export for consistency.

## Running-query feedback (roadmap item)
A UI-thread clock ticks the elapsed time while a query (or EXPLAIN) is in flight, shown in the status bar next to an indeterminate progress bar — so a slow statement that hasn't produced a batch yet shows visible progress instead of a frozen "Running…". The clock starts/stops off `IsRunning`, which flips on the UI thread, so the `DispatcherTimer` lifecycle is safe.

## Verification
Built clean (0 warnings). The command-bar change is pure XAML reordering with compiled bindings validated at build; the running indicator is a small `DispatcherTimer` + `ProgressBar` bound to existing `IsRunning`. (Note: headless-display runtime capture was flaky in this environment, so these two UI changes were verified by a clean compiled-bindings build rather than a fresh screenshot; the transaction feature they build on was screenshot-verified in #53.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012PAcHmABj5CUFk94jbrswn)_