### PR TITLE
SQL completion: CTE output columns for member access and WHERE narrowing

### DIFF
--- a/PgNimbus.App/Completion/SqlCompletionProvider.cs
+++ b/PgNimbus.App/Completion/SqlCompletionProvider.cs
@@ -208,18 +208,36 @@ public sealed class SqlCompletionProvider
         };
     }
 
-    // After "qualifier.": the columns of the table the qualifier names (directly
-    // or via a FROM-clause alias), or — when the qualifier is a schema — that
-    // schema's tables. Empty when nothing resolves (so no stray list pops up).
+    // After "qualifier.": the columns of the CTE or table the qualifier names
+    // (directly or via a FROM-clause alias), or — when the qualifier is a
+    // schema — that schema's tables. A CTE shadows a same-named catalog table,
+    // matching how Postgres resolves the reference. Empty when nothing
+    // resolves (so no stray list pops up).
     private IReadOnlyList<SqlCompletionData> GetMemberCompletions(string qualifier, string sql)
     {
+        var ctes = SqlCompletionContext.ExtractCteDefinitions(sql);
+
         foreach (var table in SqlCompletionContext.ExtractTables(sql))
         {
-            if (table.Alias is not null && string.Equals(table.Alias, qualifier, StringComparison.OrdinalIgnoreCase)
-                && ColumnsFor(table.Schema, table.Table) is { } aliased)
+            if (table.Alias is null || !string.Equals(table.Alias, qualifier, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (table.Schema.Length == 0 && CteColumnItems(table.Table, ctes) is { Count: > 0 } viaAlias)
+            {
+                return viaAlias;
+            }
+
+            if (ColumnsFor(table.Schema, table.Table) is { } aliased)
             {
                 return ColumnItems(aliased);
             }
+        }
+
+        if (CteColumnItems(qualifier, ctes) is { Count: > 0 } cteColumns)
+        {
+            return cteColumns;
         }
 
         if (ColumnsFor(schema: "", qualifier) is { } direct)
@@ -345,13 +363,16 @@ public sealed class SqlCompletionProvider
     }
 
     // The current statement's own contributions — every FROM/UPDATE/INTO table's
-    // columns (top priority) and aliases, plus CTE names. Sets
+    // columns (top priority) and aliases, plus CTE names. A FROM table that is
+    // really one of the statement's CTEs contributes the CTE's derived output
+    // columns instead of (shadowed) catalog ones. Sets
     // <paramref name="resolvedColumns"/> when at least one table resolved to real
-    // catalog columns, so a predicate caret knows whether it can safely narrow.
+    // columns, so a predicate caret knows whether it can safely narrow.
     private List<SqlCompletionData> CollectStatementItems(string sql, out bool resolvedColumns)
     {
         var items = new List<SqlCompletionData>();
         var added = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var ctes = SqlCompletionContext.ExtractCteDefinitions(sql);
         resolvedColumns = false;
 
         foreach (var table in SqlCompletionContext.ExtractTables(sql))
@@ -365,7 +386,19 @@ public sealed class SqlCompletionProvider
                 });
             }
 
-            if (!added.Add($"{table.Schema}.{table.Table}") || ColumnsFor(table.Schema, table.Table) is not { } columns)
+            if (!added.Add($"{table.Schema}.{table.Table}"))
+            {
+                continue;
+            }
+
+            if (table.Schema.Length == 0 && CteColumnItems(table.Table, ctes) is { Count: > 0 } cteColumns)
+            {
+                resolvedColumns = true;
+                items.AddRange(cteColumns);
+                continue;
+            }
+
+            if (ColumnsFor(table.Schema, table.Table) is not { } columns)
             {
                 continue;
             }
@@ -377,12 +410,92 @@ public sealed class SqlCompletionProvider
             }
         }
 
-        foreach (var cte in SqlCompletionContext.ExtractCteNames(sql))
+        foreach (var cte in ctes)
         {
-            items.Add(new SqlCompletionData(cte, SqlCompletionKind.Cte, SqlIdentifier.QuoteIfNeeded(cte), CtePriority));
+            items.Add(new SqlCompletionData(cte.Name, SqlCompletionKind.Cte, SqlIdentifier.QuoteIfNeeded(cte.Name), CtePriority));
         }
 
         return items;
