### PR TITLE
SQL editor ergonomics: more auto-open spots, auto-alias on table accept, auto-close pairs

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -37,6 +37,10 @@ public partial class App : Application
     private static void PersistShowAdvancedSchemaObjects(bool value) =>
         SettingsStore.Save(SettingsStore.Load() with { ShowAdvancedSchemaObjects = value });
 
+    /// <summary>Remembers the editor's auto-alias-tables toggle so it survives a restart.</summary>
+    private static void PersistAutoAliasTables(bool value) =>
+        SettingsStore.Save(SettingsStore.Load() with { AutoAliasTables = value });
+
     private static ThemeVariant ThemeFromString(string? theme) => theme?.ToLowerInvariant() switch
     {
         "light" => ThemeVariant.Light,
@@ -133,7 +137,9 @@ public partial class App : Application
                 engine, explainService, schemaTree, schemaService, schemaEditor, ddlService, completionProvider, notifyMonitor, activityService, importService,
                 accentColor,
                 connectionHost: csb.Host ?? "",
-                connectionDatabase: csb.Database ?? ""),
+                connectionDatabase: csb.Database ?? "",
+                autoAliasTables: SettingsStore.Load().AutoAliasTables,
+                persistAutoAliasTables: PersistAutoAliasTables),
         };
 
         window.Closed += async (_, _) =>

--- a/PgNimbus.App/Completion/SqlCompletionContext.cs
+++ b/PgNimbus.App/Completion/SqlCompletionContext.cs
@@ -7,9 +7,11 @@ internal enum SqlClause
 {
     /// <summary>No clause identified — offer the full catalog.</summary>
     None,
-    /// <summary>A table/view name goes here (after FROM, INTO, UPDATE, TABLE…).</summary>
+    /// <summary>A table/view name goes here (after INTO, UPDATE, TABLE, TRUNCATE…).</summary>
     TableRef,
-    /// <summary>A table/view name goes here, specifically after JOIN — FK-connected tables float to the top.</summary>
+    /// <summary>A table/view name goes here, specifically after FROM — same list as <see cref="TableRef"/>, but a table accepted here can also take an auto-alias (INTO/TRUNCATE targets can't).</summary>
+    FromTableRef,
+    /// <summary>A table/view name goes here, specifically after JOIN — FK-connected tables float to the top, and an accepted table can take an auto-alias.</summary>
     JoinTableRef,
     /// <summary>A column/expression goes here (after SELECT, SET, RETURNING…) — the full catalog, current tables' columns floated up.</summary>
     ColumnRef,
@@ -140,7 +142,7 @@ internal static partial class SqlCompletionContext
                 // "INSERT INTO t (" — the parenthesised list is columns, not more
                 // tables. (A "FROM (" subquery also lands here, and its own SELECT
                 // will re-set the clause the moment it's typed.)
-                if (clause == SqlClause.TableRef)
+                if (clause is SqlClause.TableRef or SqlClause.FromTableRef)
                 {
                     clause = SqlClause.ColumnRef;
                 }
@@ -175,11 +177,17 @@ internal static partial class SqlCompletionContext
     // everything else leaves the clause as-is.
     private static SqlClause ClassifyKeyword(ReadOnlySpan<char> word, SqlClause current)
     {
-        // Split out from TableClauseKeywords so FK-aware JOIN ranking only kicks
-        // in after an actual JOIN, not FROM/INTO/UPDATE.
+        // JOIN and FROM split out from TableClauseKeywords: FK-aware ranking
+        // only kicks in after an actual JOIN, and auto-aliasing only after
+        // FROM/JOIN (an INTO/TRUNCATE target can't legally take a bare alias).
         if (word.Equals("join", StringComparison.OrdinalIgnoreCase))
         {
             return SqlClause.JoinTableRef;
+        }
+
+        if (word.Equals("from", StringComparison.OrdinalIgnoreCase))
+        {
+            return SqlClause.FromTableRef;
         }
 
         foreach (var kw in TableClauseKeywords)
@@ -209,9 +217,9 @@ internal static partial class SqlCompletionContext
         return current;
     }
 
-    /// <summary>The keywords a table reference follows (besides JOIN, classified separately above). "update" also covers <c>ON CONFLICT DO UPDATE</c> — its SET flips back to columns.</summary>
+    /// <summary>The keywords a table reference follows (besides FROM and JOIN, classified separately above). "update" also covers <c>ON CONFLICT DO UPDATE</c> — its SET flips back to columns.</summary>
     private static readonly string[] TableClauseKeywords =
-        ["from", "into", "update", "table", "truncate"];
+        ["into", "update", "table", "truncate"];
 
     // Row-scoped column contexts: a predicate (WHERE/ON/HAVING) or a
     // GROUP/ORDER BY / USING list can only name columns of the tables already in

--- a/PgNimbus.App/Completion/SqlCompletionData.cs
+++ b/PgNimbus.App/Completion/SqlCompletionData.cs
@@ -36,6 +36,14 @@ public sealed class SqlCompletionData : ICompletionData
     /// <summary>The literal inserted on completion — may be quoted even when <see cref="Text"/> isn't.</summary>
     public string InsertText { get; }
 
+    /// <summary>
+    /// The bare table name when this item completes a table — the seed for the
+    /// auto-alias appended after an accept in FROM/JOIN position (see
+    /// <c>MainWindow.MaybeInsertTableAlias</c>). Null for anything that isn't a
+    /// table, which opts the item out of aliasing entirely.
+    /// </summary>
+    public string? AliasTable { get; init; }
+
     public object Content => Text;
 
     public object Description { get; }

--- a/PgNimbus.App/Completion/SqlCompletionProvider.cs
+++ b/PgNimbus.App/Completion/SqlCompletionProvider.cs
@@ -148,8 +148,8 @@ public sealed class SqlCompletionProvider
                 // (after FROM/JOIN) it completes schema-qualified ("public.users")
                 // so the reference is unambiguous whatever the search_path is.
                 var qualified = $"{SqlIdentifier.QuoteIfNeeded(schema.Name)}.{SqlIdentifier.QuoteIfNeeded(table.Name)}";
-                baseItems.Add(new SqlCompletionData(table.Name, $"table ({schema.Name})", SqlIdentifier.QuoteIfNeeded(table.Name), TablePriority));
-                tableRefItems.Add(new SqlCompletionData(table.Name, $"table ({schema.Name})", qualified, TablePriority));
+                baseItems.Add(new SqlCompletionData(table.Name, $"table ({schema.Name})", SqlIdentifier.QuoteIfNeeded(table.Name), TablePriority) { AliasTable = table.Name });
+                tableRefItems.Add(new SqlCompletionData(table.Name, $"table ({schema.Name})", qualified, TablePriority) { AliasTable = table.Name });
             }
 
             var columns = await _schemaService.GetAllColumnsAsync(schema.Name, ct);
