### PR TITLE
UI polish: fixed brand accent, Windows Mica backdrop, vector icons

### DIFF
--- a/PgNimbus.App/Converters/MinWidthVisibilityConverter.cs
+++ b/PgNimbus.App/Converters/MinWidthVisibilityConverter.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace PgNimbus.App.Converters;
+
+/// <summary>
+/// True when an incoming width (double) is at least the threshold passed as the
+/// converter parameter. Used to reveal a control's label only once its container
+/// is wide enough — e.g. the sidebar nav collapses to icons-only when narrow and
+/// grows the "Schemas / Queries / Notify" text back when there's room.
+/// </summary>
+public sealed class MinWidthVisibilityConverter : IValueConverter
+{
+    public static readonly MinWidthVisibilityConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var width = value is double d ? d : 0;
+        var threshold = parameter is string s
+            && double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var t) ? t : 0;
+        return width >= threshold;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -3,11 +3,48 @@
 
     <!--
         PowerToys-inspired design tokens: soft rounded cards, pill-shaped nav
-        selection, accent-colored primary actions. Keep everything driven off
-        FluentTheme's DynamicResource brushes so light/dark and accent-color
-        changes keep working automatically.
+        selection, accent-colored primary actions. Neutral surfaces stay driven
+        off FluentTheme's DynamicResource brushes so light/dark keeps working;
+        the accent itself is a FIXED brand blue (AppAccentBrush below), NOT the
+        OS SystemAccentColor — see the note on that brush for why.
     -->
     <Styles.Resources>
+        <ResourceDictionary>
+            <!--
+                Windows 11 Mica: the translucent base tone the backdrop shows
+                through. Theme-split so the frost reads right in light/dark; only
+                applied when the platform honors Mica (MainWindow code-behind).
+            -->
+            <!--
+                Alpha kept high (~90%): Avalonia's Mica shows the wallpaper more
+                strongly than native Windows Mica, so a thinner frost let a dark
+                wallpaper darken the base until dimmed text (breadcrumb, section
+                headers) went grey-on-grey. 0xE6 keeps a stable tinted surface
+                with just a hint of the backdrop.
+            -->
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="ShellBackdropBrush" Color="#E6F3F3F3" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <SolidColorBrush x:Key="ShellBackdropBrush" Color="#E6202020" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+
+            <!--
+                Fixed brand accent, theme-independent. Deliberately NOT the OS
+                SystemAccentColor: the Windows accent can land anywhere on the
+                wheel (neon green, magenta…), and every selection/hover/primary
+                surface then has to stay legible against an unknown hue — not
+                worth the polish cost. A fixed blue we control keeps contrast
+                predictable.
+            -->
+            <SolidColorBrush x:Key="AppAccentBrush" Color="#2D7FF9" />
+            <SolidColorBrush x:Key="AppAccentHoverBrush" Color="#4A93FA" />
+            <SolidColorBrush x:Key="AppAccentPressedBrush" Color="#1E63D6" />
+            <!-- Low-alpha accent for row/pill selection washes; reads on both themes -->
+            <SolidColorBrush x:Key="AppSelectionBrush" Color="#282D7FF9" />
+
         <CornerRadius x:Key="CardCornerRadius">8</CornerRadius>
         <CornerRadius x:Key="ControlCornerRadius">6</CornerRadius>
         <CornerRadius x:Key="PillCornerRadius">16</CornerRadius>
@@ -28,9 +65,9 @@
             paint with. This StyleInclude loads after FluentTheme, so these
             take priority in resource lookup.
         -->
-        <StaticResource x:Key="TabItemHeaderBackgroundSelected" ResourceKey="SystemControlHighlightListAccentLowBrush" />
-        <StaticResource x:Key="TabItemHeaderBackgroundSelectedPointerOver" ResourceKey="SystemControlHighlightListAccentLowBrush" />
-        <StaticResource x:Key="TabItemHeaderBackgroundSelectedPressed" ResourceKey="SystemControlHighlightListAccentLowBrush" />
+        <StaticResource x:Key="TabItemHeaderBackgroundSelected" ResourceKey="AppSelectionBrush" />
+        <StaticResource x:Key="TabItemHeaderBackgroundSelectedPointerOver" ResourceKey="AppSelectionBrush" />
+        <StaticResource x:Key="TabItemHeaderBackgroundSelectedPressed" ResourceKey="AppSelectionBrush" />
         <StaticResource x:Key="TabItemHeaderBackgroundUnselectedPointerOver" ResourceKey="HoverBackgroundBrush" />
         <StaticResource x:Key="TabItemHeaderBackgroundUnselectedPressed" ResourceKey="HoverBackgroundBrush" />
         <!-- The pill *is* the selection indicator - hide the stock underline pipe -->
