### PR TITLE
Expand SELECT * into explicit columns via the command palette

### DIFF
--- a/PgNimbus.App/Completion/SqlCompletionProvider.cs
+++ b/PgNimbus.App/Completion/SqlCompletionProvider.cs
@@ -418,6 +418,26 @@ public sealed class SqlCompletionProvider
         return items;
     }
 
+    /// <summary>
+    /// Expands the <c>*</c> / <c>alias.*</c> in the select list of the
+    /// statement under the caret into explicit columns — CTEs resolve through
+    /// their derived output columns, everything else through the catalog.
+    /// Null when there's no star to expand or a table can't be resolved.
+    /// </summary>
+    public SqlCompletionContext.StarExpansion? ExpandSelectStar(string sql, int caret)
+    {
+        var ctes = SqlCompletionContext.ExtractCteDefinitions(sql);
+        return SqlCompletionContext.ExpandSelectStar(sql, caret, (schema, table) =>
+        {
+            if (schema.Length == 0 && CteColumnItems(table, ctes) is { Count: > 0 } cteColumns)
+            {
+                return cteColumns.Select(c => c.Text).ToList();
+            }
+
+            return ColumnsFor(schema, table)?.Select(c => c.Column).ToList();
+        });
+    }
+
     // The columns `name` exposes when it names one of the statement's CTEs:
     // the derived output columns, plus — when the CTE SELECTs * — the columns
     // of its source tables, each itself a CTE (recursively; a self-reference

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -46,6 +46,9 @@ public sealed partial class MainViewModel : ObservableObject
     // Raised to pretty-print the statement under the caret; MainWindow owns the
     // editor text (AvaloniaEdit's Text isn't bindable) so it does the rewrite.
     public event Action? FormatSqlRequested;
+    // Raised to replace the statement's SELECT * with the explicit column
+    // list; MainWindow applies the rewrite, same split as Format SQL.
+    public event Action? ExpandStarRequested;
     // Raised to open (or focus) the Server Activity window, which the view owns.
     public event Action? ActivityRequested;
     // Raised to collapse/restore the sidebar (the view owns the grid column).
@@ -452,6 +455,7 @@ public sealed partial class MainViewModel : ObservableObject
         yield return new PaletteItem("Next tab", "Action", "›", Invoke(() => NextTabCommand), Hotkeys.Label("PgDn"));
         yield return new PaletteItem("Previous tab", "Action", "‹", Invoke(() => PreviousTabCommand), Hotkeys.Label("PgUp"));
         yield return new PaletteItem("Format SQL", "Action", "❖", () => { FormatSqlRequested?.Invoke(); return Task.CompletedTask; }, Hotkeys.Label("Shift+F"));
+        yield return new PaletteItem("Expand SELECT * into columns", "Action", "✳", () => { ExpandStarRequested?.Invoke(); return Task.CompletedTask; });
         yield return new PaletteItem("Toggle sidebar", "Action", "◫", () => { SidebarToggleRequested?.Invoke(); return Task.CompletedTask; }, Hotkeys.Label("B"));
         yield return new PaletteItem("Toggle auto-alias tables (orders → orders o)", "Action", "a", Invoke(() => ToggleAutoAliasCommand), Hotkeys.Label("Shift+A"));
         yield return new PaletteItem("Switch connection…", "Action", "⇄", () => { SwitchConnectionRequested?.Invoke(); return Task.CompletedTask; });

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -359,6 +359,7 @@ public partial class MainWindow : Window
             _viewModel.ShortcutsRequested -= ShowShortcutsWindow;
             _viewModel.SwitchConnectionRequested -= SwitchConnection;
             _viewModel.FormatSqlRequested -= FormatCurrentStatement;
+            _viewModel.ExpandStarRequested -= ExpandSelectStar;
             _viewModel.ActivityRequested -= ShowActivityWindow;
             _viewModel.SidebarToggleRequested -= ToggleSidebar;
             _viewModel.PreferencesRequested -= ShowPreferencesWindow;