@@ -198,7 +198,7 @@ public sealed class SqlCompletionProvider
 
         return context.Clause switch
         {
-            SqlClause.TableRef => GetTableRefCompletions(sql),
+            SqlClause.TableRef or SqlClause.FromTableRef => GetTableRefCompletions(sql),
             SqlClause.JoinTableRef => GetJoinTableRefCompletions(sql),
             SqlClause.Predicate when SqlCompletionContext.IsAfterOnKeyword(sql, caretOffset) => GetJoinConditionCompletions(sql),
             SqlClause.Predicate => GetPredicateCompletions(sql),
@@ -228,7 +228,7 @@ public sealed class SqlCompletionProvider
         // schema. → the schema's tables
         return _tables
             .Where(t => string.Equals(t.Schema, qualifier, StringComparison.OrdinalIgnoreCase))
-            .Select(t => new SqlCompletionData(t.Table, $"table ({t.Schema})", SqlIdentifier.QuoteIfNeeded(t.Table), TablePriority))
+            .Select(t => new SqlCompletionData(t.Table, $"table ({t.Schema})", SqlIdentifier.QuoteIfNeeded(t.Table), TablePriority) { AliasTable = t.Table })
             .ToList();
     }
 
@@ -269,7 +269,7 @@ public sealed class SqlCompletionProvider
         foreach (var (neighborSchema, neighborTable) in ForeignKeyMatcher.FindJoinCandidates(statementTables, _foreignKeys))
         {
             var qualified = $"{SqlIdentifier.QuoteIfNeeded(neighborSchema)}.{SqlIdentifier.QuoteIfNeeded(neighborTable)}";
-            items.Add(new SqlCompletionData(neighborTable, $"table ({neighborSchema}) · FK", qualified, FkTablePriority));
+            items.Add(new SqlCompletionData(neighborTable, $"table ({neighborSchema}) · FK", qualified, FkTablePriority) { AliasTable = neighborTable });
         }
 
         return items;

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -86,6 +86,19 @@ public sealed partial class MainViewModel : ObservableObject
     [ObservableProperty]
     private bool _isInTransaction;
 
