### PR TITLE
SQL editor: run-selection, Shift+Enter fix, auto-alias default off

### DIFF
--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -43,6 +43,15 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private string _sql = "SELECT 1;";
 
+    /// <summary>
+    /// The SQL editor's current selection, pushed from the view on every
+    /// selection change (null/blank when nothing is highlighted). When set,
+    /// <see cref="RunCommand"/> executes just this instead of the whole buffer,
+    /// so highlighting one statement out of many and hitting Run runs only it.
+    /// Not observable — pure view→VM input state, read at run time.
+    /// </summary>
+    public string? SelectedSql { get; set; }
+
     [ObservableProperty]
     private string _status = "Ready";
 
@@ -190,7 +199,14 @@ public sealed partial class QueryViewModel : ObservableObject
     private bool CanRun() => !IsRunning;
 
     [RelayCommand(CanExecute = nameof(CanRun))]
-    private Task RunAsync() => RunCoreAsync(Sql, isEntireScript: true);
+    private Task RunAsync() =>
+        // "Run" (button, Ctrl+Enter, F5) executes just the highlighted SQL when
+        // the editor has a selection — so running one statement out of several
+        // is a matter of selecting it — and the whole buffer otherwise. A
+        // selection run doesn't touch the tab's dirty flag: only part ran.
+        string.IsNullOrWhiteSpace(SelectedSql)
+            ? RunCoreAsync(Sql, trackAsFullRun: true)
+            : RunCoreAsync(SelectedSql, trackAsFullRun: false);
 
     /// <summary>
     /// Runs a single statement in isolation - e.g. the one the caret sits in,
@@ -201,14 +217,14 @@ public sealed partial class QueryViewModel : ObservableObject
     /// while a run is already in flight, same as <see cref="RunCommand"/>.
     /// </summary>
     public Task RunStatementAsync(string statementSql) =>
-        CanRun() ? RunCoreAsync(statementSql, isEntireScript: false) : Task.CompletedTask;
+        CanRun() ? RunCoreAsync(statementSql, trackAsFullRun: false) : Task.CompletedTask;
 
-    private async Task RunCoreAsync(string executedSql, bool isEntireScript)
+    private async Task RunCoreAsync(string executedSql, bool trackAsFullRun)
     {
         _cts = new CancellationTokenSource();
         var ct = _cts.Token;
 
-        if (isEntireScript)
+        if (trackAsFullRun)
         {
             // Running clears the dirty flag: the on-screen SQL is now what produced the result.
             _lastRunSql = executedSql;
@@ -235,25 +251,23 @@ public sealed partial class QueryViewModel : ObservableObject
 
         try
         {
-            if (isEntireScript)
+            // Split off the multi-statement script path. A single statement keeps the
+            // streaming/editing/browse path below untouched; only a genuine script
+            // (two or more statements) runs on one shared connection with per-statement
+            // result sections. Applies to whatever is being run — the whole buffer or
+            // just a selection; a lone statement (RunStatementAsync) splits to one and
+            // falls through to the path below unchanged.
+            var statements = SqlScriptSplitter.Split(executedSql);
+            if (statements.Count > 1)
             {
-                // Split off the multi-statement script path. A single statement keeps the
-                // streaming/editing/browse path below untouched; only a genuine script
-                // (two or more statements) runs on one shared connection with per-statement
-                // result sections. A statement run in isolation (RunStatementAsync) is
-                // already exactly one statement, so it always takes the path below.
-                var statements = SqlScriptSplitter.Split(executedSql);
-                if (statements.Count > 1)
+                await RunScriptAsync(statements, stopwatch, ct);
+                if (HasError)
                 {
-                    await RunScriptAsync(statements, stopwatch, ct);
-                    if (HasError)
-                    {
-                        await TryOfferFixAsync(executedSql);
-                    }
-
-                    Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, StatusSummary()));
-                    return;
+                    await TryOfferFixAsync(executedSql);
                 }
+
+                Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, StatusSummary()));
+                return;
             }
 
             // Ask for one row past the cap: receiving it proves the result was
@@ -667,6 +681,12 @@ public sealed partial class QueryViewModel : ObservableObject
         FixSuggestionSql = null;
         FixSuggestionText = null;
 
+        // Any change to the buffer drops a stale selection: the view re-pushes
+        // the live one on the next SelectionChanged. This also keeps programmatic
+        // "set Sql, then RunCommand" callers (apply-fix, browse, import preview)
+        // running the whole buffer they just set, not a leftover highlight.
+        SelectedSql = null;
+
         IsShowingPlan = false;
         IsDirty = !string.Equals(value, _lastRunSql, StringComparison.Ordinal);
         UpdateTabTitle();
