### PR TITLE
Use transparent icon for the MSI Start Menu shortcut

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,13 +76,15 @@ jobs:
         run: dotnet tool install --global wix --version 5.*
 
       - name: Build MSI
-        # PublishDir/IconFile must be absolute: WiX resolves relative -d
-        # paths against the .wxs file's own directory, not the cwd.
+        # PublishDir/IconFile/StartMenuIconFile must be absolute: WiX
+        # resolves relative -d paths against the .wxs file's own directory,
+        # not the cwd.
         run: >
           wix build installer/windows/Product.wxs
           -d PublishDir=${{ github.workspace }}\publish\win-x64
           -d Version=${{ env.VERSION }}
           -d IconFile=${{ github.workspace }}\PgNimbus.App\Assets\app.ico
+          -d StartMenuIconFile=${{ github.workspace }}\PgNimbus.App\Assets\window-icon-dark.ico
           -arch x64
           -o pgNimbus-${{ env.VERSION }}-win-x64.msi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,9 +108,15 @@ csproj / WiX / MSIX manifest reference them unchanged:
   (almost always dark) taskbar whenever the app ran the light theme.
 - `window-icon-light.ico` / `window-icon-dark.ico` — theme-tinted
   transparent line-art icons (16/24/32/48/256, all PNG entries) built from
-  the `window/` masters. **Not consumed in-app anymore** — superseded by the
-  plated `app.ico` window icon above (2026-07); still generated in case
-  transparent themed line art is wanted later.
+  the `window/` masters. Superseded as the runtime window icon by the plated
+  `app.ico` (2026-07 — see above). `window-icon-dark.ico` *is* consumed
+  though: `Product.wxs`'s Start Menu shortcut uses it (via the
+  `StartMenuIconFile` WiX define, see "Release pipeline" below) so the
+  pinned tile matches every other app's transparent Start tile instead of
+  showing a plated square — a shortcut's icon is static metadata read only
+  while the app isn't running, so it doesn't hit the WM_SETICON
+  can't-diverge constraint above. `window-icon-light.ico` still has no
+  consumer (kept in case a light-Start-background variant is wanted later).
 - `Assets/Msix/*` — MSIX tiles, packaging-time-only. Each of
   `Square44x44Logo`/`Square150x150Logo`/`StoreLogo` ships as
   `.scale-{100,125,150,200,400}.png` (not one flat file — Windows will
@@ -305,7 +311,10 @@ job so it never publishes). It produces, per tag:
 - **Windows** — `dotnet publish -r win-x64 -p:PublishAot=true`, then a
   per-user WiX v5 MSI built from [`installer/windows/Product.wxs`](installer/windows/Product.wxs)
   via the `wix` .NET global tool (`wix build ... -d PublishDir=... -d
-  Version=...`). Per-user (installs to `%LocalAppData%`, no elevation) is
+  Version=... -d IconFile=... -d StartMenuIconFile=...`). The Start Menu
+  shortcut is deliberately pointed at the transparent `window-icon-dark.ico`
+  rather than the plated `IconFile`/`app.ico` — see "App icon / logo assets"
+  above. Per-user (installs to `%LocalAppData%`, no elevation) is
   deliberate: the MSI is currently **unsigned** (no code-signing cert yet),
   and per-machine + unsigned is a much worse UAC/SmartScreen experience.
   The `UpgradeCode` GUID in `Product.wxs` is fixed forever — never

--- a/design/DESIGNER-BRIEF.md
+++ b/design/DESIGNER-BRIEF.md
@@ -37,8 +37,8 @@ design/masters/
 
 | Type | Background | Used as… |
 |---|---|---|
-| **App icon "tile"** (`icon/`) | **Solid color, fills the whole square** | The app's icon on the desktop, taskbar, Start menu, Dock, and in the app stores. It's a little colored square. |
-| **Window / line-art** (`window/`, `logo/`) | **Transparent** | Drawn *on top of* the app's UI and the website. No background — it must look right on both white and near-black. |
+| **App icon "tile"** (`icon/`) | **Solid color, fills the whole square** | The app's icon on the desktop, taskbar, window title bar, Dock, and in the app stores. It's a little colored square. |
+| **Window / line-art** (`window/`, `logo/`) | **Transparent** | Drawn *on top of* the app's UI and the website, plus the Windows Start Menu pinned tile (so it matches every other app's transparent tile there). No background — it must look right on both white and near-black. |
 
 **2. Small icons must be redrawn simpler, not just shrunk.**
 The whole reason for this brief: today the small icons are just the big one

--- a/design/LOGO-ASSETS.md
+++ b/design/LOGO-ASSETS.md
@@ -65,9 +65,9 @@ MSIX manifest / CI reference them unchanged.
 
 | File | Size(s) | Bg | Consumed by |
 |---|---|---|---|
-| `app.ico` | 16,24,32,48,64,128,256 | solid tile | exe icon (`ApplicationIcon` in csproj) + MSI (`Product.wxs` → `ARPPRODUCTICON`, shortcut) + runtime window icon, title bar + taskbar (`ThemedWindowChrome.cs`) |
+| `app.ico` | 16,24,32,48,64,128,256 | solid tile | exe icon (`ApplicationIcon` in csproj) + MSI (`Product.wxs` → `ARPPRODUCTICON`) + runtime window icon, title bar + taskbar (`ThemedWindowChrome.cs`) |
 | `window-icon-light.ico` | 16,24,32,48,256 | transparent | **nothing right now** — was the light-theme window icon until 2026-07, superseded by the plated `app.ico` (title bar/taskbar/Alt+Tab share one `WM_SETICON` slot, and theme-swapped line art was unreadable on the dark taskbar in light theme); still generated |
-| `window-icon-dark.ico` | 16,24,32,48,256 | transparent | **nothing right now** — same as above (was the dark-theme window icon) |
+| `window-icon-dark.ico` | 16,24,32,48,256 | transparent | MSI Start Menu shortcut icon (`Product.wxs` → `StartMenuIconFile`), so the pinned tile is transparent like every other app's instead of a plated square. A shortcut icon is static (read only while not running), so it doesn't hit the `WM_SETICON` constraint above |
 | `Msix/Square44x44Logo.scale-{100,125,150,200,400}.png` | 44,55,66,88,176 | solid tile | MSIX small tile (`Package.appxmanifest`) |
 | `Msix/Square150x150Logo.scale-{100,125,150,200,400}.png` | 150,188,225,300,600 | solid tile | MSIX medium tile |
 | `Msix/StoreLogo.scale-{100,125,150,200,400}.png` | 50,63,75,100,200 | solid tile | MSIX `Properties/Logo` |
@@ -93,7 +93,7 @@ derives only larger sizes:
 
 ```
 window/window-light-256.png ── resize to 16/24/32/48/256 ──► Assets/window-icon-light.ico