+    /// <summary>
+    /// Whether accepting a table from completion after FROM/JOIN also appends a
+    /// short alias. Bound to the toolbar's "AS" toggle; persisted via the
+    /// callback so the choice survives a restart (same pattern as the sidebar's
+    /// advanced-objects toggle).
+    /// </summary>
+    [ObservableProperty]
+    private bool _autoAliasTables;
+
+    private readonly Action<bool>? _persistAutoAliasTables;
+
+    partial void OnAutoAliasTablesChanged(bool value) => _persistAutoAliasTables?.Invoke(value);
+
     public MainViewModel(
         QueryEngine engine,
         ExplainService explainService,
@@ -99,10 +112,14 @@ public sealed partial class MainViewModel : ObservableObject
         ImportService importService,
         string? accentColor = null,
         string connectionHost = "",
-        string connectionDatabase = "")
+        string connectionDatabase = "",
+        bool autoAliasTables = true,
+        Action<bool>? persistAutoAliasTables = null)
     {
         ConnectionHost = connectionHost;
         ConnectionDatabase = connectionDatabase;
+        _autoAliasTables = autoAliasTables;
+        _persistAutoAliasTables = persistAutoAliasTables;
         _engine = engine;
         _explainService = explainService;
         SchemaTree = schemaTree;

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -589,6 +589,15 @@
                             <TextBlock Text="Import" VerticalAlignment="Center" />
                         </StackPanel>
                     </Button>
+
+                    <!-- Group 5 — editor behavior: auto-alias on table completion
+                         ("FROM public.orders" completes to "… orders o") -->
+                    <Rectangle Classes="statusSeparator" Margin="7,0" />
+                    <ToggleButton Classes="chip" VerticalAlignment="Center"
+                                  IsChecked="{Binding AutoAliasTables}"
+                                  ToolTip.Tip="Auto-alias tables accepted from completion after FROM/JOIN (orders → orders o)">
+                        <TextBlock Text="AS" FontSize="11" FontWeight="SemiBold" />
+                    </ToggleButton>
                 </StackPanel>
             </Border>
 

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -37,6 +37,9 @@ public partial class MainWindow : Window
     private CompletionWindow? _completionWindow;
     // "Accepted a moment ago" tie-breaker for the completion ranking; session-scoped.
     private readonly CompletionRecency _completionRecency = new();
+    // Closer promised by OnSqlTextEntering's InsertPair verdict, written by
+    // OnSqlTextEntered once the opener is in the document. '\0' = none pending.
+    private char _pendingAutoCloser;
     // Set while an accepted filter-completion writes back into the box, so the
     // resulting TextChanged doesn't immediately re-open the popup on the word we
     // just inserted.
@@ -122,6 +125,7 @@ public partial class MainWindow : Window
         ResultsGrid.KeyDown += OnResultsGridKeyDown;
         ResultsGrid.Sorting += OnResultsGridSorting;
 
+        SqlEditor.TextArea.TextEntering += OnSqlTextEntering;
         SqlEditor.TextArea.TextEntered += OnSqlTextEntered;
         SqlEditor.KeyDown += OnSqlEditorKeyDown;
 
@@ -809,6 +813,45 @@ public partial class MainWindow : Window
         await _queryViewModel.CommitCellEditAsync(row, columnIndex, text);
     }
 
+    // Auto-close pairs. Decided here — before the character lands — because a
+    // TypeOver must suppress the insertion entirely, and an InsertPair verdict
+    // needs the pre-insert text (AutoClosePairs.Decide's contract). The closer
+    // itself is written in OnSqlTextEntered, after the opener exists.
+    private void OnSqlTextEntering(object? sender, TextInputEventArgs e)
+    {
+        _pendingAutoCloser = '\0';
+        if (e.Text is not { Length: 1 } entered || entered[0] is not ('(' or ')' or '\'' or '"'))
+        {
+            return;
+        }
+
+        var typed = entered[0];
+        var textArea = SqlEditor.TextArea;
+
+        // Typing an opener over a selection wraps it instead of replacing it.
+        if (typed is not ')' && !textArea.Selection.IsEmpty)
+        {
+            textArea.Selection.ReplaceSelectionWithText(
+                typed + textArea.Selection.GetText() + AutoClosePairs.CloserFor(typed));
+            e.Handled = true;
+            return;
+        }
+
+        var text = SqlEditor.Text;
+        var caret = SqlEditor.CaretOffset;
+        var inStringOrComment = SqlCompletionContext.GetCaretContext(text, caret).InStringOrComment;
+        switch (AutoClosePairs.Decide(text, caret, typed, inStringOrComment))
+        {
+            case AutoClosePairs.Verdict.TypeOver:
+                SqlEditor.CaretOffset = caret + 1;
+                e.Handled = true;
+                break;
+            case AutoClosePairs.Verdict.InsertPair:
+                _pendingAutoCloser = AutoClosePairs.CloserFor(typed);
+                break;
+        }
+    }
+
     private void OnSqlTextEntered(object? sender, TextInputEventArgs e)
     {
         if (string.IsNullOrEmpty(e.Text))
@@ -817,6 +860,18 @@ public partial class MainWindow : Window
         }
 
         var c = e.Text[0];
+
+        // The closer OnSqlTextEntering promised: write it after the caret so
+        // the pair hugs it — "(|)" — and typing continues between them.
+        if (_pendingAutoCloser != '\0')
+        {
+            var closer = _pendingAutoCloser;
+            _pendingAutoCloser = '\0';
+            var openerEnd = SqlEditor.CaretOffset;
+            SqlEditor.Document.Insert(openerEnd, closer.ToString());
+            SqlEditor.CaretOffset = openerEnd;
+            return;
+        }
 
         // A dot starts member access (alias./table./schema.). Re-trigger even
         // when a bare-identifier list is already open, so it switches to the
@@ -839,14 +894,48 @@ public partial class MainWindow : Window
             return;
         }
 
