### PR TITLE
Completion popup visual polish: kind glyphs, in-row data types, Files-style card

### DIFF
--- a/PgNimbus.App/Completion/CompletionKindVisuals.cs
+++ b/PgNimbus.App/Completion/CompletionKindVisuals.cs
@@ -1,0 +1,61 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+
+namespace PgNimbus.App.Completion;
+
+/// <summary>
+/// The glyph + color a completion row shows for its <see cref="SqlCompletionKind"/>.
+/// Geometries are the shared icon resources in <c>Styles/Theme.axaml</c> (one
+/// source for all app iconography), resolved once and cached — the popup only
+/// exists long after the app's styles are loaded. Colors are fixed hexes chosen
+/// to stay legible on both themes, same convention as the status-bar amber.
+/// </summary>
+internal static class CompletionKindVisuals
+{
+    private static readonly Dictionary<SqlCompletionKind, Geometry?> Glyphs = [];
+
+    private static readonly IReadOnlyDictionary<SqlCompletionKind, IBrush> Brushes = new Dictionary<SqlCompletionKind, IBrush>
+    {
+        [SqlCompletionKind.Keyword] = Fixed("#909090"),
+        [SqlCompletionKind.Function] = Fixed("#A56EDB"),
+        [SqlCompletionKind.Schema] = Fixed("#D9822B"),
+        [SqlCompletionKind.Table] = Fixed("#2D7FF9"),
+        [SqlCompletionKind.Column] = Fixed("#2E9E63"),
+        [SqlCompletionKind.Alias] = Fixed("#1CA8C4"),
+        [SqlCompletionKind.Cte] = Fixed("#7B6CDF"),
+        [SqlCompletionKind.JoinCondition] = Fixed("#C9A227"),
+    };
+
+    public static IBrush Brush(SqlCompletionKind kind) => Brushes[kind];
+
+    // UI-thread only (items are built and rendered there), so a plain cache is fine.
+    public static Geometry? Glyph(SqlCompletionKind kind)
+    {
+        if (!Glyphs.TryGetValue(kind, out var glyph))
+        {
+            Glyphs[kind] = glyph =
+                Application.Current is { } app && app.TryGetResource(ResourceKey(kind), null, out var resource)
+                    ? resource as Geometry
+                    : null;
+        }
+
+        return glyph;
+    }
+
+    private static string ResourceKey(SqlCompletionKind kind) => kind switch
+    {
+        SqlCompletionKind.Keyword => "TagIconGeometry",
+        SqlCompletionKind.Function => "FunctionIconGeometry",
+        SqlCompletionKind.Schema => "DatabaseIconGeometry",
+        SqlCompletionKind.Table => "TableIconGeometry",
+        SqlCompletionKind.Column => "TableColumnIconGeometry",
+        SqlCompletionKind.Alias => "SwapHorizontalIconGeometry",
+        SqlCompletionKind.Cte => "LayersIconGeometry",
+        SqlCompletionKind.JoinCondition => "LinkIconGeometry",
+        _ => "TableIconGeometry",
+    };
+
+    private static ImmutableSolidColorBrush Fixed(string hex) => new(Color.Parse(hex));
+}

--- a/PgNimbus.App/Completion/SqlCompletionData.cs
+++ b/PgNimbus.App/Completion/SqlCompletionData.cs
@@ -5,10 +5,27 @@ using AvaloniaEdit.Editing;
 
 namespace PgNimbus.App.Completion;
 