@@ -371,6 +372,7 @@ public partial class MainWindow : Window
         _viewModel.ShortcutsRequested += ShowShortcutsWindow;
         _viewModel.SwitchConnectionRequested += SwitchConnection;
         _viewModel.FormatSqlRequested += FormatCurrentStatement;
+        _viewModel.ExpandStarRequested += ExpandSelectStar;
         _viewModel.ActivityRequested += ShowActivityWindow;
         _viewModel.SidebarToggleRequested += ToggleSidebar;
         _viewModel.PreferencesRequested += ShowPreferencesWindow;
@@ -1355,6 +1357,21 @@ public partial class MainWindow : Window
 
         SqlEditor.Document.Replace(start, end - start, formatted);
         SqlEditor.CaretOffset = start + formatted.Length;
+    }
+
+    // Palette "Expand SELECT *": replace the star(s) in the statement under
+    // the caret with the explicit column list — CTEs and catalog tables both
+    // resolve (see SqlCompletionProvider.ExpandSelectStar). A no-op when
+    // there's no star or a table is unknown: better nothing than a wrong list.
+    private void ExpandSelectStar()
+    {
+        if (_viewModel?.CompletionProvider.ExpandSelectStar(SqlEditor.Text, SqlEditor.CaretOffset) is not { } expansion)
+        {
+            return;
+        }
+
+        SqlEditor.Document.Replace(expansion.Start, expansion.Length, expansion.Replacement);
+        SqlEditor.CaretOffset = expansion.Start + expansion.Replacement.Length;
     }
 
     // Ctrl+C copies the selection as TSV (spreadsheet-friendly). ClipboardCopyMode

