### PR TITLE
Drag-and-drop from the schema tree into the editor; compact tree indent

### DIFF
--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -166,6 +166,13 @@
                                     <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay, DataType=vm:SchemaTreeNode}" />
                                     <Setter Property="IsVisible" Value="{Binding IsFilteredIn, Mode=OneWay, DataType=vm:SchemaTreeNode}" />
                                 </Style>
+                                <!-- Compact per-level indent: the header's own indent is Level*16px,
+                                     set at Template priority (unbeatable from a style), but each
+                                     nested items presenter's Margin is NOT template-set, so a
+                                     -8px counter-offset here nets out to 8px per level. -->
+                                <Style Selector="TreeViewItem /template/ ItemsPresenter#PART_ItemsPresenter">
+                                    <Setter Property="Margin" Value="-8,0,0,0" />
+                                </Style>
                             </TreeView.Styles>
                             <TreeView.ItemTemplate>
                                 <TreeDataTemplate ItemsSource="{Binding Children}">

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -94,6 +94,18 @@ public partial class MainWindow : Window
         // event Handled, so it never reaches a plain `+=` subscription on the
         // parent TreeView. Use AddHandler with handledEventsToo to still see it.
         SchemaTreeView.AddHandler(InputElement.DoubleTappedEvent, OnSchemaTreeDoubleTapped, RoutingStrategies.Bubble, handledEventsToo: true);
+
+        // Drag a schema/table/column out of the tree and drop it into the SQL
+        // editor as a properly quoted identifier. The drag arms on press and
+        // only starts after a small movement threshold, so plain clicks,
+        // expander toggles, and double-click previews all behave as before.
+        SchemaTreeView.AddHandler(InputElement.PointerPressedEvent, OnSchemaTreePointerPressed, RoutingStrategies.Tunnel);
+        SchemaTreeView.AddHandler(InputElement.PointerMovedEvent, OnSchemaTreePointerMoved, RoutingStrategies.Tunnel);
+        SchemaTreeView.AddHandler(InputElement.PointerReleasedEvent, (_, _) => _treeDragCandidate = null, RoutingStrategies.Tunnel);
+
+        DragDrop.SetAllowDrop(SqlEditor, true);
+        SqlEditor.AddHandler(DragDrop.DragOverEvent, OnEditorDragOver);
+        SqlEditor.AddHandler(DragDrop.DropEvent, OnEditorDrop);
         ResultsGrid.CellEditEnding += OnCellEditEnding;
         ResultsGrid.CellEditEnded += OnCellEditEnded;
         ResultsGrid.PreparingCellForEdit += OnPreparingCellForEdit;
@@ -317,6 +329,97 @@ public partial class MainWindow : Window
         {
             _viewModel?.CloseTabCommand.Execute(tab);
         }
+    }
+
+    // --- Schema-tree drag & drop into the editor --------------------------
+
+    // Armed on press over a draggable node; the drag itself starts only after
+    // the pointer moves past a threshold with the button still down. The press
+    // args are kept because DoDragDropAsync can only start from them.
+    private (Point Origin, string Text, PointerPressedEventArgs PressArgs)? _treeDragCandidate;
+    private const double DragThreshold = 4;
+
+    /// <summary>The SQL identifier a tree node drops as, quoted only where a bare name wouldn't round-trip.</summary>
+    private static string? DragTextFor(object? node) => node switch
+    {
+        ColumnNode column => SqlIdentifier.QuoteIfNeeded(column.Name),
+        TableNode table => $"{SqlIdentifier.QuoteIfNeeded(table.Schema)}.{SqlIdentifier.QuoteIfNeeded(table.Name)}",
+        SchemaNode schema => SqlIdentifier.QuoteIfNeeded(schema.Name),
+        _ => null,
+    };
+
+    private void OnSchemaTreePointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(SchemaTreeView).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        var node = (e.Source as Visual)?.DataContext;
+        _treeDragCandidate = DragTextFor(node) is { } text
+            ? (e.GetPosition(SchemaTreeView), text, e)
+            : null;
+    }
+
+    private async void OnSchemaTreePointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_treeDragCandidate is not { } candidate)
+        {
+            return;
+        }
+
+        if (!e.GetCurrentPoint(SchemaTreeView).Properties.IsLeftButtonPressed)
+        {
+            _treeDragCandidate = null;
+            return;
+        }
+
+        var position = e.GetPosition(SchemaTreeView);
+        if (Math.Abs(position.X - candidate.Origin.X) < DragThreshold &&
+            Math.Abs(position.Y - candidate.Origin.Y) < DragThreshold)
+        {
+            return;
+        }
+
+        _treeDragCandidate = null;
+        var data = new DataTransfer();
+        data.Add(DataTransferItem.CreateText(candidate.Text));
+        await DragDrop.DoDragDropAsync(candidate.PressArgs, data, DragDropEffects.Copy);
+    }
+
+    private void OnEditorDragOver(object? sender, DragEventArgs e)
+    {
+        if (!e.DataTransfer.Formats.Contains(DataFormat.Text))
+        {
+            e.DragEffects = DragDropEffects.None;
+            return;
+        }
+
+        e.DragEffects = DragDropEffects.Copy;
+        // Live caret preview: the caret tracks the pointer so it's obvious
+        // where the identifier will land.
+        if (SqlEditor.GetPositionFromPoint(e.GetPosition(SqlEditor)) is { } position)
+        {
+            SqlEditor.TextArea.Caret.Position = position;
+        }
+
+        e.Handled = true;
+    }
+
+    private void OnEditorDrop(object? sender, DragEventArgs e)
+    {
+        if (e.DataTransfer.TryGetText() is not { Length: > 0 } text)
+        {
+            return;
+        }
+
+        var offset = SqlEditor.GetPositionFromPoint(e.GetPosition(SqlEditor)) is { } position
+            ? SqlEditor.Document.GetOffset(position.Location)
+            : SqlEditor.CaretOffset;
+        SqlEditor.Document.Insert(offset, text);
+        SqlEditor.CaretOffset = offset + text.Length;
+        SqlEditor.TextArea.Focus();
+        e.Handled = true;
     }
 
     // --- Tab-strip navigation extras -------------------------------------

