### PR TITLE
Address Gemini review: crash hardening, resource leaks, and edit/filter fixes

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -136,9 +136,14 @@ public partial class App : Application
                 connectionDatabase: csb.Database ?? ""),
         };
 
-        window.Closed += (_, _) =>
+        window.Closed += async (_, _) =>
         {
-            _ = notifyMonitor.DisposeAsync();
+            // Order matters: drain the notify listener's connection back to the
+            // pool first, then dispose the data source (the pool itself, which
+            // otherwise leaks on every "switch connection"), then the SSH tunnel
+            // that carries all of it.
+            await notifyMonitor.DisposeAsync();
+            await dataSource.DisposeAsync();
             tunnel?.Dispose();
         };
 

--- a/PgNimbus.App/BracketHighlightRenderer.cs
+++ b/PgNimbus.App/BracketHighlightRenderer.cs
@@ -33,8 +33,13 @@ public sealed class BracketHighlightRenderer : IBackgroundRenderer
 
     public KnownLayer Layer => KnownLayer.Selection;
 
-    /// <summary>Recomputes the highlighted pair for the given caret offset and repaints.</summary>
-    public void Update(string text, int caretOffset)
+    /// <summary>
+    /// Recomputes the highlighted pair for the given caret offset and repaints.
+    /// Takes the live document (an <see cref="ITextSource"/>) rather than a
+    /// string so caret movement doesn't allocate a full-document copy on every
+    /// tick — only a couple of characters around the caret are ever read.
+    /// </summary>
+    public void Update(ITextSource text, int caretOffset)
     {
         var (first, second) = FindPair(text, caretOffset);
         if (first == _firstOffset && second == _secondOffset)
@@ -71,14 +76,15 @@ public sealed class BracketHighlightRenderer : IBackgroundRenderer
     /// before the caret wins over the one after it, matching how the caret
     /// visually "sits after" what was just typed.
     /// </summary>
-    private static (int First, int Second) FindPair(string text, int caretOffset)
+    private static (int First, int Second) FindPair(ITextSource text, int caretOffset)
     {
+        var length = text.TextLength;
         var bracketOffset = -1;
-        if (caretOffset > 0 && caretOffset <= text.Length && IsBracket(text[caretOffset - 1]))
+        if (caretOffset > 0 && caretOffset <= length && IsBracket(text.GetCharAt(caretOffset - 1)))
         {
             bracketOffset = caretOffset - 1;
         }
-        else if (caretOffset >= 0 && caretOffset < text.Length && IsBracket(text[caretOffset]))
+        else if (caretOffset >= 0 && caretOffset < length && IsBracket(text.GetCharAt(caretOffset)))
         {
             bracketOffset = caretOffset;
         }
@@ -88,7 +94,7 @@ public sealed class BracketHighlightRenderer : IBackgroundRenderer
             return (-1, -1);
         }
 
-        var c = text[bracketOffset];
+        var c = text.GetCharAt(bracketOffset);
         var openIndex = Open.IndexOf(c);
         var forward = openIndex >= 0;
         var (open, close) = forward
@@ -97,13 +103,14 @@ public sealed class BracketHighlightRenderer : IBackgroundRenderer
 
         var depth = 0;
         var step = forward ? 1 : -1;
-        for (var i = bracketOffset; i >= 0 && i < text.Length; i += step)
+        for (var i = bracketOffset; i >= 0 && i < length; i += step)
         {
-            if (text[i] == open)
+            var ch = text.GetCharAt(i);
+            if (ch == open)
             {
                 depth += step;
             }
-            else if (text[i] == close)
+            else if (ch == close)
             {
                 depth -= step;
             }

--- a/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
+++ b/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
@@ -366,6 +366,14 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
     [RelayCommand]
     private async Task ConnectAsync()
     {
+        // Guard re-entry: a double-click on a profile (which fires ConnectCommand)
+        // could otherwise start a second connect and spin up a duplicate SSH
+        // tunnel while the first is still in flight.
+        if (IsConnecting)
+        {
+            return;
+        }
+
         if (!TryBuildProfile(out var profile, out var error))
         {
             ErrorMessage = error;
@@ -375,11 +383,12 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         ErrorMessage = null;
         IsConnecting = true;
 
+        SshTunnel? tunnel = null;
         try
         {
             if (profile.SshTunnel is { } sshOptions)
             {
-                var tunnel = await Task.Run(() => SshTunnel.Connect(sshOptions, SshPassword, profile.Host, profile.Port));
+                tunnel = await Task.Run(() => SshTunnel.Connect(sshOptions, SshPassword, profile.Host, profile.Port));
                 var connectionString = profile.BuildConnectionString(
                     string.IsNullOrEmpty(Password) ? null : Password,
                     (tunnel.LocalHost, tunnel.LocalPort));
@@ -393,7 +402,12 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            ErrorMessage = $"SSH tunnel failed: {ex.Message}";
+            // If the tunnel came up but the hand-off threw (or nothing was
+            // listening on Connected), it owns a live SSH session and port
+            // forward the main window's Closed handler will never dispose —
+            // release it here so it doesn't leak.
+            tunnel?.Dispose();
+            ErrorMessage = $"Connection failed: {ex.Message}";
         }
         finally
         {

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -313,6 +313,11 @@ public sealed partial class MainViewModel : ObservableObject
         // ActiveTab = null synchronously, so comparing afterwards misses.
         var wasActive = ReferenceEquals(ActiveTab, tab);
 
+        // A query still running in the closed tab would otherwise keep streaming
+        // in the background, holding a pool connection and server-side work for a
+        // result nothing will show — cancel it as the tab goes away.
+        tab.CancelCommand.Execute(null);
+
         tab.Executed -= SavedQueries.RecordExecution;
         Tabs.RemoveAt(index);
 
@@ -345,12 +350,17 @@ public sealed partial class MainViewModel : ObservableObject
 
     public async Task PreviewTableAsync(string schema, string name)
     {
+        // Capture the target tab before the await: if the user switches tabs
+        // while the metadata loads, ActiveTab changes, and browse mode would
+        // otherwise open in whichever tab happens to be active on resume.
+        var tab = ActiveTab;
+
         var columns = await _schemaService.GetColumnsAsync(schema, name, CancellationToken.None);
         var primaryKeyColumns = columns.Where(c => c.IsPrimaryKey).Select(c => c.Name).ToList();
 
         // Open the table in no-SQL browse mode: server-side filter/sort/paging,
         // with inline editing when the table has a primary key.
-        await ActiveTab.StartBrowseAsync(schema, name, primaryKeyColumns);
+        await tab.StartBrowseAsync(schema, name, primaryKeyColumns);
     }
 
     /// <summary>

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -397,6 +397,16 @@ public sealed partial class QueryViewModel : ObservableObject
             Status = "Cancelled";
             Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, StatusSummary()));
         }
+        catch (Exception ex)
+        {
+            // A mid-stream failure the engine couldn't turn into a QueryError
+            // (e.g. a dropped connection surfacing while the batches enumerate on
+            // the background thread). Surface it in the status bar instead of
+            // letting it escape the command and crash the app.
+            Status = $"Error: {ex.Message}";
+            HasError = true;
+            Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, StatusSummary()));
+        }
         finally
         {
             IsRunning = false;
@@ -552,19 +562,31 @@ public sealed partial class QueryViewModel : ObservableObject
 
     private async Task RunExplainAsync(bool analyze)
     {
+        // Own a CTS so the Cancel button (enabled by IsRunning) actually cancels
+        // the EXPLAIN, not just SELECTs.
+        _cts = new CancellationTokenSource();
+        var ct = _cts.Token;
+
         IsRunning = true;
         Status = analyze ? "Running EXPLAIN ANALYZE..." : "Running EXPLAIN...";
         HasError = false;
+        // Hide any plan already on screen until this run yields a fresh one, so a
+        // failed or cancelled re-run can't leave a stale plan beside the new error.
+        IsShowingPlan = false;
 
         try
         {
-            var result = await _explainService.ExplainAsync(Sql, analyze, CancellationToken.None);
+            var result = await _explainService.ExplainAsync(Sql, analyze, ct);
             ExplainRoot = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
             var planningFragment = result.PlanningTimeMs is { } planMs ? $"Planning: {planMs:F3} ms" : null;
             var executionFragment = result.ExecutionTimeMs is { } execMs ? $"Execution: {execMs:F3} ms" : null;
             ExplainSummary = string.Join("   ", new[] { planningFragment, executionFragment }.Where(f => f is not null));
             IsShowingPlan = true;
             Status = "Plan ready";
+        }
+        catch (OperationCanceledException)
+        {
+            Status = "Cancelled";
         }
         catch (PostgresException ex)
         {
@@ -579,6 +601,8 @@ public sealed partial class QueryViewModel : ObservableObject
         finally
         {
             IsRunning = false;
+            _cts?.Dispose();
+            _cts = null;
         }
     }
 
@@ -891,6 +915,30 @@ public sealed partial class QueryViewModel : ObservableObject
             return Guid.Parse(text);
         }
 
+        // Common Postgres types Npgsql maps to CLR types that don't implement
+        // IConvertible (timestamptz→DateTimeOffset, date→DateOnly, time→TimeOnly,
+        // interval→TimeSpan). Convert.ChangeType throws on these, so a raw string
+        // would fall through and hit a Postgres type-mismatch - parse explicitly.
+        if (underlying == typeof(DateTimeOffset))
+        {
+            return DateTimeOffset.Parse(text, CultureInfo.InvariantCulture);
+        }
+
+        if (underlying == typeof(DateOnly))
+        {
+            return DateOnly.Parse(text, CultureInfo.InvariantCulture);
+        }
+
+        if (underlying == typeof(TimeOnly))
+        {
+            return TimeOnly.Parse(text, CultureInfo.InvariantCulture);
+        }
+
+        if (underlying == typeof(TimeSpan))
+        {
+            return TimeSpan.Parse(text, CultureInfo.InvariantCulture);
+        }
+
         if (typeof(IConvertible).IsAssignableFrom(underlying))
         {
             return Convert.ChangeType(text, underlying, CultureInfo.InvariantCulture);
@@ -977,13 +1025,31 @@ public sealed partial class QueryViewModel : ObservableObject
     public Task RefreshCurrentAsync() =>
         Browse is { } browse ? browse.LoadAsync() : RunCommand.ExecuteAsync(null);
 
-    public void ExportCsv(Stream stream)
+    /// <summary>
+    /// Snapshots the current result (columns + rows) and returns a writer that
+    /// renders it as CSV. The snapshot is taken synchronously on the calling
+    /// (UI) thread, so the returned delegate is safe to run on a background
+    /// thread — a large export then writes without freezing the UI or racing a
+    /// concurrent grid mutation.
+    /// </summary>
+    public Action<Stream> CreateCsvExport()
     {
-        using var writer = new StreamWriter(stream, leaveOpen: true);
-        ResultExporter.WriteCsv(writer, ColumnNames, Rows);
+        var columns = ColumnNames.ToList();
+        var rows = Rows.ToList();
+        return stream =>
+        {
+            using var writer = new StreamWriter(stream, leaveOpen: true);
+            ResultExporter.WriteCsv(writer, columns, rows);
+        };
     }
 
-    public void ExportJson(Stream stream) => ResultExporter.WriteJson(stream, ColumnNames, Rows);
+    /// <summary>JSON counterpart of <see cref="CreateCsvExport"/> — snapshots on the UI thread, writes off it.</summary>
+    public Action<Stream> CreateJsonExport()
+    {
+        var columns = ColumnNames.ToList();
+        var rows = Rows.ToList();
+        return stream => ResultExporter.WriteJson(stream, columns, rows);
+    }
 
     /// <summary>The clipboard "Copy as" shapes the results grid offers.</summary>
     public enum CopyFormat

--- a/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
@@ -83,28 +83,45 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
 
         if (query.Length == 0)
         {
-            foreach (var schema in Schemas)
+            foreach (var node in Schemas)
             {
-                schema.IsFilteredIn = true;
-                foreach (var table in schema.Children)
+                node.IsFilteredIn = true;
+                foreach (var child in node.Children)
                 {
-                    table.IsFilteredIn = true;
+                    child.IsFilteredIn = true;
                 }
             }
 
             return;
         }
 
-        foreach (var schema in Schemas)
+        foreach (var node in Schemas)
         {
+            // The root-level Extensions/Roles groups aren't schemas and their
+            // children aren't tables, so a schema/table-name filter has nothing
+            // to say about them - keep them in rather than hiding them outright.
+            if (node is not SchemaNode schema)
+            {
+                node.IsFilteredIn = true;
+                foreach (var child in node.Children)
+                {
+                    child.IsFilteredIn = true;
+                }
+
+                continue;
+            }
+
             var schemaMatches = Contains(schema.Name, query);
             var anyTableMatches = false;
 
-            foreach (var table in schema.Children)
+            foreach (var child in schema.Children)
             {
-                // Placeholder/error rows have no meaningful name to match; ride the schema's own visibility.
-                var tableMatches = table is TableNode && Contains(table.Name, query);
-                table.IsFilteredIn = schemaMatches || tableMatches;
+                // Only real tables are matched by name. Sub-groups (Functions)
+                // and placeholder/error rows aren't tables and have no name to
+                // match, so they ride the schema's own visibility instead of
+                // being filtered out.
+                var tableMatches = child is TableNode && Contains(child.Name, query);
+                child.IsFilteredIn = schemaMatches || tableMatches || child is not TableNode;
                 anyTableMatches |= tableMatches;
             }
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -601,8 +601,10 @@
 
             <Border Grid.Row="3" Classes="card" Margin="0,12,0,12">
                 <DockPanel>
-                    <!-- Browse bar: server-side WHERE filter, ORDER BY (via header click), LIMIT/OFFSET paging -->
+                    <!-- Browse bar: server-side WHERE filter, ORDER BY (via header click), LIMIT/OFFSET paging.
+                         Disabled while a query is in flight so Apply/paging can't kick off a second concurrent run. -->
                     <Border DockPanel.Dock="Top" IsVisible="{Binding ActiveTab.IsBrowsing}"
+                            IsEnabled="{Binding !ActiveTab.IsRunning}"
                             BorderThickness="0,0,0,1" BorderBrush="{StaticResource CardBorderBrush}"
                             Padding="8,7" Margin="0,0,0,4">
                         <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto"

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -938,7 +938,9 @@ public partial class MainWindow : Window
         SqlEditor.FontSize = Math.Clamp(SqlEditor.FontSize + delta, MinEditorFontSize, MaxEditorFontSize);
 
     private void UpdateBracketHighlight() =>
-        _bracketRenderer.Update(SqlEditor.Text, SqlEditor.CaretOffset);
+        // Pass the live document, not SqlEditor.Text — the latter allocates a
+        // full-document string on every caret move, this reads a few chars.
+        _bracketRenderer.Update(SqlEditor.Document, SqlEditor.CaretOffset);
 
     private void ShowCompletion(bool includeTypedChar)
     {
@@ -1067,7 +1069,16 @@ public partial class MainWindow : Window
             return;
         }
 
-        await clipboard.SetTextAsync(_viewModel.CellInspector.DisplayText);
+        try
+        {
+            await clipboard.SetTextAsync(_viewModel.CellInspector.DisplayText);
+        }
+        catch
+        {
+            // Clipboard access can throw if another app holds it locked. This is
+            // an async void handler, so an unhandled throw would crash the app —
+            // a failed copy is not worth that.
+        }
     }
 
     private void OnCellInspectorScrimPressed(object? sender, PointerPressedEventArgs e) =>
@@ -1083,7 +1094,12 @@ public partial class MainWindow : Window
         if (_queryViewModel?.Browse is { } browse && e.Column.Header is string columnName)
         {
             e.Handled = true;
-            _ = browse.SortByAsync(columnName);
+            // A header click re-queries page 1; ignore it while a run is already
+            // in flight so it can't start a second concurrent execution.
+            if (!_queryViewModel.IsRunning)
+            {
+                _ = browse.SortByAsync(columnName);
+            }
         }
     }
 
@@ -1293,7 +1309,8 @@ public partial class MainWindow : Window
         var query = _queryViewModel;
         if (query is not null)
         {
-            await ExportAsync("csv", "CSV", ["*.csv"], stream => query.ExportCsv(stream));
+            // Snapshot on the UI thread; ExportAsync runs the returned writer off it.
+            await ExportAsync("csv", "CSV", ["*.csv"], query.CreateCsvExport());
         }
     }
 
@@ -1302,7 +1319,7 @@ public partial class MainWindow : Window
         var query = _queryViewModel;
         if (query is not null)
         {
-            await ExportAsync("json", "JSON", ["*.json"], stream => query.ExportJson(stream));
+            await ExportAsync("json", "JSON", ["*.json"], query.CreateJsonExport());
         }
     }
 
