### PR TITLE
Modern slim scrollbars app-wide

### DIFF
--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -76,6 +76,37 @@
         <SolidColorBrush x:Key="TabItemHeaderSelectedPipeFill" Color="Transparent" />
 
         <!--
+            Modern slim scrollbars, app-wide. FluentTheme's ScrollBar is 16px
+            with a near-opaque track band and end arrow buttons, drawn OVER the
+            content it scrolls. The template sizes and paints every part via
+            DynamicResource lookups, so overriding the resources here (this
+            include loads after FluentTheme) restyles all scrollbars without
+            replacing the ControlTheme: 10px thumb-only overlay, no track, no
+            arrows (hidden by the ScrollBar styles after this dictionary).
+            Fixed-alpha neutral grey like the card tokens above, so the thumb
+            reads the same in light and dark.
+        -->
+        <x:Double x:Key="ScrollBarSize">10</x:Double>
+        <SolidColorBrush x:Key="ScrollBarTrackFill" Color="Transparent" />
+        <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="Transparent" />
+        <!-- Expanded thumb (a Color by contract: Fluent's template assigns it
+             to Thumb.Background directly), hover/pressed darken from there -->
+        <Color x:Key="ScrollBarThumbBackgroundColor">#66808080</Color>
+        <SolidColorBrush x:Key="ScrollBarThumbFillPointerOver" Color="#99808080" />
+        <SolidColorBrush x:Key="ScrollBarThumbFillPressed" Color="#B3808080" />
+        <!-- Collapsed (idle) thumb -->
+        <SolidColorBrush x:Key="ScrollBarPanningThumbBackground" Color="#66808080" />
+        <!-- Corner square where two visible bars would meet -->
+        <SolidColorBrush x:Key="ScrollViewerScrollBarsSeparatorBackground" Color="Transparent" />
+        <!--
+            Idle thumb = the expanded thumb scaled down. Fluent's 0.125 factor
+            gives a 2px line at 16px; at 10px it would vanish (1.25px), so
+            scale 0.3 → a 3px line, kept 2px off the content edge.
+        -->
+        <TransformOperations x:Key="VerticalSmallScrollThumbScaleTransform">scaleX(0.3) translateX(-2px)</TransformOperations>
+        <TransformOperations x:Key="HorizontalSmallScrollThumbScaleTransform">scaleY(0.3) translateY(-2px)</TransformOperations>
+
+        <!--
             Vector icons (Material Design Icons, Apache-2.0, pictogrammers.com).
             Emoji glyphs render as tofu boxes on Linux without a color emoji
             font; PathIcon fills with the inherited Foreground, so these also
@@ -150,6 +181,24 @@
         </ControlTheme>
         </ResourceDictionary>
     </Styles.Resources>
+
+    <!--
+        Scrollbar part tweaks that can't be done via resources. Both properties
+        are NOT set by the Fluent template (only Theme/size/transform are), so
+        plain styles reach them — unlike template-set values, which outrank
+        app styles (see the TabItem note above).
+    -->
+    <!-- Pill thumb: half of ScrollBarSize -->
+    <Style Selector="ScrollBar /template/ Thumb">
+        <Setter Property="CornerRadius" Value="5" />
+    </Style>
+    <!-- Drop the end arrow buttons; the track then spans the full length -->
+    <Style Selector="ScrollBar /template/ RepeatButton#PART_LineUpButton">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="ScrollBar /template/ RepeatButton#PART_LineDownButton">
+        <Setter Property="IsVisible" Value="False" />
+    </Style>
 
     <!-- Card container: Border Classes="card" wraps a grouped panel -->
     <Style Selector="Border.card">

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -688,29 +688,11 @@
                             BorderThickness="0,0,0,1" BorderBrush="{StaticResource CardBorderBrush}"
                             Padding="2,2,2,2" Margin="0,0,0,4">
                         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
-                            <ScrollViewer.Resources>
-                                <!--
-                                    Slim scrollbar for this one-row chip strip: the stock
-                                    Fluent bar is 16px with an opaque track + arrow buttons
-                                    and overlays (covers) the chips' bottom text line. The
-                                    template sizes its parts via DynamicResource lookups, so
-                                    scoping smaller/transparent values here restyles just
-                                    this strip — thumb only, no track band, no end arrows.
-                                    The ListBox's bottom padding reserves the 8px the overlay
-                                    thumb occupies, so it never sits on top of the chips.
-                                -->
-                                <x:Double x:Key="ScrollBarSize">8</x:Double>
-                                <SolidColorBrush x:Key="ScrollBarTrackFill" Color="Transparent" />
-                                <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="Transparent" />
-                                <SolidColorBrush x:Key="ScrollBarButtonBackgroundPointerOver" Color="Transparent" />
-                                <SolidColorBrush x:Key="ScrollBarButtonBackgroundPressed" Color="Transparent" />
-                                <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="Transparent" />
-                                <SolidColorBrush x:Key="ScrollBarButtonArrowForegroundPointerOver" Color="Transparent" />
-                                <SolidColorBrush x:Key="ScrollBarButtonArrowForegroundPressed" Color="Transparent" />
-                            </ScrollViewer.Resources>
+                            <!-- Bottom padding = ScrollBarSize: the overlay thumb gets its
+                                 own lane below the chips instead of covering their text -->
                             <ListBox ItemsSource="{Binding ActiveTab.ResultSections}"
                                      SelectedItem="{Binding ActiveTab.SelectedSection, Mode=TwoWay}"