@@ -55,8 +92,18 @@
         <StreamGeometry x:Key="MagnifyIconGeometry">M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z</StreamGeometry>
         <StreamGeometry x:Key="CloseIconGeometry">M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z</StreamGeometry>
         <StreamGeometry x:Key="RefreshIconGeometry">M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z</StreamGeometry>
+        <!-- Transaction control (Begin/Commit/Rollback) + paging, as vectors so they
+             align on the same 12px box as the other command-bar PathIcons instead
+             of sitting on a glyph baseline. flag / check / restore-arrow (MDI). -->
+        <StreamGeometry x:Key="FlagIconGeometry">M14.4,6L14,4H5V21H7V14H12.6L13,16H20V6H14.4Z</StreamGeometry>
+        <StreamGeometry x:Key="CheckIconGeometry">M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z</StreamGeometry>
+        <StreamGeometry x:Key="UndoIconGeometry">M13,3A9,9 0 0,0 4,12H1L4.89,15.89L4.96,16.03L9,12H6A7,7 0 0,1 13,5A7,7 0 0,1 20,12A7,7 0 0,1 13,19C11.07,19 9.32,18.21 8.06,16.94L6.64,18.36C8.27,20 10.5,21 13,21A9,9 0 0,0 22,12A9,9 0 0,0 13,3Z</StreamGeometry>
+        <StreamGeometry x:Key="ChevronLeftIconGeometry">M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z</StreamGeometry>
+        <StreamGeometry x:Key="ChevronRightIconGeometry">M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z</StreamGeometry>
+        <StreamGeometry x:Key="SwapHorizontalIconGeometry">M21,9L17,5V8H10V10H17V13M7,11L3,15L7,19V16H14V14H7V11Z</StreamGeometry>
         <StreamGeometry x:Key="WeatherSunnyIconGeometry">M12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,2L14.39,5.42C13.65,5.15 12.84,5 12,5C11.16,5 10.35,5.15 9.61,5.42L12,2M3.34,7L7.5,6.65C6.9,7.16 6.36,7.78 5.94,8.5C5.5,9.24 5.25,10 5.11,10.79L3.34,7M3.36,17L5.12,13.23C5.26,14 5.53,14.78 5.95,15.5C6.37,16.24 6.91,16.86 7.5,17.37L3.36,17M20.65,7L18.88,10.79C18.74,10 18.47,9.23 18.05,8.5C17.63,7.78 17.1,7.15 16.5,6.64L20.65,7M20.64,17L16.5,17.36C17.09,16.85 17.62,16.22 18.04,15.5C18.46,14.77 18.73,14 18.87,13.21L20.64,17M12,22L9.59,18.56C10.33,18.83 11.14,19 12,19C12.82,19 13.63,18.85 14.37,18.58L12,22Z</StreamGeometry>
         <StreamGeometry x:Key="WeatherNightIconGeometry">M17.75,4.09L15.22,6.03L16.13,9.09L13.5,7.28L10.87,9.09L11.78,6.03L9.25,4.09L12.44,4L13.5,1L14.56,4L17.75,4.09M21.25,11L19.61,12.25L20.2,14.23L18.5,13.06L16.8,14.23L17.39,12.25L15.75,11L17.81,10.95L18.5,9L19.19,10.95L21.25,11M18.97,15.95C19.8,15.87 20.69,17.05 20.16,17.8C19.84,18.25 19.5,18.67 19.08,19.07C15.17,23 8.84,23 4.94,19.07C1.03,15.17 1.03,8.83 4.94,4.93C5.34,4.53 5.76,4.17 6.21,3.85C6.96,3.32 8.14,4.21 8.06,5.04C7.79,7.9 8.75,10.87 10.95,13.06C13.14,15.26 16.1,16.22 18.97,15.95Z</StreamGeometry>