@@ -1420,7 +1437,9 @@ public partial class MainWindow : Window
         }
 
         await using var stream = await file.OpenWriteAsync();
-        write(stream);
+        // The writer was snapshotted on the UI thread; do the (potentially large)
+        // formatting + file write off it so the interface stays responsive.
+        await Task.Run(() => write(stream));
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/PgNimbus.Core/Connections/ConnectionProfileStore.cs
+++ b/PgNimbus.Core/Connections/ConnectionProfileStore.cs
@@ -24,8 +24,17 @@ public sealed class ConnectionProfileStore
             return [];
         }
 
-        var json = File.ReadAllText(_filePath);
-        return JsonSerializer.Deserialize(json, ConnectionProfileJsonContext.Default.ListConnectionProfile) ?? [];
+        // A corrupt/empty/half-written file must never block the connection
+        // dialog - fall back to an empty list rather than throwing at startup.
+        try
+        {
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize(json, ConnectionProfileJsonContext.Default.ListConnectionProfile) ?? [];
+        }
+        catch (Exception e) when (e is IOException or JsonException or UnauthorizedAccessException)
+        {
+            return [];
+        }
     }
 
     public void Save(IEnumerable<ConnectionProfile> profiles)

--- a/PgNimbus.Core/Connections/PlainFileCredentialStore.cs
+++ b/PgNimbus.Core/Connections/PlainFileCredentialStore.cs
@@ -21,12 +21,26 @@ public sealed class PlainFileCredentialStore : ICredentialStore
     {
         Directory.CreateDirectory(_directory);
         var path = GetFilePath(connectionId);
-        File.WriteAllText(path, Convert.ToBase64String(Encoding.UTF8.GetBytes(password)));
+        var contents = Convert.ToBase64String(Encoding.UTF8.GetBytes(password));
 
-        if (!OperatingSystem.IsWindows())
+        if (OperatingSystem.IsWindows())
         {
-            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            File.WriteAllText(path, contents);
+            return;
         }
+
+        // Create with 0600 from the start. Writing the file first and tightening
+        // permissions afterwards (File.SetUnixFileMode) leaves a window where the
+        // credential is world/group-readable per the process umask (CWE-377/732).
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.Create,
+            Access = FileAccess.Write,
+            UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite,
+        };
+        using var stream = new FileStream(path, options);
+        using var writer = new StreamWriter(stream);
+        writer.Write(contents);
     }
 
     public string? LoadPassword(Guid connectionId)