@@ -1023,7 +1043,10 @@ public sealed partial class QueryViewModel : ObservableObject
 
     /// <summary>Reloads whatever the grid currently shows — the browse page if browsing, else the last query — after an out-of-band change (e.g. a row insert).</summary>
     public Task RefreshCurrentAsync() =>
-        Browse is { } browse ? browse.LoadAsync() : RunCommand.ExecuteAsync(null);
+        // Full buffer, never the current selection: a background reload after an
+        // out-of-band change re-runs what's on screen, independent of any live
+        // highlight (unlike the user-driven RunCommand).
+        Browse is { } browse ? browse.LoadAsync() : RunCoreAsync(Sql, trackAsFullRun: true);
 
     /// <summary>
     /// Snapshots the current result (columns + rows) and returns a writer that

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -103,6 +103,20 @@ public partial class MainWindow : Window
             _queryViewModel.Sql = SqlEditor.Text;
         };
 
+        // Feed the editor's live selection to the active tab so "Run" executes
+        // just the highlighted SQL when there is a selection (see RunAsync).
+        // Empty selection -> null, i.e. run the whole buffer.
+        SqlEditor.TextArea.SelectionChanged += (_, _) =>
+        {
+            if (_queryViewModel is null)
+            {
+                return;
+            }
+
+            var selected = SqlEditor.SelectedText;
+            _queryViewModel.SelectedSql = string.IsNullOrEmpty(selected) ? null : selected;
+        };
+
         // TreeViewItem's own DoubleTapped handling (toggling expand) marks the
         // event Handled, so it never reaches a plain `+=` subscription on the
         // parent TreeView. Use AddHandler with handledEventsToo to still see it.
@@ -127,7 +141,11 @@ public partial class MainWindow : Window
 
         SqlEditor.TextArea.TextEntering += OnSqlTextEntering;
         SqlEditor.TextArea.TextEntered += OnSqlTextEntered;
-        SqlEditor.KeyDown += OnSqlEditorKeyDown;
+        // Tunnel on the TextArea: AvaloniaEdit's editing input handler consumes
+        // Enter (inserts a newline) and marks the event handled before it bubbles
+        // up to the editor, so a plain bubbling KeyDown handler never sees
+        // Shift+Enter. Tunneling runs us first, so our shortcuts win.
+        SqlEditor.TextArea.AddHandler(KeyDownEvent, OnSqlEditorKeyDown, RoutingStrategies.Tunnel);
 
         // Editor niceties: current-line wash (brushes are theme-resolved in
         // ApplySqlHighlightingTheme), matching-bracket highlight, and

--- a/PgNimbus.Core.Tests/Settings/AppSettingsStoreTests.cs
+++ b/PgNimbus.Core.Tests/Settings/AppSettingsStoreTests.cs
@@ -12,26 +12,29 @@ public class AppSettingsStoreTests
         var settings = store.Load();
 
         await Assert.That(settings.Theme).IsEqualTo("system");