+        </ResourceDictionary>
     </Styles.Resources>
 
     <!-- Card container: Border Classes="card" wraps a grouped panel -->
@@ -127,16 +174,16 @@
     </Style>
 
     <Style Selector="Button.accent">
-        <Setter Property="Background" Value="{DynamicResource SystemAccentColor}" />
+        <Setter Property="Background" Value="{StaticResource AppAccentBrush}" />
         <Setter Property="Foreground" Value="White" />
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="BorderThickness" Value="0" />
     </Style>
     <Style Selector="Button.accent:pointerover">
-        <Setter Property="Background" Value="{DynamicResource SystemAccentColorLight1}" />
+        <Setter Property="Background" Value="{StaticResource AppAccentHoverBrush}" />
     </Style>
     <Style Selector="Button.accent:pressed">
-        <Setter Property="Background" Value="{DynamicResource SystemAccentColorDark1}" />
+        <Setter Property="Background" Value="{StaticResource AppAccentPressedBrush}" />
     </Style>
     <Style Selector="Button.accent:disabled">
         <Setter Property="Background" Value="{DynamicResource SystemControlDisabledBaseLowBrush}" />
@@ -189,7 +236,7 @@
         <Setter Property="MinWidth" Value="0" />
     </Style>
     <Style Selector="TabItem:selected">
-        <Setter Property="Foreground" Value="{DynamicResource SystemAccentColor}" />
+        <Setter Property="Foreground" Value="{StaticResource AppAccentBrush}" />
         <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
 
@@ -205,14 +252,16 @@
         <Setter Property="Margin" Value="0,1" />
     </Style>
     <Style Selector="ListBoxItem:selected">
-        <Setter Property="Background" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}" />
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
     </Style>
     <Style Selector="TreeViewItem">
         <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
-        <Setter Property="Padding" Value="4,4" />
+        <Setter Property="Padding" Value="4,3" />
+        <!-- Tighter rows than Fluent's ~30px default -->
+        <Setter Property="MinHeight" Value="26" />
     </Style>
     <Style Selector="TreeViewItem:selected /template/ Border#PART_LayoutRoot">
-        <Setter Property="Background" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}" />
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
     </Style>
 
     <!-- Inputs: rounded to match the rest of the surface -->

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -18,7 +18,9 @@
         WindowStartupLocation="CenterOwner"
         Width="1100" Height="800"
         MinWidth="940" MinHeight="560"
-        FontFamily="{StaticResource InterFont}">
+        FontFamily="{StaticResource InterFont}"
+        Background="Transparent"
+        TransparencyLevelHint="Mica,AcrylicBlur">
 
     <Window.DataTemplates>
         <DataTemplate DataType="vm:SchemaNode">
@@ -73,8 +75,14 @@
     <!-- Root grid layers the command-palette overlay above the whole shell -->
     <Grid>
 
-    <!-- Two-tone shell (Files-style): chrome-tinted base; the content pane is a raised layer -->
-    <DockPanel Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}">
+    <!--
+        Two-tone shell (Files-style): chrome-tinted base; the content pane is a
+        raised layer. On Windows 11 the base becomes the translucent layer the
+        Mica backdrop shows through - ApplyBackdrop (code-behind) swaps this
+        opaque tone for ShellBackdropBrush when the platform honors Mica, and
+        leaves it opaque otherwise so the base is never a see-through hole.
+    -->
+    <DockPanel Name="ShellBase" Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}">
         <Border DockPanel.Dock="Top" Height="40" Padding="16,0"
                 BorderThickness="0,0,0,1" BorderBrush="{StaticResource CardBorderBrush}">
             <DockPanel>
@@ -94,11 +102,13 @@
                 <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
                     <TextBlock Text="pgNimbus" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
                     <!-- Files-style breadcrumb: where am I connected -->
-                    <TextBlock Text="{Binding ConnectionHost}" FontSize="12" Opacity="0.65" VerticalAlignment="Center" Margin="10,0,0,0" />
+                    <TextBlock Text="{Binding ConnectionHost}" FontSize="12" Opacity="0.75" VerticalAlignment="Center" Margin="10,0,0,0" />
                     <TextBlock Text="›" FontSize="12" Opacity="0.45" VerticalAlignment="Center" />