--- a/PgNimbus.Core.Tests/Text/SelectStarExpansionTests.cs
+++ b/PgNimbus.Core.Tests/Text/SelectStarExpansionTests.cs
@@ -1,0 +1,161 @@
+using PgNimbus.Core.Text;
+
+namespace PgNimbus.Core.Tests.Text;
+
+/// <summary>
+/// Exercises <see cref="SqlCompletionContext.ExpandSelectStar"/> — the
+/// "Expand SELECT *" action — against a fake catalog resolver.
+/// </summary>
+public class SelectStarExpansionTests
+{
+    // The fake catalog: bare and schema-qualified spellings both resolve,
+    // mirroring how the App's resolver answers.
+    private static readonly Dictionary<string, string[]> Catalog = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["orders"] = ["id", "customer_id", "total"],
+        ["public.orders"] = ["id", "customer_id", "total"],
+        ["customers"] = ["id", "name"],
+        ["public.customers"] = ["id", "name"],
+        ["weird"] = ["Weird Name", "ok"],
+        ["source_rows"] = ["a", "b"],
+    };
+
+    private static IReadOnlyList<string>? ColumnsFor(string schema, string table)
+    {
+        var key = schema.Length == 0 ? table : $"{schema}.{table}";
+        return Catalog.TryGetValue(key, out var columns) ? columns : null;
+    }
+
+    private static string? Apply(string sql, int? caret = null)
+    {
+        var expansion = SqlCompletionContext.ExpandSelectStar(sql, caret ?? sql.Length, ColumnsFor);
+        if (expansion is not { } e)
+        {
+            return null;
+        }
+
+        return sql.Remove(e.Start, e.Length).Insert(e.Start, e.Replacement);
+    }
+
+    [Test]
+    public async Task SingleTable_ExpandsUnqualified()
+    {
+        await Assert.That(Apply("SELECT * FROM orders"))
+            .IsEqualTo("SELECT id, customer_id, total FROM orders");
+    }
+
+    [Test]
+    public async Task MultiTable_QualifiesByAliasOrName()
+    {
+        await Assert.That(Apply("SELECT * FROM orders o JOIN customers ON customers.id = o.customer_id"))
+            .IsEqualTo("SELECT o.id, o.customer_id, o.total, customers.id, customers.name FROM orders o JOIN customers ON customers.id = o.customer_id");
+    }
+
+    [Test]
+    public async Task QualifiedStar_ExpandsJustThatTable_KeepingOtherItems()
+    {
+        await Assert.That(Apply("SELECT o.*, c.name FROM orders o JOIN customers c ON c.id = o.customer_id"))
+            .IsEqualTo("SELECT o.id, o.customer_id, o.total, c.name FROM orders o JOIN customers c ON c.id = o.customer_id");
+    }
+
+    [Test]
+    public async Task NonStarItems_SurviveVerbatim_IncludingLiterals()
+    {
+        await Assert.That(Apply("SELECT 'x' AS label, * FROM customers"))
+            .IsEqualTo("SELECT 'x' AS label, id, name FROM customers");
+    }
+
+    [Test]
+    public async Task Distinct_KeepsTheQuantifier()
+    {
+        await Assert.That(Apply("SELECT DISTINCT * FROM customers"))
+            .IsEqualTo("SELECT DISTINCT id, name FROM customers");
+    }
+
+    [Test]
+    public async Task UnknownTable_ExpandsNothing()
+    {
+        await Assert.That(Apply("SELECT * FROM mystery_table")).IsNull();
+    }
+
+    [Test]
+    public async Task UnknownTableInAJoin_ExpandsNothing_AllOrNothing()
+    {
+        await Assert.That(Apply("SELECT * FROM orders o JOIN mystery m ON m.id = o.id")).IsNull();
+    }
+
+    [Test]
+    public async Task NoStar_ExpandsNothing()
+    {
+        await Assert.That(Apply("SELECT id, name FROM customers")).IsNull();
+    }
+
+    [Test]
+    public async Task CountStar_IsNotASelectListStar()
+    {
+        await Assert.That(Apply("SELECT count(*) FROM orders")).IsNull();
+    }
+
+    [Test]
+    public async Task NoFromYet_ExpandsNothing()
+    {
+        await Assert.That(Apply("SELECT * ")).IsNull();
+    }
+
+    [Test]
+    public async Task WithCte_OuterStarUsesOuterFromOnly()
+    {
+        // The resolver knows nothing about "recent", so the CTE body's
+        // "orders" must not leak in as an expansion source; the caller (App)
+        // resolves CTE names itself — here it can't, so: nothing.
+        await Assert.That(Apply("WITH recent AS (SELECT id FROM orders) SELECT * FROM recent")).IsNull();
+
+        // And when the resolver does answer for the CTE name, only its
+        // columns appear — not orders'.
+        var sql = "WITH recent AS (SELECT id FROM orders) SELECT * FROM source_rows";
+        await Assert.That(Apply(sql))
+            .IsEqualTo("WITH recent AS (SELECT id FROM orders) SELECT a, b FROM source_rows");
+    }
+
+    [Test]
+    public async Task InsertSelect_ExpandsTheFromTable_NotTheTarget()
+    {
+        await Assert.That(Apply("INSERT INTO customers SELECT * FROM source_rows"))
+            .IsEqualTo("INSERT INTO customers SELECT a, b FROM source_rows");
+    }
+
+    [Test]
+    public async Task SecondStatement_ExpandsAtTheCaret()
+    {
+        var sql = "SELECT 1; SELECT * FROM customers";
+        await Assert.That(Apply(sql, sql.Length))
+            .IsEqualTo("SELECT 1; SELECT id, name FROM customers");
+    }
+
+    [Test]
+    public async Task ColumnsNeedingQuotes_GetThem()
+    {
+        await Assert.That(Apply("SELECT * FROM weird"))
+            .IsEqualTo("SELECT \"Weird Name\", ok FROM weird");
+    }
+
+    [Test]
+    public async Task AliasedTable_QualifiedStarByAlias()
+    {
+        await Assert.That(Apply("SELECT o.* FROM orders o"))
+            .IsEqualTo("SELECT o.id, o.customer_id, o.total FROM orders o");
+    }
+
+    [Test]
+    public async Task SchemaQualifiedTable_Resolves()
+    {
+        await Assert.That(Apply("SELECT * FROM public.orders"))
+            .IsEqualTo("SELECT id, customer_id, total FROM public.orders");
+    }
+
+    [Test]
+    public async Task StarInsideAStringLiteral_IsNotAStar()
+    {
+        await Assert.That(Apply("SELECT '*' AS star FROM orders")).IsNull();
+    }
+}