--- a/PgNimbus.Core/Notifications/NotificationListener.cs
+++ b/PgNimbus.Core/Notifications/NotificationListener.cs
@@ -33,12 +33,23 @@ public sealed class NotificationListener : IAsyncDisposable
         await StopAsync();
 
         var connection = await _dataSource.OpenConnectionAsync(ct);
-        connection.Notification += OnNotification;
-
-        foreach (var channel in channels)
+        try
         {
-            await using var command = new NpgsqlCommand($"LISTEN {SqlIdentifier.Quote(channel)}", connection);
-            await command.ExecuteNonQueryAsync(ct);
+            connection.Notification += OnNotification;
+
+            foreach (var channel in channels)
+            {
+                await using var command = new NpgsqlCommand($"LISTEN {SqlIdentifier.Quote(channel)}", connection);
+                await command.ExecuteNonQueryAsync(ct);
+            }
+        }
+        catch
+        {
+            // The connection isn't assigned to _connection yet, so StopAsync
+            // couldn't dispose it - do it here or it leaks out of the pool.
+            connection.Notification -= OnNotification;
+            await connection.DisposeAsync();
+            throw;
         }
 
         _connection = connection;
@@ -59,6 +70,12 @@ public sealed class NotificationListener : IAsyncDisposable
             catch (OperationCanceledException)
             {
                 // Expected: cancelling the wait loop on stop.
+            }
+            catch
+            {
+                // The loop faulted (e.g. the connection dropped). Swallow it so
+                // cleanup below still runs - rethrowing here would leave the
+                // listener half-stopped with the connection never disposed.
             }
         }
 

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -442,6 +442,14 @@ public sealed class QueryEngine
                 Position = ParsePosition(pg.Position),
             };
         }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A non-Postgres failure (dropped connection, socket timeout, ...):