-        await Assert.That(settings.AutoAliasTables).IsTrue();
+        await Assert.That(settings.AutoAliasTables).IsFalse();
     }
 
     [Test]
     public async Task Load_FileFromOlderBuild_MissingFieldsFallBackToTheirDefaults()
     {
         // The trap this guards: the source-generated JSON deserializer bypasses
-        // property initializers for init-only setters, so a default-true flag
-        // added after this file was written would silently load as false if
-        // AppSettings ever regressed from set to init accessors.
+        // property initializers for init-only setters, so a non-zero default
+        // added after this file was written would silently load as null/false if
+        // AppSettings ever regressed from set to init accessors. Theme carries
+        // that guard — a file omitting it must still fall back to "system", not
+        // null. ShowAdvancedSchemaObjects and AutoAliasTables default to false,
+        // so they can't detect the regression; they're checked for completeness.
         var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
-        await File.WriteAllTextAsync(path, """{ "Theme": "dark", "ShowAdvancedSchemaObjects": true }""");
+        await File.WriteAllTextAsync(path, """{ "ShowAdvancedSchemaObjects": true }""");
 
         try
         {
             var settings = new AppSettingsStore(path).Load();
 
-            await Assert.That(settings.Theme).IsEqualTo("dark");
+            await Assert.That(settings.Theme).IsEqualTo("system");
             await Assert.That(settings.ShowAdvancedSchemaObjects).IsTrue();
-            await Assert.That(settings.AutoAliasTables).IsTrue();
+            await Assert.That(settings.AutoAliasTables).IsFalse();
         }
         finally
         {

--- a/PgNimbus.Core/Settings/AppSettings.cs
+++ b/PgNimbus.Core/Settings/AppSettings.cs
@@ -28,7 +28,8 @@ public sealed record AppSettings
     /// <summary>
     /// Whether accepting a table from completion after FROM/JOIN also appends a
     /// short alias (<c>public.orders</c> → <c>public.orders o</c>), so the
-    /// <c>o.</c> member-access flow is available immediately. On by default.
+    /// <c>o.</c> member-access flow is available immediately. Off by default;
+    /// opt in from the completion preferences toggle.
     /// </summary>
-    public bool AutoAliasTables { get; set; } = true;
+    public bool AutoAliasTables { get; set; }
 }

--- a/README.md
+++ b/README.md
@@ -358,18 +358,18 @@ impact order:
   in the completion list, breaking ties by exact-prefix, then shorter name,
   then recency of use. Requires replacing the stock AvaloniaEdit
   `CompletionList` filter.
-- [ ] **Auto-open in more predictable spots** — the list opens by itself
+- [x] **Auto-open in more predictable spots** — the list opens by itself
   only after FROM/JOIN/INTO/UPDATE today. `WHERE `, `ON `, `AND `/`OR `,
   `SELECT ` and a comma inside a select list are just as predictable (the
   statement's own columns are already scoped and floated there) but
   currently require Ctrl+Space.
-- [ ] **Auto-alias on table accept** — accepting `sales.orders` after
+- [x] **Auto-alias on table accept** — accepting `sales.orders` after
   FROM/JOIN could also insert a short alias (`o`, dedup as `o2`…) so the
   `o.` member-access flow is immediately available; make it a setting.
-- [ ] **Auto-close pairs** — `(`, `'`, `"` should insert their closer with
+- [x] **Auto-close pairs** — `(`, `'`, `"` should insert their closer with
   type-over on the closing character; today `coalesce()` from a completion
   accept is the only paired insert in the editor.
-- [ ] **Completion popup visual polish** — stock AvaloniaEdit look: no kind
+- [x] **Completion popup visual polish** — stock AvaloniaEdit look: no kind
   icons, no type column. Give items a kind glyph + color (table / column /
   function / keyword / schema / alias / CTE), right-align the column data
   type that's currently buried in the description panel, and restyle the


### PR DESCRIPTION
Three related SQL-editor changes from one session, plus the backlog update.

## Run the selection
"Run" (button, Ctrl+Enter, F5) now executes just the highlighted SQL when the editor has a selection, and the whole buffer otherwise — so running one statement out of several is a matter of selecting it. Previously a partial selection was ignored and the whole buffer ran (e.g. selecting the second `SELECT` still concatenated both statements → syntax error).

- The view pushes the live selection to the active tab; `RunAsync` prefers it as an isolated run that leaves the tab's dirty flag alone (only part ran).
- Script-splitting is decoupled from the dirty-flag bookkeeping, so a multi-statement selection still runs as a script with per-statement result sections.
- `OnSqlChanged` drops a stale selection, so programmatic set-Sql-then-run callers (apply-fix, browse paging, import preview) always run what they just set.

## Fix Shift+Enter (run statement under caret)
Shift+Enter did nothing but insert a newline: AvaloniaEdit's editing input handler consumes Enter and marks it handled before the bubbling `KeyDown` handler runs. The editor shortcut handler is now a **tunnel** handler on the `TextArea`, so Shift+Enter / Ctrl+Space / Ctrl+Shift+F / Ctrl+zoom win first. (Audited the rest of the shortcuts — this was the only one in that broken class; all others use keys AvaloniaEdit doesn't consume.)

## Default auto-alias to off
`AutoAliasTables` now defaults to `false` — appending a short alias on every table accepted from completion is opt-in from the existing toolbar toggle. Existing users who already have it saved keep their choice. The older-build set-vs-init regression test guard moves onto `Theme`'s `"system"` default (a default-false flag can't detect that trap).

## README
Marks the "completion that predicts the next move" backlog done except **`SELECT *` expansion**: auto-open in more spots, auto-alias on table accept, auto-close pairs, and completion popup visual polish are all shipped.

## Testing
- Full solution build clean.
- Core test suite: 97/97 pass.
- Run-selection / Shift+Enter behaviors to be validated in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)