### PR TITLE
Add a benchmark pipeline and clean up the README

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,87 @@
+name: Benchmarks
+
+# Measures the headline performance numbers (startup time, memory, binary
+# size, query-engine latency/throughput) on every PR and push to main, so a
+# regression shows up in the change that caused it instead of in a user
+# report. scripts/benchmarks/run-benchmarks.sh does the actual measuring;
+# results land in the job summary, a downloadable artifact, and — for pushes
+# to main — the gh-pages benchmark history (charts at
+# https://shman4ik.github.io/pgNimbus/dev/bench/).
+#
+# Shared runners are noisy: treat the trend and big jumps as signal, not
+# single-digit-percent wiggles between runs.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+env:
+  DOTNET_NOLOGO: "1"
+  DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    # contents: write is for the gh-pages history push on main; PRs from
+    # forks get a read-only token automatically, so this doesn't widen them.
+    permissions:
+      contents: write
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      # Xvfb: the startup benchmark opens a real window. clang/zlib are the
+      # NativeAOT publish prerequisites (usually preinstalled on the runner,
+      # but cheap to make explicit).
+      - name: Install benchmark dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb clang zlib1g-dev
+
+      - name: Run benchmarks
+        run: scripts/benchmarks/run-benchmarks.sh
+        env:
+          PGNIMBUS_BENCH_CONN: "Host=localhost;Port=5432;Database=postgres;Username=postgres;Password=postgres"
+
+      - name: Upload results
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-results
+          path: bench-results/
+
+      # Push-to-main runs append to the benchmark history on gh-pages
+      # (./dev/bench), which renders per-metric trend charts. PR runs skip
+      # this — they only get the job-summary table above.
+      - name: Record benchmark history
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: pgNimbus benchmarks
+          tool: customSmallerIsBetter
+          output-file-path: bench-results/benchmarks.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Shared-runner noise: only flag genuinely large regressions, as a
+          # job-summary alert rather than a commit comment.
+          alert-threshold: "150%"
+          comment-on-alert: false
+          fail-on-alert: false

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ Thumbs.db
 *.trx
 *.coverage
 *.coveragexml
+
+# Benchmark output (scripts/benchmarks/run-benchmarks.sh)
+bench-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,9 @@ regenerate via that script instead of hand-editing:
   `test.runner` opt-in in the repo-root `global.json`) or plain
   `dotnet run --project PgNimbus.Core.Tests`. Never add
   `Microsoft.NET.Test.Sdk` to a TUnit project — it breaks test discovery.
+- Benchmarks: `PgNimbus.Benchmarks` — a plain console project (Core-only, no
+  UI deps) measuring the query engine through its streaming API; see
+  "Benchmarks pipeline" below.
 - `AvaloniaUseCompiledBindingsByDefault` is on — don't add uncompiled
   (reflection) bindings.
 
@@ -189,6 +192,39 @@ Notes:
 - This is how the Avalonia 11→12 upgrade and the PowerToys-style UI polish
   were actually verified (not just built) in a Claude Code sandbox with no
   prior .NET/GUI tooling.
+
+## Benchmarks pipeline
+
+"Fast" is measured, not asserted. `.github/workflows/benchmark.yml` runs
+[`scripts/benchmarks/run-benchmarks.sh`](scripts/benchmarks/run-benchmarks.sh)
+on every PR and push to `main` (ubuntu runner + a `postgres:17` service
+container). Results go to the job summary and a `bench-results` artifact;
+pushes to `main` also append to the gh-pages history via
+`benchmark-action/github-action-benchmark` (charts at
+`https://shman4ik.github.io/pgNimbus/dev/bench/`). Three moving parts:
+
+1. **Startup probe** — `PGNIMBUS_STARTUP_PROBE=1` makes the app print
+   `PGNIMBUS_STARTUP_PROBE window_ms=… rss_bytes=…` after its first window
+   renders its first frame, then exit (`PgNimbus.App/StartupProbe.cs`, armed
+   in `App.OnFrameworkInitializationCompleted`). `window_ms` is measured from
+   OS process start, so it captures AOT-vs-JIT differences honestly.
+2. **`PgNimbus.Benchmarks`** — console project measuring connect (cold pool),
+   `SELECT 1` round-trip, time-to-first-`RowBatch`, and full-stream
+   throughput of a 100k-row mixed-type SELECT, through `QueryEngine`'s
+   streaming path (the same API the UI uses). Prints `PGNIMBUS_BENCH
+   name=value` lines; config via `PGNIMBUS_BENCH_CONN/ROWS/ITERS`.
+3. **The script** — builds JIT Release, publishes linux-x64 NativeAOT, runs
+   the startup probe N times per mode under Xvfb (one discarded warm-up run,
+   then medians), runs the query benchmarks, and writes
+   `bench-results/benchmarks.json` (github-action-benchmark
+   `customSmallerIsBetter` format — keep every metric smaller-is-better, so
+   throughput is reported as stream *time*) plus `summary.md`.
+   `PGNIMBUS_BENCH_SKIP_AOT=1` skips the slow AOT publish for local runs.
+
+Numbers are machine-relative (this sandbox: ~160 ms AOT / ~2 s JIT to first
+frame; CI runners differ) — the point is the trend per commit, not the
+absolute value. If a change renames a metric in `benchmarks.json`, its
+gh-pages history starts over under the new name.
 
 ## Release pipeline
 

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -75,6 +75,8 @@ public partial class App : Application
             {
                 desktop.MainWindow = BuildConnectionDialog(desktop);
             }
