### PR TITLE
Add community scaffolding: CoC, contributing guide, security policy, CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Something in pgNimbus doesn't work the way it should.
+labels: [bug]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, what happened instead?
+      placeholder: |
+        1. Connect to …
+        2. Run …
+        3. Expected …, but got …
+    validations:
+      required: true
+
+  - type: input
+    id: pgnimbus-version
+    attributes:
+      label: pgNimbus version
+      description: Shown in the installer/dmg file name, or the commit if built from source.
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Install method
+      options:
+        - Windows MSI
+        - macOS dmg
+        - Built from source
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "Windows 11 24H2 / macOS 15.5 / Ubuntu 24.04"
+    validations:
+      required: true
+
+  - type: input
+    id: postgres-version
+    attributes:
+      label: PostgreSQL version
+      description: "`SELECT version();` — include the hosting flavor if relevant (RDS, Supabase, Neon…)."
+      placeholder: "PostgreSQL 17.2"
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Screenshots, the SQL involved, error text, SSH tunnel in play, etc. Please redact hostnames and credentials.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/Shman4ik/pgNimbus/security/advisories/new
+    about: Please report security issues privately, not via a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest an improvement or a new capability.
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please skim the [README backlog](https://github.com/Shman4ik/pgNimbus#backlog)
+        first — a lot of planned work is already listed there. If your idea is
+        on it, an issue is still welcome as a place to discuss specifics or
+        register demand; just link the backlog line.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the workflow that's currently painful or impossible, not just the feature itself.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would it look like? How do other clients (psql, TablePlus, DBeaver…) handle it, if they do?
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      # Avalonia packages version-lockstep with each other; one PR per bump.
+      avalonia:
+        patterns:
+          - "Avalonia*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+# The PR/push quality gate: does it build, do the tests pass. Release
+# packaging lives in release.yml (tag-triggered) — this stays fast and
+# runs on every change instead.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: "1"
+  DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      # Debug first: it's the configuration that includes the Debug-only
+      # AvaloniaUI.DiagnosticsSupport reference, so both dependency graphs
+      # get compiled.
+      - name: Build (Debug)
+        run: dotnet build -c Debug
+
+      - name: Build (Release)
+        run: dotnet build -c Release
+
+      # TUnit on Microsoft.Testing.Platform — "dotnet test --project" works
+      # via the test.runner opt-in in the repo-root global.json.
+      - name: Test
+        run: dotnet test --project PgNimbus.Core.Tests -c Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ and wrong project memory is worse than none.
 - App: `Avalonia`, `Avalonia.Desktop`, `Avalonia.Themes.Fluent`,
   `Avalonia.Fonts.Inter`, `Avalonia.Controls.DataGrid`, `Avalonia.AvaloniaEdit`,
   `CommunityToolkit.Mvvm`, `AvaloniaUI.DiagnosticsSupport` (DevTools/MCP —
-  wired via `.WithDeveloperTools()` in `Program.cs`, see below).
+  Debug-only, wired via `.WithDeveloperTools()` in `Program.cs`, see below).
 - Tests: `PgNimbus.Core.Tests` — TUnit on Microsoft.Testing.Platform. Run
   `dotnet test --project PgNimbus.Core.Tests` (MTP mode comes from the
   `test.runner` opt-in in the repo-root `global.json`) or plain
@@ -88,8 +88,14 @@ Code, VS, Rider) via the Avalonia DevTools MCP server. Two pieces make it work:
 
 1. **In the app** — `AvaloniaUI.DiagnosticsSupport` is referenced and
    `.WithDeveloperTools()` is on the `AppBuilder` in `Program.cs`. Without