+            // the shared-connection script/transaction paths turn any statement
+            // failure into a QueryError rather than letting it escape and crash
+            // the app. Cancellation still propagates so it reads as "Cancelled".
+            return new QueryError { Elapsed = stopwatch.Elapsed, Message = ex.Message };
+        }
         finally
         {
             if (reader is not null)
@@ -454,6 +462,11 @@ public sealed class QueryEngine
                 {
                     // The backend acknowledged the row-cap cancel while draining;
                     // the rows already collected are still valid.
+                }
+                catch
+                {
+                    // The connection faulted mid-drain; the result we're returning
+                    // is already built and the connection is being discarded.
                 }
             }
         }
@@ -543,9 +556,16 @@ public sealed class QueryEngine
                 // The backend acknowledged the row-cap cancel while the reader
                 // was draining; the rows already yielded are still valid.
             }
-
-            await command.DisposeAsync();
-            await connection.DisposeAsync();
+            catch
+            {
+                // A faulted reader (e.g. a dropped connection) must not skip the
+                // command/connection disposals below, or the pool connection leaks.
+            }
+            finally
+            {
+                await command.DisposeAsync();
+                await connection.DisposeAsync();
+            }
         }
     }
 

--- a/PgNimbus.Core/Query/QueryHistoryStore.cs
+++ b/PgNimbus.Core/Query/QueryHistoryStore.cs
@@ -23,8 +23,17 @@ public sealed class QueryHistoryStore
             return [];
         }
 
