### PR TITLE
UX batch from manual-testing feedback + Preferences page & Ctrl/Cmd hotkey scheme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,22 @@ and wrong project memory is worse than none.
    `PlainFileCredentialStore`) at connect time, never persisted on the
    profile record itself.
 
+## UI design rules
+
+1. **Minimalist design is a priority.** Every new always-visible control —
+   especially a toolbar button — must be explicitly discussed and justified
+   before it's added; the default answer is no. Secondary/rare actions belong
+   in the command palette (Ctrl+K) or a context menu, not on the toolbar
+   (that's why the auto-alias "AS" toggle moved from the toolbar to the
+   palette, 2026-07).
+2. **Double-click triggers the default action.** Anywhere a list/tree item
+   has an obvious primary action, double-clicking it must perform that
+   action: schema-tree table → browse, function → source, saved query /
+   history entry → open in a new tab, connection profile → connect, result
+   cell → inspector. Apply the same rule to any new list-like UI.
+3. **Loading a query never overwrites the active tab.** Saved queries,
+   history entries, and generated DDL all open in a *new* tab.
+
 ## App icon / logo assets
 
 Full reference: [`design/LOGO-ASSETS.md`](design/LOGO-ASSETS.md); the

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -308,6 +308,11 @@
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Opacity" Value="0.6" />
+        <!-- Buttons default to Stretch content alignment, which pins a glyph
+             smaller than MinWidth/MinHeight to the top-left of the rounded
+             highlight (visible on the tab ✕ and the new-tab +) - center it. -->
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
     <Style Selector="Button.chip:pointerover, ToggleButton.chip:pointerover">
         <Setter Property="Background" Value="{StaticResource HoverBackgroundBrush}" />

--- a/PgNimbus.App/ViewModels/CommandPaletteViewModel.cs
+++ b/PgNimbus.App/ViewModels/CommandPaletteViewModel.cs
@@ -10,7 +10,8 @@ namespace PgNimbus.App.ViewModels;
 /// <param name="Category">A quiet right-aligned tag ("Table", "Saved query", "Action").</param>
 /// <param name="Glyph">A single-character icon shown at the leading edge.</param>
 /// <param name="InvokeAsync">Runs the entry's effect; awaited after the palette closes.</param>
-public sealed record PaletteItem(string Title, string Category, string Glyph, Func<Task> InvokeAsync);
+/// <param name="Shortcut">The action's hotkey ("Ctrl+Enter"), shown so users learn it; null when it has none.</param>
+public sealed record PaletteItem(string Title, string Category, string Glyph, Func<Task> InvokeAsync, string? Shortcut = null);
 
 /// <summary>
 /// The command palette (Ctrl+K / Ctrl+P): one keyboard-first control to

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -48,6 +48,8 @@ public sealed partial class MainViewModel : ObservableObject
     public event Action? FormatSqlRequested;
     // Raised to open (or focus) the Server Activity window, which the view owns.
     public event Action? ActivityRequested;
+    // Raised to collapse/restore the sidebar (the view owns the grid column).
+    public event Action? SidebarToggleRequested;
 
     [RelayCommand]
     private void SwitchConnection() => SwitchConnectionRequested?.Invoke();
@@ -88,7 +90,7 @@ public sealed partial class MainViewModel : ObservableObject
 
     /// <summary>
     /// Whether accepting a table from completion after FROM/JOIN also appends a
-    /// short alias. Bound to the toolbar's "AS" toggle; persisted via the
+    /// short alias. Toggled from the command palette; persisted via the
     /// callback so the choice survives a restart (same pattern as the sidebar's
     /// advanced-objects toggle).
     /// </summary>
@@ -131,6 +133,12 @@ public sealed partial class MainViewModel : ObservableObject
             new SavedQueryStore(),
             new QueryHistoryStore(),
             () => ActiveTab,
+            (title, sql) =>
+            {
+                var tab = NewTab();
+                tab.TitleOverride = title;
+                tab.Sql = sql;
+            },
             // History entries are stamped with this label for per-connection scoping.
             () => string.IsNullOrEmpty(ConnectionHost) ? null : $"{ConnectionHost}/{ConnectionDatabase}");
         NotifyMonitor = notifyMonitor;
