### PR TITLE
Connect dialog: replace Fill button with clipboard icon

### DIFF
--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -136,6 +136,7 @@
         <StreamGeometry x:Key="MenuDownIconGeometry">M7,10L12,15L17,10H7Z</StreamGeometry>
         <StreamGeometry x:Key="PinIconGeometry">M16,12V4H17V2H7V4H8V12L6,14V16H11.2V22H12.8V16H18V14L16,12Z</StreamGeometry>
         <StreamGeometry x:Key="ImportIconGeometry">M2,12H4V17H20V12H22V17A2,2 0 0,1 20,19H4A2,2 0 0,1 2,17V12M12,2L6.46,7.46L7.88,8.88L11,5.75V15H13V5.75L16.13,8.88L17.55,7.45L12,2Z</StreamGeometry>
+        <StreamGeometry x:Key="ClipboardIconGeometry">M19,20H5V4H7V7H17V4H19M12,2A1,1 0 0,1 13,3A1,1 0 0,1 12,4A1,1 0 0,1 11,3A1,1 0 0,1 12,2M19,2H14.82C14.4,0.84 13.3,0 12,0C10.7,0 9.6,0.84 9.18,2H5A2,2 0 0,0 3,4V20A2,2 0 0,0 5,22H19A2,2 0 0,0 21,20V4A2,2 0 0,0 19,2Z</StreamGeometry>
         <StreamGeometry x:Key="PulseIconGeometry">M3,13H5.79L10.1,4.79L11.28,13.75L14.5,9.66L17.83,13H21V15H16.96L14.69,12.74L10.72,17.79L9.64,9.66L7,15H3V13Z</StreamGeometry>
         <!-- Schema-tree catalog groups: function-variant / puzzle / account-multiple (MDI) -->
         <StreamGeometry x:Key="FunctionIconGeometry">M15.6,5.29C14.5,5.19 13.53,6 13.43,7.11L13.18,10H16V12H13L12.56,17.07C12.37,19.27 10.43,20.9 8.23,20.7C6.92,20.59 5.82,19.86 5.17,18.83L6.67,17.33C6.91,18.11 7.57,18.63 8.43,18.71C9.5,18.81 10.5,18 10.57,16.89L11,12H8V10H11.17L11.44,6.93C11.63,4.73 13.57,3.1 15.77,3.3C17.08,3.41 18.18,4.14 18.83,5.17L17.33,6.67C17.09,5.89 16.43,5.37 15.6,5.29Z</StreamGeometry>

--- a/PgNimbus.App/Views/ConnectionDialog.axaml
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml
@@ -55,8 +55,8 @@
                     <KeyBinding Gesture="Enter" Command="{Binding ImportConnectionStringCommand}" />
                 </TextBox.KeyBindings>
             </TextBox>
-            <Button Grid.Column="1" Classes="chip" Padding="7" Command="{Binding ImportConnectionStringCommand}"
-                    ToolTip.Tip="Re-apply the pasted connection string (already applied automatically on paste)">
+            <Button Grid.Column="1" Classes="chip" Padding="7" Click="OnCopyConnectionStringClick"
+                    ToolTip.Tip="Copy connection string to clipboard">
                 <PathIcon Data="{StaticResource ClipboardIconGeometry}" Width="14" Height="14" />
             </Button>
         </Grid>

--- a/PgNimbus.App/Views/ConnectionDialog.axaml
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml
@@ -55,8 +55,10 @@
                     <KeyBinding Gesture="Enter" Command="{Binding ImportConnectionStringCommand}" />
                 </TextBox.KeyBindings>
             </TextBox>
-            <Button Grid.Column="1" Content="Fill" Command="{Binding ImportConnectionStringCommand}"
-                    ToolTip.Tip="Re-apply the pasted connection string (already applied automatically on paste)" />
+            <Button Grid.Column="1" Classes="chip" Padding="7" Command="{Binding ImportConnectionStringCommand}"
+                    ToolTip.Tip="Re-apply the pasted connection string (already applied automatically on paste)">
+                <PathIcon Data="{StaticResource ClipboardIconGeometry}" Width="14" Height="14" />
+            </Button>
         </Grid>
 
         <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">

--- a/PgNimbus.App/Views/ConnectionDialog.axaml.cs
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 using PgNimbus.App.ViewModels;
 using PgNimbus.Core.Connections;
@@ -26,6 +28,25 @@ public partial class ConnectionDialog : Window
         {
             vm.SelectedProfile = profile;
             vm.ConnectCommand.Execute(null);
+        }
+    }
+
+    private async void OnCopyConnectionStringClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not ConnectionDialogViewModel vm || TopLevel.GetTopLevel(this)?.Clipboard is not { } clipboard)
+        {
+            return;
+        }
+
+        try
+        {
+            await clipboard.SetTextAsync(vm.ImportText);
+        }
+        catch
+        {
+            // Clipboard access can throw if another app holds it locked. This is
+            // an async void handler, so an unhandled throw would crash the app —
+            // a failed copy is not worth that.
         }
     }
 }


### PR DESCRIPTION
## Summary
- The Connect dialog's paste-connection-string row had a text button labeled "Fill" that re-applied whatever was in the import box back onto the form fields.
- Replaced it with an icon-only clipboard button, matching the icon-button style used throughout the rest of the app (toolbar chips, sidebar toggle, etc.) instead of a standalone text label.
- Changed its behavior to match the new icon: it now **copies** the live connection-string preview (`ImportText`, kept in sync with the form fields) to the OS clipboard, instead of re-importing/re-parsing it. Uses the same `TopLevel.Clipboard` pattern as the results-grid cell inspector's copy button.
- The textbox's Enter-key binding still re-parses pasted text via `ImportConnectionStringCommand` as before — only the button's role changed.

## Test plan
- [x] `dotnet build PgNimbus.App` succeeds
- [ ] Manually open the Connect dialog, fill in fields (or paste a connection string), click the clipboard icon, and confirm the built connection string lands on the clipboard
- [ ] Confirm pasting a connection string into the box and pressing Enter still re-applies it to the form fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)