-   this, a running app can't be discovered by the MCP server. Keep it wired
-   up (it's the discovery hook, not a Debug-only convenience).
+   this, a running app can't be discovered by the MCP server. Both are
+   **Debug-only** (a `Condition` on the `PackageReference`, `#if DEBUG`
+   around the call): the package is part of AvaloniaUI's commercial
+   Developer Tools and ships no explicit redistribution license, so it must
+   not be linked into public Release/AOT binaries. Consequence: MCP
+   inspection only works against a Debug build — `dotnet run` (default
+   Debug) is fine, a `-c Release` or published AOT binary won't be
+   discoverable.
 2. **The MCP server** — the `avdt` global .NET tool runs as `avdt mcp`.
    Register it once at user scope; it reads its license from the
    `AVALONIA_TOOLS_LICENSE_KEY` env var (`ACCELERATE_LICENSE_KEY` on

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<shman4ik@gmail.com>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to pgNimbus
+
+Thanks for your interest! pgNimbus is a fast, open-source PostgreSQL GUI
+client (.NET 10 + Avalonia 12, MIT). Contributions of all sizes are
+welcome — the [README backlog](README.md#backlog) is intentionally scoped
+as individually shippable pieces, and issues labeled `good first issue`
+are a fine place to start.
+
+## Building
+
+See [Building and running](README.md#building-and-running) in the README.
+Short version: install the .NET 10 SDK, then
+
+```bash
+dotnet build
+dotnet run --project PgNimbus.App
+```
+
+Run the tests with:
+
+```bash
+dotnet test --project PgNimbus.Core.Tests
+```
+
+(The test project uses TUnit on Microsoft.Testing.Platform — never add
+`Microsoft.NET.Test.Sdk` to it, that breaks test discovery.)
+
+## The two hard architectural rules
+
+Every PR is gated on these — they're what keeps the project's thesis
+(truly fast, PostgreSQL-first) intact:
+
+1. **`PgNimbus.Core` has zero UI dependencies.** It references only
+   `Npgsql` (plus credential/SSH support libraries). Nothing from
+   `Avalonia.*` or `CommunityToolkit.Mvvm` may leak into it — anything
+   UI-related belongs in `PgNimbus.App`. This keeps the engine reusable
+   for a future CLI or test harness.
+2. **Streaming + cancellation are non-negotiable.**
+   `QueryEngine.ExecuteAsync` returns rows via `IAsyncEnumerable<RowBatch>`
+   in ~200-row batches so the UI renders before the full result set
+   arrives. Every execution takes a `CancellationToken` and must actually
+   stop mid-flight, not just at the start. (The one deliberate exception —
+   materialized results inside an explicit transaction — is documented in
+   [CLAUDE.md](CLAUDE.md).)
+
+Also: PostgreSQL-first, not lowest-common-denominator. Schema
+introspection reads `pg_catalog` directly, not `information_schema`. And
+passwords never live on `ConnectionProfile` — they come from
+`ICredentialStore` at connect time.
+
+## Coding conventions
+
+- DTOs are `record`s.
+- MVVM via CommunityToolkit source generators (`[ObservableProperty]`,
+  `[RelayCommand]`) — no hand-written `INotifyPropertyChanged`.
+- Async all the way; no sync-over-async, no blocking `.Result`/`.Wait()`.
+- `Nullable` is enabled — respect it; don't silence warnings with `!`
+  unless the value is truly provably non-null.
+- `AvaloniaUseCompiledBindingsByDefault` is on — don't add uncompiled
+  (reflection) bindings. This also matters for NativeAOT: the app ships
+  as an AOT binary, so no reflection-dependent code paths.
+
+## Verifying UI changes
+
+UI work should be verified in the running app, not just by compilation.
+On a headless Linux box (or CI-like sandbox) the loop is: `Xvfb` for a
+virtual display, a local PostgreSQL with seed data, `PGNIMBUS_CONN` to
+skip the connection dialog, `xdotool` to drive, and ImageMagick's
+`import` for screenshots. The exact commands are in
+[CLAUDE.md](CLAUDE.md#bootstrapping-a-fresh-linuxci-sandbox-no-net-no-display-no-postgres).
+Please check both themes (the in-app light/dark toggle) for visual
+changes.
+
+## Pull requests
+
+- Keep PRs focused — one feature or fix per PR.
+- CI must pass (`dotnet build` + tests on every PR).
+- If your change alters behavior documented in README or CLAUDE.md,
+  update those files in the same PR — a stale doc is treated as a bug.
+- New pure logic in `PgNimbus.Core` (parsers, formatters, matchers…) is
+  the easiest thing to test — please add TUnit tests alongside it.

--- a/PgNimbus.App/PgNimbus.App.csproj
+++ b/PgNimbus.App/PgNimbus.App.csproj
@@ -22,6 +22,12 @@
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <RuntimeIdentifiers>win-x64;osx-arm64</RuntimeIdentifiers>
+    <Authors>Shman4ik</Authors>
+    <Product>pgNimbus</Product>
+    <Description>A fast, open-source PostgreSQL GUI client built with .NET and Avalonia.</Description>
+    <Copyright>Copyright (c) 2026 Shman4ik</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/Shman4ik/pgNimbus</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,7 +41,10 @@
     <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.5" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.1" />
     <PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
-    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
+    <!-- Part of AvaloniaUI's commercial Developer Tools; the package ships no
+         explicit redistribution license, so it must not end up in Release
+         binaries — Debug-only, matching the vendor's own #if DEBUG guidance. -->
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
   </ItemGroup>
 

--- a/PgNimbus.App/Program.cs
+++ b/PgNimbus.App/Program.cs
@@ -11,7 +11,9 @@ internal static class Program
 
     public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>()
         .UsePlatformDetect()
+#if DEBUG
         .WithDeveloperTools()
+#endif
         .WithInterFont()
         .LogToTrace();
 }

--- a/PgNimbus.Core/PgNimbus.Core.csproj
+++ b/PgNimbus.Core/PgNimbus.Core.csproj
@@ -7,6 +7,12 @@
     <RootNamespace>PgNimbus.Core</RootNamespace>
     <AssemblyName>PgNimbus.Core</AssemblyName>
     <IsAotCompatible>true</IsAotCompatible>
+    <Authors>Shman4ik</Authors>
+    <Product>pgNimbus</Product>
+    <Description>PostgreSQL engine for pgNimbus: connections, streaming query execution, and pg_catalog schema introspection. No UI dependencies.</Description>
+    <Copyright>Copyright (c) 2026 Shman4ik</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/Shman4ik/pgNimbus</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+pgNimbus is a database client: it handles connection credentials, SSH
+tunnel keys, and query results. Security reports are taken seriously.
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for security problems. Instead, use
+GitHub's private vulnerability reporting:
+
+**[Report a vulnerability](https://github.com/Shman4ik/pgNimbus/security/advisories/new)**
+
+(Repository → Security → "Report a vulnerability".)
+
+Include what you can: affected version or commit, platform, reproduction
+steps, and impact as you understand it. You should get an initial
+response within a few days. Please give a reasonable window for a fix
+before public disclosure.
+
+## Scope notes
+
+Things especially worth reporting:
+
+- Credential handling — passwords are supposed to live only in the OS
+  credential store (DPAPI on Windows, a permission-restricted file
+  elsewhere), never in profile/settings JSON or logs.
+- SSH tunnel handling (host key verification, key material).
+- Anything that lets a malicious *server* or a crafted query result
+  execute code or corrupt the client.
+
+Unsigned release binaries (SmartScreen/Gatekeeper warnings) are a known,
+documented limitation — not a vulnerability report.
+
+## Supported versions
+
+Pre-1.0, only the latest release receives fixes.

--- a/docs/PRE-LAUNCH-CHECKLIST.md
+++ b/docs/PRE-LAUNCH-CHECKLIST.md
@@ -30,69 +30,80 @@ anything embarrassing or sensitive must be dealt with *before*, not after.
       for open source, but if you'd rather use GitHub's noreply address
       going forward, set `git config user.email` now — rewriting history
       for the old ones is not worth it.
-- [ ] **Verify the `AvaloniaUI.DiagnosticsSupport` license situation.**
-      The package (and the `avdt` MCP tool it pairs with) is part of
-      AvaloniaUI's commercial tooling. Confirm its license permits
-      referencing it in a public MIT repo and shipping it in release
-      binaries; if it doesn't, gate the reference behind a `Debug`-only
-      condition or a local-only project override before going public.
+- [x] **Verify the `AvaloniaUI.DiagnosticsSupport` license situation.**
+      Verified against the 2.2.3 nupkg: it ships **no license at all** — no
+      `<license>`/`<licenseUrl>` in the nuspec, no LICENSE file in the
+      package — and its own README shows the `#if DEBUG` pattern. No
+      explicit grant means no redistribution right to assume, so the
+      reference is now gated: `Condition="'$(Configuration)' == 'Debug'"`
+      on the `PackageReference` and `#if DEBUG` around
+      `.WithDeveloperTools()` in `Program.cs`. Release/AOT binaries no
+      longer link it; MCP inspection still works against Debug builds
+      (`dotnet run` is Debug by default). CLAUDE.md updated to match.
       (The `AVALONIA_TOOLS_LICENSE_KEY` itself is only in local MCP
       config, never committed — that part is fine.)
-- [ ] **Skim `docs/PROGRESS.md` and `CLAUDE.md` one last time** with
-      "public reader" glasses. Both are clean of secrets and honestly
-      good marketing for how the app is built, but they're the two files
-      that were written assuming a private audience.
-- [ ] **Add package metadata to the csproj files** — `Authors`,
+- [x] **Skim `docs/PROGRESS.md` and `CLAUDE.md` one last time** with
+      "public reader" glasses. Done 2026-07-08: no secrets, no internal
+      hostnames, nothing embarrassing — both read as engineering notes a
+      public audience can see. (CLAUDE.md's DevTools section was updated
+      for the Debug-only gating above in the same pass.)
+- [x] **Add package metadata to the csproj files** — `Authors`,
       `Description`, `Copyright`, `PackageLicenseExpression`,
       `RepositoryUrl`. Cosmetic, but it's what shows in file properties
-      of shipped binaries.
+      of shipped binaries. Added to `PgNimbus.Core` and `PgNimbus.App`
+      (the test project isn't packable/shipped).
 
 ## Phase 2 — CI and quality gates
 
 Once outside PRs are possible, an untested default branch becomes a
 liability. These exist to protect `main`, not to chase coverage numbers.
 
-- [ ] **Add a PR/push build workflow** (`.github/workflows/ci.yml`):
+- [x] **Add a PR/push build workflow** (`.github/workflows/ci.yml`):
       `dotnet build` + `dotnet test` on ubuntu-latest for every PR and
-      push to `main`. Today nothing verifies that a PR even compiles —
-      `release.yml` only runs on tags.
-- [ ] **Add a first test project** (`PgNimbus.Core.Tests`). The
-      highest-value, zero-infrastructure targets are the pure functions:
-      `ConnectionStringParser` (five input syntaxes, quoting/escaping
-      edge cases) and `FuzzyMatcher`. Even a small suite makes the CI
-      gate meaningful and signals to contributors that tests are wanted.
+      push to `main`. Builds both Debug (which includes the Debug-only
+      DiagnosticsSupport reference) and Release, then runs the tests.
+- [x] **Add a first test project** (`PgNimbus.Core.Tests`). Exists since
+      this item was written — TUnit on Microsoft.Testing.Platform, currently
+      covering `SqlFormatter` and `SqlScriptSplitter`. Still-open
+      good-first-test targets: `ConnectionStringParser` (five input
+      syntaxes, quoting/escaping edge cases) and `FuzzyMatcher`.
 - [ ] **Enable branch protection on `main`** — require the CI check to
       pass, require PRs (no direct pushes). Do this right after the CI
       workflow exists.
-- [ ] **Turn on Dependabot** (`.github/dependabot.yml`) for NuGet and
-      GitHub Actions. Low noise on a project this size, and it keeps
-      Npgsql/Avalonia patch releases flowing.
+- [x] **Turn on Dependabot** (`.github/dependabot.yml`) for NuGet and
+      GitHub Actions, weekly, with Avalonia packages grouped into one PR
+      (they bump in lockstep).
 
 ## Phase 3 — Community scaffolding
 
 What a stranger needs to file a good issue or PR without asking.
 
-- [ ] **CONTRIBUTING.md** — how to build (link the README section), the
+- [x] **CONTRIBUTING.md** — how to build (links the README section), the
       two hard architectural rules that gate every PR (`PgNimbus.Core`
       has zero UI dependencies; streaming + cancellation are
       non-negotiable), coding conventions (records, MVVM source
       generators, no sync-over-async), and how UI changes get verified
       (the Xvfb + screenshot loop from CLAUDE.md).
-- [ ] **SECURITY.md** — where to privately report vulnerabilities
-      (GitHub private vulnerability reporting is the zero-infrastructure
-      option — enable it in Settings → Code security). A DB client holds
-      credentials; someone *will* look.
-- [ ] **CODE_OF_CONDUCT.md** — stock Contributor Covenant is fine.
-- [ ] **Issue templates** (`.github/ISSUE_TEMPLATE/`): a bug report that
-      asks for OS, install method (MSI/dmg/source), PostgreSQL version,
-      and repro steps; a feature request that links the README backlog
-      first.
-- [ ] **Curate "good first issue" candidates.** Move 5–10 of the small
-      unchecked README backlog items (empty state for the connection
-      dialog, persist the theme choice, abbreviated column types in the
-      tree, tab-bar navigation extras…) into actual GitHub issues with
-      the `good first issue` label. An empty issue tracker at launch
-      reads as "not really open to contributors".
+- [x] **SECURITY.md** — points at GitHub private vulnerability reporting.
+      **Still manual:** enable the feature itself (Settings → Code
+      security → Private vulnerability reporting) once the repo is
+      public, or the link 404s.
+- [x] **CODE_OF_CONDUCT.md** — stock Contributor Covenant 2.1.
+- [x] **Issue templates** (`.github/ISSUE_TEMPLATE/`): a bug-report form
+      (OS, install method MSI/dmg/source, pgNimbus + PostgreSQL versions,
+      repro steps) and a feature-request form that links the README
+      backlog first, plus a config that routes security reports to
+      private reporting.
+- [ ] **Curate "good first issue" candidates.** Move 5–10 small README
+      backlog items into actual GitHub issues with the `good first
+      issue` label. An empty issue tracker at launch reads as "not
+      really open to contributors". *Note (2026-07-08): the examples
+      originally listed here (connection-dialog empty state, theme
+      persistence, abbreviated column types, tab-bar extras) have all
+      shipped since — pick from what's still open, e.g.
+      `ConnectionStringParser`/`FuzzyMatcher` test coverage, the Win32
+      min-track-size clamp from PROGRESS.md's open items, or slices of
+      the "Later" backlog.*
 
 ## Phase 4 — First release
 


### PR DESCRIPTION
Completes Phase 2–3 of the pre-launch checklist: establishes CI/quality gates, community contribution guidelines, and security reporting infrastructure ahead of public release.

## Changes

**Community & governance:**
- Add `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
- Add `CONTRIBUTING.md` with build instructions, the two hard architectural rules, coding conventions, and UI verification guidance
- Add `SECURITY.md` with private vulnerability reporting instructions
- Add `.github/ISSUE_TEMPLATE/` with bug-report and feature-request forms, plus config routing security reports to private reporting

**CI & quality gates:**
- Add `.github/workflows/ci.yml`: builds Debug (includes DiagnosticsSupport) and Release configurations, then runs tests on every PR and push to `main`
- Add `.github/dependabot.yml`: weekly NuGet and GitHub Actions updates, with Avalonia packages grouped into a single PR

**Package metadata:**
- Add `Authors`, `Description`, `Copyright`, `PackageLicenseExpression`, `RepositoryUrl` to both `PgNimbus.Core.csproj` and `PgNimbus.App.csproj`

**License compliance:**
- Gate `AvaloniaUI.DiagnosticsSupport` reference behind `Condition="'$(Configuration)' == 'Debug'"` in the App csproj (the package ships with no license, so it cannot be redistributed in Release/AOT binaries)
- Wrap `.WithDeveloperTools()` in `#if DEBUG` in `Program.cs` to match the conditional reference
- Update `CLAUDE.md` to document that DevTools is Debug-only and explain the licensing rationale

**Checklist updates:**
- Mark completed items in `docs/PRE-LAUNCH-CHECKLIST.md` with notes on what was done and current status

## Implementation notes

- The DiagnosticsSupport gating ensures Release and AOT binaries do not link an unlicensed package, while Debug builds (used locally and in `dotnet run`) retain MCP inspection capability.
- CI builds both Debug and Release to verify both dependency graphs compile; tests run in Release mode.
- Issue templates ask for pgNimbus version, install method, OS, and PostgreSQL version — the minimum needed to triage a report.
- `CONTRIBUTING.md` links back to the README for build instructions and explicitly calls out the two hard architectural rules and the streaming/cancellation requirement, making them discoverable to new contributors.

https://claude.ai/code/session_01WBuJDz4QhDj8Q5YVa6tgU5