+
+            StartupProbe.ArmIfRequested(desktop);
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/PgNimbus.App/StartupProbe.cs
+++ b/PgNimbus.App/StartupProbe.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
+
+namespace PgNimbus.App;
+
+/// <summary>
+/// Headless startup measurement, used by <c>scripts/benchmarks/run-benchmarks.sh</c>
+/// and the Benchmarks CI workflow. When <c>PGNIMBUS_STARTUP_PROBE=1</c>, the app
+/// prints one machine-readable line after its first window has rendered its first
+/// frame and then exits:
+///
+/// <code>PGNIMBUS_STARTUP_PROBE window_ms=123 rss_bytes=45678901</code>
+///
+/// <c>window_ms</c> is measured from OS process start (not <c>Main</c>), so it
+/// includes process spawn and runtime init — the number a user actually
+/// experiences between double-click and a visible window.
+/// </summary>
+internal static class StartupProbe
+{
+    public static void ArmIfRequested(IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        if (Environment.GetEnvironmentVariable("PGNIMBUS_STARTUP_PROBE") != "1" ||
+            desktop.MainWindow is not { } window)
+        {
+            return;
+        }
+
+        window.Opened += (_, _) =>
+            // Opened fires before the first render pass. A Background-priority
+            // dispatcher callback queues behind Render, so by the time it runs
+            // the first frame has actually been drawn.
+            Dispatcher.UIThread.Post(() =>
+            {
+                using var process = Process.GetCurrentProcess();
+                var elapsed = DateTime.Now - process.StartTime;
+                Console.WriteLine(
+                    $"PGNIMBUS_STARTUP_PROBE window_ms={elapsed.TotalMilliseconds:F0} rss_bytes={process.WorkingSet64}");
+                desktop.Shutdown();
+            }, DispatcherPriority.Background);
+    }
+}

--- a/PgNimbus.Benchmarks/PgNimbus.Benchmarks.csproj
+++ b/PgNimbus.Benchmarks/PgNimbus.Benchmarks.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>PgNimbus.Benchmarks</RootNamespace>
+    <AssemblyName>PgNimbus.Benchmarks</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PgNimbus.Core\PgNimbus.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PgNimbus.Benchmarks/Program.cs
+++ b/PgNimbus.Benchmarks/Program.cs
@@ -1,0 +1,142 @@
+using System.Diagnostics;
+using Npgsql;
+using PgNimbus.Core.Connections;
+using PgNimbus.Core.Query;
+
+// Query-engine benchmarks for pgNimbus, run by scripts/benchmarks/run-benchmarks.sh
+// and the Benchmarks CI workflow. Measures the engine the way the app uses it —
+// through QueryEngine's streaming IAsyncEnumerable<RowBatch> path — against a real
+// PostgreSQL server, and prints one machine-readable line per metric:
+//
+//   PGNIMBUS_BENCH connect_ms=12.3
+//
+// Configuration (env vars):
+//   PGNIMBUS_BENCH_CONN  connection string, any format ConnectionStringParser
+//                        understands (default: localhost/postgres/postgres)
+//   PGNIMBUS_BENCH_ROWS  row count for the streaming benchmarks (default 100000)
+//   PGNIMBUS_BENCH_ITERS iterations per metric; the median is reported (default 5)
+
+var rawConnectionString = Environment.GetEnvironmentVariable("PGNIMBUS_BENCH_CONN")
+    ?? "Host=localhost;Port=5432;Database=postgres;Username=postgres;Password=postgres";
+var rows = int.TryParse(Environment.GetEnvironmentVariable("PGNIMBUS_BENCH_ROWS"), out var r) ? r : 100_000;
+var iterations = int.TryParse(Environment.GetEnvironmentVariable("PGNIMBUS_BENCH_ITERS"), out var i) ? i : 5;
+
+var connectionString = ConnectionStringParser.NormalizeToNpgsql(rawConnectionString);
+
+// A realistic mixed-type row (int, text, timestamp, numeric) so the streaming
+// numbers reflect real column materialization, not just integer shuffling.
+var streamSql = $"""
+    SELECT g AS id,
+           'row #' || g AS name,
+           now() + (g || ' seconds')::interval AS ts,
+           (g % 100000)::numeric / 7 AS amount
+      FROM generate_series(1, {rows}) g
+    """;
+
+// --- connect: first physical connection on a cold pool ---------------------
+double connectMs;
+{
+    var stopwatch = Stopwatch.StartNew();
+    await using var coldDataSource = NpgsqlDataSource.Create(connectionString);
+    await using (await coldDataSource.OpenConnectionAsync())
+    {
+        connectMs = stopwatch.Elapsed.TotalMilliseconds;
+    }
+}
+
+await using var dataSource = NpgsqlDataSource.Create(connectionString);
+var engine = new QueryEngine(dataSource);
+
+// Warm the pool and the JIT before anything is timed.
+await DrainAsync(engine, "SELECT 1");
+
+// --- roundtrip: SELECT 1 on a warm pooled connection ------------------------
+var roundtripMs = await MedianAsync(iterations, async () =>
+{
+    var stopwatch = Stopwatch.StartNew();
+    await DrainAsync(engine, "SELECT 1");
+    return stopwatch.Elapsed.TotalMilliseconds;
+});
+
+// --- first_batch: call → first RowBatch of a large streaming result --------
+// The number behind "the first screenful renders before the full result set
+// arrives" — how long until the UI has rows it can paint.
+var firstBatchMs = await MedianAsync(iterations, async () =>
+{
+    var stopwatch = Stopwatch.StartNew();
+    var result = await engine.ExecuteAsync(streamSql, CancellationToken.None);
+    if (result is not ResultSet resultSet)
+    {
+        throw new InvalidOperationException($"Expected a ResultSet, got {result}");
+    }
+
+    double elapsed = -1;
+    await foreach (var batch in resultSet.Batches)
+    {
+        if (elapsed < 0)
+        {
+            elapsed = stopwatch.Elapsed.TotalMilliseconds;
+        }
+        // Keep draining: disposal drains the remaining rows anyway (to leave
+        // the connection usable), so stopping early would still pay full cost.
+    }
+
+    return elapsed;
+});
+
+// --- stream: full drain of the large result through RowBatch-es ------------
+long streamedRows = 0;
+var streamMs = await MedianAsync(iterations, async () =>
+{
+    var stopwatch = Stopwatch.StartNew();
+    streamedRows = await DrainAsync(engine, streamSql);
+    return stopwatch.Elapsed.TotalMilliseconds;
+});
+
+if (streamedRows != rows)
+{
+    throw new InvalidOperationException($"Streamed {streamedRows} rows, expected {rows}");
+}
+
+var rowsPerSec = rows / (streamMs / 1000.0);
+
+Console.WriteLine($"PGNIMBUS_BENCH connect_ms={connectMs:F1}");
+Console.WriteLine($"PGNIMBUS_BENCH roundtrip_ms={roundtripMs:F2}");
+Console.WriteLine($"PGNIMBUS_BENCH first_batch_ms={firstBatchMs:F1}");
+Console.WriteLine($"PGNIMBUS_BENCH stream_ms={streamMs:F1}");
+Console.WriteLine($"PGNIMBUS_BENCH stream_rows={rows}");
+Console.WriteLine($"PGNIMBUS_BENCH rows_per_sec={rowsPerSec:F0}");
+return 0;
+
+static async Task<long> DrainAsync(QueryEngine engine, string sql)
+{
+    var result = await engine.ExecuteAsync(sql, CancellationToken.None);
+    if (result is QueryError error)
+    {
+        throw new InvalidOperationException($"Query failed: {error.Message}");
+    }
+
+    long count = 0;
+    if (result is ResultSet resultSet)
+    {
+        await foreach (var batch in resultSet.Batches)
+        {
+            count += batch.Rows.Count;
+        }
+    }
+
+    return count;
+}
+
+static async Task<double> MedianAsync(int iterations, Func<Task<double>> measure)
+{
+    var samples = new List<double>(iterations);
+    for (var i = 0; i < iterations; i++)
+    {
+        samples.Add(await measure());
+    }
+
+    samples.Sort();
+    var mid = samples.Count / 2;
+    return samples.Count % 2 == 1 ? samples[mid] : (samples[mid - 1] + samples[mid]) / 2.0;
+}