-                    <TextBlock Text="{Binding ConnectionDatabase}" FontSize="12" Opacity="0.65" VerticalAlignment="Center" />
-                    <Button Classes="chip" Content="⇄" FontSize="12" VerticalAlignment="Center" Margin="4,0,0,0"
-                            Click="OnSwitchConnectionClick" ToolTip.Tip="Switch connection" />
+                    <TextBlock Text="{Binding ConnectionDatabase}" FontSize="12" Opacity="0.75" VerticalAlignment="Center" />
+                    <Button Classes="chip" Padding="5" VerticalAlignment="Center" Margin="4,0,0,0"
+                            Click="OnSwitchConnectionClick" ToolTip.Tip="Switch connection">
+                        <PathIcon Data="{StaticResource SwapHorizontalIconGeometry}" Width="12" Height="12" />
+                    </Button>
                 </StackPanel>
             </DockPanel>
         </Border>
@@ -112,11 +122,13 @@
         </Grid.ColumnDefinitions>
 
         <TabControl Name="SidebarTabs" Grid.Column="0">
-            <TabItem>
+            <TabItem ToolTip.Tip="Schemas">
                 <TabItem.Header>
-                    <StackPanel Orientation="Horizontal" Spacing="8">
+                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                         <PathIcon Data="{StaticResource DatabaseIconGeometry}" Width="14" Height="14" VerticalAlignment="Center" />
-                        <TextBlock Text="Schemas" />
+                        <!-- Label collapses to icon-only when the sidebar is too narrow to fit all three -->
+                        <TextBlock Text="Schemas" VerticalAlignment="Center"
+                                   IsVisible="{Binding $parent[TabControl].Bounds.Width, Converter={x:Static conv2:MinWidthVisibilityConverter.Instance}, ConverterParameter=260}" />
                     </StackPanel>
                 </TabItem.Header>
                 <Grid RowDefinitions="Auto,*,Auto" Margin="0,8,0,0">
@@ -167,11 +179,12 @@
                                Foreground="IndianRed" TextWrapping="Wrap" Margin="4" FontSize="11" />
                 </Grid>
             </TabItem>
-            <TabItem>
+            <TabItem ToolTip.Tip="Queries">
                 <TabItem.Header>
-                    <StackPanel Orientation="Horizontal" Spacing="8">
+                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                         <PathIcon Data="{StaticResource QueriesIconGeometry}" Width="14" Height="14" VerticalAlignment="Center" />
-                        <TextBlock Text="Queries" />
+                        <TextBlock Text="Queries" VerticalAlignment="Center"
+                                   IsVisible="{Binding $parent[TabControl].Bounds.Width, Converter={x:Static conv2:MinWidthVisibilityConverter.Instance}, ConverterParameter=260}" />
                     </StackPanel>
                 </TabItem.Header>
                 <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0" x:DataType="vm:SavedQueriesViewModel" DataContext="{Binding SavedQueries}">
@@ -222,11 +235,12 @@
                     </StackPanel>
                 </Grid>
             </TabItem>
-            <TabItem>
+            <TabItem ToolTip.Tip="Notify">
                 <TabItem.Header>
-                    <StackPanel Orientation="Horizontal" Spacing="8">
+                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
                         <PathIcon Data="{StaticResource BellIconGeometry}" Width="14" Height="14" VerticalAlignment="Center" />
-                        <TextBlock Text="Notify" />
+                        <TextBlock Text="Notify" VerticalAlignment="Center"
+                                   IsVisible="{Binding $parent[TabControl].Bounds.Width, Converter={x:Static conv2:MinWidthVisibilityConverter.Instance}, ConverterParameter=260}" />
                     </StackPanel>
                 </TabItem.Header>
                 <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0" x:DataType="vm:NotifyMonitorViewModel" DataContext="{Binding NotifyMonitor}">
@@ -312,7 +326,7 @@
                                 <TextBlock Text="{Binding TabTitle}" VerticalAlignment="Center" />
                                 <!-- Dirty-state dot: SQL edited since last run -->
                                 <Ellipse Width="6" Height="6" VerticalAlignment="Center"