@@ -411,23 +419,25 @@ public sealed partial class MainViewModel : ObservableObject
 
     private IEnumerable<PaletteItem> BuildActionItems()
     {
-        yield return new PaletteItem("Run query", "Action", "▶", Invoke(() => ActiveTab.RunCommand));
-        yield return new PaletteItem("Cancel query", "Action", "■", Invoke(() => ActiveTab.CancelCommand));
+        yield return new PaletteItem("Run query", "Action", "▶", Invoke(() => ActiveTab.RunCommand), "Ctrl+Enter");
+        yield return new PaletteItem("Cancel query", "Action", "■", Invoke(() => ActiveTab.CancelCommand), "Esc");
         yield return new PaletteItem("Explain", "Action", "⚡", Invoke(() => ActiveTab.ExplainCommand));
         yield return new PaletteItem("Explain Analyze", "Action", "⚡", Invoke(() => ActiveTab.ExplainAnalyzeCommand));
         yield return new PaletteItem("Begin transaction", "Action", "⛃", Invoke(() => BeginTransactionCommand));
         yield return new PaletteItem("Commit transaction", "Action", "✓", Invoke(() => CommitTransactionCommand));
         yield return new PaletteItem("Rollback transaction", "Action", "↺", Invoke(() => RollbackTransactionCommand));
-        yield return new PaletteItem("Refresh database & schema", "Action", "⟳", Invoke(() => RefreshSchemaCommand));
+        yield return new PaletteItem("Refresh database & schema", "Action", "⟳", Invoke(() => RefreshSchemaCommand), "Ctrl+Shift+R");
         yield return new PaletteItem("Server activity", "Action", "∿", () => { ActivityRequested?.Invoke(); return Task.CompletedTask; });
-        yield return new PaletteItem("New query tab", "Action", "＋", Invoke(() => AddTabCommand));
-        yield return new PaletteItem("Close tab", "Action", "✕", Invoke(() => CloseTabCommand));
-        yield return new PaletteItem("Next tab", "Action", "›", Invoke(() => NextTabCommand));
-        yield return new PaletteItem("Previous tab", "Action", "‹", Invoke(() => PreviousTabCommand));
-        yield return new PaletteItem("Format SQL", "Action", "❖", () => { FormatSqlRequested?.Invoke(); return Task.CompletedTask; });
+        yield return new PaletteItem("New query tab", "Action", "＋", Invoke(() => AddTabCommand), "Ctrl+T");
+        yield return new PaletteItem("Close tab", "Action", "✕", Invoke(() => CloseTabCommand), "Ctrl+W");
+        yield return new PaletteItem("Next tab", "Action", "›", Invoke(() => NextTabCommand), "Ctrl+PgDn");
+        yield return new PaletteItem("Previous tab", "Action", "‹", Invoke(() => PreviousTabCommand), "Ctrl+PgUp");
+        yield return new PaletteItem("Format SQL", "Action", "❖", () => { FormatSqlRequested?.Invoke(); return Task.CompletedTask; }, "Ctrl+Shift+F");
+        yield return new PaletteItem("Toggle sidebar", "Action", "◫", () => { SidebarToggleRequested?.Invoke(); return Task.CompletedTask; }, "Ctrl+B");
+        yield return new PaletteItem("Toggle auto-alias tables (orders → orders o)", "Action", "a", () => { AutoAliasTables = !AutoAliasTables; return Task.CompletedTask; });
         yield return new PaletteItem("Switch connection…", "Action", "⇄", () => { SwitchConnectionRequested?.Invoke(); return Task.CompletedTask; });
         yield return new PaletteItem("Toggle light/dark theme", "Action", "◐", () => { ThemeToggleRequested?.Invoke(); return Task.CompletedTask; });
-        yield return new PaletteItem("Keyboard shortcuts", "Action", "?", () => { ShortcutsRequested?.Invoke(); return Task.CompletedTask; });
+        yield return new PaletteItem("Keyboard shortcuts", "Action", "?", () => { ShortcutsRequested?.Invoke(); return Task.CompletedTask; }, "F1");
     }
 
     private IEnumerable<PaletteItem> BuildSavedQueryItems() =>