--- a/README.md
+++ b/README.md
@@ -359,9 +359,11 @@ bar (the Files community app remains the visual north star):
   remembered across launches (saved to `settings.json` alongside the other
   persisted app state) instead of snapping back to the OS default; a fresh
   install with no saved choice still follows the OS.
-- [ ] **Drag-and-drop from the schema tree** — drag a table, column, or other
-  object from the sidebar tree into the SQL editor and drop a valid, quoted
-  identifier at the cursor (e.g. `"CreatedAt"`).
+- [x] **Drag-and-drop from the schema tree** — drag a schema, table, or column
+  from the sidebar tree into the SQL editor and it drops as a valid identifier
+  at the pointer (schema-qualified for tables, quoted only when a bare name
+  wouldn't round-trip, e.g. `"CreatedAt"`); the caret tracks the pointer during
+  the drag so the landing spot is always visible.
 - [x] **Collapsible sidebar** — a 200px minimum width on manual resize (so it
   can't shrink to an unreadable sliver) plus a collapse button (the ☰ in the
   title bar) / <kbd>Ctrl</kbd>+<kbd>B</kbd> that fully hides the sidebar and gives
@@ -399,7 +401,9 @@ bar (the Files community app remains the visual north star):
   (initially: custom result visualizers).
 - [ ] **Localization** — externalize UI strings; ship Russian and German first.
 
-Recently shipped: tab-bar navigation extras (overflow-only ‹/› scroll arrows
+Recently shipped: drag-and-drop from the schema tree into the editor
+(quoted-as-needed identifiers, caret tracks the pointer), a more compact
+schema-tree indent, tab-bar navigation extras (overflow-only ‹/› scroll arrows
 and an all-tabs dropdown with type-to-search), a connection-dialog
 empty-state hint, transaction control (Begin/Commit/Rollback toolbar state, an
 "in transaction" status-bar indicator, and auto-rollback on error), abbreviated column types in the schema tree

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -184,6 +184,13 @@ means for pgNimbus. Adopting its language where Avalonia allows.
 | Connection-dialog empty state | The Saved Connections list was a bare grey panel on first launch; it now shows the same centered dimmed hint the saved-queries/history lists use ("No saved connections yet — fill in the form and press Save to keep one here"), driven by `HasNoProfiles` on `ConnectionDialogViewModel` (recomputed on every `Profiles` collection change). Verified under Xvfb with a fresh `$HOME`: hint shows on first launch and disappears the moment a profile is saved. | (this commit) |
 | README hygiene | The running-query-feedback backlog entry was still unchecked although #54 shipped it — flipped, with the description updated to what was actually built. | (this commit) |
 
+## Iteration 26
+
+| Item | Outcome | Commit |
+| --- | --- | --- |
+| Drag-and-drop from the schema tree | Schemas, tables, and columns drag out of the sidebar tree and drop into the SQL editor as identifiers quoted only where a bare name wouldn't round-trip (`SqlIdentifier.QuoteIfNeeded`; tables drop schema-qualified). The drag arms on press over a draggable node and starts only past a 4 px movement threshold, so clicks, expander toggles, and double-click previews behave exactly as before. **Avalonia 12 landmine:** the old `DataObject`/`DataFormats`/`DoDragDrop` API is compile-error obsolete — it's `DataTransfer` + `DataTransferItem.CreateText` + `DragDrop.DoDragDropAsync` now, and `DoDragDropAsync` only starts from the original `PointerPressedEventArgs`, so the press args ride along in the armed-candidate tuple. On the editor side `DragOver` moves the caret with the pointer (live landing preview) and `Drop` inserts at that position and focuses the editor. Verified under Xvfb: `customers` dropped as `public.customers` at the pointer; the `name` column dropped mid-token exactly at the pointer position. | (this commit) |
+| Compact schema-tree indent | The deferred item from the open list, via path (a): the header's own indent is `Level*16` px set at Template priority (unbeatable from a style), but each nested `PART_ItemsPresenter`'s `Margin` is *not* template-set, so a `-8,0,0,0` style counter-offset (scoped inside the schema `TreeView.Styles`) nets out to ~8 px per level. Verified on a live three-level tree (schema → table → columns) — clearly tighter, chevrons and key icons intact. | (this commit) |
+
 ## Open / candidate items
 - [x] Mica/acrylic backdrop on Windows — `MainWindow` sets
       `TransparencyLevelHint="Mica,AcrylicBlur"` + transparent window
@@ -199,17 +206,10 @@ means for pgNimbus. Adopting its language where Avalonia allows.
       keeping every selection/hover/primary surface legible against it wasn't
       worth polishing. Per-connection `AccentColor` (the connection dot) is
       unrelated and untouched.
-- [ ] Compact schema tree — reduce the *per-level* horizontal indent. Row
-      height/padding was tightened via `TreeViewItem` style setters (those win
-      over the ControlTheme's setters), but the indent lives on
-      `PART_Header.Margin` (a `MultiBinding` on `TreeViewItem.Level`) set inside
-      the Fluent **template**, which is `BindingPriority.Template` — higher than
-      an app-level `Style`, so a `/template/` setter override is silently
-      ignored. Two viable paths: (a) counter-offset each nested
-      `PART_ItemsPresenter` with a negative left `Margin` via a plain style
-      (its margin is *not* template-set, so a style can win there); or (b) ship
-      a full replacement `TreeViewItem` ControlTheme with a smaller indent
-      converter. Deferred — needs verification on a live tree.
+- [x] Compact schema tree — done in Iteration 26 via path (a): a `-8,0,0,0`
+      style margin on each nested `PART_ItemsPresenter` (not template-set, so
+      a style wins) counter-offsets the template's `Level*16` header indent
+      to ~8 px per level. Verified on a live three-level tree.
 - [ ] `Window.MinWidth`/`MinHeight` clamp the layout size (and the `Width`
       property) but do **not** feed the Win32 min-track-size, so an OS frame
       drag can still shrink the window below `940` and squeeze the right pane


### PR DESCRIPTION
Two sidebar-tree items — the last unchecked UI backlog entry that's verifiable headless, plus the compact-indent item deferred in `docs/PROGRESS.md`. Both verified by driving the app under Xvfb.

## Drag-and-drop from the schema tree

Drag a schema, table, or column out of the sidebar tree and drop it into the SQL editor as a valid identifier:

- Tables drop **schema-qualified** (`public.customers`); every part is quoted only when a bare name wouldn't round-trip (`SqlIdentifier.QuoteIfNeeded`, so `"CreatedAt"` gets quotes but `users` stays clean).
- The drag arms on press and starts only past a 4 px movement threshold — plain clicks, expander toggles, and double-click previews behave exactly as before.
- During the drag the editor caret tracks the pointer (live landing preview); the drop inserts at that position and focuses the editor.
- Uses Avalonia 12's new `DataTransfer` API (the `DataObject`/`DataFormats`/`DoDragDrop` surface is compile-error obsolete). `DoDragDropAsync` can only start from the original `PointerPressedEventArgs`, so the press args ride along in the armed-candidate tuple — noted in `docs/PROGRESS.md` as a landmine for future drag sources.

Verified: `customers` dropped as `public.customers` at the pointer; the `name` column dropped exactly at the pointer position (mid-token), proving position-accurate insertion.

## Compact schema-tree indent

The deferred path (a) from the progress log: the Fluent template sets the header indent (`Level*16` px) at Template priority where app styles can't win, but each nested `PART_ItemsPresenter`'s `Margin` is **not** template-set — so a `-8,0,0,0` style counter-offset (scoped inside the schema `TreeView.Styles`) nets out to ~8 px per level. Verified on a live three-level tree (schema → table → columns): clearly tighter, chevrons and key icons intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dSXd5X2EnaTpXsXZh2BhN

---
_Generated by [Claude Code](https://claude.ai/code/session_011dSXd5X2EnaTpXsXZh2BhN)_