### PR TITLE
Fix benchmark job failing on gh-pages history push

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -46,7 +46,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
@@ -81,8 +81,14 @@ jobs:
       # gh-pages (./dev/bench), which renders per-metric trend charts.
       # workflow_dispatch test runs skip this by default — they only get the
       # job-summary table above, unless record_history is explicitly set.
+      #
+      # continue-on-error: this is best-effort history bookkeeping, not the
+      # point of the job — a gh-pages push hiccup (e.g. a race between two
+      # concurrent releases) shouldn't mark the whole benchmark job failed
+      # when the actual measurements above already succeeded.
       - name: Record benchmark history
         if: inputs.record_history
+        continue-on-error: true
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: pgNimbus benchmarks


### PR DESCRIPTION
## Summary

The `benchmark` job (`.github/workflows/release.yml` → `.github/workflows/benchmark.yml`) has failed the last two release runs (v0.3.5 [run 29144201478](https://github.com/Shman4ik/pgNimbus/actions/runs/29144201478), v0.4.0 [run 29150568201](https://github.com/Shman4ik/pgNimbus/actions/runs/29150568201)) at the "Record benchmark history" step:

```
fatal: couldn't find remote ref gh-pages
Error: The process '/usr/bin/git' failed with exit code 128
```

`benchmark-action/github-action-benchmark`'s `auto-push` does `git fetch gh-pages:gh-pages`, which requires the branch to already exist — it doesn't create it. This repo never had one, so the very first tag-triggered run that tried to record history (v0.3.5) failed, and v0.4.0 repeated it.

I bootstrapped an empty orphan `gh-pages` branch directly (pushed already, no code change needed for that part) and this PR:

- Adds `continue-on-error: true` to the history step, so a future `gh-pages` push hiccup (e.g. a race between two concurrent release runs) can't fail the whole job when the actual benchmark measurements already succeeded.
- Pins the postgres service's health check to `pg_isready -U postgres`. This is a red herring I ran into while investigating, not the actual cause of the failure: with no explicit user, the health check authenticated as its own OS user (`root`) and logged `FATAL: role "root" does not exist` every 5s for the container's whole lifetime — harmless (the health check still went `healthy` in ~7s both times, since `pg_isready`/`PQping` treats an auth rejection as "server is up"), but noisy and misleading when reading the logs.

The `Run benchmarks` step itself was never broken — it already connects as `postgres` correctly and printed valid numbers in both failing runs.

## Test plan

- [ ] Next tagged release (or a manual `workflow_dispatch` of `benchmark.yml`/`release.yml` with `record_history: true`) completes the `benchmark` job successfully and the gh-pages history/chart updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)