--- a/PgNimbus.App/ViewModels/SavedQueriesViewModel.cs
+++ b/PgNimbus.App/ViewModels/SavedQueriesViewModel.cs
@@ -17,6 +17,7 @@ public sealed partial class SavedQueriesViewModel : ObservableObject
     private readonly SavedQueryStore _savedQueryStore;
     private readonly QueryHistoryStore _historyStore;
     private readonly Func<QueryViewModel?> _getActiveQuery;
+    private readonly Action<string?, string> _openInNewTab;
     private readonly Func<string?> _getConnectionLabel;
 
     [ObservableProperty]
@@ -47,11 +48,12 @@ public sealed partial class SavedQueriesViewModel : ObservableObject
     /// <summary>True when history exists but the filter/scope hides all of it — drives a "no matches" hint.</summary>
     public bool HasNoHistoryMatches => History.Count > 0 && FilteredHistory.Count == 0;
 
-    public SavedQueriesViewModel(SavedQueryStore savedQueryStore, QueryHistoryStore historyStore, Func<QueryViewModel?> getActiveQuery, Func<string?>? getConnectionLabel = null)
+    public SavedQueriesViewModel(SavedQueryStore savedQueryStore, QueryHistoryStore historyStore, Func<QueryViewModel?> getActiveQuery, Action<string?, string> openInNewTab, Func<string?>? getConnectionLabel = null)
     {
         _savedQueryStore = savedQueryStore;
         _historyStore = historyStore;
         _getActiveQuery = getActiveQuery;
+        _openInNewTab = openInNewTab;
         _getConnectionLabel = getConnectionLabel ?? (() => null);
 
         foreach (var saved in _savedQueryStore.Load())
@@ -152,21 +154,23 @@ public sealed partial class SavedQueriesViewModel : ObservableObject
         _savedQueryStore.Save(SavedQueries);
     }
 
+    // Loading always lands in a fresh tab: it must never overwrite whatever the
+    // active tab holds (double-click on a list item takes the same path).
     [RelayCommand]
     private void LoadSavedQuery(SavedQuery? query)
     {
-        if (query is not null && _getActiveQuery() is { } active)
+        if (query is not null)
         {
-            active.Sql = query.Sql;
+            _openInNewTab(query.Name, query.Sql);
         }
     }
 
     [RelayCommand]
     private void LoadHistoryEntry(QueryHistoryEntry? entry)
     {
-        if (entry is not null && _getActiveQuery() is { } active)
+        if (entry is not null)
         {
-            active.Sql = entry.Sql;
+            _openInNewTab(null, entry.Sql);
         }
     }
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -281,7 +281,8 @@
                     <TextBox Grid.Row="2" Name="NewQueryNameBox" Text="{Binding NewQueryName}" PlaceholderText="Query name" Margin="0,8,0,0" />
                     <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
                         <Button Content="Save" Command="{Binding SaveCurrentQueryCommand}" />
-                        <Button Content="Load" Command="{Binding LoadSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}" />
+                        <Button Content="Load" Command="{Binding LoadSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}"
+                                ToolTip.Tip="Open the selected query in a new tab (or double-click it)" />
                         <Button Content="Delete" Command="{Binding DeleteSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}" />
                     </StackPanel>
                     <TextBlock Grid.Row="4" Classes="sectionHeader" Text="HISTORY" Margin="4,16,4,6" />
@@ -348,7 +349,8 @@
                         </Grid>
                     </Border>
                     <StackPanel Grid.Row="7" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
-                        <Button Content="Load selected" Command="{Binding LoadHistoryEntryCommand}" CommandParameter="{Binding #HistoryList.SelectedItem}" />
+                        <Button Content="Load selected" Command="{Binding LoadHistoryEntryCommand}" CommandParameter="{Binding #HistoryList.SelectedItem}"
+                                ToolTip.Tip="Open the selected entry in a new tab (or double-click it)" />
                         <Button Content="Clear history" Command="{Binding ClearHistoryCommand}" />
                     </StackPanel>
                 </Grid>
@@ -499,6 +501,17 @@
                     -->
                     <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="Transparent" />
                 </Border.Resources>