-        var json = File.ReadAllText(_filePath);
-        return JsonSerializer.Deserialize(json, QueryHistoryJsonContext.Default.ListQueryHistoryEntry) ?? [];
+        // A corrupt/empty/half-written file must never block startup - fall back
+        // to an empty history rather than throwing out of the constructor path.
+        try
+        {
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize(json, QueryHistoryJsonContext.Default.ListQueryHistoryEntry) ?? [];
+        }
+        catch (Exception e) when (e is IOException or JsonException or UnauthorizedAccessException)
+        {
+            return [];
+        }
     }
 
     public void Append(QueryHistoryEntry entry)

--- a/PgNimbus.Core/Query/SavedQueryStore.cs
+++ b/PgNimbus.Core/Query/SavedQueryStore.cs
@@ -21,8 +21,17 @@ public sealed class SavedQueryStore
             return [];
         }
 
-        var json = File.ReadAllText(_filePath);
-        return JsonSerializer.Deserialize(json, SavedQueryJsonContext.Default.ListSavedQuery) ?? [];
+        // A corrupt/empty/half-written file must never block startup - fall back
+        // to an empty list rather than throwing out of the constructor path.
+        try
+        {
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize(json, SavedQueryJsonContext.Default.ListSavedQuery) ?? [];
+        }
+        catch (Exception e) when (e is IOException or JsonException or UnauthorizedAccessException)
+        {
+            return [];
+        }
     }
 
     public void Save(IEnumerable<SavedQuery> queries)