+/// <summary>
+/// What a completion item names. Drives the kind glyph + color at the left of
+/// the popup row (see <see cref="CompletionKindVisuals"/>) and the default
+/// tooltip label.
+/// </summary>
+public enum SqlCompletionKind
+{
+    Keyword,
+    Function,
+    Schema,
+    Table,
+    Column,
+    Alias,
+    Cte,
+    JoinCondition,
+}
+
 public sealed class SqlCompletionData : ICompletionData
 {
     /// <param name="text">The name shown in the list and matched against what the user typed.</param>
-    /// <param name="description">The right-hand hint (keyword / schema / table / column).</param>
+    /// <param name="kind">What the item names — picks the row glyph/color and the default tooltip label.</param>
     /// <param name="insertText">
     /// What actually gets written when the item is accepted. Defaults to
     /// <paramref name="text"/>; a schema/table/column passes its quote-if-needed
@@ -21,10 +38,10 @@ public sealed class SqlCompletionData : ICompletionData
     /// completion float the current table's columns above the rest of the
     /// catalog (see <see cref="SqlCompletionProvider"/>).
     /// </param>
-    public SqlCompletionData(string text, string description, string? insertText = null, double priority = 0)
+    public SqlCompletionData(string text, SqlCompletionKind kind, string? insertText = null, double priority = 0)
     {
         Text = text;
-        Description = description;
+        Kind = kind;
         InsertText = insertText ?? text;
         Priority = priority;
     }
@@ -33,8 +50,22 @@ public sealed class SqlCompletionData : ICompletionData
 
     public string Text { get; }
 
+    public SqlCompletionKind Kind { get; }
+
     /// <summary>The literal inserted on completion — may be quoted even when <see cref="Text"/> isn't.</summary>
     public string InsertText { get; }
+
+    /// <summary>
+    /// Dim right-aligned text in the popup row: a column's data type, a table's
+    /// schema, an alias's target table. Null renders nothing.
+    /// </summary>
+    public string? Detail { get; init; }
+
+    /// <summary>
+    /// Tooltip text next to the list; defaults to the kind's plain label
+    /// ("keyword", "table", …) when not set.
+    /// </summary>
+    public string? DescriptionText { get; init; }
 
     /// <summary>
     /// The bare table name when this item completes a table — the seed for the
@@ -46,7 +77,23 @@ public sealed class SqlCompletionData : ICompletionData
 
     public object Content => Text;
 
-    public object Description { get; }
+    public object Description => DescriptionText ?? Kind switch
+    {
+        SqlCompletionKind.Keyword => "keyword",
+        SqlCompletionKind.Function => "function",
+        SqlCompletionKind.Schema => "schema",
+        SqlCompletionKind.Table => "table",
+        SqlCompletionKind.Column => "column",
+        SqlCompletionKind.Alias => "alias",
+        SqlCompletionKind.Cte => "CTE",
+        SqlCompletionKind.JoinCondition => "FK join condition",
+        _ => "item",
+    };
+
+    // Bound by the popup row template in Theme.axaml.
+    public Geometry? KindGlyph => CompletionKindVisuals.Glyph(Kind);
+
+    public IBrush KindBrush => CompletionKindVisuals.Brush(Kind);
 
     public double Priority { get; }
 

--- a/PgNimbus.App/Completion/SqlCompletionProvider.cs
+++ b/PgNimbus.App/Completion/SqlCompletionProvider.cs
@@ -122,8 +122,8 @@ public sealed class SqlCompletionProvider
         var tables = new List<(string Schema, string Table)>();
         var columnsByTable = new Dictionary<string, List<TableColumn>>(StringComparer.OrdinalIgnoreCase);
 
-        var keywordItems = Keywords.Select(k => new SqlCompletionData(k, "keyword")).ToList();
-        var functionItems = Functions.Select(f => new SqlCompletionData(f, "function", $"{f}()", FunctionPriority)).ToList();
+        var keywordItems = Keywords.Select(k => new SqlCompletionData(k, SqlCompletionKind.Keyword)).ToList();
+        var functionItems = Functions.Select(f => new SqlCompletionData(f, SqlCompletionKind.Function, $"{f}()", FunctionPriority)).ToList();
         var baseItems = new List<SqlCompletionData>(keywordItems);
         baseItems.AddRange(functionItems);
         // Keywords go *after* the catalog here: with nothing typed yet the list
@@ -136,7 +136,7 @@ public sealed class SqlCompletionProvider
         {
             // The bare name filters the list; the quote-if-needed form is what gets
             // inserted, so accepting a mixed-case object writes "Spells" not spells.
-            var schemaItem = new SqlCompletionData(schema.Name, "schema", SqlIdentifier.QuoteIfNeeded(schema.Name), SchemaPriority);
+            var schemaItem = new SqlCompletionData(schema.Name, SqlCompletionKind.Schema, SqlIdentifier.QuoteIfNeeded(schema.Name), SchemaPriority);
             baseItems.Add(schemaItem);
             tableRefItems.Add(schemaItem);
 
@@ -148,8 +148,8 @@ public sealed class SqlCompletionProvider
                 // (after FROM/JOIN) it completes schema-qualified ("public.users")
                 // so the reference is unambiguous whatever the search_path is.
                 var qualified = $"{SqlIdentifier.QuoteIfNeeded(schema.Name)}.{SqlIdentifier.QuoteIfNeeded(table.Name)}";
-                baseItems.Add(new SqlCompletionData(table.Name, $"table ({schema.Name})", SqlIdentifier.QuoteIfNeeded(table.Name), TablePriority) { AliasTable = table.Name });
-                tableRefItems.Add(new SqlCompletionData(table.Name, $"table ({schema.Name})", qualified, TablePriority) { AliasTable = table.Name });
+                baseItems.Add(new SqlCompletionData(table.Name, SqlCompletionKind.Table, SqlIdentifier.QuoteIfNeeded(table.Name), TablePriority) { AliasTable = table.Name, Detail = schema.Name });
+                tableRefItems.Add(new SqlCompletionData(table.Name, SqlCompletionKind.Table, qualified, TablePriority) { AliasTable = table.Name, Detail = schema.Name });
             }
 
             var columns = await _schemaService.GetAllColumnsAsync(schema.Name, ct);
@@ -228,7 +228,7 @@ public sealed class SqlCompletionProvider
         // schema. → the schema's tables
         return _tables
             .Where(t => string.Equals(t.Schema, qualifier, StringComparison.OrdinalIgnoreCase))
-            .Select(t => new SqlCompletionData(t.Table, $"table ({t.Schema})", SqlIdentifier.QuoteIfNeeded(t.Table), TablePriority) { AliasTable = t.Table })
+            .Select(t => new SqlCompletionData(t.Table, SqlCompletionKind.Table, SqlIdentifier.QuoteIfNeeded(t.Table), TablePriority) { AliasTable = t.Table, Detail = t.Schema })
             .ToList();
     }
 