+                <Border.Styles>
+                    <!-- Responsive command bar: on a narrow window (or a wide
+                         sidebar) the secondary buttons drop their text labels
+                         and fall back to icon + tooltip, so the bar never
+                         clips off the pane's right edge. $parent[Grid] is the
+                         editor pane's row grid - its width is what the bar
+                         actually has to fit into. -->
+                    <Style Selector="TextBlock.collapsible">
+                        <Setter Property="IsVisible" Value="{Binding $parent[Grid].Bounds.Width, Converter={x:Static conv2:MinWidthVisibilityConverter.Instance}, ConverterParameter=660}" />
+                    </Style>
+                </Border.Styles>
                 <StackPanel Orientation="Horizontal" Spacing="2">
                     <!-- Group 1 — execution: the primary Run + its Cancel -->
                     <Button Classes="accent" Command="{Binding ActiveTab.RunCommand}" ToolTip.Tip="Run (Ctrl+Enter)">
@@ -510,7 +523,7 @@
                     <Button Classes="toolbar" Command="{Binding ActiveTab.CancelCommand}" ToolTip.Tip="Cancel (Esc)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource StopIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                            <TextBlock Text="Cancel" VerticalAlignment="Center" />
+                            <TextBlock Text="Cancel" VerticalAlignment="Center" Classes="collapsible" />
                         </StackPanel>
                     </Button>
 
@@ -525,7 +538,7 @@
                             ToolTip.Tip="Begin a transaction (BEGIN)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource FlagIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                            <TextBlock Text="Begin" VerticalAlignment="Center" />
+                            <TextBlock Text="Begin" VerticalAlignment="Center" Classes="collapsible" />
                         </StackPanel>
                     </Button>
                     <Button Classes="toolbar" Command="{Binding CommitTransactionCommand}"
@@ -534,7 +547,7 @@
                             ToolTip.Tip="Commit the transaction (COMMIT)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource CheckIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                            <TextBlock Text="Commit" FontWeight="SemiBold" VerticalAlignment="Center" />
+                            <TextBlock Text="Commit" FontWeight="SemiBold" VerticalAlignment="Center" Classes="collapsible" />
                         </StackPanel>
                     </Button>
                     <Button Classes="toolbar" Command="{Binding RollbackTransactionCommand}"
@@ -543,7 +556,7 @@
                             ToolTip.Tip="Roll back the transaction (ROLLBACK)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource UndoIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                            <TextBlock Text="Rollback" VerticalAlignment="Center" />
+                            <TextBlock Text="Rollback" VerticalAlignment="Center" Classes="collapsible" />
                         </StackPanel>
                     </Button>
 
@@ -552,20 +565,20 @@
                     <Button Classes="toolbar" Command="{Binding ActiveTab.ExplainCommand}" ToolTip.Tip="Show the query plan (EXPLAIN)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource FlashIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                            <TextBlock Text="Explain" VerticalAlignment="Center" />
+                            <TextBlock Text="Explain" VerticalAlignment="Center" Classes="collapsible" />
                         </StackPanel>
                     </Button>
                     <Button Classes="toolbar" Command="{Binding ActiveTab.ExplainAnalyzeCommand}" ToolTip.Tip="Run and show the actual plan (EXPLAIN ANALYZE)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource GaugeIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                            <TextBlock Text="Explain Analyze" VerticalAlignment="Center" />
+                            <TextBlock Text="Explain Analyze" VerticalAlignment="Center" Classes="collapsible" />
                         </StackPanel>
                     </Button>
                     <Button Classes="toolbar" Command="{Binding ActiveTab.ShowResultsCommand}"
                             IsVisible="{Binding ActiveTab.IsShowingPlan}">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource TableIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                            <TextBlock Text="Show results" VerticalAlignment="Center" />
+                            <TextBlock Text="Show results" VerticalAlignment="Center" Classes="collapsible" />
                         </StackPanel>
                     </Button>
 
@@ -574,7 +587,7 @@
                     <Button Classes="toolbar" Name="ExportButton" ToolTip.Tip="Export results (CSV / JSON)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource ExportIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                            <TextBlock Text="Export" VerticalAlignment="Center" />
+                            <TextBlock Text="Export" VerticalAlignment="Center" Classes="collapsible" />
                         </StackPanel>
                         <Button.Flyout>
                             <MenuFlyout>