-        // The space right after FROM/JOIN/INTO/UPDATE/ON opens the list
-        // unprompted — the spots where what comes next is most predictable (ON
-        // is where the FK join-condition suggestion shows up, when there is one).
-        if (c == ' ' && WordBeforeCaretTriggersAutoOpen())
+        // A comma continuing a list (SELECT list, FROM list, GROUP/ORDER BY …)
+        // reopens the list on the spot — the next item is as predictable as the
+        // first one was right after the clause keyword.
+        if (c == ',' && CaretIsInKnownClause())
+        {
+            ShowCompletion(includeTypedChar: false);
+            return;
+        }
+
+        if (c != ' ')
+        {
+            return;
+        }
+
+        // The space right after a clause keyword (FROM/WHERE/SELECT/AND …)
+        // opens the list unprompted — the spots where what comes next is most
+        // predictable (ON is where the FK join-condition suggestion shows up,
+        // when there is one). A space right after a comma re-opens the list the
+        // comma itself opened (the space closed it by matching nothing).
+        var caret = SqlEditor.CaretOffset;
+        var text = SqlEditor.Text;
+        var beforeSpace = caret >= 2 && caret <= text.Length ? text[caret - 2] : '\0';
+        if (beforeSpace == ',' ? CaretIsInKnownClause() : WordBeforeCaretTriggersAutoOpen())
         {
             ShowCompletion(includeTypedChar: false);
         }
     }
+
+    // True when the caret sits in a recognized clause (table position, select
+    // list, predicate…) outside strings/comments — the contexts where the
+    // popup's contents are scoped enough to be worth opening unasked.
+    private bool CaretIsInKnownClause()
+    {
+        var context = SqlCompletionContext.GetCaretContext(SqlEditor.Text, SqlEditor.CaretOffset);
+        return !context.InStringOrComment && context.Clause != SqlClause.None;
+    }
+
+    // The keywords whose trailing space auto-opens the popup: the ones after
+    // which the very next token is predictable — a table (FROM/JOIN/INTO/
+    // UPDATE), a scoped column (WHERE/ON/AND/OR), or a select-list expression.
+    private static readonly string[] AutoOpenKeywords =
+        ["from", "join", "into", "update", "on", "where", "and", "or", "select"];
 
     // True when the word just left of the caret (which sits right after the
     // freshly typed space) is a keyword after which the popup should open itself.
@@ -866,11 +955,15 @@ public partial class MainWindow : Window
         }
 
         var word = text.AsSpan(start, Math.Max(end - start, 0));
-        return word.Equals("from", StringComparison.OrdinalIgnoreCase)
-            || word.Equals("join", StringComparison.OrdinalIgnoreCase)
-            || word.Equals("into", StringComparison.OrdinalIgnoreCase)
-            || word.Equals("update", StringComparison.OrdinalIgnoreCase)
-            || word.Equals("on", StringComparison.OrdinalIgnoreCase);
+        foreach (var keyword in AutoOpenKeywords)
+        {
+            if (word.Equals(keyword, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void OnSqlEditorKeyDown(object? sender, KeyEventArgs e)
@@ -990,12 +1083,18 @@ public partial class MainWindow : Window
         };
         SqlEditor.TextArea.Caret.PositionChanged += caretMoved;
 
-        // Feed the "picked it recently" ranking tie-breaker on every accept.
+        // On accept: feed the "picked it recently" ranking tie-breaker, and
+        // append the auto-alias when a table just landed after FROM/JOIN. The
+        // alias insert is posted, not run inline: this handler's order relative
+        // to the window's own (which writes the completion text) isn't
+        // guaranteed — text inserted before Complete() runs sits inside the
+        // completion segment and gets replaced away with the filter word.
         completionWindow.CompletionList.InsertionRequested += (_, _) =>
         {
             if (completionWindow.CompletionList.SelectedItem is SqlCompletionData accepted)
             {
                 _completionRecency.Record(accepted.Text);
+                Dispatcher.UIThread.Post(() => MaybeInsertTableAlias(accepted));
             }
         };
 
@@ -1006,6 +1105,45 @@ public partial class MainWindow : Window
         };
         completionWindow.Show();
         _completionWindow = completionWindow;
+    }
+
+    // Appends the short auto-alias after a table accepted in FROM/JOIN position
+    // ("FROM public.orders" → "FROM public.orders o") so the "o." member-access
+    // flow works immediately — deduped against every name the statement already
+    // uses (aliases, table names, CTEs). Gated by the persisted "AS" toggle and
+    // re-checked against the clause at the caret, because the same table item
+    // can be accepted in places where an alias is wrong (SELECT list) or
+    // illegal (INSERT INTO / TRUNCATE targets).
+    private void MaybeInsertTableAlias(SqlCompletionData accepted)
+    {
+        if (accepted.AliasTable is null || _viewModel is not { AutoAliasTables: true })
+        {
+            return;
+        }
+
+        var text = SqlEditor.Text;
+        var caret = SqlEditor.CaretOffset;
+        var context = SqlCompletionContext.GetCaretContext(text, caret);
+        if (context.Clause is not (SqlClause.FromTableRef or SqlClause.JoinTableRef))
+        {
+            return;
+        }
+
+        var taken = new List<string>();
+        foreach (var table in SqlCompletionContext.ExtractTables(text))
+        {
+            taken.Add(table.Table);
+            if (table.Alias is not null)
+            {
+                taken.Add(table.Alias);
+            }
+        }
+
+        taken.AddRange(SqlCompletionContext.ExtractCteNames(text));
+
+        var alias = TableAliaser.Derive(accepted.AliasTable, taken);
+        SqlEditor.Document.Insert(caret, " " + alias);
+        SqlEditor.CaretOffset = caret + alias.Length + 1;
     }
 
     // Re-ranks the candidate set against the segment typed since the popup opened