-window/window-dark-256.png  ── resize to 16/24/32/48/256 ──► Assets/window-icon-dark.ico
+window/window-dark-256.png  ── resize to 16/24/32/48/256 ──► Assets/window-icon-dark.ico  (→ MSI Start Menu shortcut)
 icon/icon-{16,24,32,48}.png ── copy (as-is) ─┐
 icon/icon-256.png ── downscale → 64,128 ─────┼─► Assets/app.ico  (7 entries)
 icon/icon-48.png   ── → 44,55,66 ────────────► Assets/Msix/Square44x44Logo.scale-{100,125,150}.png

--- a/installer/windows/Product.wxs
+++ b/installer/windows/Product.wxs
@@ -4,11 +4,20 @@
                -d PublishDir=<absolute path to dotnet publish output dir>
                -d Version=<x.y.z, no leading v>
                -d IconFile=<absolute path to app.ico>
+               -d StartMenuIconFile=<absolute path to window-icon-dark.ico>
                -arch x64
                -o pgNimbus-<version>-win-x64.msi
 
-  PublishDir/IconFile must be absolute paths: WiX resolves relative -d
-  values against this .wxs file's own directory, not the caller's cwd.
+  PublishDir/IconFile/StartMenuIconFile must be absolute paths: WiX resolves
+  relative -d values against this .wxs file's own directory, not the
+  caller's cwd.
+
+  IconFile (the plated app.ico) drives the exe/MSI/ARP icon; the Start Menu
+  shortcut instead uses StartMenuIconFile, the transparent unplated line-art
+  icon, so the pinned tile matches every other app's transparent Start tile
+  (see CLAUDE.md "App icon / logo assets"). This is independent of the
+  runtime window/taskbar icon (set via WM_SETICON, always plated) — a
+  shortcut's icon is static metadata read only while the app isn't running.
 
   Per-user install (no elevation) into %LocalAppData%\pgNimbus — deliberate,
   since this MSI is unsigned for now and per-machine + unsigned is a much
@@ -27,6 +36,7 @@
     <MediaTemplate EmbedCab="yes" />
 
     <Icon Id="AppIcon.ico" SourceFile="$(var.IconFile)" />
+    <Icon Id="StartMenuIcon.ico" SourceFile="$(var.StartMenuIconFile)" />
     <Property Id="ARPPRODUCTICON" Value="AppIcon.ico" />
     <Property Id="ARPURLINFOABOUT" Value="https://github.com/Shman4ik/pgNimbus" />
     <Property Id="ARPNOMODIFY" Value="1" />
@@ -43,7 +53,7 @@
                     Description="A fast, open-source PostgreSQL GUI client"
                     Target="[INSTALLFOLDER]PgNimbus.App.exe"
                     WorkingDirectory="INSTALLFOLDER"
-                    Icon="AppIcon.ico" />
+                    Icon="StartMenuIcon.ico" />
           <RemoveFolder Id="RemoveProgramMenuDir" Directory="ProgramMenuDir" On="uninstall" />
           <RegistryValue Root="HKCU"
                           Key="Software\pgNimbus\pgNimbus"


### PR DESCRIPTION
## Summary
- The per-user MSI's Start Menu shortcut used the plated `app.ico`, so pgNimbus's pinned tile was a solid colored square while every other app in Start (Word, Excel, Settings, Spotify, ...) shows a transparent icon on the dark backdrop.
- The shortcut icon is static metadata read only while the app isn't running, so it's independent of the runtime window/taskbar icon (`WM_SETICON`, which stays plated per the existing 2026-07 decision documented in CLAUDE.md — that constraint is about the *running* window, not the shortcut).
- Wires the already-generated but previously-unused `window-icon-dark.ico` (transparent line art, built from `design/masters/window/window-dark-256.png`) as the shortcut icon via a new `StartMenuIconFile` WiX define, and updates the design docs (`CLAUDE.md`, `design/LOGO-ASSETS.md`, `design/DESIGNER-BRIEF.md`) to reflect the new consumer.

## Test plan
- [ ] Build the MSI locally (`wix build installer/windows/Product.wxs -d PublishDir=... -d Version=... -d IconFile=...\app.ico -d StartMenuIconFile=...\window-icon-dark.ico -arch x64 -o test.msi`) and confirm the Start Menu pinned tile is transparent while the taskbar/title bar icon when running stays plated.
- [ ] Confirm the release workflow's MSI build step still succeeds with the new `-d StartMenuIconFile=...` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)