@@ -249,7 +249,7 @@ public sealed class SqlCompletionProvider
         var items = new List<SqlCompletionData>();
         foreach (var cte in SqlCompletionContext.ExtractCteNames(sql))
         {
-            items.Add(new SqlCompletionData(cte, "CTE", SqlIdentifier.QuoteIfNeeded(cte), CtePriority));
+            items.Add(new SqlCompletionData(cte, SqlCompletionKind.Cte, SqlIdentifier.QuoteIfNeeded(cte), CtePriority));
         }
 
         items.AddRange(boosted);
@@ -269,7 +269,12 @@ public sealed class SqlCompletionProvider
         foreach (var (neighborSchema, neighborTable) in ForeignKeyMatcher.FindJoinCandidates(statementTables, _foreignKeys))
         {
             var qualified = $"{SqlIdentifier.QuoteIfNeeded(neighborSchema)}.{SqlIdentifier.QuoteIfNeeded(neighborTable)}";
-            items.Add(new SqlCompletionData(neighborTable, $"table ({neighborSchema}) · FK", qualified, FkTablePriority) { AliasTable = neighborTable });
+            items.Add(new SqlCompletionData(neighborTable, SqlCompletionKind.Table, qualified, FkTablePriority)
+            {
+                AliasTable = neighborTable,
+                Detail = neighborSchema,
+                DescriptionText = "table · FK match",
+            });
         }
 
         return items;
@@ -288,7 +293,7 @@ public sealed class SqlCompletionProvider
             return predicateItems;
         }
 
-        var joinItem = new SqlCompletionData(condition, "FK join condition", condition, JoinConditionPriority);
+        var joinItem = new SqlCompletionData(condition, SqlCompletionKind.JoinCondition, condition, JoinConditionPriority);
         var items = new List<SqlCompletionData>(predicateItems.Count + 1) { joinItem };
         items.AddRange(predicateItems);
         return Dedupe(items);