### PR DESCRIPTION
Works through the high/critical items from the Gemini review log, keeping only
the ones that still reproduce on main (many were already fixed) and skipping the
ones that don't apply.

Crash hardening
- QueryViewModel.RunCoreAsync: catch non-cancellation exceptions so a dropped
  connection mid-stream shows an error in the status bar instead of escaping the
  command and crashing the app.
- QueryEngine.ExecuteOnConnectionAsync: convert non-Postgres failures (socket
  timeouts, dropped connections) on the shared script/transaction connection to
  a QueryError instead of letting them propagate.
- QueryHistoryStore/SavedQueryStore/ConnectionProfileStore Load(): fall back to
  an empty list on a corrupt/half-written JSON file rather than throwing on
  startup (matching AppSettingsStore, which already did this).

Resource leaks
- App.BuildMainWindow: dispose the NpgsqlDataSource on window close (drained
  after the notify listener, before the SSH tunnel); it previously leaked the
  whole pool on every "switch connection".
- NotificationListener: dispose the connection if LISTEN setup fails before it's
  assigned, and swallow a faulted listen loop in StopAsync so cleanup completes.
- QueryEngine.StreamBatches: dispose command/connection even when the reader
  disposal throws.
- ConnectionDialogViewModel.ConnectAsync: guard re-entry (double-click) and
  dispose the tunnel if the hand-off throws.