+    }
+
+    // The columns `name` exposes when it names one of the statement's CTEs:
+    // the derived output columns, plus — when the CTE SELECTs * — the columns
+    // of its source tables, each itself a CTE (recursively; a self-reference
+    // in a RECURSIVE body is cut by the visited set) or a catalog table. Null
+    // when `name` names no CTE at all.
+    private List<SqlCompletionData>? CteColumnItems(string name, IReadOnlyList<SqlCompletionContext.CteDefinition> ctes)
+    {
+        var items = new List<SqlCompletionData>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        return AddCteColumns(name, ctes, items, seen, visited) ? items : null;
+    }
+
+    private bool AddCteColumns(
+        string name,
+        IReadOnlyList<SqlCompletionContext.CteDefinition> ctes,
+        List<SqlCompletionData> items,
+        HashSet<string> seen,
+        HashSet<string> visited)
+    {
+        if (!visited.Add(name))
+        {
+            return false;
+        }
+
+        SqlCompletionContext.CteDefinition? found = null;
+        foreach (var candidate in ctes)
+        {
+            if (string.Equals(candidate.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                found = candidate;
+                break;
+            }
+        }
+
+        if (found is not { } cte)
+        {
+            return false;
+        }
+
+        foreach (var column in cte.Columns)
+        {
+            if (seen.Add(column))
+            {
+                items.Add(new SqlCompletionData(column, SqlCompletionKind.Column, SqlIdentifier.QuoteIfNeeded(column), CurrentColumnPriority)
+                {
+                    DescriptionText = $"column · {cte.Name}",
+                });
+            }
+        }
+
+        if (!cte.SelectsStar)
+        {
+            return true;
+        }
+
+        foreach (var source in cte.SourceTables)
+        {
+            if (source.Schema.Length == 0 && AddCteColumns(source.Table, ctes, items, seen, visited))
+            {
+                continue;
+            }
+
+            if (ColumnsFor(source.Schema, source.Table) is not { } columns)
+            {
+                continue;
+            }
+
+            foreach (var column in columns)
+            {
+                if (seen.Add(column.Column))
+                {
+                    items.Add(ColumnItem(column, CurrentColumnPriority));
+                }
+            }
+        }
+
+        return true;
     }
 
     private IReadOnlyList<TableColumn>? ColumnsFor(string schema, string table)

--- a/PgNimbus.Core.Tests/Text/SqlCteDefinitionTests.cs
+++ b/PgNimbus.Core.Tests/Text/SqlCteDefinitionTests.cs
@@ -1,0 +1,193 @@
+using PgNimbus.Core.Text;
+
+namespace PgNimbus.Core.Tests.Text;
+
+/// <summary>
+/// Exercises <see cref="SqlCompletionContext.ExtractCteDefinitions"/> — the
+/// derivation of a CTE's output columns that lets <c>cte.</c> member access
+/// and WHERE-narrowing work over WITH queries.
+/// </summary>
+public class SqlCteDefinitionTests
+{
+    private static SqlCompletionContext.CteDefinition Single(string sql)
+    {
+        var defs = SqlCompletionContext.ExtractCteDefinitions(sql);
+        return defs.Count == 1 ? defs[0] : throw new InvalidOperationException($"expected 1 CTE, got {defs.Count}");
+    }
+
+    [Test]
+    public async Task DeclaredColumnList_IsTheOutputShape()
+    {
+        var cte = Single("WITH x (a, b) AS (SELECT 1, 2) SELECT * FROM x");
+
+        await Assert.That(cte.Name).IsEqualTo("x");
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "a", "b" });
+        await Assert.That(cte.SelectsStar).IsFalse();
+    }
+
+    [Test]
+    public async Task SelectList_BareAndDottedReferences()
+    {
+        var cte = Single("WITH recent AS (SELECT id, o.total FROM orders o) SELECT * FROM recent");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "id", "total" });
+        await Assert.That(cte.SelectsStar).IsFalse();
+    }
+
+    [Test]
+    public async Task SelectList_ExplicitAndImplicitAliases()
+    {
+        var cte = Single("WITH s AS (SELECT count(*) AS cnt, max(total) top_total FROM orders) SELECT * FROM s");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "cnt", "top_total" });
+    }
+
+    [Test]
+    public async Task SelectList_UnaliasedExpressionIsSkipped()
+    {
+        var cte = Single("WITH x AS (SELECT price * qty, id FROM order_items) SELECT * FROM x");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "id" });
+    }
+
+    [Test]
+    public async Task SelectStar_FlagsStarAndKeepsSourceTables()
+    {
+        var cte = Single("WITH x AS (SELECT * FROM public.orders) SELECT * FROM x");
+
+        await Assert.That(cte.Columns).IsEmpty();
+        await Assert.That(cte.SelectsStar).IsTrue();
+        await Assert.That(cte.SourceTables).HasCount().EqualTo(1);
+        await Assert.That(cte.SourceTables[0].Table).IsEqualTo("orders");
+        await Assert.That(cte.SourceTables[0].Schema).IsEqualTo("public");
+    }
+
+    [Test]
+    public async Task QualifiedStar_MixesWithNamedColumns()
+    {
+        var cte = Single(
+            "WITH x AS (SELECT o.*, c.name FROM orders o JOIN customers c ON c.id = o.customer_id) SELECT * FROM x");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "name" });
+        await Assert.That(cte.SelectsStar).IsTrue();
+    }
+
+    [Test]
+    public async Task ChainedCtes_EachGetsItsOwnDefinition()
+    {
+        var defs = SqlCompletionContext.ExtractCteDefinitions(
+            "WITH a AS (SELECT id FROM t), b AS (SELECT * FROM a) SELECT * FROM b");
+
+        await Assert.That(defs).HasCount().EqualTo(2);
+        await Assert.That(defs[0].Name).IsEqualTo("a");
+        await Assert.That(defs[0].Columns).IsEquivalentTo(new[] { "id" });
+        await Assert.That(defs[1].Name).IsEqualTo("b");
+        await Assert.That(defs[1].SelectsStar).IsTrue();
+        await Assert.That(defs[1].SourceTables[0].Table).IsEqualTo("a");
+    }
+
+    [Test]
+    public async Task RecursiveCte_ColumnsComeFromTheFirstBranch()
+    {
+        var cte = Single(
+            "WITH RECURSIVE tree AS (SELECT id, parent FROM nodes UNION ALL SELECT n.id, n.parent FROM nodes n JOIN tree t ON n.parent = t.id) SELECT * FROM tree");
+
+        await Assert.That(cte.Name).IsEqualTo("tree");
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "id", "parent" });
+    }
+
+    [Test]
+    public async Task DistinctOn_QuantifierIsNotAColumn()
+    {
+        var cte = Single(
+            "WITH latest AS (SELECT DISTINCT ON (customer_id) customer_id, total FROM orders ORDER BY customer_id, created_at DESC) SELECT * FROM latest");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "customer_id", "total" });
+    }
+
+    [Test]
+    public async Task Distinct_WithoutOn()
+    {
+        var cte = Single("WITH s AS (SELECT DISTINCT status FROM orders) SELECT * FROM s");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "status" });
+    }
+
+    [Test]
+    public async Task QuotedIdentifiers_Unquote()
+    {
+        var cte = Single("WITH q AS (SELECT \"Weird Name\", t.\"Other\" FROM t) SELECT * FROM q");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "Weird Name", "Other" });
+    }
+
+    [Test]
+    public async Task ScalarSubqueryInTheList_DoesNotSplitOrLeakItsFrom()
+    {
+        var cte = Single("WITH x AS (SELECT id, (SELECT max(v) FROM other) AS peak FROM t) SELECT * FROM x");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "id", "peak" });
+    }
+
+    [Test]
+    public async Task CaseExpression_OnlyCountsWithAnAlias()
+    {
+        var without = Single("WITH x AS (SELECT CASE WHEN a THEN 1 ELSE 2 END, b FROM t) SELECT * FROM x");
+        await Assert.That(without.Columns).IsEquivalentTo(new[] { "b" });
+
+        var with = Single("WITH x AS (SELECT CASE WHEN a THEN 1 END AS flag FROM t) SELECT * FROM x");
+        await Assert.That(with.Columns).IsEquivalentTo(new[] { "flag" });
+    }
+
+    [Test]
+    public async Task StringLiteralWithAlias_KeepsTheAlias()
+    {
+        var cte = Single("WITH x AS (SELECT 'fixed' AS label, id FROM t) SELECT * FROM x");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "label", "id" });
+    }
+
+    [Test]
+    public async Task FunctionWithFromInsideItsParens_DoesNotEndTheList()
+    {
+        var cte = Single("WITH x AS (SELECT extract(year from created_at) AS yr, id FROM t) SELECT * FROM x");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "yr", "id" });
+    }
+
+    [Test]
+    public async Task SelectWithoutFrom()
+    {
+        var cte = Single("WITH one AS (SELECT 1 AS v) SELECT * FROM one");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "v" });
+        await Assert.That(cte.SourceTables).IsEmpty();
+    }
+
+    [Test]
+    public async Task ValuesCte_YieldsNoColumnsWithoutADeclaredList()
+    {
+        var cte = Single("WITH v AS (VALUES (1, 2)) SELECT * FROM v");
+
+        await Assert.That(cte.Columns).IsEmpty();
+        await Assert.That(cte.SelectsStar).IsFalse();
+    }
+
+    [Test]
+    public async Task UnterminatedBody_StillYieldsWhatIsTypedSoFar()
+    {
+        // Mid-typing: the WITH body's paren isn't closed yet.
+        var cte = Single("WITH recent AS (SELECT id, total FROM orders");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "id", "total" });
+        await Assert.That(cte.SourceTables[0].Table).IsEqualTo("orders");
+    }
+
+    [Test]
+    public async Task NumericLiteralAndBooleanTail_AreNotAliases()
+    {
+        var cte = Single("WITH x AS (SELECT 1 + 2, active IS NOT NULL, id FROM t) SELECT * FROM x");
+
+        await Assert.That(cte.Columns).IsEquivalentTo(new[] { "id" });
+    }
+}