@@ -586,18 +599,9 @@
                     <Button Classes="toolbar" Click="OnImportClick" ToolTip.Tip="Import a CSV or JSON file into a table">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource ImportIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                            <TextBlock Text="Import" VerticalAlignment="Center" />
+                            <TextBlock Text="Import" VerticalAlignment="Center" Classes="collapsible" />
                         </StackPanel>
                     </Button>
-
-                    <!-- Group 5 — editor behavior: auto-alias on table completion
-                         ("FROM public.orders" completes to "… orders o") -->
-                    <Rectangle Classes="statusSeparator" Margin="7,0" />
-                    <ToggleButton Classes="chip" VerticalAlignment="Center"
-                                  IsChecked="{Binding AutoAliasTables}"
-                                  ToolTip.Tip="Auto-alias tables accepted from completion after FROM/JOIN (orders → orders o)">
-                        <TextBlock Text="AS" FontSize="11" FontWeight="SemiBold" />
-                    </ToggleButton>
                 </StackPanel>
             </Border>
 
@@ -881,12 +885,17 @@
                                  ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                             <ListBox.ItemTemplate>
                                 <DataTemplate x:DataType="vm:PaletteItem">
-                                    <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <Grid ColumnDefinitions="Auto,*,Auto,Auto">
                                         <TextBlock Grid.Column="0" Text="{Binding Glyph}" Width="20"
                                                    Opacity="0.7" VerticalAlignment="Center" />
                                         <TextBlock Grid.Column="1" Text="{Binding Title}"
                                                    TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
-                                        <TextBlock Grid.Column="2" Text="{Binding Category}"
+                                        <!-- The action's hotkey, so the palette doubles as a way to learn them -->
+                                        <TextBlock Grid.Column="2" Text="{Binding Shortcut}"
+                                                   IsVisible="{Binding Shortcut, Converter={x:Static conv:ObjectConverters.IsNotNull}}"
+                                                   FontSize="11" Opacity="0.55" VerticalAlignment="Center"
+                                                   Margin="12,0,0,0" />
+                                        <TextBlock Grid.Column="3" Text="{Binding Category}"
                                                    FontSize="11" Opacity="0.45" VerticalAlignment="Center"
                                                    Margin="12,0,0,0" />
                                     </Grid>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -176,6 +176,19 @@ public partial class MainWindow : Window
             }
         };
 
+        // Double-click on a saved query or history entry opens it in a new tab
+        // (the same action as its Load button - see SavedQueriesViewModel).
+        SavedQueriesList.DoubleTapped += (_, e) => OnQueryListDoubleTapped(e,
+            item => _viewModel?.SavedQueries.LoadSavedQueryCommand.Execute(item as SavedQuery));
+        HistoryList.DoubleTapped += (_, e) => OnQueryListDoubleTapped(e,
+            item => _viewModel?.SavedQueries.LoadHistoryEntryCommand.Execute(item as QueryHistoryEntry));
+
+        // Trackpads and tilt-wheels scroll the results grid horizontally on
+        // hover: the DataGrid's own wheel handling only consumes the vertical
+        // axis, so a mostly-horizontal delta is fed to its horizontal
+        // scrollbar here (tunneled - the grid marks wheel events handled).
+        ResultsGrid.AddHandler(PointerWheelChangedEvent, OnResultsGridPointerWheel, RoutingStrategies.Tunnel);
+
         // Column autocomplete inside the browse WHERE box (see the popup in XAML).
         BrowseFilterBox.TextChanged += OnBrowseFilterTextChanged;
         BrowseFilterBox.LostFocus += (_, _) => CloseFilterCompletion();
@@ -308,6 +321,7 @@ public partial class MainWindow : Window
             _viewModel.SwitchConnectionRequested -= SwitchConnection;
             _viewModel.FormatSqlRequested -= FormatCurrentStatement;
             _viewModel.ActivityRequested -= ShowActivityWindow;
+            _viewModel.SidebarToggleRequested -= ToggleSidebar;
         }
 
         _viewModel = vm;
@@ -318,6 +332,7 @@ public partial class MainWindow : Window
         _viewModel.SwitchConnectionRequested += SwitchConnection;
         _viewModel.FormatSqlRequested += FormatCurrentStatement;
         _viewModel.ActivityRequested += ShowActivityWindow;