--- a/PgNimbus.Core.Tests/Settings/AppSettingsStoreTests.cs
+++ b/PgNimbus.Core.Tests/Settings/AppSettingsStoreTests.cs
@@ -1,0 +1,62 @@
+using PgNimbus.Core.Settings;
+
+namespace PgNimbus.Core.Tests.Settings;
+
+public class AppSettingsStoreTests
+{
+    [Test]
+    public async Task Load_NoFile_ReturnsDefaults()
+    {
+        var store = new AppSettingsStore(Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json"));
+
+        var settings = store.Load();
+
+        await Assert.That(settings.Theme).IsEqualTo("system");
+        await Assert.That(settings.AutoAliasTables).IsTrue();
+    }
+
+    [Test]
+    public async Task Load_FileFromOlderBuild_MissingFieldsFallBackToTheirDefaults()
+    {
+        // The trap this guards: the source-generated JSON deserializer bypasses
+        // property initializers for init-only setters, so a default-true flag
+        // added after this file was written would silently load as false if
+        // AppSettings ever regressed from set to init accessors.
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(path, """{ "Theme": "dark", "ShowAdvancedSchemaObjects": true }""");
+
+        try
+        {
+            var settings = new AppSettingsStore(path).Load();
+
+            await Assert.That(settings.Theme).IsEqualTo("dark");
+            await Assert.That(settings.ShowAdvancedSchemaObjects).IsTrue();
+            await Assert.That(settings.AutoAliasTables).IsTrue();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task SaveThenLoad_RoundTrips()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var store = new AppSettingsStore(path);
+            store.Save(new AppSettings { Theme = "light", AutoAliasTables = false });
+
+            var settings = store.Load();
+
+            await Assert.That(settings.Theme).IsEqualTo("light");
+            await Assert.That(settings.AutoAliasTables).IsFalse();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/PgNimbus.Core.Tests/Text/AutoClosePairsTests.cs
+++ b/PgNimbus.Core.Tests/Text/AutoClosePairsTests.cs
@@ -1,0 +1,90 @@
+using PgNimbus.Core.Text;
+
+namespace PgNimbus.Core.Tests.Text;
+
+public class AutoClosePairsTests
+{
+    [Test]
+    [Arguments("SELECT coalesce", 15, '(')]
+    [Arguments("SELECT ( FROM t", 7, '(')] // before whitespace
+    [Arguments("SELECT f())", 9, '(')] // before an existing closer
+    [Arguments("WHERE name = ", 13, '\'')]
+    [Arguments("SELECT ", 7, '"')]
+    public async Task Opener_BeforeBoundary_InsertsPair(string text, int caret, char typed)
+    {
+        await Assert.That(AutoClosePairs.Decide(text, caret, typed, inStringOrComment: false))
+            .IsEqualTo(AutoClosePairs.Verdict.InsertPair);
+    }
+
+    [Test]
+    [Arguments("SELECT name FROM t", 7, '(')] // directly before a word
+    [Arguments("WHERE x = 'abc'", 10, '\'')] // directly before another quote
+    [Arguments("SELECT \"col\"", 7, '"')]
+    public async Task Opener_BeforeWordOrQuote_DoesNothing(string text, int caret, char typed)
+    {
+        await Assert.That(AutoClosePairs.Decide(text, caret, typed, inStringOrComment: false))
+            .IsEqualTo(AutoClosePairs.Verdict.None);
+    }
+
+    [Test]
+    public async Task Opener_InsideStringOrComment_DoesNothing()
+    {
+        // The apostrophe in a comment, the paren in a string: plain characters.
+        await Assert.That(AutoClosePairs.Decide("-- don", 6, '\'', inStringOrComment: true))
+            .IsEqualTo(AutoClosePairs.Verdict.None);
+        await Assert.That(AutoClosePairs.Decide("'a ", 3, '(', inStringOrComment: true))
+            .IsEqualTo(AutoClosePairs.Verdict.None);
+    }
+
+    [Test]
+    public async Task ClosingParen_BeforeClosingParen_TypesOver()
+    {
+        // The caret sits between the parens "coalesce()" completion left behind.
+        await Assert.That(AutoClosePairs.Decide("coalesce()", 9, ')', inStringOrComment: false))
+            .IsEqualTo(AutoClosePairs.Verdict.TypeOver);
+    }
+
+    [Test]
+    public async Task ClosingParen_ElsewhereOrInString_Inserts()
+    {
+        await Assert.That(AutoClosePairs.Decide("f(x", 3, ')', inStringOrComment: false))
+            .IsEqualTo(AutoClosePairs.Verdict.None);
+        await Assert.That(AutoClosePairs.Decide("'())'", 3, ')', inStringOrComment: true))
+            .IsEqualTo(AutoClosePairs.Verdict.None);
+    }
+
+    [Test]
+    public async Task Quote_BeforeSameQuote_TypesOver_EvenInsideTheString()
+    {
+        // 'abc|' — typing ' closes the literal by stepping over its closer.
+        await Assert.That(AutoClosePairs.Decide("'abc'", 4, '\'', inStringOrComment: true))
+            .IsEqualTo(AutoClosePairs.Verdict.TypeOver);
+        await Assert.That(AutoClosePairs.Decide("\"col\"", 4, '"', inStringOrComment: true))
+            .IsEqualTo(AutoClosePairs.Verdict.TypeOver);
+    }
+
+    [Test]
+    public async Task Quote_InsideStringNotAtCloser_DoesNothing()
+    {
+        // 'it|s ' — an interior apostrophe must not auto-pair.
+        await Assert.That(AutoClosePairs.Decide("'its '", 3, '\'', inStringOrComment: true))
+            .IsEqualTo(AutoClosePairs.Verdict.None);
+    }
+
+    [Test]
+    public async Task AtEndOfText_OpenersPair_ClosersInsert()
+    {
+        await Assert.That(AutoClosePairs.Decide("", 0, '(', inStringOrComment: false))
+            .IsEqualTo(AutoClosePairs.Verdict.InsertPair);
+        await Assert.That(AutoClosePairs.Decide("f(x", 3, ')', inStringOrComment: false))
+            .IsEqualTo(AutoClosePairs.Verdict.None);
+    }
+
+    [Test]
+    public async Task CloserFor_MapsOpeners()
+    {
+        await Assert.That(AutoClosePairs.CloserFor('(')).IsEqualTo(')');
+        await Assert.That(AutoClosePairs.CloserFor('\'')).IsEqualTo('\'');
+        await Assert.That(AutoClosePairs.CloserFor('"')).IsEqualTo('"');
+    }
+}

--- a/PgNimbus.Core.Tests/Text/TableAliaserTests.cs
+++ b/PgNimbus.Core.Tests/Text/TableAliaserTests.cs
@@ -1,0 +1,53 @@
+using PgNimbus.Core.Text;
+
+namespace PgNimbus.Core.Tests.Text;
+
+public class TableAliaserTests
+{
+    [Test]
+    [Arguments("orders", "o")]
+    [Arguments("order_items", "oi")]
+    [Arguments("customer_order_items", "coi")]
+    [Arguments("OrderItems", "oi")]
+    [Arguments("Spells", "s")]
+    public async Task Derive_TakesWordInitials(string table, string expected)
+    {
+        await Assert.That(TableAliaser.Derive(table, [])).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task Derive_DedupesWithNumericSuffix()
+    {
+        await Assert.That(TableAliaser.Derive("orders", ["o"])).IsEqualTo("o2");
+        await Assert.That(TableAliaser.Derive("orders", ["o", "o2"])).IsEqualTo("o3");
+    }
+
+    [Test]
+    public async Task Derive_TakenIsCaseInsensitive()
+    {
+        await Assert.That(TableAliaser.Derive("orders", ["O"])).IsEqualTo("o2");
+    }
+
+    [Test]
+    public async Task Derive_SkipsReservedWords()
+    {
+        // "order_names" → "on" would misparse after a JOIN; go numbered.
+        await Assert.That(TableAliaser.Derive("order_names", [])).IsEqualTo("on2");
+        await Assert.That(TableAliaser.Derive("order_names", ["on2"])).IsEqualTo("on3");
+    }
+
+    [Test]
+    public async Task Derive_NoLetters_FallsBackToT()
+    {
+        await Assert.That(TableAliaser.Derive("1234", [])).IsEqualTo("t");
+        await Assert.That(TableAliaser.Derive("1234", ["t"])).IsEqualTo("t2");
+    }
+
+    [Test]
+    public async Task Derive_DigitsAndPunctuationSplitWords()
+    {
+        // The letter after a non-letter starts a new word.
+        await Assert.That(TableAliaser.Derive("audit2024_log", [])).IsEqualTo("al");
+        await Assert.That(TableAliaser.Derive("user-events", [])).IsEqualTo("ue");
+    }
+}

--- a/PgNimbus.Core/Settings/AppSettings.cs
+++ b/PgNimbus.Core/Settings/AppSettings.cs
@@ -2,9 +2,12 @@ namespace PgNimbus.Core.Settings;
 
 /// <summary>
 /// Small bag of persisted, cross-session app preferences. A record with
-/// defaulted <c>init</c> properties so a settings file written by an older
-/// build — missing a field added later — still loads, with the new field
-/// falling back to its default.
+/// defaulted properties so a settings file written by an older build — missing
+/// a field added later — still loads, with the new field falling back to its
+/// default. The properties are <c>set</c>, not <c>init</c>, and that is
+/// load-bearing: the source-generated JSON deserializer bypasses property
+/// initializers for init-only setters, so an <c>init</c> flag defaulting to
+/// true would silently read false from any settings file predating it.
 /// </summary>
 public sealed record AppSettings
 {
@@ -13,12 +16,19 @@ public sealed record AppSettings
     /// the OS). Kept as a plain string so <c>PgNimbus.Core</c> stays free of any
     /// UI-framework types; the App maps it to/from Avalonia's ThemeVariant.
     /// </summary>
-    public string Theme { get; init; } = "system";
+    public string Theme { get; set; } = "system";
 
     /// <summary>
     /// Whether the schema sidebar shows advanced catalog objects (per-schema
     /// Functions groups and the root Extensions group) in addition to the
     /// default schemas/tables/roles view.
     /// </summary>
-    public bool ShowAdvancedSchemaObjects { get; init; }
+    public bool ShowAdvancedSchemaObjects { get; set; }
+
+    /// <summary>
+    /// Whether accepting a table from completion after FROM/JOIN also appends a
+    /// short alias (<c>public.orders</c> → <c>public.orders o</c>), so the
+    /// <c>o.</c> member-access flow is available immediately. On by default.
+    /// </summary>
+    public bool AutoAliasTables { get; set; } = true;
 }

--- a/PgNimbus.Core/Text/AutoClosePairs.cs
+++ b/PgNimbus.Core/Text/AutoClosePairs.cs
@@ -1,0 +1,70 @@
+namespace PgNimbus.Core.Text;
+
+/// <summary>
+/// Decides what typing <c>(</c>, <c>)</c>, <c>'</c>, or <c>"</c> should do in
+/// the SQL editor beyond inserting the character: auto-insert the matching
+/// closer (caret staying between the pair), or step over a closer that is
+/// already there instead of doubling it. Pure decision logic — the editor
+/// wiring supplies the caret's string/comment state (it already computes that
+/// per keystroke for completion) and applies the verdict to the document.
+/// </summary>
+public static class AutoClosePairs
+{
+    public enum Verdict
+    {
+        /// <summary>Nothing special — let the character insert as typed.</summary>
+        None,
+        /// <summary>Insert the matching closer after the typed character; the caret stays between them.</summary>
+        InsertPair,
+        /// <summary>Skip over the identical character already at the caret instead of inserting a second one.</summary>
+        TypeOver,
+    }
+
+    /// <summary>
+    /// The verdict for <paramref name="typed"/> about to be inserted at
+    /// <paramref name="caret"/> in <paramref name="text"/> (both reflect the
+    /// state <b>before</b> insertion). <paramref name="inStringOrComment"/> is
+    /// the caret's literal/comment state: no pairing happens inside prose —
+    /// except stepping over a quote, which is exactly how a string closes.
+    /// </summary>
+    public static Verdict Decide(string text, int caret, char typed, bool inStringOrComment)
+    {
+        var next = caret >= 0 && caret < text.Length ? text[caret] : '\0';
+
+        switch (typed)
+        {
+            case '(':
+                return !inStringOrComment && ClosingHereReadsCleanly(next) ? Verdict.InsertPair : Verdict.None;
+
+            case ')':
+                return !inStringOrComment && next == ')' ? Verdict.TypeOver : Verdict.None;
+
+            case '\'' or '"':
+                if (next == typed)
+                {
+                    // Only a caret *inside* the literal is looking at its
+                    // closer; outside, the neighboring quote opens a different
+                    // literal and stepping over it would jump into it.
+                    return inStringOrComment ? Verdict.TypeOver : Verdict.None;
+                }
+
+                // A quote inside a string/comment is content ('it''s, a doc
+                // comment's apostrophe), never the start of a new literal.
+                return !inStringOrComment && ClosingHereReadsCleanly(next) ? Verdict.InsertPair : Verdict.None;
+
+            default:
+                return Verdict.None;
+        }
+    }
+
+    /// <summary>The closer for an opener that earned <see cref="Verdict.InsertPair"/>.</summary>
+    public static char CloserFor(char opener) => opener == '(' ? ')' : opener;
+
+    // Auto-closing is only helpful when the pair lands before a boundary (end
+    // of text, whitespace, an operator, a closer…). Typing an opener directly
+    // in front of a word or another quote means the user is editing existing
+    // text — wrapping is their call, not ours.
+    private static bool ClosingHereReadsCleanly(char next) =>
+        next == '\0'
+        || (!char.IsLetterOrDigit(next) && next is not ('_' or '$' or '\'' or '"'));
+}

--- a/PgNimbus.Core/Text/TableAliaser.cs
+++ b/PgNimbus.Core/Text/TableAliaser.cs
@@ -1,0 +1,63 @@
+namespace PgNimbus.Core.Text;
+
+/// <summary>
+/// Derives the short alias completion appends when a table is accepted after
+/// FROM/JOIN: the initials of the name's words (<c>order_items</c> → <c>oi</c>,
+/// <c>orders</c> → <c>o</c>), deduplicated against the names already taken in
+/// the statement with a numeric suffix (<c>o</c>, <c>o2</c>, <c>o3</c>…).
+/// </summary>
+public static class TableAliaser
+{
+    /// <summary>
+    /// The alias for <paramref name="table"/> (its bare, unquoted name), unique
+    /// against <paramref name="taken"/> — the statement's existing aliases,
+    /// table and CTE names, compared case-insensitively.
+    /// </summary>
+    public static string Derive(string table, IEnumerable<string> taken)
+    {
+        var takenSet = new HashSet<string>(taken, StringComparer.OrdinalIgnoreCase);
+        var stem = Initials(table);
+
+        // A reserved word can't stand as a bare alias ("FROM order_names on"
+        // would misparse) — skip straight to the numbered form.
+        var candidate = ReservedStems.Contains(stem) ? stem + "2" : stem;
+        for (var n = 2; takenSet.Contains(candidate); n++)
+        {
+            candidate = stem + n;
+        }
+
+        return candidate;
+    }
+
+    // First letter of each word, splitting on underscores/digits/punctuation
+    // and on lowercase→uppercase transitions ("OrderItems" → "oi"), lowercased.
+    // Falls back to "t" when the name yields no letters (e.g. all digits).
+    private static string Initials(string table)
+    {
+        Span<char> initials = stackalloc char[table.Length];
+        var count = 0;
+        var previous = '\0';
+        foreach (var c in table)
+        {
+            if (char.IsLetter(c) && (!char.IsLetter(previous) || (char.IsUpper(c) && char.IsLower(previous))))
+            {
+                initials[count++] = char.ToLowerInvariant(c);
+            }
+
+            previous = c;
+        }
+
+        return count == 0 ? "t" : new string(initials[..count]);
+    }
+
+    // The short PostgreSQL reserved keywords an initials-derived alias could
+    // realistically collide with. Longer reserved words (SELECT, BETWEEN…)
+    // can't come out of Initials, so they're not listed.
+    private static readonly HashSet<string> ReservedStems = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "all", "and", "any", "as", "asc", "both", "case", "cast", "desc", "do",
+        "else", "end", "for", "from", "in", "into", "is", "not", "null", "on",
+        "only", "or", "some", "then", "to", "true", "false", "user", "when",
+        "with",
+    };
+}


### PR DESCRIPTION
Three completion/editor behaviors that remove keystrokes from the common flows, live-validated on Windows against Postgres 17.

## Auto-open in more predictable spots
The popup already opened itself after `FROM`/`JOIN`/`INTO`/`UPDATE`/`ON`. It now also opens:
- after `WHERE`, `AND`, `OR`, `SELECT` — the statement''s own columns are already scoped and floated there;
- on a comma continuing any recognized clause (select list, FROM list, GROUP BY…), and on the space typed after that comma (the comma-opened list closes when the space matches nothing, so the space re-opens it).

## Auto-alias on table accept
Accepting a table after `FROM`/`JOIN` appends a short alias: `public.orders` → `public.orders o`, `order_items` → `oi` (snake/camel initials), deduped `o` → `o2`, reserved-word stems (`on`, `or`…) skipped. The `o.` member-access flow and the FK ON-condition suggestion (`oi.order_id = o.id`) then work with zero extra keystrokes.

- Setting: the **AS** toggle at the end of the editor toolbar, persisted in `settings.json`, on by default.
- The alias is gated at accept time on the clause at the caret (`FROM`/`JOIN` only), so the same table item accepted in a SELECT list or after `INSERT INTO`/`TRUNCATE` — where a bare alias is wrong or illegal — never grows one.
- Derivation is pure Core logic (`Core/Text/TableAliaser`) with tests.

## Auto-close pairs
Typing `(` `''` `"` inserts the closer with the caret between; typing a closer that''s already at the caret steps over it instead of doubling — including the `()` a `coalesce()` completion accept leaves behind. Quotes respect string/comment context: no pairing inside literals, and quote type-over only fires when the caret is actually inside the string. Typing an opener over a selection wraps it. Decision logic is pure Core (`Core/Text/AutoClosePairs`) with tests.

## Settings landmine fixed along the way
Live validation caught the new default-true flag loading as **false**: the source-generated JSON deserializer bypasses property initializers for init-only setters, so any settings file written before the field existed deserialized it to the type default. `AppSettings` properties are now `set` (not `init`) — empirically initializers are honored then — with a doc comment making the accessor load-bearing and a regression test covering the older-file upgrade path.

Also fixed while validating: the alias insert is posted to the dispatcher rather than run inline from `InsertionRequested`, because handler order vs the completion window''s own insertion handler isn''t guaranteed — inline it ran first and `Complete()` replaced the alias away with the filter word.

## Validation
- 97/97 Core tests pass (new: `TableAliaserTests`, `AutoClosePairsTests`, `AppSettingsStoreTests`).
- Driven end-to-end in the running app: `SELECT * FROM ord⏎` → `public.orders o`; `JOIN order_i⏎` → `public.order_items oi` (FK-boosted); `ON ` → accepts `oi.order_id = o.id`; `WHERE `/`AND `/`SELECT 1,` all auto-open scoped lists; `SELECT coalesce(1) || ''x''` typed with zero manual closers; AS toggle off → no alias, and the choice persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)