--- a/PgNimbus.Core/Text/SqlCompletionContext.Ctes.cs
+++ b/PgNimbus.Core/Text/SqlCompletionContext.Ctes.cs
@@ -1,0 +1,442 @@
+namespace PgNimbus.Core.Text;
+
+public static partial class SqlCompletionContext
+{
+    /// <summary>
+    /// A CTE with the output columns completion could derive for it.
+    /// <paramref name="Columns"/> is what the CTE's declared column list or its
+    /// SELECT list names (expressions without an alias are skipped rather than
+    /// guessed); <paramref name="SelectsStar"/> is true when the list contains a
+    /// <c>*</c> / <c>t.*</c>, in which case the columns of
+    /// <paramref name="SourceTables"/> (its FROM/JOIN tables — each possibly
+    /// another CTE) complete the picture on the provider side, where the
+    /// catalog lives.
+    /// </summary>
+    public readonly record struct CteDefinition(
+        string Name,
+        IReadOnlyList<string> Columns,
+        bool SelectsStar,
+        IReadOnlyList<TableRef> SourceTables);
+
+    /// <summary>
+    /// The CTEs a <c>WITH</c> clause introduces, each with the output columns
+    /// derivable from its declared column list (<c>WITH x (a, b) AS …</c>) or,
+    /// failing that, its body's top-level SELECT list. Same heuristic spirit as
+    /// the rest of this class: handles the shapes people actually write, gives
+    /// up quietly (empty columns) on the rest.
+    /// </summary>
+    public static IReadOnlyList<CteDefinition> ExtractCteDefinitions(string sql)
+    {
+        var masked = MaskCommentsAndStrings(sql);
+        var defs = new List<CteDefinition>();
+
+        foreach (System.Text.RegularExpressions.Match match in CteNameRegex().Matches(masked))
+        {
+            var name = Unquote(match.Groups["name"].Value);
+            // The regex ends at the body's opening paren; find its balanced close.
+            var bodyStart = match.Index + match.Length;
+            var body = masked[bodyStart..FindBalancedClose(masked, bodyStart)];
+
+            List<string> columns;
+            var selectsStar = false;
+            if (match.Groups["cols"].Success)
+            {
+                // WITH x (a, b) AS (…) — the declared list *is* the output shape.
+                var declared = match.Groups["cols"].Value.Trim();
+                columns = SplitTopLevel(declared[1..^1])
+                    .Select(c => Unquote(c.Trim()))
+                    .Where(c => c.Length > 0)
+                    .ToList();
+            }
+            else
+            {
+                columns = DeriveSelectListColumns(body, out selectsStar);
+            }
+
+            defs.Add(new CteDefinition(name, columns, selectsStar, ExtractTables(body)));
+        }
+
+        return defs;
+    }
+
+    // The output column names a body's top-level SELECT list yields: aliases
+    // (explicit AS or implicit), the last segment of a plain dotted reference,
+    // nothing for an unaliased expression. For a recursive/UNION body only the
+    // first branch is read — that's the one that names the columns anyway.
+    private static List<string> DeriveSelectListColumns(string body, out bool selectsStar)
+    {
+        selectsStar = false;
+        var columns = new List<string>();
+        if (FindSelectListSpan(body) is not var (start, end) || start >= end)
+        {
+            return columns;
+        }
+
+        foreach (var raw in SplitTopLevel(body[start..end]))
+        {
+            var item = raw.Trim();
+            if (item.Length == 0)
+            {
+                continue;
+            }
+
+            if (item == "*" || item.EndsWith(".*", StringComparison.Ordinal))
+            {
+                selectsStar = true;
+                continue;
+            }
+
+            if (DeriveItemName(item) is { } column)
+            {
+                columns.Add(column);
+            }
+        }
+
+        return columns;
+    }
+
+    // Locates the span between the body's first top-level SELECT (past its
+    // ALL/DISTINCT [ON (…)] quantifier) and the clause keyword that ends the
+    // list. Null when the body has no top-level SELECT (e.g. a VALUES CTE).
+    private static (int Start, int End)? FindSelectListSpan(string body)
+    {
+        var i = 0;
+        var depth = 0;
+        int? start = null;
+
+        while (i < body.Length)
+        {
+            var c = body[i];
+            if (c == '"')
+            {
+                var close = body.IndexOf('"', i + 1);
+                i = close < 0 ? body.Length : close + 1;
+                continue;
+            }
+
+            if (c == '(' || c == '[')
+            {
+                depth++;
+                i++;
+                continue;
+            }
+
+            if (c == ')' || c == ']')
+            {
+                depth--;
+                i++;
+                continue;
+            }
+
+            if (IsIdentPart(c))
+            {
+                var wordStart = i;
+                while (i < body.Length && IsIdentPart(body[i]))
+                {
+                    i++;
+                }
+
+                if (depth == 0 && !char.IsAsciiDigit(c))
+                {
+                    var word = body.AsSpan(wordStart, i - wordStart);
+                    if (start is null)
+                    {
+                        if (word.Equals("select", StringComparison.OrdinalIgnoreCase))
+                        {
+                            SkipSelectQuantifier(body, ref i);
+                            start = i;
+                        }
+                    }
+                    else if (IsSelectListStop(word))
+                    {
+                        return (start.Value, wordStart);
+                    }
+                }
+
+                continue;
+            }
+
+            i++;
+        }
+
+        return start is null ? null : (start.Value, body.Length);
+    }
+
+    // Advances past SELECT's ALL / DISTINCT / DISTINCT ON (…) quantifier so the
+    // list span starts at the first actual item.
+    private static void SkipSelectQuantifier(string body, ref int i)
+    {
+        var j = i;
+        SkipWhitespace(body, ref j);
+        var word = ReadWord(body, ref j);
+        if (word.Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            i = j;
+            return;
+        }
+
+        if (!word.Equals("distinct", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        i = j;
+        SkipWhitespace(body, ref j);
+        if (!ReadWord(body, ref j).Equals("on", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        SkipWhitespace(body, ref j);
+        if (j >= body.Length || body[j] != '(')
+        {
+            // "DISTINCT on_hand, …" — that ON-looking word was an item, and
+            // `i` already sits right before it.
+            return;
+        }
+
+        var depth = 0;
+        while (j < body.Length)
+        {
+            var c = body[j];
+            if (c == '"')
+            {
+                var close = body.IndexOf('"', j + 1);
+                j = close < 0 ? body.Length : close + 1;
+                continue;
+            }
+
+            if (c == '(')
+            {
+                depth++;
+            }
+            else if (c == ')' && --depth == 0)
+            {
+                j++;
+                break;
+            }
+
+            j++;
+        }
+
+        i = j;
+    }
+
+    private static bool IsSelectListStop(ReadOnlySpan<char> word) =>
+        word.Equals("from", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("where", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("group", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("having", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("order", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("limit", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("offset", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("fetch", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("union", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("intersect", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("except", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("window", StringComparison.OrdinalIgnoreCase)
+        || word.Equals("into", StringComparison.OrdinalIgnoreCase);
+
+    // The output name of one (trimmed) SELECT-list item, or null when the item
+    // is an expression whose name we can't know without executing it:
+    //   "total"            → total          (bare reference)
+    //   "o.total"          → total          (dotted reference, pure chain only)
+    //   "count(*) AS cnt"  → cnt            (explicit alias)
+    //   "count(*) cnt"     → cnt            (implicit alias)
+    //   "price * qty"      → null           (unaliased expression)
+    //   "CASE … END"       → null           (END is never an alias)
+    private static string? DeriveItemName(string item)
+    {
+        var end = item.Length;
+        while (end > 0 && char.IsWhiteSpace(item[end - 1]))
+        {
+            end--;
+        }
+
+        if (end == 0)
+        {
+            return null;
+        }
+
+        // The trailing token, quoted or bare — anything else (')', ']', an
+        // operator) means the item doesn't end in an identifier at all.
+        int tokenStart;
+        var quoted = item[end - 1] == '"';
+        if (quoted)
+        {
+            tokenStart = item.LastIndexOf('"', end - 2);
+            if (tokenStart < 0)
+            {
+                return null;
+            }
+        }
+        else if (IsIdentPart(item[end - 1]))
+        {
+            tokenStart = end;
+            while (tokenStart > 0 && IsIdentPart(item[tokenStart - 1]))
+            {
+                tokenStart--;
+            }
+
+            if (char.IsAsciiDigit(item[tokenStart]))
+            {
+                return null; // a numeric literal, not an identifier
+            }
+        }
+        else
+        {
+            return null;
+        }
+
+        var token = item[tokenStart..end];
+        if (!quoted && AliasStopWords.Contains(token))
+        {
+            return null; // "CASE … END", "x IS NOT NULL", … — expression tail, not an alias
+        }
+
+        var p = tokenStart;
+        var hadSpace = false;
+        while (p > 0 && char.IsWhiteSpace(item[p - 1]))
+        {
+            p--;
+            hadSpace = true;
+        }
+
+        if (p == 0)
+        {
+            return Unquote(token); // the whole item is this one identifier
+        }
+
+        if (item[p - 1] == '.')
+        {
+            if (hadSpace)
+            {
+                return null;
+            }
+
+            // "o.total" names total; "t.a + u.b" names nothing — only a pure
+            // qualifier chain back to the item start counts as a reference.
+            var q = p - 1;
+            while (q > 0 && (IsIdentPart(item[q - 1]) || item[q - 1] == '"' || item[q - 1] == '.'))
+            {
+                q--;
+            }
+
+            return q == 0 ? Unquote(token) : null;
+        }
+
+        if (!hadSpace)
+        {
+            return null;
+        }
+
+        // "<something> alias": the something must *end* like a value — another
+        // identifier (covers the AS keyword too), a close paren/bracket, or a
+        // quoted identifier. An operator there means the item is still one
+        // unaliased expression.
+        var prev = item[p - 1];
+        return prev == ')' || prev == ']' || prev == '"' || IsIdentPart(prev)
+            ? Unquote(token)
+            : null;
+    }
+
+    // Words that can legally *end* a SELECT-list expression but are never its
+    // alias — seeing one as the trailing token means "unaliased expression".
+    private static readonly HashSet<string> AliasStopWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "end", "null", "true", "false", "not", "and", "or", "is", "in",
+        "like", "ilike", "similar", "between", "asc", "desc", "over",
+        "filter", "within", "escape", "collate", "interval", "at", "time",
+        "zone", "then", "else", "when", "case", "distinct", "all", "as",
+    };
+
+    // Index of the ')' that closes an open paren group starting just past
+    // `start` (depth already 1), or the string's length when unterminated —
+    // a half-typed CTE body still yields whatever columns it has so far.
+    private static int FindBalancedClose(string s, int start)
+    {
+        var depth = 1;
+        var i = start;
+        while (i < s.Length)
+        {
+            var c = s[i];
+            if (c == '"')
+            {
+                var close = s.IndexOf('"', i + 1);
+                i = close < 0 ? s.Length : close + 1;
+                continue;
+            }
+
+            if (c == '(')
+            {
+                depth++;
+            }
+            else if (c == ')' && --depth == 0)
+            {
+                return i;
+            }
+
+            i++;
+        }
+
+        return s.Length;
+    }
+
+    // Splits on the commas at paren/bracket depth 0 — the separators between
+    // SELECT-list items or declared column names, not the ones inside calls.
+    private static List<string> SplitTopLevel(string s)
+    {
+        var parts = new List<string>();
+        var depth = 0;
+        var start = 0;
+        var i = 0;
+        while (i < s.Length)
+        {
+            var c = s[i];
+            if (c == '"')
+            {
+                var close = s.IndexOf('"', i + 1);
+                i = close < 0 ? s.Length : close + 1;
+                continue;
+            }
+
+            if (c == '(' || c == '[')
+            {
+                depth++;
+            }
+            else if (c == ')' || c == ']')
+            {
+                depth--;
+            }
+            else if (c == ',' && depth == 0)
+            {
+                parts.Add(s[start..i]);
+                start = i + 1;
+            }
+
+            i++;
+        }
+
+        parts.Add(s[start..]);
+        return parts;
+    }
+
+    private static ReadOnlySpan<char> ReadWord(string s, ref int i)
+    {
+        var start = i;
+        while (i < s.Length && IsIdentPart(s[i]))
+        {
+            i++;
+        }
+
+        return s.AsSpan(start, i - start);
+    }
+
+    private static void SkipWhitespace(string s, ref int i)
+    {
+        while (i < s.Length && char.IsWhiteSpace(s[i]))
+        {
+            i++;
+        }
+    }
+}

--- a/PgNimbus.Core/Text/SqlCompletionContext.cs
+++ b/PgNimbus.Core/Text/SqlCompletionContext.cs
@@ -642,9 +642,11 @@ public static partial class SqlCompletionContext
     private static partial Regex UpdateIntoTargetRegex();
 
     // A CTE header: the name right after WITH [RECURSIVE] — or after the ") ,"
-    // that closes the previous CTE — with an optional column list, then AS (.
+    // that closes the previous CTE — with an optional declared column list
+    // (captured: it's the CTE's output shape, see ExtractCteDefinitions), then
+    // AS (. The match ends at the body's opening paren.
     [GeneratedRegex(
-        """(?:\bwith\s+(?:recursive\s+)?|\)\s*,\s*)(?<name>"[^"]+"|[\w$]+)\s*(?:\([^)]*\))?\s+as\s*(?:not\s+)?(?:materialized\s+)?\(""",
+        """(?:\bwith\s+(?:recursive\s+)?|\)\s*,\s*)(?<name>"[^"]+"|[\w$]+)\s*(?<cols>\([^)]*\))?\s+as\s*(?:not\s+)?(?:materialized\s+)?\(""",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex CteNameRegex();
 }

--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   palette; every change applies immediately.
 - **Multi-tab query editor** — schema-aware SQL autocomplete (schema-qualified
   tables after `FROM`/`JOIN`, `FROM`-scoped columns in `WHERE`/`ON`/`ORDER BY`,
-  columns with their data types elsewhere, `alias.` member access, CTE names,
+  columns with their data types elsewhere, `alias.` member access, CTE names
+  *and their output columns* — `cte.` completes what the CTE's SELECT list
+  yields, with `SELECT *` bodies resolved through the catalog,
   common functions inserted as calls), saved queries,
   run history, current-line and matching-bracket highlighting, and font-size
   zoom (<kbd>Ctrl</kbd>+wheel / <kbd>Ctrl</kbd>+<kbd>±</kbd>).
@@ -198,6 +200,17 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   one-click copy.
 - **EXPLAIN visualization** — a graphical plan tree for `EXPLAIN` and
   `EXPLAIN ANALYZE`, not just raw text output.
+- **Server activity dashboard** — a live `pg_stat_activity` view (state, wait
+  events, running statement) with per-backend **cancel statement** and
+  **terminate session** actions, so a runaway query is one click to stop.
+- **CSV/JSON import** — load a file into a new or existing table with
+  delimiter/header detection and per-column type inference, streamed via
+  `COPY`.
+- **Query history search & pinning** — history is searchable, pinnable, and
+  scoped per connection; entries open in a new tab.
+- **Copy results as…** — <kbd>Ctrl</kbd>+<kbd>C</kbd> copies selected rows as
+  TSV; the grid context menu adds CSV, JSON, Markdown table, and
+  `INSERT`-statement formats.
 - **LISTEN/NOTIFY monitor** — subscribe to channels and watch notifications
   arrive live.
 
@@ -377,6 +390,11 @@ individually shippable pieces. Shipped items graduate from this list into
   (Preferences → Keyboard, `Hotkeys.cs`) is the foundation; the next step is
   letting users rebind individual actions, persisted in `AppSettings`, with
   conflict detection and a reset-to-defaults.
+- [ ] **State the privacy guarantee** — a short README/docs section pledging
+  zero telemetry and zero network traffic beyond the database and SSH hosts
+  you configure. Costs nothing (it's already true) and is something users
+  explicitly probe new clients for
+  ([Show HN: DB Pro](https://news.ycombinator.com/item?id=46078571)).
 
 ### SQL editor — completion that predicts the next move
 
@@ -421,9 +439,89 @@ impact order:
   type that's currently buried in the description panel, and restyle the
   card (radius, shadow, padding) to match the Files-style shell in both
   themes.
+- [x] **CTE output columns** — `WITH recent AS (SELECT id, total FROM orders)`
+  followed by `recent.` used to complete nothing; now the CTE's declared
+  column list or SELECT-list aliases complete like a table's columns
+  (`SELECT *` bodies resolve through the source tables' catalog columns,
+  chained/recursive CTEs included), and WHERE over a CTE narrows to them.
 - [ ] **`SELECT *` expansion** — a completion item (and/or command-palette
   action) that replaces `*` with the explicit column list of the statement's
   FROM tables.
+
+### Next — the gaps users of competing tools keep hitting
+
+Sourced from a research pass (2026-07) over what people praise, request, and
+abandon tools over: Hacker News client threads
+([Good UI for PostgreSQL?](https://news.ycombinator.com/item?id=33776831),
+[What PostgreSQL client do you use?](https://news.ycombinator.com/item?id=23208181),
+[Show HN: DB Pro](https://news.ycombinator.com/item?id=46078571)), the
+top-👍 issues on the TablePlus and Beekeeper Studio trackers, and what
+Postico/DataGrip users single out. Multi-database support dominates those
+trackers and is deliberately out of scope — PostgreSQL-first *is* the thesis.
+Everything below is what survives that filter, roughly in impact order:
+
+- [ ] **Pending-changes review ("safe mode")** — stage grid edits, inserts,
+  and deletes locally, highlight the dirty cells/rows, show the generated SQL
+  for review, then commit everything as one transaction (or discard). Today
+  each inline edit fires immediately, which is scary on production; a staged
+  mode is TablePlus's single most-praised trust feature. The transaction
+  machinery (held session connection, auto-rollback) is most of the plumbing
+  already.
+- [ ] **Follow a foreign key from the grid** — a result/browse cell whose
+  column has an FK gets a click-through (context menu or Ctrl+click) that
+  jumps to the referenced row in browse mode, plus the reverse ("rows
+  referencing this one") from a key cell. The most-praised "little feature"
+  in DBeaver's HN comments, and the heart of Postico's row editing (FK
+  picker). The FK edges are already loaded for JOIN completion — reuse them.
+- [ ] **Workspace restore** — reopen the last session's tabs, including
+  never-saved SQL, exactly as they were — no save prompts on exit
+  (Notepad++-style, called out on HN as what makes DBeaver safe to close).
+  Persist per-connection alongside history in `AppSettings`-style JSON.
+- [ ] **Open/save `.sql` files** — Ctrl+O / Ctrl+S on a tab, a recent-files
+  list in the palette, and a dirty marker that distinguishes "unsaved
+  scratch" from "file changed on disk". A top-voted Beekeeper Studio ask
+  (it appears twice in their top 20).
+- [ ] **Multiple simultaneous connections** — today the ⇄ switch *replaces*
+  the connection; users working against dev + prod side by side want both at
+  once (top-10 Beekeeper ask). Cleanest fit for the one-window shell:
+  connection-per-window, with the palette able to open a profile in a new
+  window. Per-connection accent colors already exist to keep them apart.
+- [ ] **Auto-reconnect** — after laptop sleep or an SSH-tunnel drop, the next
+  run should quietly reopen the connection instead of surfacing a broken-pipe
+  error (or hanging — an HN complaint about other clients). Needs care with
+  the held transaction connection: an open transaction can't be silently
+  re-established, so that path surfaces a clear "transaction lost" state.
+- [ ] **Postgres-native value editing** — the grid and Add-row dialog treat
+  every column as text today. Make the editors type-aware: `enum` columns get
+  a dropdown of `pg_enum` labels, `boolean` a checkbox, `date/timestamp` a
+  picker, arrays and composites get validation, domains resolve to their base
+  type. DataGrip's missing array support was a stated deal-breaker on HN, and
+  ENUM dropdowns / user-defined types are open TablePlus asks — exactly the
+  "PostgreSQL-first, not lowest-common-denominator" differentiator.
+- [ ] **Table & index sizes and usage** — sizes in the schema tree (tooltip or
+  detail column) and a per-database overview: largest tables/indexes
+  (`pg_total_relation_size`), seq-vs-index scan counts, unused indexes, cache
+  hit rate (`pg_stat_user_tables`/`_indexes`, `pg_statio_*`). "No list of
+  tables or indexes with their sizes and usage" is a direct HN complaint
+  about DataGrip; pgAdmin buries it. Read-only `pg_catalog` queries — squarely
+  in `SchemaService`/`ActivityService` territory.
+- [ ] **Locks & blocking tree** — extend the server-activity window with a
+  who-blocks-whom view (`pg_locks` joined to `pg_stat_activity`, or
+  `pg_blocking_pids()`), so a stuck migration is a one-click
+  cancel/terminate of the *blocker*. The signal plumbing
+  (`CancelBackendAsync`/`TerminateBackendAsync`) already exists.
+- [ ] **Row detail sidebar** — a vertical name/value view of the selected row
+  (Postico's much-loved "row sidebar"), for tables too wide to read as a grid
+  row; doubles as a form-style editor and complements the cell inspector.
+- [ ] **Find & replace in the editor** — AvaloniaEdit ships a `SearchPanel`;
+  wire it up (Ctrl+F / Ctrl+H via `Hotkeys.cs`) and restyle it to match the
+  shell. A standing Beekeeper ask; table-stakes for an editor.
+- [ ] **Linux builds** — the linux-x64 NativeAOT publish already works (it's
+  how the app is exercised in CI sandboxes and benchmarks); what's missing is
+  a release-pipeline leg and packaging. Flatpak is the #2 top-voted Beekeeper
+  Studio request, and HeidiSQL adding native Linux builds in late 2025 shows
+  the demand; start with an AppImage or tarball from `release.yml`, Flatpak
+  after.
 
 ### Later — bigger bets
 
@@ -433,6 +531,26 @@ impact order:
   index) and diff the plan trees node-by-node.
 - [ ] **Backup/restore UI** — `pg_dump`/`pg_restore` orchestration with
   progress streaming.
+- [ ] **AI, privacy-first** — the 2026 table stakes in every competitor is a
+  schema-aware assistant; the differentiator for an OSS client is doing it
+  without a data-leak worry: bring-your-own-key (or local model), explicit
+  opt-in, nothing leaves the machine otherwise. Two shapes, possibly both:
+  an in-app "explain this query / write this query" assistant fed the same
+  completion catalog, and/or a built-in MCP server exposing the current
+  connection so Claude Code / Cursor / VS Code can query it (TablePlus has an
+  open ask for exactly this).
+- [ ] **Vim keybindings in the editor** — the single most-upvoted
+  editor-related request on TablePlus's tracker (180+ 👍); a modal-editing
+  layer over AvaloniaEdit, opt-in from Preferences.
+- [ ] **Parameterized queries** — recognize `:name` / `$1` placeholders and
+  prompt for values on run (remembering the last ones), so shared saved
+  queries stop being edit-before-every-run.
+- [ ] **Quick chart of a result set** — one click from a result grid to a
+  bar/line/scatter view of two chosen columns; DataGrip's inline charts get
+  cited as the reason analysts stay there.
+- [ ] **PostGIS geometry viewer** — render `geometry`/`geography` cells on a
+  map/canvas the way the cell inspector renders JSON; the one PostGIS
+  feature HN users single out pgAdmin and DBeaver for having.
 - [ ] **Notebook mode** — mixed SQL + Markdown documents with inline result
   snapshots, saved as shareable files.
 - [ ] **Plugin/extension API** — a stable surface for community panels


### PR DESCRIPTION
## What

`WITH recent AS (SELECT id, total FROM orders)` followed by `recent.` (or an aliased `FROM recent r` + `r.`) used to complete nothing — the completion catalog has never heard of a CTE. This closes that gap, the spot where native IntelliSense in competing tools most visibly falls down (per DBeaver/SQL Complete docs research).

## How

- **Core** — new `SqlCompletionContext.ExtractCteDefinitions` derives each CTE's output shape:
  - the declared column list (`WITH x (a, b) AS …`) when present, else the body's top-level SELECT list: bare/dotted references, explicit `AS` and implicit aliases; unaliased expressions are skipped rather than guessed (`price * qty` names nothing, `CASE … END` isn't an alias).
  - `DISTINCT` / `DISTINCT ON (…)` quantifiers, scalar subqueries in the list, `extract(year from …)`, quoted identifiers, and unterminated (mid-typing) bodies all handled; recursive/UNION bodies read the first branch — the one that names the columns.
  - a `*` / `t.*` item flags the CTE so the provider can resolve the star through its source tables.
- **Provider** — `qualifier.` resolves against CTEs before catalog tables (a CTE shadows a same-named table, matching Postgres). Star CTEs expand through source tables — catalog or other CTEs, recursively, with a visited guard for `WITH RECURSIVE` self-references. A FROM table that is really a CTE contributes its derived columns to predicate/general completion, so `WHERE` over a CTE narrows to real columns instead of falling back to the whole catalog.

## Testing

- 19 new Core unit tests (`SqlCteDefinitionTests`); full suite 185/185 green.
- Verified live against the seeded Docker Postgres in the running app:
  - `recent.` → exactly `id, total, customer_id` (the CTE's derived columns, not a catalog dump)
  - `r.` over a `SELECT *` body → `orders`' real catalog columns with data types
  - `WHERE ` auto-open over a CTE → CTE columns included at top priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)