+        _viewModel.SidebarToggleRequested += ToggleSidebar;
 
         AttachQuery(vm.ActiveTab);
     }
@@ -783,10 +798,64 @@ public partial class MainWindow : Window
         // wasn't already selected, SelectedItem can still be stale/null at
         // the point this handler runs.
         var container = (e.Source as Visual)?.FindAncestorOfType<TreeViewItem>(includeSelf: true);
-        if (_viewModel is not null && container?.DataContext is TableNode table)
+        if (_viewModel is null)
         {
-            _ = _viewModel.PreviewTableAsync(table);
+            return;
         }
+
+        switch (container?.DataContext)
+        {
+            case TableNode table:
+                _ = _viewModel.PreviewTableAsync(table);
+                break;
+            // A function's natural default action is its source - same as the
+            // context menu's "Source (DDL)".
+            case FunctionNode { HasSource: true } function:
+                _ = _viewModel.ShowFunctionSourceAsync(function);
+                break;
+        }
+    }
+
+    // Shared double-click handling for the saved-query and history lists:
+    // resolve the double-clicked row's item and load it, ignoring taps that
+    // land on an inline button (e.g. the history pin) - those own their clicks.
+    private void OnQueryListDoubleTapped(TappedEventArgs e, Action<object?> load)
+    {
+        var source = e.Source as Visual;
+        if (source?.FindAncestorOfType<Button>(includeSelf: true) is not null)
+        {
+            return;
+        }
+
+        if (source?.FindAncestorOfType<ListBoxItem>(includeSelf: true) is { DataContext: { } item })
+        {
+            load(item);
+        }
+    }
+
+    // Cached template part of the results grid; the template never re-applies
+    // for the window's lifetime, so one lookup is enough.
+    private Avalonia.Controls.Primitives.ScrollBar? _resultsHorizontalScrollBar;
+
+    private void OnResultsGridPointerWheel(object? sender, PointerWheelEventArgs e)
+    {
+        // Mostly-vertical deltas stay with the DataGrid's own wheel handling.
+        if (Math.Abs(e.Delta.X) <= Math.Abs(e.Delta.Y))
+        {
+            return;
+        }
+
+        _resultsHorizontalScrollBar ??= ResultsGrid.GetVisualDescendants()
+            .OfType<Avalonia.Controls.Primitives.ScrollBar>()
+            .FirstOrDefault(s => s.Orientation == Avalonia.Layout.Orientation.Horizontal);
+        if (_resultsHorizontalScrollBar is not { } bar)
+        {
+            return;
+        }
+
+        // Same direction convention as ScrollViewer: offset moves against the delta.
+        bar.Value = Math.Clamp(bar.Value - e.Delta.X * 48, bar.Minimum, bar.Maximum);
+        e.Handled = true;
     }
 
     private void OnPreparingCellForEdit(object? sender, DataGridPreparingCellForEditEventArgs e)