--- a/PgNimbus.sln
+++ b/PgNimbus.sln
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PgNimbus.Core.Tests", "PgNimbus.Core.Tests\PgNimbus.Core.Tests.csproj", "{5463A122-B651-48B6-ABA3-7BF061C2E154}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PgNimbus.Benchmarks", "PgNimbus.Benchmarks\PgNimbus.Benchmarks.csproj", "{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,18 @@ Global
 		{5463A122-B651-48B6-ABA3-7BF061C2E154}.Release|x64.Build.0 = Release|Any CPU
 		{5463A122-B651-48B6-ABA3-7BF061C2E154}.Release|x86.ActiveCfg = Release|Any CPU
 		{5463A122-B651-48B6-ABA3-7BF061C2E154}.Release|x86.Build.0 = Release|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Debug|x64.Build.0 = Debug|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Debug|x86.Build.0 = Debug|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Release|x64.ActiveCfg = Release|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Release|x64.Build.0 = Release|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Release|x86.ActiveCfg = Release|Any CPU
+		{671C1AE1-A437-4D8B-A135-DFDDD11DCCFD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ from the ground up.
 
 ### Differentiators
 
-1. **Native performance** — measured launch-to-window: ~100 ms as a NativeAOT
-   binary, ~0.7 s under JIT (Release, Linux container, 5-run spread).
+1. **Native performance** — launch-to-window in the ~100 ms range as a
+   NativeAOT binary. Not a one-off claim: startup, memory, and query-engine
+   numbers are measured on every commit — see [Benchmarks](#benchmarks).
 2. **PostgreSQL-first** — deep `pg_catalog` introspection (materialized views,
    real types, primary-key flags, and EXPLAIN visualization); never the
    lowest-common-denominator SQL dialect.
@@ -177,11 +178,13 @@ pgNimbus/
 │   ├── Query/QueryResult.cs
 │   ├── Query/QueryEngine.cs
 │   └── Schema/SchemaService.cs
-└── PgNimbus.App/                 # Avalonia MVVM front-end.
-    ├── ViewModels/QueryViewModel.cs
-    ├── Views/MainWindow.axaml(.cs)
-    ├── App.axaml(.cs)
-    └── Program.cs
+├── PgNimbus.App/                 # Avalonia MVVM front-end.
+│   ├── ViewModels/QueryViewModel.cs
+│   ├── Views/MainWindow.axaml(.cs)
+│   ├── App.axaml(.cs)
+│   └── Program.cs
+├── PgNimbus.Core.Tests/          # TUnit tests for the engine.
+└── PgNimbus.Benchmarks/          # Query-engine benchmarks (see Benchmarks).
 ```
 
 `PgNimbus.Core` is a plain class library that depends only on `Npgsql`. It
@@ -234,52 +237,55 @@ dotnet publish PgNimbus.App -c Release -r win-x64 -p:PublishAot=true    # Window
 dotnet publish PgNimbus.App -c Release -r linux-x64 -p:PublishAot=true  # Linux (needs clang + zlib1g-dev)
 ```
 
-The linux-x64 AOT binary is exercised as part of development: it launches to a
-window in ~100 ms and the query grid, EXPLAIN visualization, and profile
-stores all work (JSON persistence uses source-generated serializer contexts,
-and the results grid binds columns via converters instead of reflection
-paths, both of which trimming/AOT require).
+The linux-x64 AOT binary is exercised as part of development: the query grid,
+EXPLAIN visualization, and profile stores all work under AOT (JSON persistence
+uses source-generated serializer contexts, and the results grid binds columns
+via converters instead of reflection paths, both of which trimming/AOT
+require).
+
+## Benchmarks
+
+"Fast" is the thesis, so it's measured, not asserted. The
+[Benchmarks workflow](.github/workflows/benchmark.yml) runs on every PR and
+push to `main`:
+
+| Metric | What it proves |
+| --- | --- |
+| Startup, launch → first frame (NativeAOT and JIT) | The app is on screen in the ~100 ms range as an AOT binary — measured from OS process start to the first rendered frame, median of 7 runs |
+| Memory at first frame, AOT binary size | The footprint stays "native app", not "Electron app" |
+| Connect (cold pool) / round-trip (`SELECT 1`, warm) | Interactive latency of the query path |
+| First row batch of a 100 000-row `SELECT` | Streaming works: the first screenful arrives long before the full result |
+| Full 100 000-row stream (rows/s) | Sustained throughput of the `IAsyncEnumerable<RowBatch>` engine path |
+
+Each run writes the numbers to the workflow's job summary and a
+`bench-results` artifact; pushes to `main` also append to the historical
+charts at <https://shman4ik.github.io/pgNimbus/dev/bench/>, so a regression
+shows up as a visible step in the graph of the commit that caused it.
+(Shared CI runners are noisy — read trends and big jumps, not single-percent
+wiggles.)
+
+To run the suite locally (Linux, needs Xvfb and a reachable PostgreSQL):
+
+```bash
+PGNIMBUS_BENCH_CONN="Host=localhost;Database=postgres;Username=postgres;Password=postgres" \
+    scripts/benchmarks/run-benchmarks.sh          # add PGNIMBUS_BENCH_SKIP_AOT=1 to skip the slow AOT publish
+```
+
+Two small pieces make it work: `PGNIMBUS_STARTUP_PROBE=1` makes the app print
+launch-to-first-frame time and RSS and exit
+([`StartupProbe.cs`](PgNimbus.App/StartupProbe.cs)), and the
+[`PgNimbus.Benchmarks`](PgNimbus.Benchmarks/Program.cs) console project
+measures the query engine through the same streaming API the UI uses.
 
 ## Backlog
 
 Prioritized by how much they advance the thesis (fast + open + modern,
 PostgreSQL-first). Contributions welcome — these are intentionally scoped as
-individually shippable pieces.
+individually shippable pieces. Shipped items graduate from this list into
+[Features](#features) above.
 
-### Now — the daily-driver gap
+### Now — release blockers
 
-Things a person needs before pgNimbus can be their only Postgres client:
-
-- [x] **Refresh database & schema** — reload the schema tree and autocomplete
-  cache from the server on demand (toolbar button / shortcut), so newly created
-  or altered tables, columns, and other objects show up without reconnecting.
-- [x] **Command palette** (`Ctrl+K`/`Ctrl+P`) — fuzzy-jump to any table, saved
-  query, or action; the keyboard-first differentiator in one control.
-- [x] **Data browsing without SQL** — filter bar, ORDER BY on header click, and
-  paging when previewing a table, pushed down to the server (`WHERE`/`LIMIT`/
-  `OFFSET`), not client-side.
-- [x] **Row insert & delete from the grid** — cell editing exists; complete the
-  CRUD triangle with "add row" and "delete selected rows" for tables with a
-  primary key.
-- [x] **Multiple result sets per script** — run a whole script; each statement
-  gets its own result tab/section, with per-statement timings.
-- [x] **DDL view** — a "Source" tab per object: reconstructed
-  `CREATE TABLE`/`CREATE VIEW`/index definitions from `pg_catalog`.
-- [x] **Windows installer + releases** — a per-user MSI and a macOS `.dmg`
-  built and published by CI on every tag
-  ([`release.yml`](.github/workflows/release.yml)), plus generated winget
-  manifests.
-- [x] **From-scoped WHERE suggestions** — column autocomplete in the query
-  editor's `WHERE`/`ON`/`HAVING`/`GROUP BY`/`ORDER BY` clauses now offers only the
-  columns of the tables in the statement's `FROM` (plus its aliases, CTEs,
-  functions and keywords) instead of the entire schema; it falls back to the full
-  catalog when no `FROM` table has resolved yet, so an incomplete query is never
-  left with a near-empty list.
-- [x] **Automatic schema completion** — accepting a table in table position
-  (after `FROM`/`JOIN`/`INTO`/`UPDATE`) inserts it schema-qualified
-  (`public.users`, `analytics.events`), so the reference resolves regardless of
-  the server's `search_path`; the bare name still filters the list, and a table
-  referenced elsewhere (or picked after typing `schema.`) stays unqualified.
 - [ ] **Code signing** — Authenticode for the MSI, Developer ID +
   notarization for the `.dmg`. Both ship unsigned today, so SmartScreen and
   Gatekeeper warn on first run — the single biggest first-impression blocker
@@ -289,135 +295,8 @@ Things a person needs before pgNimbus can be their only Postgres client:
   release, but the first manual `winget-pkgs` PR (which registers the
   `pgNimbus.pgNimbus` identifier) hasn't been made yet.
 
-### Next — depth on the Postgres-first promise
+### Polish
 
-- [x] **Transaction control** — explicit BEGIN/COMMIT/ROLLBACK toolbar state,
-  with a visible "in transaction" indicator and auto-rollback on error.
-- [x] **SQL formatting** — one-keystroke pretty-printing of the statement under
-  the cursor (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd>, or "Format SQL" in the
-  command palette): each clause on its own line, select-list/`SET`/`GROUP BY`
-  items and JOINs broken one-per-line, `AND`/`OR` predicates stacked, subqueries
-  indented, and reserved keywords upper-cased. It re-tokenizes its own output and
-  compares it to the input, so if a layout would ever alter a token it returns the
-  text untouched — it can never corrupt a query.
-- [x] **CSV/JSON import** — the inverse of export: an Import button on the
-  command bar loads a CSV (RFC 4180 quoting, delimiter sniffed) or JSON
-  (array of objects) file into a new or existing table. Column types are
-  inferred conservatively (leading-zero codes like `007` stay text) and
-  editable in the dialog; the load itself goes through
-  `COPY … FROM STDIN (FORMAT csv)` so Postgres does the real parsing, and on
-  success the schema tree refreshes and the active tab SELECTs the fresh
-  table.
-- [x] **Server activity dashboard** — a Server Activity window (title-bar ∿
-  button or command palette) showing `pg_stat_activity` client backends with
-  a 2-second auto-refresh (pausable), lock waits highlighted amber, and
-  Cancel query (`pg_cancel_backend`) / Terminate backend
-  (`pg_terminate_backend`, confirm-guarded) on the selected row; the
-  selection survives refreshes.
-- [x] **Roles, extensions, and functions in the schema tree** — each schema
-  gains a "Functions" group (functions/procedures/aggregates with their
-  argument and return types, and a "Source (DDL)" context action via
-  `pg_get_functiondef`), and the tree root gains "Extensions" (installed ones
-  green-dotted first, the rest of `pg_available_extensions` dimmed, with
-  Install / Drop context actions) and "Roles" (non-system roles with
-  superuser/login/createdb/createrole tags). Functions and Extensions sit
-  behind an "advanced objects" sidebar toggle (persisted) so the default
-  tree stays just schemas/tables and Roles.
-- [x] **Query history search** — a search box over the history list
-  (case-insensitive, matches the SQL text), a "this connection only" scope
-  toggle (entries record which connection ran them), and pinning: pinned
-  entries float to the top, survive the 200-entry cap, and survive "Clear
-  history".
-- [x] **In-app theme toggle** — light/dark switch in the title bar (sun/moon
-  button) instead of following the OS only; the SQL syntax palette repaints
-  with it, and the choice is remembered across launches.
-
-### Polish — UX/UI fit and finish
-
-Small, individually shippable refinements toward the TablePlus-level polish
-bar (the Files community app remains the visual north star):
-
-- [x] **Schema-tree filter box** — type-to-filter above the sidebar tree
-  (schemas and loaded tables, case-insensitive substring); a schema stays
-  when its name matches or a loaded table inside it does, auto-expanding to
-  reveal the match, with a clear (✕) button.
-- [x] **Copy from the results grid** — <kbd>Ctrl</kbd>+<kbd>C</kbd> copies the
-  selected rows (or all rows) as TSV, plus "Copy as" (CSV, JSON, Markdown table,
-  `INSERT` statements) on the grid context menu.
-- [x] **Cell inspector** — a detail pane (or popover) for the selected cell so
-  long `text`/`jsonb` values are readable and copyable without inline-edit
-  tricks; pretty-print JSON. Word wrap is on by default (Notepad++-style),
-  with a "Wrap" toggle in the header, and non-ASCII text (e.g. Cyrillic)
-  displays as itself rather than `\uXXXX` escapes.
-- [x] **Set a cell to NULL from the grid** — inline editing can't express
-  "make it NULL" (empty string ≠ NULL); a "Set cell to NULL" context-menu
-  action on the results grid issues the targeted UPDATE.
-- [x] **Editor niceties** — current-line highlight, matching-bracket
-  highlight, and font-size zoom (<kbd>Ctrl</kbd>+wheel /
-  <kbd>Ctrl</kbd>+<kbd>±</kbd>, <kbd>Ctrl</kbd>+<kbd>0</kbd> resets).
-- [x] **Alias-aware autocomplete** — complete column names after
-  `alias.`/`table.`, not just bare identifiers.
-- [x] **Context-aware IntelliSense** — inside a `SELECT`, rank the current
-  table's columns first and hide noise like `pg_catalog`; in the results-grid
-  `WHERE` filter box, suggest *only* the current dataset's columns (no SQL
-  functions or unrelated tables).
-- [x] **Clause-aware IntelliSense** — the list opens by itself after
-  `FROM`/`JOIN`/`INTO`/`UPDATE` and offers only what can go there (tables,
-  schemas, the statement's CTEs — no columns); column suggestions show their
-  data type, the statement's aliases complete too, common functions insert as
-  `name()` with the caret between the parens, and nothing pops up inside
-  string literals or comments.
-- [x] **`Shift`+`Enter` smart execution** — run with <kbd>Shift</kbd>+<kbd>Enter</kbd>
-  (alongside <kbd>Ctrl</kbd>+<kbd>Enter</kbd>/<kbd>F5</kbd>), executing just the
-  statement the cursor sits in (between `;`s) without having to select it first.
-- [x] **Tab bar overflow scrolling** — with many tabs open, the strip now
-  scrolls horizontally and keeps the active tab in view. (It used to clip:
-  the "+" button overlapped the last visible tab and a newly opened tab
-  could sit fully off-screen with no way to reach it.)
-- [x] **Tab bar navigation extras** — `<`/`>` scroll arrows (shown only when
-  the strip actually overflows, disabled at the ends) and a dropdown listing
-  all open tabs with type-to-search (↑/↓ + Enter jumps), on top of the basic
-  scrolling.
-- [x] **Capped results-grid column width** — auto column width sizes to the
-  widest cell, so a single long `text` value used to push every other column
-  out of view; columns now cap at 560 px, with the cell inspector
-  (double-click) carrying the full value.
-- [x] **Content-sized cell inspector** — the inspector card sizes to its
-  value (small values get a small card) instead of always opening at full
-  height.
-- [x] **Window minimum size** — a 940×560 floor, below which the command bar
-  and browse bar used to clip into unreadability.
-- [x] **Empty state for the connection dialog** — the Saved Connections list
-  used to be a bare grey panel when empty; it now shows the same friendly hint
-  the saved-queries and history lists already have.
-- [x] **Persist the theme choice** — the in-app light/dark toggle is now
-  remembered across launches (saved to `settings.json` alongside the other
-  persisted app state) instead of snapping back to the OS default; a fresh
-  install with no saved choice still follows the OS.
-- [x] **Drag-and-drop from the schema tree** — drag a schema, table, or column
-  from the sidebar tree into the SQL editor and it drops as a valid identifier
-  at the pointer (schema-qualified for tables, quoted only when a bare name
-  wouldn't round-trip, e.g. `"CreatedAt"`); the caret tracks the pointer during
-  the drag so the landing spot is always visible.
-- [x] **Collapsible sidebar** — a 200px minimum width on manual resize (so it
-  can't shrink to an unreadable sliver) plus a collapse button (the ☰ in the
-  title bar) / <kbd>Ctrl</kbd>+<kbd>B</kbd> that fully hides the sidebar and gives
-  the editor and results the full width, restoring to the last dragged width.
-- [x] **Abbreviated column types in the tree** — long types show compactly
-  (e.g. `timestamp with time zone` → `timestamptz`, `character varying(50)` →
-  `varchar(50)`, preserving modifiers and `[]` array markers), with the full type
-  name in a tooltip on a ~150 ms hover delay (only where it was actually
-  shortened).
-- [x] **Smarter tab titles** — query tabs are named from their SQL (first table
-  referenced) instead of "Query N", with a dirty-state dot when the SQL has
-  changed since the last run.
-- [x] **Running-query feedback** — an indeterminate progress bar in the
-  status bar and a live elapsed-time tick while a query or EXPLAIN runs, so a
-  slow statement that hasn't produced a batch yet still shows visible
-  progress instead of a frozen "Running...".
-- [x] **Empty states** — friendly hints in the blank results area ("No results
-  yet — run a query with Ctrl+Enter or F5") and in empty saved-queries/history
-  lists instead of bare cards.
 - [ ] **Mica/acrylic backdrop on Windows** — the two-tone shell is ready for
   it; deliberately deferred until it can be verified on a real Windows
   desktop (transparency fallbacks can't be seen headless).
@@ -435,49 +314,6 @@ bar (the Files community app remains the visual north star):
 - [ ] **Plugin/extension API** — a stable surface for community panels
   (initially: custom result visualizers).
 - [ ] **Localization** — externalize UI strings; ship Russian and German first.
-
-Recently shipped: CSV/JSON import (type inference, editable target columns,
-COPY-based load), a server-activity window (live pg_stat_activity, amber
-lock waits, cancel/terminate backends), functions, extensions, and roles in the schema tree
-(function DDL source, extension install/drop from the sidebar),
-query-history search with per-connection scoping and
-pinning, drag-and-drop from the schema tree into the editor
-(quoted-as-needed identifiers, caret tracks the pointer), a more compact
-schema-tree indent, tab-bar navigation extras (overflow-only ‹/› scroll arrows
-and an all-tabs dropdown with type-to-search), a connection-dialog
-empty-state hint, transaction control (Begin/Commit/Rollback toolbar state, an
-"in transaction" status-bar indicator, and auto-rollback on error), abbreviated column types in the schema tree
-(timestamptz/varchar…, full name on hover), a collapsible sidebar (Ctrl+B, 200px
-resize floor), a
-remembered-across-launches theme choice, one-keystroke SQL
-formatting (Ctrl+Shift+F, block-style
-pretty-print with a never-corrupt token round-trip check), FROM-scoped
-WHERE/ORDER BY column suggestions and
-schema-qualified table completion after FROM/JOIN, tab-strip overflow scrolling,
-capped results-grid column
-widths, a content-sized cell inspector, a window minimum size,
-clause-aware SQL IntelliSense (tables after FROM/JOIN,
-typed columns, aliases, CTEs, function-call insertion, auto-popup, no popups
-inside strings/comments), editor niceties (current-line highlight,
-matching-bracket highlight, Ctrl+wheel / Ctrl+± font zoom), "Set cell to
-NULL" on the results grid, DDL "Source" view (reconstructed CREATE TABLE/VIEW +
-constraints + indexes from pg_catalog, opened in a new tab), multiple result
-sets per script (one shared connection,
-per-statement result sections + timings, stop-on-error), on-demand database &
-schema refresh (tree + autocomplete +
-palette), grid CRUD (add-row dialog + delete selected rows), no-SQL
-table browsing (server-side WHERE filter, header-click ORDER BY, LIMIT/OFFSET
-paging), the Ctrl+K/Ctrl+P command palette (fuzzy-jump to
-any table, saved query, or action), SQL-derived tab titles with a dirty dot, results-grid copy
-(Ctrl+C / Copy as CSV·JSON·Markdown·INSERT),
-empty-state hints, the in-app light/dark theme toggle, the
-schema-tree filter
-box, paste-anything connection
-string parsing (URI / JDBC /
-ADO.NET / libpq / psql), the F1 shortcuts cheat sheet, theme-aware SQL
-syntax highlighting, the segmented status bar, keyboard tab navigation,
-EXPLAIN visualization, LISTEN/NOTIFY monitor, SSH tunnels, and the
-Files-style two-tone UI.
 
 ## License
 

--- a/scripts/benchmarks/run-benchmarks.sh
+++ b/scripts/benchmarks/run-benchmarks.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Measures pgNimbus's headline performance numbers and writes them to
+# bench-results/ as JSON (for history tracking) + Markdown (for humans).
+# Run by .github/workflows/benchmark.yml on every PR and push to main;
+# also runs locally on any Linux box with the .NET 10 SDK, Xvfb, and a
+# reachable PostgreSQL.
+#
+# Metrics:
+#   startup_aot_ms   launch → first rendered frame, NativeAOT Release binary
+#   startup_jit_ms   launch → first rendered frame, JIT Release build
+#   startup_rss_mb   resident memory at first frame (AOT)
+#   binary_size_mb   size of the AOT executable
+#   connect_ms       first physical connection on a cold pool
+#   roundtrip_ms     SELECT 1 on a warm pooled connection (median)
+#   first_batch_ms   large SELECT: call → first streamed RowBatch (median)
+#   stream_ms        large SELECT: full drain through the streaming path (median)
+#
+# Startup numbers come from the app itself (PGNIMBUS_STARTUP_PROBE=1 prints
+# launch-to-first-frame and exits — see PgNimbus.App/StartupProbe.cs); query
+# numbers come from the PgNimbus.Benchmarks console project.
+#
+# Environment:
+#   PGNIMBUS_BENCH_CONN   connection string (default: localhost/postgres/postgres)
+#   PGNIMBUS_BENCH_RUNS   startup samples per mode, median reported (default 7)
+#   PGNIMBUS_BENCH_ROWS   row count for the streaming benchmarks (default 100000)
+#   PGNIMBUS_BENCH_SKIP_AOT=1   skip the AOT publish + AOT metrics (quick local runs)
+
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+CONN="${PGNIMBUS_BENCH_CONN:-Host=localhost;Port=5432;Database=postgres;Username=postgres;Password=postgres}"
+RUNS="${PGNIMBUS_BENCH_RUNS:-7}"
+ROWS="${PGNIMBUS_BENCH_ROWS:-100000}"
+OUT_DIR="bench-results"
+mkdir -p "$OUT_DIR"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+    echo "error: this script measures the linux-x64 build and only runs on Linux" >&2
+    exit 1
+fi
+
+# --- a display for the startup runs (the app needs one to open a window) ----
+if [[ -z "${DISPLAY:-}" ]]; then
+    if [[ ! -e /tmp/.X99-lock ]]; then
+        Xvfb :99 -screen 0 1280x800x24 &
+        XVFB_PID=$!
+        trap 'kill "$XVFB_PID" 2>/dev/null || true' EXIT
+        sleep 1
+    fi
+    export DISPLAY=:99
+fi
+
+median() { # median of newline-separated numbers on stdin
+    sort -n | awk '{ a[NR] = $1 } END { if (NR % 2) print a[(NR + 1) / 2]; else printf "%.1f\n", (a[NR / 2] + a[NR / 2 + 1]) / 2 }'
+}
+
+# Runs the given app binary $RUNS times under the startup probe and prints
+# "<median window_ms> <median rss_bytes>".
+measure_startup() {
+    local binary=$1 times=() rss=()
+    # One discarded warm-up run: the first-ever launch pays cold page/font
+    # caches and can be 3x the steady state.
+    PGNIMBUS_STARTUP_PROBE=1 PGNIMBUS_CONN="$CONN" timeout 120 "$binary" >/dev/null 2>&1
+    for _ in $(seq "$RUNS"); do
+        local line
+        line=$(PGNIMBUS_STARTUP_PROBE=1 PGNIMBUS_CONN="$CONN" timeout 120 "$binary" 2>/dev/null \
+            | grep -o 'PGNIMBUS_STARTUP_PROBE window_ms=[0-9.]* rss_bytes=[0-9]*')
+        times+=("$(sed 's/.*window_ms=\([0-9.]*\).*/\1/' <<<"$line")")
+        rss+=("$(sed 's/.*rss_bytes=\([0-9]*\).*/\1/' <<<"$line")")
+    done
+    echo "$(printf '%s\n' "${times[@]}" | median) $(printf '%s\n' "${rss[@]}" | median)"
+}
+
+# --- builds ------------------------------------------------------------------
+echo "== Building (JIT Release)"
+dotnet build -c Release >/dev/null
+JIT_BINARY=PgNimbus.App/bin/Release/net10.0/PgNimbus.App
+
+if [[ -z "${PGNIMBUS_BENCH_SKIP_AOT:-}" ]]; then
+    echo "== Publishing (NativeAOT linux-x64) — this is the slow part"
+    dotnet publish PgNimbus.App -c Release -r linux-x64 -p:PublishAot=true >/dev/null
+    AOT_BINARY=PgNimbus.App/bin/Release/net10.0/linux-x64/publish/PgNimbus.App
+    BINARY_SIZE_MB=$(awk "BEGIN { printf \"%.1f\", $(stat -c%s "$AOT_BINARY") / 1024 / 1024 }")
+fi
+
+# --- startup -----------------------------------------------------------------
+if [[ -n "${AOT_BINARY:-}" ]]; then
+    echo "== Startup (AOT), $RUNS runs"
+    read -r STARTUP_AOT_MS RSS_AOT_BYTES <<<"$(measure_startup "$AOT_BINARY")"
+    RSS_AOT_MB=$(awk "BEGIN { printf \"%.1f\", $RSS_AOT_BYTES / 1024 / 1024 }")
+fi
+
+echo "== Startup (JIT), $RUNS runs"
+read -r STARTUP_JIT_MS _ <<<"$(measure_startup "$JIT_BINARY")"
+
+# --- query engine -------------------------------------------------------------
+echo "== Query engine ($ROWS-row stream)"
+QUERY_OUT=$(PGNIMBUS_BENCH_CONN="$CONN" PGNIMBUS_BENCH_ROWS="$ROWS" \
+    dotnet run --project PgNimbus.Benchmarks -c Release --no-build)
+echo "$QUERY_OUT"
+bench_value() { grep -o "PGNIMBUS_BENCH $1=[0-9.]*" <<<"$QUERY_OUT" | cut -d= -f2; }
+CONNECT_MS=$(bench_value connect_ms)
+ROUNDTRIP_MS=$(bench_value roundtrip_ms)
+FIRST_BATCH_MS=$(bench_value first_batch_ms)
+STREAM_MS=$(bench_value stream_ms)
+ROWS_PER_SEC=$(bench_value rows_per_sec)
+
+# --- report ------------------------------------------------------------------
+# JSON in github-action-benchmark's "customSmallerIsBetter" format.
+{
+    echo "["
+    [[ -n "${AOT_BINARY:-}" ]] && cat <<EOF
+  { "name": "Startup, launch to first frame (NativeAOT)", "unit": "ms", "value": $STARTUP_AOT_MS },
+  { "name": "Memory at first frame (NativeAOT)", "unit": "MB", "value": $RSS_AOT_MB },
+  { "name": "Binary size (NativeAOT)", "unit": "MB", "value": $BINARY_SIZE_MB },
+EOF
+    cat <<EOF
+  { "name": "Startup, launch to first frame (JIT)", "unit": "ms", "value": $STARTUP_JIT_MS },
+  { "name": "Connect, cold pool", "unit": "ms", "value": $CONNECT_MS },
+  { "name": "Round-trip, SELECT 1 warm", "unit": "ms", "value": $ROUNDTRIP_MS },
+  { "name": "First row batch of a $ROWS-row SELECT", "unit": "ms", "value": $FIRST_BATCH_MS },
+  { "name": "Stream $ROWS rows", "unit": "ms", "value": $STREAM_MS }
+]
+EOF
+} >"$OUT_DIR/benchmarks.json"
+
+{
+    echo "### pgNimbus benchmarks"
+    echo
+    echo "| Metric | Value |"
+    echo "| --- | ---: |"
+    [[ -n "${AOT_BINARY:-}" ]] && {
+        echo "| Startup, launch → first frame (NativeAOT) | $STARTUP_AOT_MS ms |"
+        echo "| Memory at first frame (NativeAOT) | $RSS_AOT_MB MB |"
+        echo "| Binary size (NativeAOT) | $BINARY_SIZE_MB MB |"
+    }
+    echo "| Startup, launch → first frame (JIT) | $STARTUP_JIT_MS ms |"
+    echo "| Connect (cold pool) | $CONNECT_MS ms |"
+    echo "| Round-trip (\`SELECT 1\`, warm) | $ROUNDTRIP_MS ms |"
+    echo "| First row batch of a $ROWS-row SELECT | $FIRST_BATCH_MS ms |"
+    echo "| Stream $ROWS rows | $STREAM_MS ms ($ROWS_PER_SEC rows/s) |"
+    echo
+    echo "Startup is the median of $RUNS runs, measured inside the app from OS process"
+    echo "start to the first rendered frame; query metrics are medians via"
+    echo "\`PgNimbus.Benchmarks\` against a local PostgreSQL."
+} >"$OUT_DIR/summary.md"
+
+cat "$OUT_DIR/summary.md"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    cat "$OUT_DIR/summary.md" >>"$GITHUB_STEP_SUMMARY"
+fi


### PR DESCRIPTION
Benchmarks — "fast" is now measured on every change, not asserted:

- PGNIMBUS_STARTUP_PROBE=1 makes the app print launch-to-first-frame
  time and RSS and exit (StartupProbe.cs), measured from OS process
  start so AOT vs JIT differences are captured honestly.
- PgNimbus.Benchmarks: a Core-only console project measuring connect,
  SELECT 1 round-trip, time-to-first-RowBatch, and full-stream
  throughput of a 100k-row mixed-type SELECT through QueryEngine's
  streaming path (the same API the UI uses).
- scripts/benchmarks/run-benchmarks.sh orchestrates: NativeAOT publish,
  binary size, startup medians (7 runs + discarded warm-up, AOT & JIT)
  under Xvfb, query benchmarks, and writes JSON + Markdown results.
- .github/workflows/benchmark.yml runs it on every PR and main push
  (postgres:17 service container), publishes the table to the job
  summary + artifact, and records history to gh-pages via
  github-action-benchmark so regressions show as a step in the chart.

Verified end-to-end in a Linux sandbox: ~160 ms AOT / ~2.1 s JIT to
first frame, 0.35 ms warm round-trip, 100k rows streamed in ~140 ms.

README cleanup (485 → 320 lines): the Backlog now lists only open work
(done items already live in Features; the duplicate "Recently shipped"
paragraph is gone), hard-coded perf claims point at the new Benchmarks
section instead, and the architecture tree shows all four projects.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dg8qYrnj2J3KF7zzarCprH