-                                         Fill="{DynamicResource SystemAccentColor}"
+                                         Fill="{DynamicResource AppAccentBrush}"
                                          IsVisible="{Binding IsDirty}"
                                          ToolTip.Tip="Unsaved changes since last run" />
                                 <Button Classes="chip" Content="✕" FontSize="10" Tag="{Binding}" Click="OnCloseTabClick" />
@@ -359,7 +373,7 @@
                             IsVisible="{Binding !IsInTransaction}"
                             ToolTip.Tip="Begin a transaction (BEGIN)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
-                            <TextBlock Text="⛃" FontSize="13" VerticalAlignment="Center" />
+                            <PathIcon Data="{StaticResource FlagIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
                             <TextBlock Text="Begin" VerticalAlignment="Center" />
                         </StackPanel>
                     </Button>
@@ -368,7 +382,7 @@
                             Foreground="#D9822B"
                             ToolTip.Tip="Commit the transaction (COMMIT)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
-                            <TextBlock Text="✓" FontSize="13" VerticalAlignment="Center" />
+                            <PathIcon Data="{StaticResource CheckIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
                             <TextBlock Text="Commit" FontWeight="SemiBold" VerticalAlignment="Center" />
                         </StackPanel>
                     </Button>
@@ -377,7 +391,7 @@
                             Foreground="#D9822B"
                             ToolTip.Tip="Roll back the transaction (ROLLBACK)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
-                            <TextBlock Text="↺" FontSize="13" VerticalAlignment="Center" />
+                            <PathIcon Data="{StaticResource UndoIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
                             <TextBlock Text="Rollback" VerticalAlignment="Center" />
                         </StackPanel>
                     </Button>
@@ -488,12 +502,16 @@
                                        FontSize="12" Opacity="0.6" VerticalAlignment="Center" Margin="14,0,0,0" />
                             <TextBlock Grid.Column="4" Text="{Binding PageLabel}" FontSize="12" Opacity="0.6"
                                        VerticalAlignment="Center" Margin="14,0,6,0" />
-                            <Button Grid.Column="5" Classes="chip" Content="◀" FontSize="12"
+                            <Button Grid.Column="5" Classes="chip" Padding="5"
                                     Command="{Binding PreviousPageCommand}" ToolTip.Tip="Previous page"
-                                    VerticalAlignment="Center" />
-                            <Button Grid.Column="6" Classes="chip" Content="▶" FontSize="12"
+                                    VerticalAlignment="Center">
+                                <PathIcon Data="{StaticResource ChevronLeftIconGeometry}" Width="12" Height="12" />
+                            </Button>
+                            <Button Grid.Column="6" Classes="chip" Padding="5"
                                     Command="{Binding NextPageCommand}" ToolTip.Tip="Next page"
-                                    Margin="2,0,0,0" VerticalAlignment="Center" />
+                                    Margin="2,0,0,0" VerticalAlignment="Center">
+                                <PathIcon Data="{StaticResource ChevronRightIconGeometry}" Width="12" Height="12" />
+                            </Button>
                         </Grid>
                     </Border>
 
@@ -582,7 +600,7 @@
                                         <StackPanel Margin="0,2">
                                             <StackPanel Orientation="Horizontal" Spacing="6">
                                                 <Rectangle Width="{Binding BarWidth}" Height="10" RadiusX="2" RadiusY="2"
-                                                           Fill="{DynamicResource SystemAccentColor}" VerticalAlignment="Center" />
+                                                           Fill="{DynamicResource AppAccentBrush}" VerticalAlignment="Center" />
                                                 <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
                                             </StackPanel>
                                             <TextBlock Text="{Binding CostLabel}" FontSize="11" Opacity="0.7" Margin="16,0,0,0" />

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -70,11 +70,14 @@ public partial class MainWindow : Window
         {
             ApplySqlHighlightingTheme();
             UpdateThemeIcon();
+            ApplyBackdrop();
         };
         ActualThemeVariantChanged += (_, _) =>
         {
             ApplySqlHighlightingTheme();
             UpdateThemeIcon();
+            // ShellBackdropBrush is theme-split, so re-resolve on a theme flip.
+            ApplyBackdrop();
         };
 
         SqlEditor.TextChanged += (_, _) =>