--- a/README.md
+++ b/README.md
@@ -89,8 +89,35 @@ later. If you want to try it anyway:
 - `pgNimbus-<version>-macos-arm64.dmg` from
   [Releases](https://github.com/Shman4ik/pgNimbus/releases) (Apple Silicon
   only; GitHub retired hosted Intel macOS runners in December 2025, and
-  Apple hasn't sold an Intel Mac since 2023). Unsigned/unnotarized:
-  right-click the app → "Open" the first time to bypass Gatekeeper.
+  Apple hasn't sold an Intel Mac since 2023).
+
+#### Fixing the Gatekeeper "App is damaged" error
+
+Because the beta binary is currently unsigned and unnotarized, macOS
+Gatekeeper will block it on the first launch, showing a misleading security
+warning:
+
+> *"pgNimbus" is damaged and can't be opened. You should move it to the
+> Trash.*
+
+This is standard macOS behavior for unsigned apps. The file is completely
+safe. To fix this and open the app, you need to clear the quarantine flag
+via Terminal:
+
+1. Drag `pgNimbus.app` from the DMG into your **Applications** folder (or
+   keep it in `Downloads`).
+2. Open **Terminal** (`Terminal.app`) and run the corresponding command:
+
+   ```bash
+   # If you moved the app to the Applications folder:
+   xattr -cr /Applications/pgNimbus.app
+
+   # If the app is still in your Downloads folder:
+   xattr -cr ~/Downloads/pgNimbus.app
+   ```
+
+3. Launch `pgNimbus.app` normally — the warning is gone for good (each
+   downloaded update needs the command once).
 
 Every tag push (`vX.Y.Z`) builds all of the above via
 [`.github/workflows/release.yml`](.github/workflows/release.yml) — see


### PR DESCRIPTION
Covers the full 2026-07-11 manual-testing report: items 1–10 and 12 fully, item 11 (platform hotkeys) with an auto/Ctrl/Cmd scheme (per-action remapping deferred — tracked in the README backlog).

## Commit 1 — UX fixes

- **Toolbar overflow on narrow windows** — secondary buttons (Cancel, Begin/Commit/Rollback, Explain, Explain Analyze, Show results, Export, Import) drop their text labels and fall back to icon + tooltip when the editor pane is narrower than ~660 px. Run keeps its label. Verified at the 940 px window minimum.
- **AS toggle removed from the toolbar** — auto-alias is now a command-palette action. Same persisted setting underneath.
- **Chip glyph centering** — Button content alignment defaults to Stretch, which pinned the tab-close ✕ and new-tab + glyphs to the top-left of their circular hover highlight; the chip style now centers content (verified via DevTools bounds: ≤0.5 px off-center).
- **Command palette shows hotkeys** — right-aligned next to each action, plus a new "Toggle sidebar" (Ctrl+B) entry.
- **Saved queries / history open in a new tab** — Load buttons, palette entries, and (new) double-click on either list all open the SQL in a fresh tab instead of overwriting the active one. This also makes saved queries visibly *do something*.
- **Double-click audit** — new CLAUDE.md rule: double-click always triggers the item's default action. Wired the gaps: saved queries / history → new tab, schema-tree functions → source DDL (tables → browse and connection profiles → connect already worked).
- **Results-grid horizontal scroll** (mac trackpad report) — the DataGrid only consumes vertical wheel deltas; a tunneled handler now feeds mostly-horizontal deltas to its horizontal scrollbar. ⚠ needs a check on a real mac trackpad — implemented on Windows; tracked in the README backlog.
- **README** — macOS Gatekeeper "app is damaged" `xattr -cr` workaround.
- **CLAUDE.md** — new "UI design rules" section: minimalist design is a priority (any new toolbar button must be discussed), double-click = default action, loads never overwrite the active tab.

## Commit 2 — Preferences page + Ctrl/Cmd hotkey scheme

- **PreferencesWindow**: theme (system/light/dark), auto-alias on completion, shortcut modifier. Every change applies immediately — no OK/Cancel.
- **`Hotkeys` helper** — single source of truth for the command modifier: Cmd on macOS, Ctrl elsewhere, or forced via the persisted `HotkeyScheme` ("auto"/"windows"/"mac"). MainWindow builds its KeyBindings in code from it and rebuilds them live on a scheme change; all code-behind modifier checks, palette shortcut labels, and the F1 cheat sheet's key caps resolve through it. Deliberate exception: SQL autocomplete stays on physical Ctrl+Space (Cmd+Space is Spotlight).

## Commit 3 — gear button + shortcuts

- **Title-bar gear (cog) chip** opens Preferences; its tooltip is set in code so the shortcut label tracks the live Ctrl/Cmd scheme.
- **Ctrl/Cmd+,** opens Preferences (the near-universal convention); **Ctrl/Cmd+Shift+A** toggles auto-alias, reporting the new state in the status bar (the setting has no always-visible indicator).
- Both appear with their shortcuts in the command palette and the F1 cheat sheet; README shortcut table updated.
- README backlog now tracks the two follow-ups: verifying the grid trackpad scroll on a real mac, and per-action hotkey remapping.

## Verified

- `dotnet build` clean, 97/97 Core tests pass (settings round-trip includes the new field).
- Live on Windows: toolbar collapse at 940 px; palette hotkeys + new actions; saved-query save → double-click → new tab; history double-click → new tab; gear button opens Preferences (tooltip "Preferences (Ctrl+,)"); switching the scheme to Cmd instantly relabels the F1 cheat sheet (Cmd+Enter, Cmd+T, … while Autocomplete stays Ctrl+Space) and rebuilds the window bindings; setting persists to settings.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)