### PR TITLE
Open table browse in a new tab on double-click

### DIFF
--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -394,10 +394,10 @@ public sealed partial class MainViewModel : ObservableObject
 
     public async Task PreviewTableAsync(string schema, string name)
     {
-        // Capture the target tab before the await: if the user switches tabs
-        // while the metadata loads, ActiveTab changes, and browse mode would
-        // otherwise open in whichever tab happens to be active on resume.
-        var tab = ActiveTab;
+        // Opens in a new tab rather than the active one - see the "loading a
+        // query never overwrites the active tab" rule (CLAUDE.md).
+        var tab = NewTab();
+        tab.TitleOverride = name;
 
         var columns = await _schemaService.GetColumnsAsync(schema, name, CancellationToken.None);
         var primaryKeyColumns = columns.Where(c => c.IsPrimaryKey).Select(c => c.Name).ToList();


### PR DESCRIPTION
## Summary
- Double-clicking a table in the schema tree (or selecting one from the command palette) now opens browse mode in a **new** tab instead of reusing the currently active tab.
- Previously `PreviewTableAsync` captured `ActiveTab` and called `StartBrowseAsync` on it, silently overwriting any query/results already open there.
- Matches the existing project rule that loading content (saved queries, history entries, DDL source) never overwrites the active tab — see `ShowSourceAsync`/`ShowFunctionSourceAsync` for the established pattern this now follows.
- The new tab is titled after the table name via `TitleOverride`.

## Test plan
- [x] `dotnet build PgNimbus.App` succeeds
- [ ] Manually verify: open a query tab with unsaved SQL, double-click a table in the schema tree, confirm it opens browse mode in a new tab and the original tab's SQL is untouched
- [ ] Manually verify: picking a table from the command palette (Ctrl/Cmd+K) also opens a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)