-                                     Background="Transparent" Padding="0,0,0,8">
+                                     Background="Transparent" Padding="0,0,0,10">
                                 <ListBox.Styles>
                                     <Style Selector="TextBlock.err">
                                         <Setter Property="Foreground" Value="#E03131" />

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -686,11 +686,31 @@
                     <!-- Script sections: one selectable chip per statement of a multi-statement run -->
                     <Border DockPanel.Dock="Top" IsVisible="{Binding ActiveTab.IsScriptResult}"
                             BorderThickness="0,0,0,1" BorderBrush="{StaticResource CardBorderBrush}"
-                            Padding="2,2,2,5" Margin="0,0,0,4">
+                            Padding="2,2,2,2" Margin="0,0,0,4">
                         <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
+                            <ScrollViewer.Resources>
+                                <!--
+                                    Slim scrollbar for this one-row chip strip: the stock
+                                    Fluent bar is 16px with an opaque track + arrow buttons
+                                    and overlays (covers) the chips' bottom text line. The
+                                    template sizes its parts via DynamicResource lookups, so
+                                    scoping smaller/transparent values here restyles just
+                                    this strip — thumb only, no track band, no end arrows.
+                                    The ListBox's bottom padding reserves the 8px the overlay
+                                    thumb occupies, so it never sits on top of the chips.
+                                -->
+                                <x:Double x:Key="ScrollBarSize">8</x:Double>
+                                <SolidColorBrush x:Key="ScrollBarTrackFill" Color="Transparent" />
+                                <SolidColorBrush x:Key="ScrollBarTrackFillPointerOver" Color="Transparent" />
+                                <SolidColorBrush x:Key="ScrollBarButtonBackgroundPointerOver" Color="Transparent" />
+                                <SolidColorBrush x:Key="ScrollBarButtonBackgroundPressed" Color="Transparent" />
+                                <SolidColorBrush x:Key="ScrollBarButtonArrowForeground" Color="Transparent" />
+                                <SolidColorBrush x:Key="ScrollBarButtonArrowForegroundPointerOver" Color="Transparent" />
+                                <SolidColorBrush x:Key="ScrollBarButtonArrowForegroundPressed" Color="Transparent" />
+                            </ScrollViewer.Resources>
                             <ListBox ItemsSource="{Binding ActiveTab.ResultSections}"
                                      SelectedItem="{Binding ActiveTab.SelectedSection, Mode=TwoWay}"
-                                     Background="Transparent" Padding="0">
+                                     Background="Transparent" Padding="0,0,0,8">
                                 <ListBox.Styles>
                                     <Style Selector="TextBlock.err">
                                         <Setter Property="Foreground" Value="#E03131" />


### PR DESCRIPTION
## Problem

FluentTheme''s stock scrollbar is 16px thick with a near-opaque track band and end arrow buttons, drawn over the content it scrolls. Worst offender: the multi-statement result strip, where hovering dropped a grey bar right on top of the section chips and hid their bottom text line. The same heavy bar appeared in the editor, results grid, schema tree -- everywhere.

## Fix

**Global restyle via resource overrides** in `Theme.axaml` (loads after FluentTheme, same mechanism as the existing `TabItemHeaderBackground*` overrides). The Fluent `ScrollBar` template sizes and paints every part through `DynamicResource` lookups, so no ControlTheme replacement is needed:

- `ScrollBarSize` 16 -> **10px**, thumb-only overlay: track and both-bars corner separator made transparent
- Pill thumb (CornerRadius 5), fixed-alpha neutral grey (`#66808080`, matching the card tokens) so it reads the same in light and dark; darkens on hover/press
- Idle (collapsed) thumb: 3px line 2px off the edge -- Fluent''s 0.125 scale factor would leave 1.25px at this size, so 0.3
- End arrow buttons hidden, track spans the full length (thumb corner radius and button visibility are not template-set values, so plain app styles reach them -- unlike template-set values which outrank app styles)

The script-sections strip drops the first commit''s scoped overrides and keeps only the bottom padding that gives the overlay thumb its own lane below the chips.

## Verified

Debug build + DevTools MCP against local Postgres, 21-statement script with a 5,000-row x 10-column result: section strip, editor (v+h), results DataGrid (v+h, now 10px reserved instead of 16), both themes, plus forced-expanded state on each bar -- pill thumb, no track band, no arrows, no content overlap anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)