### PR TITLE
Boost ON/USING completions after a finished JOIN table+alias

### DIFF
--- a/PgNimbus.App/Completion/SqlCompletionProvider.cs
+++ b/PgNimbus.App/Completion/SqlCompletionProvider.cs
@@ -1,5 +1,6 @@
 using PgNimbus.Core.Query;
 using PgNimbus.Core.Schema;
+using PgNimbus.Core.Text;
 
 namespace PgNimbus.App.Completion;
 
@@ -199,6 +200,7 @@ public sealed class SqlCompletionProvider
         return context.Clause switch
         {
             SqlClause.TableRef or SqlClause.FromTableRef => GetTableRefCompletions(sql),
+            SqlClause.JoinTableRef when SqlCompletionContext.IsAfterCompleteJoinTarget(sql, caretOffset) => GetJoinKeywordCompletions(sql),
             SqlClause.JoinTableRef => GetJoinTableRefCompletions(sql),
             SqlClause.Predicate when SqlCompletionContext.IsAfterOnKeyword(sql, caretOffset) => GetJoinConditionCompletions(sql),
             SqlClause.Predicate => GetPredicateCompletions(sql),
@@ -243,6 +245,18 @@ public sealed class SqlCompletionProvider
     // floated above the flat catalog dump — the "flagship" JOIN magic.
     private IReadOnlyList<SqlCompletionData> GetJoinTableRefCompletions(string sql) =>
         BuildTableRefCompletions(sql, FkNeighborItems(sql));
+
+    // Table position after JOIN, but the table+alias is already fully typed
+    // (trailing whitespace) — ON/USING are the only grammatical next tokens, so
+    // they're boosted to the top instead of the flat table/keyword dump.
+    private IReadOnlyList<SqlCompletionData> GetJoinKeywordCompletions(string sql) =>
+        BuildTableRefCompletions(sql, JoinKeywordBoostItems);
+
+    private static readonly IReadOnlyList<SqlCompletionData> JoinKeywordBoostItems =
+    [
+        new SqlCompletionData("ON", SqlCompletionKind.Keyword, "ON", JoinConditionPriority),
+        new SqlCompletionData("USING", SqlCompletionKind.Keyword, "USING", JoinConditionPriority),
+    ];
 
     private IReadOnlyList<SqlCompletionData> BuildTableRefCompletions(string sql, IEnumerable<SqlCompletionData> boosted)
     {

--- a/PgNimbus.Core.Tests/Text/SqlCompletionContextTests.cs
+++ b/PgNimbus.Core.Tests/Text/SqlCompletionContextTests.cs
@@ -1,0 +1,280 @@
+using PgNimbus.Core.Text;
+
+namespace PgNimbus.Core.Tests.Text;
+
+/// <summary>
+/// Exercises the caret-context heuristics against the query shapes people
+/// actually type. The <c>|</c> marker in each SQL sample is the caret.
+/// </summary>
+public class SqlCompletionContextTests
+{
+    private static (string Sql, int Caret) AtCaret(string marked)
+    {
+        var caret = marked.IndexOf('|');
+        return (marked.Remove(caret, 1), caret);
+    }
+
+    private static SqlClause ClauseAt(string marked)
+    {
+        var (sql, caret) = AtCaret(marked);
+        return SqlCompletionContext.GetCaretContext(sql, caret).Clause;
+    }
+
+    private static bool InStringOrCommentAt(string marked)
+    {
+        var (sql, caret) = AtCaret(marked);
+        return SqlCompletionContext.GetCaretContext(sql, caret).InStringOrComment;
+    }
+
+    // --- Clause detection over the everyday statement shapes ---
+
+    [Test]
+    [Arguments("|", SqlClause.None)]
+    [Arguments("SELECT |", SqlClause.ColumnRef)]
+    [Arguments("SELECT id, |", SqlClause.ColumnRef)]
+    [Arguments("SELECT * FROM |", SqlClause.FromTableRef)]
+    [Arguments("SELECT * FROM ord|", SqlClause.FromTableRef)]
+    [Arguments("SELECT * FROM orders |", SqlClause.FromTableRef)]
+    [Arguments("SELECT * FROM orders, |", SqlClause.FromTableRef)]
+    [Arguments("SELECT * FROM orders JOIN |", SqlClause.JoinTableRef)]
+    [Arguments("SELECT * FROM orders LEFT JOIN |", SqlClause.JoinTableRef)]
+    [Arguments("SELECT * FROM orders o JOIN order_items oi |", SqlClause.JoinTableRef)]
+    [Arguments("SELECT * FROM orders WHERE |", SqlClause.Predicate)]
+    [Arguments("SELECT * FROM a JOIN b ON |", SqlClause.Predicate)]
+    [Arguments("SELECT * FROM a JOIN b USING |", SqlClause.Predicate)]
+    [Arguments("SELECT * FROM orders GROUP BY |", SqlClause.Predicate)]
+    [Arguments("SELECT * FROM orders ORDER BY |", SqlClause.Predicate)]
+    [Arguments("SELECT count(*) FROM orders GROUP BY status HAVING |", SqlClause.Predicate)]
+    [Arguments("INSERT INTO |", SqlClause.TableRef)]
+    [Arguments("INSERT INTO orders (|", SqlClause.ColumnRef)]
+    [Arguments("UPDATE |", SqlClause.TableRef)]
+    [Arguments("UPDATE orders SET |", SqlClause.ColumnRef)]
+    [Arguments("DELETE FROM |", SqlClause.FromTableRef)]
+    [Arguments("TRUNCATE |", SqlClause.TableRef)]
+    [Arguments("SELECT CASE WHEN |", SqlClause.ColumnRef)]
+    [Arguments("INSERT INTO t (a) VALUES (|", SqlClause.ColumnRef)]
+    public async Task GetCaretContext_ClassifiesClause(string marked, SqlClause expected)
+    {
+        await Assert.That(ClauseAt(marked)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task GetCaretContext_SemicolonStartsANewStatement()
+    {
+        await Assert.That(ClauseAt("SELECT * FROM orders; |")).IsEqualTo(SqlClause.None);
+        await Assert.That(ClauseAt("SELECT 1; SELECT * FROM |")).IsEqualTo(SqlClause.FromTableRef);
+    }
+
+    [Test]
+    public async Task GetCaretContext_TheWordBeingTypedIsNotContext()
+    {
+        // "WHER" in progress must not read as the WHERE keyword.
+        await Assert.That(ClauseAt("SELECT * FROM orders WHER|")).IsEqualTo(SqlClause.FromTableRef);
+    }
+
+    [Test]
+    [Arguments("SELECT 'in a |string' FROM t")]
+    [Arguments("SELECT * FROM t -- a comment |")]
+    [Arguments("SELECT * /* block | comment */ FROM t")]
+    [Arguments("SELECT * /* nested /* still | inside */ */ FROM t")]
+    [Arguments("SELECT $$dollar | quoted$$")]
+    [Arguments("SELECT 'unterminated |")]
+    public async Task GetCaretContext_SuppressesInsideStringsAndComments(string marked)
+    {
+        await Assert.That(InStringOrCommentAt(marked)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetCaretContext_AfterAClosedLiteral_IsNotSuppressed()
+    {
+        await Assert.That(InStringOrCommentAt("SELECT 'done' |")).IsFalse();
+        await Assert.That(InStringOrCommentAt("SELECT * /* done */ FROM |")).IsFalse();
+    }
+
+    // --- IsAfterCompleteJoinTarget: the ON/USING boost gate ---
+
+    [Test]
+    [Arguments("SELECT * FROM customers c JOIN public.orders o |")]
+    [Arguments("SELECT * FROM customers c JOIN orders |")]
+    [Arguments("SELECT * FROM customers c JOIN orders AS o |")]
+    [Arguments("SELECT * FROM customers c LEFT JOIN orders o |")]
+    [Arguments("SELECT * FROM customers c LEFT OUTER JOIN orders o |")]
+    [Arguments("SELECT * FROM a JOIN b ON a.id = b.a_id JOIN public.orders o |")]
+    [Arguments("SELECT * FROM t JOIN \"Order Items\" oi |")]
+    [Arguments("SELECT * FROM t JOIN orders o\n|")]
+    public async Task IsAfterCompleteJoinTarget_TrueAfterFinishedTableAndAlias(string marked)
+    {
+        var (sql, caret) = AtCaret(marked);
+        await Assert.That(SqlCompletionContext.IsAfterCompleteJoinTarget(sql, caret)).IsTrue();
+    }
+
+    [Test]
+    // No JOIN in sight at all.
+    [Arguments("SELECT * FROM orders |")]
+    // Nothing after JOIN yet — table position, not ON position.
+    [Arguments("SELECT * FROM customers c JOIN |")]
+    // Table or alias still being typed: no trailing space, and "o" could as
+    // easily become an alias as the first letter of ON.
+    [Arguments("SELECT * FROM customers c JOIN public.orders|")]
+    [Arguments("SELECT * FROM customers c JOIN public.orders o|")]
+    // AS typed, alias itself still coming.
+    [Arguments("SELECT * FROM customers c JOIN orders AS |")]
+    // The user is typing the next JOIN's flavour, not an alias.
+    [Arguments("SELECT * FROM customers c JOIN orders inner |")]
+    // Past the target entirely: ON already typed, this gate no longer applies.
+    [Arguments("SELECT * FROM a JOIN b ON |")]
+    public async Task IsAfterCompleteJoinTarget_FalseWhileTargetIsIncomplete(string marked)
+    {
+        var (sql, caret) = AtCaret(marked);
+        await Assert.That(SqlCompletionContext.IsAfterCompleteJoinTarget(sql, caret)).IsFalse();
+    }
+
+    // --- IsAfterOnKeyword: the FK join-condition trigger ---
+
+    [Test]
+    public async Task IsAfterOnKeyword_TrueRightAfterOn_IncludingMidWord()
+    {
+        var (sql, caret) = AtCaret("SELECT * FROM a JOIN b ON |");
+        await Assert.That(SqlCompletionContext.IsAfterOnKeyword(sql, caret)).IsTrue();
+
+        // The word in progress is the filter, not context — still "after ON".
+        (sql, caret) = AtCaret("SELECT * FROM a JOIN b ON a|");
+        await Assert.That(SqlCompletionContext.IsAfterOnKeyword(sql, caret)).IsTrue();
+    }
+
+    [Test]
+    [Arguments("SELECT * FROM a JOIN b ON a.id = |")]
+    [Arguments("SELECT * FROM a WHERE |")]
+    [Arguments("SELECT * FROM season |")]
+    public async Task IsAfterOnKeyword_FalseElsewhere(string marked)
+    {
+        var (sql, caret) = AtCaret(marked);
+        await Assert.That(SqlCompletionContext.IsAfterOnKeyword(sql, caret)).IsFalse();
+    }
+
+    // --- ExtractTables over the common statement shapes ---
+
+    [Test]
+    public async Task ExtractTables_SimpleFrom()
+    {
+        var tables = SqlCompletionContext.ExtractTables("SELECT * FROM orders");
+
+        await Assert.That(tables).HasCount().EqualTo(1);
+        await Assert.That(tables[0]).IsEqualTo(new SqlCompletionContext.TableRef("", "orders", null));
+    }
+
+    [Test]
+    public async Task ExtractTables_SchemaQualifiedWithAlias()
+    {
+        var tables = SqlCompletionContext.ExtractTables("SELECT * FROM public.orders o");
+
+        await Assert.That(tables[0]).IsEqualTo(new SqlCompletionContext.TableRef("public", "orders", "o"));
+    }
+
+    [Test]
+    public async Task ExtractTables_JoinChainWithAliases()
+    {
+        var tables = SqlCompletionContext.ExtractTables(
+            "SELECT * FROM customers c JOIN orders o ON c.id = o.customer_id LEFT JOIN order_items oi ON o.id = oi.order_id");
+
+        await Assert.That(tables).HasCount().EqualTo(3);
+        await Assert.That(tables[0].Table).IsEqualTo("customers");
+        await Assert.That(tables[0].Alias).IsEqualTo("c");
+        await Assert.That(tables[1].Table).IsEqualTo("orders");
+        await Assert.That(tables[1].Alias).IsEqualTo("o");
+        await Assert.That(tables[2].Table).IsEqualTo("order_items");
+        await Assert.That(tables[2].Alias).IsEqualTo("oi");
+    }
+
+    [Test]
+    public async Task ExtractTables_CommaList()
+    {
+        var tables = SqlCompletionContext.ExtractTables("SELECT * FROM customers c, orders o WHERE c.id = o.customer_id");
+
+        await Assert.That(tables).HasCount().EqualTo(2);
+        await Assert.That(tables[0].Alias).IsEqualTo("c");
+        await Assert.That(tables[1].Alias).IsEqualTo("o");
+    }
+
+    [Test]
+    public async Task ExtractTables_AsAlias()
+    {
+        var tables = SqlCompletionContext.ExtractTables("SELECT * FROM orders AS o");
+
+        await Assert.That(tables[0].Alias).IsEqualTo("o");
+    }
+
+    [Test]
+    public async Task ExtractTables_TrailingKeywordIsNotAnAlias()
+    {
+        var tables = SqlCompletionContext.ExtractTables("SELECT * FROM orders WHERE id = 1");
+
+        await Assert.That(tables[0]).IsEqualTo(new SqlCompletionContext.TableRef("", "orders", null));
+    }
+
+    [Test]
+    public async Task ExtractTables_UpdateAndInsertTargets()
+    {
+        var update = SqlCompletionContext.ExtractTables("UPDATE public.orders SET status = 'done'");
+        await Assert.That(update[0]).IsEqualTo(new SqlCompletionContext.TableRef("public", "orders", null));
+
+        var insert = SqlCompletionContext.ExtractTables("INSERT INTO orders (id, status) VALUES (1, 'new')");
+        await Assert.That(insert[0].Table).IsEqualTo("orders");
+    }
+
+    [Test]
+    public async Task ExtractTables_QuotedIdentifiers()
+    {
+        var tables = SqlCompletionContext.ExtractTables("SELECT * FROM \"Sales\".\"Order Items\" oi");
+
+        await Assert.That(tables[0]).IsEqualTo(new SqlCompletionContext.TableRef("Sales", "Order Items", "oi"));
+    }
+
+    // --- ExtractCteNames ---
+
+    [Test]
+    public async Task ExtractCteNames_SingleAndChained()
+    {
+        var single = SqlCompletionContext.ExtractCteNames("WITH recent AS (SELECT 1) SELECT * FROM recent");
+        await Assert.That(single).IsEquivalentTo(new[] { "recent" });
+
+        var chained = SqlCompletionContext.ExtractCteNames(
+            "WITH a AS (SELECT 1), b AS (SELECT 2) SELECT * FROM a JOIN b ON true");
+        await Assert.That(chained).IsEquivalentTo(new[] { "a", "b" });
+    }
+
+    [Test]
+    public async Task ExtractCteNames_Recursive()
+    {
+        var names = SqlCompletionContext.ExtractCteNames(
+            "WITH RECURSIVE tree AS (SELECT id FROM nodes UNION ALL SELECT n.id FROM nodes n JOIN tree t ON n.parent = t.id) SELECT * FROM tree");
+
+        await Assert.That(names).IsEquivalentTo(new[] { "tree" });
+    }
+
+    // --- GetQualifierBeforeCaret ---
+
+    [Test]
+    public async Task GetQualifierBeforeCaret_AliasAndMidWord()
+    {
+        var (sql, caret) = AtCaret("SELECT o.| FROM orders o");
+        await Assert.That(SqlCompletionContext.GetQualifierBeforeCaret(sql, caret)).IsEqualTo("o");
+
+        (sql, caret) = AtCaret("SELECT o.stat| FROM orders o");
+        await Assert.That(SqlCompletionContext.GetQualifierBeforeCaret(sql, caret)).IsEqualTo("o");
+    }
+
+    [Test]
+    public async Task GetQualifierBeforeCaret_QuotedQualifierUnquotes()
+    {
+        var (sql, caret) = AtCaret("SELECT \"Order Items\".| FROM \"Order Items\"");
+        await Assert.That(SqlCompletionContext.GetQualifierBeforeCaret(sql, caret)).IsEqualTo("Order Items");
+    }
+
+    [Test]
+    public async Task GetQualifierBeforeCaret_BareIdentifierHasNone()
+    {
+        var (sql, caret) = AtCaret("SELECT stat| FROM orders");
+        await Assert.That(SqlCompletionContext.GetQualifierBeforeCaret(sql, caret)).IsNull();
+    }
+}

--- a/PgNimbus.Core.Tests/Text/SqlCompletionContextTests.cs
+++ b/PgNimbus.Core.Tests/Text/SqlCompletionContextTests.cs
@@ -102,6 +102,10 @@ public class SqlCompletionContextTests
     [Arguments("SELECT * FROM a JOIN b ON a.id = b.a_id JOIN public.orders o |")]
     [Arguments("SELECT * FROM t JOIN \"Order Items\" oi |")]
     [Arguments("SELECT * FROM t JOIN orders o\n|")]
+    // A "join" inside a comment or string earlier in the statement must not
+    // pose as the JOIN whose target is being checked.
+    [Arguments("SELECT * FROM t /* join note */ JOIN orders o |")]
+    [Arguments("SELECT 'self join', * FROM t JOIN orders o |")]
     public async Task IsAfterCompleteJoinTarget_TrueAfterFinishedTableAndAlias(string marked)
     {
         var (sql, caret) = AtCaret(marked);
@@ -228,6 +232,25 @@ public class SqlCompletionContextTests
         var tables = SqlCompletionContext.ExtractTables("SELECT * FROM \"Sales\".\"Order Items\" oi");
 
         await Assert.That(tables[0]).IsEqualTo(new SqlCompletionContext.TableRef("Sales", "Order Items", "oi"));
+    }
+
+    [Test]
+    public async Task ExtractTables_KeywordInsideACommentDoesNotCutTheFromBody()
+    {
+        // "order" in the line comment must not end the FROM span before the JOIN.
+        var tables = SqlCompletionContext.ExtractTables(
+            "SELECT * FROM customers c -- order by signup date\nJOIN orders o ON c.id = o.customer_id");
+
+        await Assert.That(tables).HasCount().EqualTo(2);
+        await Assert.That(tables[1].Table).IsEqualTo("orders");
+    }
+
+    [Test]
+    public async Task ExtractTables_FromInsideAStringLiteralIsNotAFromClause()
+    {
+        var tables = SqlCompletionContext.ExtractTables("SELECT 'copied from fake_table' AS note");
+
+        await Assert.That(tables).IsEmpty();
     }
 
     // --- ExtractCteNames ---

--- a/PgNimbus.Core/Text/SqlCompletionContext.cs
+++ b/PgNimbus.Core/Text/SqlCompletionContext.cs
@@ -230,6 +230,102 @@ public static partial class SqlCompletionContext
     private static readonly string[] ColumnClauseKeywords =
         ["select", "set", "returning", "values", "when", "then", "else", "distinct"];
 
+    // Blanks the interiors of comments (--, nested /* */) and string literals
+    // ('…', $$…$$) to spaces, length-preserved so every offset stays valid —
+    // the regex heuristics below can't be made quote/comment-aware one by one,
+    // so they run over this masked text instead. Double-quoted identifiers are
+    // *kept* (they're names the heuristics need) but skipped atomically so
+    // their content can't open a fake comment/literal. Same single forward
+    // pass as GetCaretContext; returns the original string when there's
+    // nothing to mask.
+    private static string MaskCommentsAndStrings(string sql)
+    {
+        char[]? masked = null;
+        var i = 0;
+        while (i < sql.Length)
+        {
+            var c = sql[i];
+
+            if (c == '"')
+            {
+                var close = sql.IndexOf('"', i + 1);
+                i = close < 0 ? sql.Length : close + 1;
+                continue;
+            }
+
+            if (c == '-' && i + 1 < sql.Length && sql[i + 1] == '-')
+            {
+                var eol = sql.IndexOf('\n', i + 2);
+                var stop = eol < 0 ? sql.Length : eol;
+                Blank(ref masked, sql, i, stop - i);
+                i = stop;
+                continue;
+            }
+
+            if (c == '/' && i + 1 < sql.Length && sql[i + 1] == '*')
+            {
+                var start = i;
+                var depth = 1;
+                i += 2;
+                while (i < sql.Length && depth > 0)
+                {
+                    if (sql[i] == '/' && i + 1 < sql.Length && sql[i + 1] == '*')
+                    {
+                        depth++;
+                        i += 2;
+                    }
+                    else if (sql[i] == '*' && i + 1 < sql.Length && sql[i + 1] == '/')
+                    {
+                        depth--;
+                        i += 2;
+                    }
+                    else
+                    {
+                        i++;
+                    }
+                }
+
+                Blank(ref masked, sql, start, i - start);
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                var start = i;
+                var close = sql.IndexOf('\'', i + 1);
+                i = close < 0 ? sql.Length : close + 1;
+                Blank(ref masked, sql, start, i - start);
+                continue;
+            }
+
+            if (c == '$')
+            {
+                var start = i;
+                var next = i;
+                if (TrySkipDollarQuote(sql, start, sql.Length, ref next))
+                {
+                    // -1 means the literal is still open — mask to the end.
+                    i = next < 0 ? sql.Length : next;
+                    Blank(ref masked, sql, start, i - start);
+                    continue;
+                }
+            }
+
+            i++;
+        }
+
+        return masked is null ? sql : new string(masked);
+
+        static void Blank(ref char[]? masked, string sql, int start, int count)
+        {
+            masked ??= sql.ToCharArray();
+            for (var j = start; j < start + count; j++)
+            {
+                masked[j] = ' ';
+            }
+        }
+    }
+
     // Skips a $$…$$ / $tag$…$tag$ literal starting at `start`. Returns false when
     // the '$' isn't a dollar-quote opener (e.g. a $1 parameter); on true, `i` is
     // the index after the closing tag, or -1 when the literal is still open at `end`.
@@ -316,7 +412,9 @@ public static partial class SqlCompletionContext
     public static bool IsAfterCompleteJoinTarget(string sql, int caret)
     {
         var end = Math.Clamp(caret, 0, sql.Length);
-        var before = sql[..end];
+        // Masked so a "join" inside a comment or string literal before the
+        // caret can't pose as the JOIN whose target we're checking.
+        var before = MaskCommentsAndStrings(sql[..end]);
         var joins = JoinKeywordRegex().Matches(before);
         if (joins.Count == 0)
         {
@@ -353,6 +451,9 @@ public static partial class SqlCompletionContext
     /// </summary>
     public static IReadOnlyList<TableRef> ExtractTables(string sql)
     {
+        // Masked first: a FROM/JOIN/keyword inside a comment or string literal
+        // must not spawn phantom tables or cut a real FROM body short.
+        sql = MaskCommentsAndStrings(sql);
         var tables = new List<TableRef>();
 
         foreach (Match clause in FromClauseRegex().Matches(sql))
@@ -383,7 +484,7 @@ public static partial class SqlCompletionContext
     public static IReadOnlyList<string> ExtractCteNames(string sql)
     {
         var names = new List<string>();
-        foreach (Match match in CteNameRegex().Matches(sql))
+        foreach (Match match in CteNameRegex().Matches(MaskCommentsAndStrings(sql)))
         {
             names.Add(Unquote(match.Groups["name"].Value));
         }
@@ -491,11 +592,13 @@ public static partial class SqlCompletionContext
     };
 
     // FROM (or a comma/JOIN list under it), captured up to the next top-level
-    // clause keyword or statement end. Quoted sections are consumed atomically
-    // so a keyword *inside* an identifier or literal ("Order Items", 'set x')
-    // can't cut the body short; [\s\S] so the body spans newlines.
+    // clause keyword or statement end. Runs over MaskCommentsAndStrings output,
+    // so comments and string literals are already blanked; quoted identifiers
+    // survive the mask and are consumed atomically here so a keyword *inside*
+    // one ("Order Items") can't cut the body short. [\s\S] so the body spans
+    // newlines.
     [GeneratedRegex(
-        """\bfrom\b(?<body>(?:"[^"]*"|'[^']*'|[\s\S])*?)(?=\b(?:where|group|having|order|limit|offset|union|intersect|except|returning|window|for|into|values|set)\b|;|$)""",
+        """\bfrom\b(?<body>(?:"[^"]*"|[\s\S])*?)(?=\b(?:where|group|having|order|limit|offset|union|intersect|except|returning|window|for|into|values|set)\b|;|$)""",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex FromClauseRegex();
 

--- a/PgNimbus.Core/Text/SqlCompletionContext.cs
+++ b/PgNimbus.Core/Text/SqlCompletionContext.cs
@@ -1,9 +1,9 @@
 using System.Text.RegularExpressions;
 
-namespace PgNimbus.App.Completion;
+namespace PgNimbus.Core.Text;
 
 /// <summary>Where the caret sits grammatically, as far as completion cares.</summary>
-internal enum SqlClause
+public enum SqlClause
 {
     /// <summary>No clause identified — offer the full catalog.</summary>
     None,
@@ -22,7 +22,7 @@ internal enum SqlClause
 /// <summary>
 /// A lightweight, regex-based read of the SQL being edited — just enough to make
 /// completion context-aware without pulling in a full parser. It answers the
-/// questions <see cref="SqlCompletionProvider"/> asks at the caret:
+/// questions the App's completion provider asks at the caret:
 /// <list type="number">
 /// <item>Is this a <c>qualifier.partial</c> member access, and if so what is the
 /// qualifier (the alias/table/schema before the dot)?</item>
@@ -36,7 +36,7 @@ internal enum SqlClause
 /// and quietly give up on the exotic (correlated subqueries) rather than
 /// guess wrong.
 /// </summary>
-internal static partial class SqlCompletionContext
+public static partial class SqlCompletionContext
 {
     /// <summary>A table reference parsed out of a FROM/JOIN clause, with its alias if one was given.</summary>
     public readonly record struct TableRef(string Schema, string Table, string? Alias);
@@ -306,6 +306,45 @@ internal static partial class SqlCompletionContext
     }
 
     /// <summary>
+    /// True when the caret sits right after a JOIN's table reference (and its
+    /// alias, if any) plus at least one trailing space — i.e. the table/alias is
+    /// done and the only sensible next tokens are <c>ON</c>/<c>USING</c>, not
+    /// another catalog dump. Requires the trailing space specifically so a table
+    /// name or alias still being typed (no space yet, and possibly a prefix of
+    /// "on" itself, e.g. an alias like <c>o</c>) doesn't trip this early.
+    /// </summary>
+    public static bool IsAfterCompleteJoinTarget(string sql, int caret)
+    {
+        var end = Math.Clamp(caret, 0, sql.Length);
+        var before = sql[..end];
+        var joins = JoinKeywordRegex().Matches(before);
+        if (joins.Count == 0)
+        {
+            return false;
+        }
+
+        var last = joins[^1];
+        var segment = before[(last.Index + last.Length)..];
+        var match = JoinTargetCompleteRegex().Match(segment);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        // "JOIN orders AS " or "JOIN orders INNER " — the regex would swallow
+        // the keyword as the alias; those mean the target is *not* complete
+        // (an alias is still coming / another JOIN is being typed). Same
+        // keyword-pseudo-capture filter AddTableRef applies.
+        var (schema, table) = SplitQualified(match.Groups["table"].Value);
+        if (schema.Length == 0 && ReservedAfterTable.Contains(table))
+        {
+            return false;
+        }
+
+        return !match.Groups["alias"].Success || !ReservedAfterTable.Contains(Unquote(match.Groups["alias"].Value));
+    }
+
+    /// <summary>
     /// Extracts the table references the statement operates on: every FROM clause
     /// (scoped to the FROM…(WHERE/GROUP/…) span so commas in a SELECT list aren't
     /// mistaken for table separators) plus <c>UPDATE</c> / <c>INSERT INTO</c> /
@@ -452,9 +491,11 @@ internal static partial class SqlCompletionContext
     };
 
     // FROM (or a comma/JOIN list under it), captured up to the next top-level
-    // clause keyword or statement end. [\s\S] so the body spans newlines.
+    // clause keyword or statement end. Quoted sections are consumed atomically
+    // so a keyword *inside* an identifier or literal ("Order Items", 'set x')
+    // can't cut the body short; [\s\S] so the body spans newlines.
     [GeneratedRegex(
-        @"\bfrom\b(?<body>[\s\S]*?)(?=\b(?:where|group|having|order|limit|offset|union|intersect|except|returning|window|for|into|values|set)\b|;|$)",
+        """\bfrom\b(?<body>(?:"[^"]*"|'[^']*'|[\s\S])*?)(?=\b(?:where|group|having|order|limit|offset|union|intersect|except|returning|window|for|into|values|set)\b|;|$)""",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex FromClauseRegex();
 
@@ -464,6 +505,23 @@ internal static partial class SqlCompletionContext
         @",|\b(?:cross\s+|natural\s+|inner\s+|left\s+|right\s+|full\s+|outer\s+)*join\b",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex JoinSplitRegex();
+
+    // A bare JOIN keyword (with its optional flavour prefix), used to find where
+    // the current JOIN's table reference starts — unlike JoinSplitRegex this
+    // doesn't also match commas, since IsAfterCompleteJoinTarget only cares
+    // about the most recent JOIN.
+    [GeneratedRegex(
+        @"\b(?:cross\s+|natural\s+|inner\s+|left\s+|right\s+|full\s+|outer\s+)*join\b",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex JoinKeywordRegex();
+
+    // A complete table ref (optionally schema-qualified, optionally aliased)
+    // spanning the whole segment after JOIN, with mandatory trailing whitespace —
+    // that trailing space is what proves the alias/table isn't still mid-typing.
+    [GeneratedRegex(
+        """^\s*(?<table>(?:"[^"]+"|[\w$]+)(?:\s*\.\s*(?:"[^"]+"|[\w$]+))?)(?:\s+(?:as\s+)?(?<alias>"[^"]+"|[\w$]+))?\s+$""",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex JoinTargetCompleteRegex();
 
     // A single table ref at the start of a segment: an optionally schema-qualified,
     // optionally quoted name, then an optional (AS) alias.


### PR DESCRIPTION
## Summary
- After `JOIN table alias ` is fully typed (trailing space proves it's not mid-identifier), the completion popup now floats `ON`/`USING` to the top instead of showing the flat table/keyword catalog with `ON` buried ~16 items down.
- Moved `SqlCompletionContext` from `PgNimbus.App/Completion` to `PgNimbus.Core/Text` — it's pure text/regex logic with zero Avalonia dependency, and the App project isn't covered by the TUnit suite, so this was untestable in place.
- Fixed a bug the new tests caught: `FromClauseRegex` could cut the FROM body short when a clause keyword (e.g. "order") appeared inside a quoted identifier/string literal like `"Order Items"`.

## Test plan
- [x] `dotnet test --project PgNimbus.Core.Tests` — 162/162 passing, including ~50 new cases in `SqlCompletionContextTests` covering clause detection over common statement shapes (SELECT/FROM/JOIN/WHERE/ON/GROUP BY/ORDER BY/INSERT/UPDATE/DELETE/TRUNCATE/CASE), string/comment suppression, the new `IsAfterCompleteJoinTarget` gate (positive + negative cases), `ExtractTables`, `ExtractCteNames`, and `GetQualifierBeforeCaret`.
- [x] `dotnet build` — full solution builds clean, 0 warnings/errors.
- [ ] Manual click-through in the running app to confirm the popup visually (not done this session — flagging for review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)