--- a/PgNimbus.Core.Tests/Text/SelectStarExpansionTests.cs
+++ b/PgNimbus.Core.Tests/Text/SelectStarExpansionTests.cs
@@ -154,6 +154,22 @@ public class SelectStarExpansionTests
     }
 
     [Test]
+    public async Task SchemaQualifiedStar_Resolves()
+    {
+        await Assert.That(Apply("SELECT public.orders.* FROM public.orders"))
+            .IsEqualTo("SELECT public.orders.id, public.orders.customer_id, public.orders.total FROM public.orders");
+    }
+
+    [Test]
+    public async Task SchemaQualifiedStar_DoesNotMatchAnAliasedTable()
+    {
+        // An alias makes the schema-qualified spelling illegal SQL for this
+        // table ("orders o" can only be referenced as o. or orders.), so
+        // "public.orders.*" must not resolve through it.
+        await Assert.That(Apply("SELECT public.orders.* FROM public.orders o")).IsNull();
+    }
+
+    [Test]
     public async Task StarInsideAStringLiteral_IsNotAStar()
     {
         await Assert.That(Apply("SELECT '*' AS star FROM orders")).IsNull();

--- a/PgNimbus.Core/Text/SqlCompletionContext.StarExpansion.cs
+++ b/PgNimbus.Core/Text/SqlCompletionContext.StarExpansion.cs
@@ -1,0 +1,282 @@
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Text;
+
+public static partial class SqlCompletionContext
+{
+    /// <summary>
+    /// A resolved <c>SELECT *</c> expansion: replace <paramref name="Length"/>
+    /// characters at <paramref name="Start"/> (the statement's select list)
+    /// with <paramref name="Replacement"/> (the same list with every star
+    /// spelled out as explicit columns).
+    /// </summary>
+    public readonly record struct StarExpansion(int Start, int Length, string Replacement);
+
+    /// <summary>
+    /// Expands the <c>*</c> / <c>alias.*</c> items in the select list of the
+    /// statement under <paramref name="caret"/> into explicit column lists,
+    /// resolving each FROM/JOIN table's columns through
+    /// <paramref name="columnsFor"/> (schema, table → column names; null when
+    /// unknown — the caller owns the catalog and can also answer for CTEs).
+    /// All-or-nothing: if any table a star covers can't be resolved, returns
+    /// null rather than a semantically different partial list. Columns are
+    /// qualified with the table's alias (or name) when more than one table is
+    /// in scope; a qualified star keeps its qualifier as typed. Only the
+    /// outer select list expands — CTE bodies are out of scope here (each CTE
+    /// can be expanded from inside its own statement… once subquery editing
+    /// lands; today the caret's statement is the unit).
+    /// </summary>
+    public static StarExpansion? ExpandSelectStar(
+        string sql,
+        int caret,
+        Func<string, string, IReadOnlyList<string>?> columnsFor)
+    {
+        if (SqlScriptSplitter.StatementSpanAt(sql, caret) is not { } stmt)
+        {
+            return null;
+        }
+
+        var statement = sql[stmt.Start..stmt.End];
+        // Masked twice: literals/comments first (as everywhere), then CTE
+        // bodies — so the select list, FROM tables, and star items found
+        // below all belong to the *outer* query, not a WITH body.
+        var masked = MaskCteBodies(MaskCommentsAndStrings(statement));
+
+        if (FindSelectListSpan(masked) is not { } span)
+        {
+            return null;
+        }
+
+        var (listStart, listEnd) = span;
+        while (listStart < listEnd && char.IsWhiteSpace(masked[listStart]))
+        {
+            listStart++;
+        }
+
+        while (listEnd > listStart && char.IsWhiteSpace(masked[listEnd - 1]))
+        {
+            listEnd--;
+        }
+
+        if (listStart >= listEnd)
+        {
+            return null;
+        }
+
+        var tables = ExtractFromTables(masked);
+        var items = new List<string>();
+        var expandedAny = false;
+
+        foreach (var (itemStart, itemEnd) in SplitTopLevelSpans(masked, listStart, listEnd))
+        {
+            var s = itemStart;
+            var e = itemEnd;
+            while (s < e && char.IsWhiteSpace(masked[s]))
+            {
+                s++;
+            }
+
+            while (e > s && char.IsWhiteSpace(masked[e - 1]))
+            {
+                e--;
+            }
+
+            var item = masked[s..e];
+            if (item == "*")
+            {
+                if (tables.Count == 0 || !TryExpandBareStar(tables, columnsFor, items))
+                {
+                    return null;
+                }
+
+                expandedAny = true;
+                continue;
+            }
+
+            if (item.EndsWith(".*", StringComparison.Ordinal) && IsPureChain(item.AsSpan(0, item.Length - 2)))
+            {
+                if (!TryExpandQualifiedStar(item[..^2], tables, columnsFor, items))
+                {
+                    return null;
+                }
+
+                expandedAny = true;
+                continue;
+            }
+
+            // Any other item survives verbatim — from the *original* text:
+            // the masked copy has string literals blanked out.
+            items.Add(sql.Substring(stmt.Start + s, e - s));
+        }
+
+        if (!expandedAny)
+        {
+            return null;
+        }
+
+        return new StarExpansion(stmt.Start + listStart, listEnd - listStart, string.Join(", ", items));
+    }
+
+    // "*" covers every FROM/JOIN table, in FROM order; columns are qualified
+    // by alias-or-name when the join makes bare names ambiguous.
+    private static bool TryExpandBareStar(
+        IReadOnlyList<TableRef> tables,
+        Func<string, string, IReadOnlyList<string>?> columnsFor,
+        List<string> items)
+    {
+        var qualify = tables.Count > 1;
+        foreach (var table in tables)
+        {
+            if (columnsFor(table.Schema, table.Table) is not { Count: > 0 } columns)
+            {
+                return false;
+            }
+
+            var qualifier = qualify ? SqlIdentifier.QuoteIfNeeded(table.Alias ?? table.Table) : null;
+            AppendColumns(items, qualifier, columns);
+        }
+
+        return true;
+    }
+
+    // "q.*" covers the one table q names — a FROM alias or a table name —
+    // and keeps q as the qualifier so the expansion resolves exactly like
+    // the star did.
+    private static bool TryExpandQualifiedStar(
+        string qualifierAsTyped,
+        IReadOnlyList<TableRef> tables,
+        Func<string, string, IReadOnlyList<string>?> columnsFor,
+        List<string> items)
+    {
+        var qualifier = Unquote(qualifierAsTyped);
+        foreach (var table in tables)
+        {
+            var matches = (table.Alias is not null && string.Equals(table.Alias, qualifier, StringComparison.OrdinalIgnoreCase))
+                || (table.Alias is null && string.Equals(table.Table, qualifier, StringComparison.OrdinalIgnoreCase));
+            if (!matches)
+            {
+                continue;
+            }
+
+            if (columnsFor(table.Schema, table.Table) is not { Count: > 0 } columns)
+            {
+                return false;
+            }
+
+            AppendColumns(items, qualifierAsTyped.Trim(), columns);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void AppendColumns(List<string> items, string? qualifier, IReadOnlyList<string> columns)
+    {
+        foreach (var column in columns)
+        {
+            var quoted = SqlIdentifier.QuoteIfNeeded(column);
+            items.Add(qualifier is null ? quoted : $"{qualifier}.{quoted}");
+        }
+    }
+
+    // True when the span is a bare identifier chain ("o", "public.orders",
+    // "\"Order Items\"") — the only thing that can legally qualify a star.
+    private static bool IsPureChain(ReadOnlySpan<char> s)
+    {
+        if (s.IsEmpty)
+        {
+            return false;
+        }
+
+        foreach (var c in s)
+        {
+            if (!IsIdentPart(c) && c != '.' && c != '"')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // The FROM/JOIN tables only — ExtractTables minus the UPDATE / INSERT
+    // INTO targets, because "INSERT INTO t SELECT * FROM s" expands to s's
+    // columns, never t's. Expects already-masked input.
+    private static List<TableRef> ExtractFromTables(string maskedSql)
+    {
+        var tables = new List<TableRef>();
+        foreach (System.Text.RegularExpressions.Match clause in FromClauseRegex().Matches(maskedSql))
+        {
+            foreach (var segment in JoinSplitRegex().Split(clause.Groups["body"].Value))
+            {
+                AddTableRef(tables, SingleTableRefRegex().Match(segment));
+            }
+        }
+
+        return tables;
+    }
+
+    // Blanks the interior of every CTE body (the parens survive, keeping
+    // depth intact) so the outer statement's SELECT/FROM are the only ones
+    // at paren depth 0. Length-preserving, like MaskCommentsAndStrings.
+    private static string MaskCteBodies(string masked)
+    {
+        char[]? buffer = null;
+        foreach (System.Text.RegularExpressions.Match match in CteNameRegex().Matches(masked))
+        {
+            var bodyStart = match.Index + match.Length;
+            var bodyEnd = FindBalancedClose(masked, bodyStart);
+            if (bodyEnd <= bodyStart)
+            {
+                continue;
+            }
+
+            buffer ??= masked.ToCharArray();
+            for (var i = bodyStart; i < bodyEnd; i++)
+            {
+                buffer[i] = ' ';
+            }
+        }
+
+        return buffer is null ? masked : new string(buffer);
+    }
+
+    // The [start, end) spans of the top-level comma-separated items inside
+    // s[from..to] — SplitTopLevel with offsets instead of substrings.
+    private static List<(int Start, int End)> SplitTopLevelSpans(string s, int from, int to)
+    {
+        var spans = new List<(int, int)>();
+        var depth = 0;
+        var start = from;
+        var i = from;
+        while (i < to)
+        {
+            var c = s[i];
+            if (c == '"')
+            {
+                var close = s.IndexOf('"', i + 1);
+                i = close < 0 || close >= to ? to : close + 1;
+                continue;
+            }
+
+            if (c == '(' || c == '[')
+            {
+                depth++;
+            }
+            else if (c == ')' || c == ']')
+            {
+                depth--;
+            }
+            else if (c == ',' && depth == 0)
+            {
+                spans.Add((start, i));
+                start = i + 1;
+            }
+
+            i++;
+        }
+
+        spans.Add((start, to));
+        return spans;
+    }
+}

--- a/PgNimbus.Core/Text/SqlCompletionContext.StarExpansion.cs
+++ b/PgNimbus.Core/Text/SqlCompletionContext.StarExpansion.cs
@@ -139,7 +139,8 @@ public static partial class SqlCompletionContext
         return true;
     }
 
-    // "q.*" covers the one table q names — a FROM alias or a table name —
+    // "q.*" covers the one table q names — a FROM alias, a bare table name,
+    // or (when the table has no alias) a schema-qualified "schema.table" —
     // and keeps q as the qualifier so the expansion resolves exactly like
     // the star did.
     private static bool TryExpandQualifiedStar(
@@ -148,11 +149,13 @@ public static partial class SqlCompletionContext
         Func<string, string, IReadOnlyList<string>?> columnsFor,
         List<string> items)
     {
-        var qualifier = Unquote(qualifierAsTyped);
+        var (qSchema, qTable) = SplitQualified(qualifierAsTyped);
         foreach (var table in tables)
         {
-            var matches = (table.Alias is not null && string.Equals(table.Alias, qualifier, StringComparison.OrdinalIgnoreCase))
-                || (table.Alias is null && string.Equals(table.Table, qualifier, StringComparison.OrdinalIgnoreCase));
+            var matches = table.Alias is not null
+                ? qSchema.Length == 0 && string.Equals(table.Alias, qTable, StringComparison.OrdinalIgnoreCase)
+                : string.Equals(table.Table, qTable, StringComparison.OrdinalIgnoreCase)
+                    && (qSchema.Length == 0 || string.Equals(table.Schema, qSchema, StringComparison.OrdinalIgnoreCase));
             if (!matches)
             {
                 continue;

--- a/README.md
+++ b/README.md
@@ -444,9 +444,12 @@ impact order:
   column list or SELECT-list aliases complete like a table's columns
   (`SELECT *` bodies resolve through the source tables' catalog columns,
   chained/recursive CTEs included), and WHERE over a CTE narrows to them.
-- [ ] **`SELECT *` expansion** — a completion item (and/or command-palette
-  action) that replaces `*` with the explicit column list of the statement's
-  FROM tables.
+- [x] **`SELECT *` expansion** — "Expand SELECT * into columns" in the
+  command palette replaces the statement's `*` / `alias.*` with the explicit
+  column list of its FROM tables (qualified by alias when the statement joins
+  more than one; CTEs resolve through their derived output columns).
+  All-or-nothing: an unresolvable table means no rewrite, never a wrong one.
+  Deliberately palette-only — no popup item on every typed `*`.
 
 ### Next — the gaps users of competing tools keep hitting
 


### PR DESCRIPTION
## What

"Expand SELECT * into columns" (Ctrl+K palette) rewrites the statement under the caret: every top-level `*` / `alias.*` in its select list becomes the explicit column list of the statement's FROM/JOIN tables, qualified by alias-or-name when more than one table is in scope.

Builds on #97's CTE output-column derivation — a CTE name in the star's scope resolves through its derived columns, not the catalog.

## How

- **Core** — `SqlCompletionContext.ExpandSelectStar` finds the select list of the statement under the caret (via `SqlScriptSplitter.StatementSpanAt`, so multi-statement scripts only touch the one under the cursor), masks CTE bodies so only the outer query's list/FROM count, and rewrites each `*`/`alias.*` item using a caller-supplied `(schema, table) → columns` resolver — Core stays catalog-agnostic.
- **All-or-nothing** — if any table a star covers can't be resolved, nothing is rewritten. A wrong or partial column list is worse than no rewrite.
- **Provider** — supplies the resolver: CTE names resolve through their derived output columns first (shadowing, same as #97's member access), everything else through the catalog.
- **Wiring** — same event pattern as the existing "Format SQL" palette action (`MainViewModel` raises `ExpandStarRequested`, `MainWindow` owns the editor text and applies the rewrite).

Deliberately palette-only, not a completion-popup item — a `SELECT *` doesn't need a popup on every keystroke, just an explicit action once the statement is written.

## Testing

- 17 new Core unit tests (`SelectStarExpansionTests`) — single/multi-table qualification, qualified `alias.*`, CTE resolution (including "resolver doesn't know the CTE" → no rewrite), `INSERT INTO t SELECT * FROM s` expands `s` not `t`, `count(*)` and `'*'` literals left alone, `DISTINCT` preserved, unresolvable table → no rewrite. Full suite 202/202 green.
- Verified live against the seeded Docker Postgres in the running app:
  - `SELECT * FROM orders o JOIN customers c ON …` → `SELECT o.id, o.customer_id, o.total, o.created_at, c.id, c.name, c.email FROM orders o …`
  - `WITH recent AS (SELECT id, total FROM orders) SELECT * FROM recent` → outer `*` expands to `id, total` via the CTE, the CTE body itself untouched
  - `SELECT * FROM nonexistent_table` → left completely alone (all-or-nothing safety)

🤖 Generated with [Claude Code](https://claude.com/claude-code)