@@ -353,6 +356,30 @@ public partial class MainWindow : Window
         if (this.TryFindResource(key, out var geometry) && geometry is Geometry data)
         {
             ThemeIcon.Data = data;
+        }
+    }
+
+    // Windows 11 Mica backdrop. When the platform honors a translucent backdrop
+    // (Mica, or Acrylic as the Windows 10 fallback), the two-tone shell's base
+    // becomes ShellBackdropBrush so the backdrop shows through it; the content
+    // pane stays opaque. Anywhere the hint can't be honored (Linux, macOS, older
+    // Windows, transparency disabled), ActualTransparencyLevel is None and the
+    // base keeps its opaque chrome tone.
+    private void ApplyBackdrop()
+    {
+        var backdropActive = ActualTransparencyLevel == WindowTransparencyLevel.Mica
+            || ActualTransparencyLevel == WindowTransparencyLevel.AcrylicBlur;
+
+        var key = backdropActive
+            ? "ShellBackdropBrush"
+            : "SystemControlBackgroundChromeMediumLowBrush";
+
+        // Must resolve against the actual theme: ShellBackdropBrush lives only in
+        // Light/Dark theme dictionaries (no Default), so the theme-less overload
+        // silently misses it and the swap never happens.
+        if (this.TryFindResource(key, ActualThemeVariant, out var resource) && resource is IBrush brush)
+        {
+            ShellBase.Background = brush;
         }
     }
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -177,7 +177,36 @@ means for pgNimbus. Adopting its language where Avalonia allows.
 | Smarter SQL IntelliSense | Completion now reads the caret's grammatical position instead of always dumping the catalog. A new single-pass scanner (`SqlCompletionContext.GetCaretContext`) tracks string/comment state (`'…'` with `''` escapes, quoted identifiers, `--`, nestable `/* */`, `$tag$…$tag$`) and the governing clause per statement, so: **(1)** nothing pops up inside literals/comments; **(2)** after `FROM`/`JOIN`/`INTO`/`UPDATE` only tables/schemas/CTE names (+keywords) are offered — the list opens by itself on the space after those keywords, tables first — while `INSERT INTO t (` flips back to columns; **(3)** everywhere else the statement's own columns float to the top as before, now also from `UPDATE`/`INSERT INTO` targets (new `UpdateIntoTargetRegex`) and joined by the statement's aliases and `WITH` CTE names (new `CteNameRegex`). Column items now carry their `format_type` data type (`GetAllColumnsAsync` returns it; description reads `column (users) : integer`), and ~70 curated everyday functions (`coalesce`, `date_trunc`, `string_agg`, window functions…) complete as `name()` with the caret placed between the parens. Logic verified by a 58-case scratch harness (clause detection, suppression, table/CTE extraction — all pass) and end-to-end under Xvfb: `FROM ` auto-opened tables-first list; `cu`→Enter inserted `customers`; `c.` listed exactly its 4 columns; the selected column's tooltip showed `column (customers) : integer`; typing inside `'nam` showed no popup; `coale`→Enter produced `coalesce(│)` with the next popup led by alias `c` + floated columns; a `WITH recent AS (…)` query listed `recent` first after `FROM `. | (this commit) |
 
 ## Open / candidate items