- MainViewModel.CloseTab: cancel a running query when its tab is closed.

Editing / correctness
- ConvertEditedValue: parse DateTimeOffset/DateOnly/TimeOnly/TimeSpan explicitly
  (they aren't IConvertible), so editing timestamptz/date/time/interval cells no
  longer hits a Postgres type mismatch.
- SchemaTreeViewModel.ApplyFilter: stop hiding the Functions/Extensions/Roles
  groups (their nodes aren't TableNodes) when a filter is typed.

UI responsiveness / robustness
- Export: snapshot columns+rows on the UI thread and run the file write on a
  background thread so large exports don't freeze the UI.
- Browse bar: disable it (and header-click sorting) while a query runs to
  prevent concurrent executions on the tab.
- RunExplainAsync: own a CTS so Cancel actually cancels EXPLAIN, and hide any
  prior plan up front so a failed re-run can't leave a stale plan on screen.
- OnCellInspectorCopyClick: guard the clipboard call (async void handler).
- BracketHighlightRenderer: read the live document via ITextSource instead of
  allocating a full-document string on every caret move.
- PreviewTableAsync: capture the target tab before awaiting metadata.

Security
- PlainFileCredentialStore: create the credential file with 0600 atomically via
  FileStreamOptions.UnixCreateMode instead of tightening permissions after the
  write (CWE-377/732).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fv8ZyND7yL7B6NHwZX9XXF