@@ -339,7 +344,11 @@ public sealed class SqlCompletionProvider
         {
             if (table.Alias is not null)
             {
-                items.Add(new SqlCompletionData(table.Alias, $"alias ({table.Table})", table.Alias, AliasPriority));
+                items.Add(new SqlCompletionData(table.Alias, SqlCompletionKind.Alias, table.Alias, AliasPriority)
+                {
+                    Detail = table.Table,
+                    DescriptionText = $"alias for {table.Table}",
+                });
             }
 
             if (!added.Add($"{table.Schema}.{table.Table}") || ColumnsFor(table.Schema, table.Table) is not { } columns)
@@ -356,7 +365,7 @@ public sealed class SqlCompletionProvider
 
         foreach (var cte in SqlCompletionContext.ExtractCteNames(sql))
         {
-            items.Add(new SqlCompletionData(cte, "CTE", SqlIdentifier.QuoteIfNeeded(cte), CtePriority));
+            items.Add(new SqlCompletionData(cte, SqlCompletionKind.Cte, SqlIdentifier.QuoteIfNeeded(cte), CtePriority));
         }
 
         return items;
@@ -375,8 +384,14 @@ public sealed class SqlCompletionProvider
     private static List<SqlCompletionData> ColumnItems(IReadOnlyList<TableColumn> columns) =>
         columns.Select(c => ColumnItem(c, CurrentColumnPriority)).ToList();
 
+    // The data type rides in Detail (right-aligned in the row); the tooltip
+    // names the owning table, which the row itself doesn't show.
     private static SqlCompletionData ColumnItem(TableColumn column, double priority) =>
-        new(column.Column, $"column ({column.Table}) : {column.DataType}", SqlIdentifier.QuoteIfNeeded(column.Column), priority);
+        new(column.Column, SqlCompletionKind.Column, SqlIdentifier.QuoteIfNeeded(column.Column), priority)
+        {
+            Detail = column.DataType,
+            DescriptionText = $"column · {column.Table}",
+        };
 
     private static void Index(Dictionary<string, List<TableColumn>> map, string key, TableColumn column)
     {

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -1,5 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:cc="clr-namespace:AvaloniaEdit.CodeCompletion;assembly=AvaloniaEdit"
+        xmlns:completion="using:PgNimbus.App.Completion">
 
     <!--
         PowerToys-inspired design tokens: soft rounded cards, pill-shaped nav
@@ -115,6 +117,37 @@
         <StreamGeometry x:Key="SidebarToggleIconGeometry">M5,3C3.9,3 3,3.9 3,5V19C3,20.11 3.9,21 5,21H19C20.11,21 21,20.11 21,19V5C21,3.9 20.11,3 19,3H5M10,5H19V19H10V5Z</StreamGeometry>
         <StreamGeometry x:Key="WeatherSunnyIconGeometry">M12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,2L14.39,5.42C13.65,5.15 12.84,5 12,5C11.16,5 10.35,5.15 9.61,5.42L12,2M3.34,7L7.5,6.65C6.9,7.16 6.36,7.78 5.94,8.5C5.5,9.24 5.25,10 5.11,10.79L3.34,7M3.36,17L5.12,13.23C5.26,14 5.53,14.78 5.95,15.5C6.37,16.24 6.91,16.86 7.5,17.37L3.36,17M20.65,7L18.88,10.79C18.74,10 18.47,9.23 18.05,8.5C17.63,7.78 17.1,7.15 16.5,6.64L20.65,7M20.64,17L16.5,17.36C17.09,16.85 17.62,16.22 18.04,15.5C18.46,14.77 18.73,14 18.87,13.21L20.64,17M12,22L9.59,18.56C10.33,18.83 11.14,19 12,19C12.82,19 13.63,18.85 14.37,18.58L12,22Z</StreamGeometry>
         <StreamGeometry x:Key="WeatherNightIconGeometry">M17.75,4.09L15.22,6.03L16.13,9.09L13.5,7.28L10.87,9.09L11.78,6.03L9.25,4.09L12.44,4L13.5,1L14.56,4L17.75,4.09M21.25,11L19.61,12.25L20.2,14.23L18.5,13.06L16.8,14.23L17.39,12.25L15.75,11L17.81,10.95L18.5,9L19.19,10.95L21.25,11M18.97,15.95C19.8,15.87 20.69,17.05 20.16,17.8C19.84,18.25 19.5,18.67 19.08,19.07C15.17,23 8.84,23 4.94,19.07C1.03,15.17 1.03,8.83 4.94,4.93C5.34,4.53 5.76,4.17 6.21,3.85C6.96,3.32 8.14,4.21 8.06,5.04C7.79,7.9 8.75,10.87 10.95,13.06C13.14,15.26 16.1,16.22 18.97,15.95Z</StreamGeometry>
+        <!-- Completion popup kind glyphs: tag / table-column / layers-triple / link-variant (MDI).
+             The other kinds reuse the shared icons above (table, database, function, swap);
+             CompletionKindVisuals maps kind → resource key + fixed color. -->
+        <StreamGeometry x:Key="TagIconGeometry">M5.5,7A1.5,1.5 0 0,1 4,5.5A1.5,1.5 0 0,1 5.5,4A1.5,1.5 0 0,1 7,5.5A1.5,1.5 0 0,1 5.5,7M21.41,11.58L12.41,2.58C12.05,2.22 11.55,2 11,2H4C2.89,2 2,2.89 2,4V11C2,11.55 2.22,12.05 2.59,12.41L11.58,21.41C11.95,21.77 12.45,22 13,22C13.55,22 14.05,21.77 14.41,21.41L21.41,14.41C21.78,14.05 22,13.55 22,13C22,12.44 21.77,11.94 21.41,11.58Z</StreamGeometry>
+        <StreamGeometry x:Key="TableColumnIconGeometry">M10,10.02H15V21H10V10.02M17,21H20C21.1,21 22,20.1 22,19V10H17V21M20,3H5C3.9,3 3,3.9 3,5V8H22V5C22,3.9 21.1,3 20,3M3,19C3,20.1 3.9,21 5,21H8V10H3V19Z</StreamGeometry>
+        <StreamGeometry x:Key="LayersIconGeometry">M12,16L19.36,10.27L21,9L12,2L3,9L4.63,10.27M12,18.54L4.62,12.81L3,14.07L12,21.07L21,14.07L19.37,12.8L12,18.54Z</StreamGeometry>
+        <StreamGeometry x:Key="LinkIconGeometry">M10.59,13.41C11,13.8 11,14.44 10.59,14.83C10.2,15.22 9.56,15.22 9.17,14.83C7.22,12.88 7.22,9.71 9.17,7.76V7.76L12.71,4.22C14.66,2.27 17.83,2.27 19.78,4.22C21.73,6.17 21.73,9.34 19.78,11.29L18.29,12.78C18.3,11.96 18.17,11.14 17.89,10.36L18.36,9.88C19.54,8.71 19.54,6.81 18.36,5.64C17.19,4.46 15.29,4.46 14.12,5.64L10.59,9.17C9.41,10.34 9.41,12.24 10.59,13.41M13.41,9.17C13.8,8.78 14.44,8.78 14.83,9.17C16.78,11.12 16.78,14.29 14.83,16.24V16.24L11.29,19.78C9.34,21.73 6.17,21.73 4.22,19.78C2.27,17.83 2.27,14.66 4.22,12.71L5.71,11.22C5.7,12.04 5.83,12.86 6.11,13.65L5.64,14.12C4.46,15.29 4.46,17.19 5.64,18.36C6.81,19.54 8.71,19.54 9.88,18.36L13.41,14.83C14.59,13.66 14.59,11.76 13.41,10.59C13,10.2 13,9.56 13.41,9.17Z</StreamGeometry>
+
+        <!--
+            SQL completion popup card. Replaces AvaloniaEdit's CompletionList
+            theme (bare ListBox) with a Files-style raised layer — page
+            background, hairline border, rounded corners, soft shadow. The
+            margin gives the popup's transparent surface room to draw the
+            shadow. Row visuals live in the cc|CompletionListBox styles at the
+            bottom of this file; this include loads after AvaloniaEdit's, so
+            this theme wins the implicit-resource lookup.
+        -->
+        <ControlTheme x:Key="{x:Type cc:CompletionList}" TargetType="cc:CompletionList">
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Margin="4,2,10,14"
+                            Background="{DynamicResource SystemControlPageBackgroundAltHighBrush}"
+                            BorderBrush="{StaticResource CardBorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="{StaticResource CardCornerRadius}"
+                            BoxShadow="0 4 16 0 #38000000">
+                        <cc:CompletionListBox Name="PART_ListBox" />
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+        </ControlTheme>
         </ResourceDictionary>
     </Styles.Resources>
 
@@ -290,6 +323,51 @@
         <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}" />
         <Setter Property="RowBackground" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
+    </Style>
+
+    <!--
+        SQL completion popup rows (the card shell is the CompletionList
+        ControlTheme in Styles.Resources above). The list itself goes
+        transparent — the card Border paints the surface — and each row is
+        kind-glyph + name + right-aligned detail (a column's data type, a
+        table's schema, an alias's target). Items are always SqlCompletionData;
+        the glyph/color pair comes from CompletionKindVisuals.
+    -->
+    <Style Selector="cc|CompletionListBox">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="4" />
+        <Setter Property="ItemTemplate">
+            <DataTemplate x:DataType="completion:SqlCompletionData">
+                <Grid ColumnDefinitions="Auto,*,Auto">
+                    <Path Grid.Column="0" Width="13" Height="13" Margin="1,0,9,0"
+                          VerticalAlignment="Center" Stretch="Uniform"
+                          Data="{Binding KindGlyph}" Fill="{Binding KindBrush}" />
+                    <TextBlock Grid.Column="1" Text="{Binding Text}"
+                               VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
+                    <TextBlock Grid.Column="2" Text="{Binding Detail}"
+                               VerticalAlignment="Center" Margin="18,0,2,0"
+                               FontSize="11" Opacity="0.55"
+                               IsVisible="{Binding Detail, Converter={x:Static ObjectConverters.IsNotNull}}" />
+                </Grid>
+            </DataTemplate>
+        </Setter>
+    </Style>
+    <!-- Denser rows than the app-wide ListBoxItem padding; pill selection is inherited -->
+    <Style Selector="cc|CompletionListBox ListBoxItem">
+        <Setter Property="Padding" Value="8,4" />
+        <Setter Property="MinHeight" Value="0" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+    </Style>
+
+    <!-- The description tip beside the popup, restyled to the same card language -->
+    <Style Selector="cc|CompletionTipContentControl">
+        <Setter Property="Background" Value="{DynamicResource SystemControlPageBackgroundAltHighBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="10,5" />
+        <Setter Property="FontSize" Value="12" />
     </Style>
 
 </Styles>


### PR DESCRIPTION
## What

Replaces the stock AvaloniaEdit completion popup (bare list, no icons, data types buried in the description tip) with the app's own visual language:

- **Kind glyph + color on every row** — table (blue), column (green), function (purple ƒ), keyword (grey tag), schema (amber database), alias (cyan swap), CTE (indigo layers), FK join condition (gold link). `SqlCompletionKind` on each item; `CompletionKindVisuals` maps kind → shared Theme.axaml icon + a fixed hex that stays legible on both themes (same convention as the status-bar amber).
- **Right-aligned detail column** — a column's data type moves out of the description tip into the row itself; tables show their schema, aliases their target table.
- **Files-style card shell** — the `CompletionList` ControlTheme override wraps the list in a raised layer (page background, hairline border, `CardCornerRadius`, soft shadow) with denser pill-selection rows; the description tip gets the same card treatment and slims down to the kind label (`column · orders`, `table · FK match`).

No behavior changes: ranking, fuzzy filter, auto-alias, and accept flows are untouched (`Text`/`Priority`/`InsertText`/`AliasTable` contract unchanged).

## How

- `SqlCompletionData` gains `Kind`, `Detail` (right text), `DescriptionText` (tip override) — the old free-form description strings are gone.
- App styles load after AvaloniaEdit's in `App.axaml`, so the app-level `ControlTheme x:Key="{x:Type cc:CompletionList}"` wins the implicit-theme lookup (same mechanism as the existing TabItem resource overrides).
- New MDI geometries in Theme.axaml: tag, table-column, layers-triple, link-variant.

## Verification

Driven live on Windows (Debug build + computer-use) against Postgres 17, both themes: every kind renders its glyph/color; column types right-align across SELECT/WHERE/ON lists; the ON popup shows the gold-link FK condition, cyan aliases with their tables, and green columns with `integer`/`numeric`/`timestamp with time zone`; light theme shows the white rounded card with hairline border + shadow and the restyled tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)