-- [ ] Mica/acrylic backdrop remains blocked on safe verification (a headless
-      sandbox can't see transparency failures).
+- [x] Mica/acrylic backdrop on Windows — `MainWindow` sets
+      `TransparencyLevelHint="Mica,AcrylicBlur"` + transparent window
+      background; `ApplyBackdrop` (code-behind) swaps the two-tone shell's base
+      (`ShellBase`) to the theme-split `ShellBackdropBrush` when
+      `ActualTransparencyLevel` is Mica/Acrylic, and keeps the opaque chrome
+      tone otherwise (Win10-, Linux, macOS, transparency off) so the base is
+      never a see-through hole. Content pane stays opaque. Needs a live desktop
+      to eyeball the frost.
+- [x] Dropped the OS `SystemAccentColor`/`SystemControlHighlightListAccentLowBrush`
+      for a fixed brand blue (`AppAccentBrush`/`Hover`/`Pressed` + low-alpha
+      `AppSelectionBrush` in `Theme.axaml`). The OS accent could be any hue, so
+      keeping every selection/hover/primary surface legible against it wasn't
+      worth polishing. Per-connection `AccentColor` (the connection dot) is
+      unrelated and untouched.
+- [ ] Compact schema tree — reduce the *per-level* horizontal indent. Row
+      height/padding was tightened via `TreeViewItem` style setters (those win
+      over the ControlTheme's setters), but the indent lives on
+      `PART_Header.Margin` (a `MultiBinding` on `TreeViewItem.Level`) set inside
+      the Fluent **template**, which is `BindingPriority.Template` — higher than
+      an app-level `Style`, so a `/template/` setter override is silently
+      ignored. Two viable paths: (a) counter-offset each nested
+      `PART_ItemsPresenter` with a negative left `Margin` via a plain style
+      (its margin is *not* template-set, so a style can win there); or (b) ship
+      a full replacement `TreeViewItem` ControlTheme with a smaller indent
+      converter. Deferred — needs verification on a live tree.
+- [ ] `Window.MinWidth`/`MinHeight` clamp the layout size (and the `Width`
+      property) but do **not** feed the Win32 min-track-size, so an OS frame
+      drag can still shrink the window below `940` and squeeze the right pane
+      to a sliver (content clips / DataGrid auto-scrolls a clicked cell into
+      view). Fix candidates: push the min into the platform impl, or make the
+      command bar wrap and the pane degrade gracefully. Deferred.
 - [ ] Roadmap features (extension manager, plugin API) — out of polish
       scope


### PR DESCRIPTION
## Summary

Replaces the OS system accent with a fixed brand blue, adds a Windows 11 Mica backdrop to the two-tone shell, and swaps the last emoji-glyph icons for vectors. Verified live on Windows against a local Postgres via the Avalonia DevTools MCP.

## Changes

**Fixed brand accent** — drops `SystemAccentColor` / `SystemControlHighlightListAccentLowBrush` everywhere (primary button + hover/pressed, nav pill + list/tree selection, selected-tab foreground, dirty-dot, explain bars) for fixed `AppAccentBrush` / `AppAccentHoverBrush` / `AppAccentPressedBrush` and a low-alpha `AppSelectionBrush`. The OS accent can be any hue, which makes keeping every selection/hover/primary surface legible an unwinnable polish problem. The per-connection `AccentColor` (connection dot) is a separate feature and is untouched.

**Windows Mica backdrop** — `MainWindow` sets `TransparencyLevelHint="Mica,AcrylicBlur"` + a transparent window background. `ApplyBackdrop` (code-behind) swaps the shell base (`ShellBase`) to the theme-split `ShellBackdropBrush` when `ActualTransparencyLevel` resolves to Mica/Acrylic, and keeps the opaque chrome tone otherwise (Win10-, Linux, macOS, transparency off) so the base is never a see-through hole. The content pane stays opaque. Frost alpha is kept high (~90%) because Avalonia renders the wallpaper more strongly than native Mica — a thinner frost let a dark wallpaper push dimmed text to grey-on-grey.

**Vector icons** — transaction Begin/Commit/Rollback (previously emoji glyphs sitting on a text baseline, misaligned with the vector buttons around them), the pagination arrows, and the switch-connection button are now `PathIcon`s on the same 12px box as the rest of the command bar.

**Sidebar** — nav labels (Schemas / Queries / Notify) collapse to icon-only when the sidebar is too narrow to fit all three (`MinWidthVisibilityConverter`, tooltips added for the collapsed state). Tree rows tightened via padding + `MinHeight`.

## Verification

Driven live via the Avalonia DevTools MCP against a local Postgres:
- `MainWindow.ActualTransparencyLevel = Mica`; `ShellBase.Background` resolves to the translucent `ShellBackdropBrush`.
- Command bar renders all icons on one aligned baseline.
- Nav shows icon+text at 300px, collapses to icons when narrow.

## Deferred (documented in `docs/PROGRESS.md`)

- **Per-level tree indent** — the Fluent template sets `PART_Header.Margin` (a `MultiBinding` on `Level`) at `BindingPriority.Template`, which outranks app-level `Style` overrides, so a `/template/` setter is silently ignored. Needs either a negative-margin counter-offset on the nested `ItemsPresenter` or a full replacement ControlTheme.
- **Window min size** — `MinWidth`/`MinHeight` clamp layout but don't feed the Win32 min-track-size, so an OS frame drag can still shrink the window below `940` and squeeze the right pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)