### PR TITLE
macOS manual-testing batch: real wheel scrolling, native chrome, connection dialog UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,27 @@ and wrong project memory is worse than none.
    (`PreferencesWindow`, opened from the palette), persisted in
    `AppSettings`.
 
+## Platform window chrome
+
+- **Windows** — every window calls `ThemedWindowChrome.Attach(this)` (icon +
+  caption color; details in the icon section below).
+- **macOS** — `MainWindow.SetUpMacTitleBar()` merges the 40px command bar
+  with the title bar (`ExtendClientAreaToDecorationsHint` +
+  `ExtendClientAreaTitleBarHeightHint = 40`; Avalonia 12 dropped the old
+  `ExtendClientAreaChromeHints` enum — native traffic lights stay by
+  default). The bar gets 84px left padding to clear the traffic lights and
+  drags the window from its empty space (`BeginMoveDrag`). The macOS app
+  menu name and "About pgNimbus" item come from `Name="pgNimbus"` +
+  `NativeMenu.Menu` in `App.axaml` — without them Avalonia shows
+  "Avalonia Application"/"About Avalonia". The sidebar toggle icon is
+  platform-picked via `{OnPlatform}` (SF-style geometry on macOS).
+- **Results-grid scrolling is the DataGrid's own.** Avalonia 12's DataGrid
+  handles both wheel axes natively (`UpdateScroll`). Don't reintroduce a
+  tunneled wheel handler that writes `ScrollBar.Value` directly — the
+  DataGrid only reacts to user `Scroll` events, so that moves the bar
+  without the content (the 2026-07 macOS "scrollbar moves, results don't"
+  bug, since removed).
+
 ## App icon / logo assets
 
 Full reference: [`design/LOGO-ASSETS.md`](design/LOGO-ASSETS.md); the

--- a/PgNimbus.App/App.axaml
+++ b/PgNimbus.App/App.axaml
@@ -1,7 +1,18 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="PgNimbus.App.App"
+             Name="pgNimbus"
              RequestedThemeVariant="Default">
+
+    <!-- macOS app menu (ignored elsewhere). Name above is what the menu bar
+         and the "Hide ..." item display - without it, Avalonia's exporter
+         falls back to "Avalonia Application". The standard Services / Hide /
+         Quit block is appended automatically by Avalonia. -->
+    <NativeMenu.Menu>
+        <NativeMenu>
+            <NativeMenuItem Header="About pgNimbus" Click="OnAboutMenuItemClicked" />
+        </NativeMenu>
+    </NativeMenu.Menu>
 
     <Application.Styles>
         <FluentTheme />

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -71,6 +71,24 @@ public partial class App : Application
 
     private static string ThemeToString(ThemeVariant variant) =>
         variant == ThemeVariant.Dark ? "dark" : variant == ThemeVariant.Light ? "light" : "system";
+
+    /// <summary>
+    /// "About pgNimbus" in the macOS app menu (see App.axaml). Opens the
+    /// project page - version/license already live in the connection dialog's
+    /// footer, so a dedicated About window would just duplicate them.
+    /// </summary>
+    private void OnAboutMenuItemClicked(object? sender, EventArgs e)
+    {
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("https://github.com/Shman4ik/pgNimbus") { UseShellExecute = true });
+        }
+        catch
+        {
+            // No browser to hand off to is not worth crashing the app menu.
+        }
+    }
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -148,6 +148,11 @@
         <!-- Custom (VS Code-style "layout sidebar left"): window frame with the
              left pane filled - reads as collapse/expand sidebar, not a menu. -->
         <StreamGeometry x:Key="SidebarToggleIconGeometry">M5,3C3.9,3 3,3.9 3,5V19C3,20.11 3.9,21 5,21H19C20.11,21 21,20.11 21,19V5C21,3.9 20.11,3 19,3H5M10,5H19V19H10V5Z</StreamGeometry>
+        <!-- macOS variant (SF Symbols "sidebar.leading" proportions): landscape
+             rounded rect, thin ring, leading pane filled - what Finder/Safari
+             toolbars use, so the toggle reads native there. Picked per-platform
+             via OnPlatform where the button is declared (MainWindow). -->
+        <StreamGeometry x:Key="SidebarToggleMacIconGeometry">M6,4C3.79,4 2,5.79 2,8V16C2,18.21 3.79,20 6,20H18C20.21,20 22,18.21 22,16V8C22,5.79 20.21,4 18,4H6M9.5,5.5H18C19.38,5.5 20.5,6.62 20.5,8V16C20.5,17.38 19.38,18.5 18,18.5H9.5V5.5Z</StreamGeometry>
         <StreamGeometry x:Key="WeatherSunnyIconGeometry">M12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,2L14.39,5.42C13.65,5.15 12.84,5 12,5C11.16,5 10.35,5.15 9.61,5.42L12,2M3.34,7L7.5,6.65C6.9,7.16 6.36,7.78 5.94,8.5C5.5,9.24 5.25,10 5.11,10.79L3.34,7M3.36,17L5.12,13.23C5.26,14 5.53,14.78 5.95,15.5C6.37,16.24 6.91,16.86 7.5,17.37L3.36,17M20.65,7L18.88,10.79C18.74,10 18.47,9.23 18.05,8.5C17.63,7.78 17.1,7.15 16.5,6.64L20.65,7M20.64,17L16.5,17.36C17.09,16.85 17.62,16.22 18.04,15.5C18.46,14.77 18.73,14 18.87,13.21L20.64,17M12,22L9.59,18.56C10.33,18.83 11.14,19 12,19C12.82,19 13.63,18.85 14.37,18.58L12,22Z</StreamGeometry>
         <StreamGeometry x:Key="WeatherNightIconGeometry">M17.75,4.09L15.22,6.03L16.13,9.09L13.5,7.28L10.87,9.09L11.78,6.03L9.25,4.09L12.44,4L13.5,1L14.56,4L17.75,4.09M21.25,11L19.61,12.25L20.2,14.23L18.5,13.06L16.8,14.23L17.39,12.25L15.75,11L17.81,10.95L18.5,9L19.19,10.95L21.25,11M18.97,15.95C19.8,15.87 20.69,17.05 20.16,17.8C19.84,18.25 19.5,18.67 19.08,19.07C15.17,23 8.84,23 4.94,19.07C1.03,15.17 1.03,8.83 4.94,4.93C5.34,4.53 5.76,4.17 6.21,3.85C6.96,3.32 8.14,4.21 8.06,5.04C7.79,7.9 8.75,10.87 10.95,13.06C13.14,15.26 16.1,16.22 18.97,15.95Z</StreamGeometry>
         <!-- Completion popup kind glyphs: tag / table-column / layers-triple / link-variant (MDI).

--- a/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
+++ b/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
@@ -207,6 +207,9 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
     [RelayCommand]
     private void SelectAccentColor(string? color) => AccentColor = color;
 
+    /// <summary>Persists the list's current order after a drag-reorder in the dialog (the store writes profiles in enumeration order).</summary>
+    public void PersistProfileOrder() => _store.Save(Profiles);
+
     /// <summary>
     /// Re-parses whatever connection string is in the import box — postgres://
     /// URI, JDBC URL, Key=Value;, libpq keywords, or a full psql command line —
@@ -274,7 +277,11 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
                 Username = parsed.Username;
             }
 
-            if (parsed.Password is not null)
+            // The preview renders the password as mask bullets (see
+            // BuildPreviewConnectionString) - when the user hand-edits some
+            // other part of the preview, the re-parse hands those bullets
+            // back here, and they must not overwrite the real password.
+            if (parsed.Password is not null && !parsed.Password.Contains(PasswordMaskChar))
             {
                 Password = parsed.Password;
             }
@@ -317,8 +324,15 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         }
     }
 
-    /// <summary>Renders the current fields as a postgres:// URI — the most widely recognized connection string format.</summary>
-    private string BuildPreviewConnectionString()
+    private const char PasswordMaskChar = '•';
+
+    /// <summary>Renders the current fields as a postgres:// URI — the most widely recognized connection string format. The password shows as mask bullets; <see cref="BuildClipboardConnectionString"/> carries the real one.</summary>
+    private string BuildPreviewConnectionString() => BuildConnectionStringUri(maskPassword: true);
+
+    /// <summary>The full postgres:// URI with the real password, for the explicit copy-to-clipboard action only — never shown on screen.</summary>
+    public string BuildClipboardConnectionString() => BuildConnectionStringUri(maskPassword: false);
+
+    private string BuildConnectionStringUri(bool maskPassword)
     {
         var builder = new StringBuilder("postgres://");
 
@@ -327,7 +341,9 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
             builder.Append(Uri.EscapeDataString(Username));
             if (!string.IsNullOrEmpty(Password))
             {
-                builder.Append(':').Append(Uri.EscapeDataString(Password));
+                builder.Append(':').Append(maskPassword
+                    ? new string(PasswordMaskChar, 6)
+                    : Uri.EscapeDataString(Password));
             }
 
             builder.Append('@');

--- a/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
+++ b/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
@@ -277,11 +277,13 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
                 Username = parsed.Username;
             }
 
-            // The preview renders the password as mask bullets (see
+            // The preview renders the password as the fixed mask string (see
             // BuildPreviewConnectionString) - when the user hand-edits some
-            // other part of the preview, the re-parse hands those bullets
-            // back here, and they must not overwrite the real password.
-            if (parsed.Password is not null && !parsed.Password.Contains(PasswordMaskChar))
+            // other part of the preview, the re-parse hands that mask back
+            // here, and it must not overwrite the real password. Only the
+            // exact mask is skipped, so a genuine pasted password that merely
+            // contains a bullet still imports.
+            if (parsed.Password is not null && parsed.Password != PasswordMask)
             {
                 Password = parsed.Password;
             }
@@ -324,7 +326,7 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         }
     }
 
-    private const char PasswordMaskChar = '•';
+    private const string PasswordMask = "••••••";
 
     /// <summary>Renders the current fields as a postgres:// URI — the most widely recognized connection string format. The password shows as mask bullets; <see cref="BuildClipboardConnectionString"/> carries the real one.</summary>
     private string BuildPreviewConnectionString() => BuildConnectionStringUri(maskPassword: true);
@@ -342,7 +344,7 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
             if (!string.IsNullOrEmpty(Password))
             {
                 builder.Append(':').Append(maskPassword
-                    ? new string(PasswordMaskChar, 6)
+                    ? PasswordMask
                     : Uri.EscapeDataString(Password));
             }
 

--- a/PgNimbus.App/Views/ConnectionDialog.axaml
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml
@@ -20,7 +20,9 @@
             <TextBlock Grid.Row="0" Text="Saved Connections" FontWeight="SemiBold" Margin="0,0,0,8" />
             <Border Grid.Row="1" Classes="card">
                 <Grid>
-                    <ListBox ItemsSource="{Binding Profiles}" SelectedItem="{Binding SelectedProfile}"
+                    <!-- Rows reorder by drag (pointer handlers in code-behind);
+                         the new order persists to connections.json on release. -->
+                    <ListBox Name="ProfilesList" ItemsSource="{Binding Profiles}" SelectedItem="{Binding SelectedProfile}"
                              DoubleTapped="OnProfileDoubleTapped">
                         <ListBox.ItemTemplate>
                             <DataTemplate DataType="conn:ConnectionProfile">
@@ -57,7 +59,7 @@
                 </TextBox.KeyBindings>
             </TextBox>
             <Button Grid.Column="1" Classes="chip" Padding="7" Click="OnCopyConnectionStringClick"
-                    ToolTip.Tip="Copy connection string to clipboard">
+                    ToolTip.Tip="Copy connection string to clipboard (includes the password)">
                 <PathIcon Data="{StaticResource ClipboardIconGeometry}" Width="14" Height="14" />
             </Button>
         </Grid>
@@ -91,7 +93,8 @@
 
             <StackPanel Grid.Row="7" Margin="0,0,0,8">
                 <TextBlock Text="Password" />
-                <TextBox Text="{Binding Password}" PasswordChar="•" />
+                <!-- revealPasswordButton = Fluent's built-in eye toggle -->
+                <TextBox Text="{Binding Password}" PasswordChar="•" Classes="revealPasswordButton" />
             </StackPanel>
 
             <StackPanel Grid.Row="8" Orientation="Horizontal" Spacing="8" Margin="0,0,0,8">
@@ -128,7 +131,7 @@
 
                     <StackPanel Grid.Row="4">
                         <TextBlock Text="SSH Password / Passphrase" />
-                        <TextBox Text="{Binding SshPassword}" PasswordChar="•" />
+                        <TextBox Text="{Binding SshPassword}" PasswordChar="•" Classes="revealPasswordButton" />
                     </StackPanel>
                 </Grid>
             </Border>

--- a/PgNimbus.App/Views/ConnectionDialog.axaml.cs
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml.cs
@@ -11,10 +11,81 @@ namespace PgNimbus.App.Views;
 
 public partial class ConnectionDialog : Window
 {
+    // Drag-to-reorder state for the saved-connections list: the row the
+    // pointer went down on, where, and whether it has moved far enough to
+    // count as a reorder rather than a click.
+    private ConnectionProfile? _dragProfile;
+    private Avalonia.Point _dragStartPoint;
+    private bool _isReordering;
+
     public ConnectionDialog()
     {
         InitializeComponent();
         ThemedWindowChrome.Attach(this);
+
+        // Reorder saved connections by dragging rows. Live-moves the row while
+        // the pointer travels (the list itself is the drop preview), then
+        // persists the order on release. Tunneled press so the row is known
+        // even if a child ever marks the event handled.
+        ProfilesList.AddHandler(PointerPressedEvent, OnProfilesPointerPressed, Avalonia.Interactivity.RoutingStrategies.Tunnel);
+        ProfilesList.PointerMoved += OnProfilesPointerMoved;
+        ProfilesList.PointerReleased += OnProfilesPointerReleased;
+    }
+
+    private void OnProfilesPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(ProfilesList).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        _dragProfile = (e.Source as Visual)?.FindAncestorOfType<ListBoxItem>(includeSelf: true)?.DataContext as ConnectionProfile;
+        _dragStartPoint = e.GetPosition(ProfilesList);
+        _isReordering = false;
+    }
+
+    private void OnProfilesPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_dragProfile is not { } dragged || DataContext is not ConnectionDialogViewModel vm
+            || !e.GetCurrentPoint(ProfilesList).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        var position = e.GetPosition(ProfilesList);
+        if (!_isReordering && Math.Abs(position.Y - _dragStartPoint.Y) < 6)
+        {
+            return; // still a click, not a drag
+        }
+
+        _isReordering = true;
+
+        // The pressed row holds the pointer capture, so e.Source is useless
+        // here - hit-test the list by position to find the row underneath.
+        var target = ProfilesList.GetVisualAt(position)?.FindAncestorOfType<ListBoxItem>(includeSelf: true)?.DataContext as ConnectionProfile;
+        if (target is null || ReferenceEquals(target, dragged))
+        {
+            return;
+        }
+
+        var from = vm.Profiles.IndexOf(dragged);
+        var to = vm.Profiles.IndexOf(target);
+        if (from >= 0 && to >= 0 && from != to)
+        {
+            vm.Profiles.Move(from, to);
+        }
+    }
+
+    private void OnProfilesPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (_isReordering && _dragProfile is { } dragged && DataContext is ConnectionDialogViewModel vm)
+        {
+            vm.SelectedProfile = dragged;
+            vm.PersistProfileOrder();
+        }
+
+        _dragProfile = null;
+        _isReordering = false;
     }
 
     // Reads the profile off the tapped ListBoxItem's DataContext rather than
@@ -40,7 +111,9 @@ public partial class ConnectionDialog : Window
 
         try
         {
-            await clipboard.SetTextAsync(vm.ImportText);
+            // The visible preview masks the password - the clipboard gets the
+            // real, usable connection string.
+            await clipboard.SetTextAsync(vm.BuildClipboardConnectionString());
         }
         catch
         {

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -129,13 +129,17 @@
         leaves it opaque otherwise so the base is never a see-through hole.
     -->
     <DockPanel Name="ShellBase" Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}">
-        <Border DockPanel.Dock="Top" Height="40" Padding="16,0"
+        <!-- On macOS this bar doubles as the title bar: SetUpMacTitleBar
+             (code-behind) extends the client area under the system one, pads
+             the left edge clear of the traffic lights, and makes the bar's
+             empty space drag the window. -->
+        <Border Name="CommandBar" DockPanel.Dock="Top" Height="40" Padding="16,0"
                 BorderThickness="0,0,0,1" BorderBrush="{StaticResource CardBorderBrush}">
             <DockPanel>
                 <Button Name="SidebarToggleButton" DockPanel.Dock="Left" Classes="chip" Padding="5"
                         Margin="0,0,10,0" VerticalAlignment="Center"
                         Click="OnToggleSidebarClick" ToolTip.Tip="Toggle sidebar (Ctrl+B)">
-                    <PathIcon Data="{StaticResource SidebarToggleIconGeometry}" Width="14" Height="14" />
+                    <PathIcon Data="{OnPlatform Default={StaticResource SidebarToggleIconGeometry}, macOS={StaticResource SidebarToggleMacIconGeometry}}" Width="14" Height="14" />
                 </Button>
                 <Border DockPanel.Dock="Left" Width="10" Height="10" CornerRadius="5" Margin="0,0,10,0"
                         VerticalAlignment="Center"

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -66,6 +66,7 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         ThemedWindowChrome.Attach(this);
+        SetUpMacTitleBar();
 
         // Gestures use the platform/preference command modifier (Ctrl or Cmd),
         // so they're built in code, and rebuilt live when the scheme changes.
@@ -189,12 +190,6 @@ public partial class MainWindow : Window
         HistoryList.DoubleTapped += (_, e) => OnQueryListDoubleTapped(e,
             item => _viewModel?.SavedQueries.LoadHistoryEntryCommand.Execute(item as QueryHistoryEntry));
 
-        // Trackpads and tilt-wheels scroll the results grid horizontally on
-        // hover: the DataGrid's own wheel handling only consumes the vertical
-        // axis, so a mostly-horizontal delta is fed to its horizontal
-        // scrollbar here (tunneled - the grid marks wheel events handled).
-        ResultsGrid.AddHandler(PointerWheelChangedEvent, OnResultsGridPointerWheel, RoutingStrategies.Tunnel);
-
         // Column autocomplete inside the browse WHERE box (see the popup in XAML).
         BrowseFilterBox.TextChanged += OnBrowseFilterTextChanged;
         BrowseFilterBox.LostFocus += (_, _) => CloseFilterCompletion();
@@ -214,6 +209,37 @@ public partial class MainWindow : Window
             if (DataContext is MainViewModel vm)
             {
                 Attach(vm);
+            }
+        };
+    }
+
+    /// <summary>
+    /// macOS-only: merges the command bar with the title bar, TablePlus-style.
+    /// The system title bar collapses to just the traffic lights (drawn over
+    /// our 40px bar, which matches the standard macOS title bar height), the
+    /// bar's left padding keeps the sidebar toggle clear of them, and pressing
+    /// the bar's empty space drags the window - buttons mark their presses
+    /// handled, so this never swallows a click. No-op everywhere else; on
+    /// Windows the title bar is themed by <see cref="ThemedWindowChrome"/>.
+    /// </summary>
+    private void SetUpMacTitleBar()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        // Avalonia 12 keeps the native traffic lights when extending on macOS
+        // (the old ExtendClientAreaChromeHints enum is gone).
+        ExtendClientAreaToDecorationsHint = true;
+        ExtendClientAreaTitleBarHeightHint = 40;
+        // 16px original left padding + room for the traffic-light cluster.
+        CommandBar.Padding = new Thickness(84, 0, 16, 0);
+        CommandBar.PointerPressed += (_, e) =>
+        {
+            if (e.GetCurrentPoint(CommandBar).Properties.IsLeftButtonPressed)
+            {
+                BeginMoveDrag(e);
             }
         };
     }
@@ -897,31 +923,6 @@ public partial class MainWindow : Window
         {
             load(item);
         }
-    }
-
-    // Cached template part of the results grid; the template never re-applies
-    // for the window's lifetime, so one lookup is enough.
-    private Avalonia.Controls.Primitives.ScrollBar? _resultsHorizontalScrollBar;
-
-    private void OnResultsGridPointerWheel(object? sender, PointerWheelEventArgs e)
-    {
-        // Mostly-vertical deltas stay with the DataGrid's own wheel handling.
-        if (Math.Abs(e.Delta.X) <= Math.Abs(e.Delta.Y))
-        {
-            return;
-        }
-
-        _resultsHorizontalScrollBar ??= ResultsGrid.GetVisualDescendants()
-            .OfType<Avalonia.Controls.Primitives.ScrollBar>()
-            .FirstOrDefault(s => s.Orientation == Avalonia.Layout.Orientation.Horizontal);
-        if (_resultsHorizontalScrollBar is not { } bar)
-        {
-            return;
-        }
-
-        // Same direction convention as ScrollViewer: offset moves against the delta.
-        bar.Value = Math.Clamp(bar.Value - e.Delta.X * 48, bar.Minimum, bar.Maximum);
-        e.Handled = true;
     }
 
     private void OnPreparingCellForEdit(object? sender, DataGridPreparingCellForEditEventArgs e)

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -237,7 +237,19 @@ public partial class MainWindow : Window
         CommandBar.Padding = new Thickness(84, 0, 16, 0);
         CommandBar.PointerPressed += (_, e) =>
         {
-            if (e.GetCurrentPoint(CommandBar).Properties.IsLeftButtonPressed)
+            if (!e.GetCurrentPoint(CommandBar).Properties.IsLeftButtonPressed)
+            {
+                return;
+            }
+
+            // Match the native macOS title bar: single press drags, double
+            // click zooms. BeginMoveDrag swallows the second press, so the
+            // zoom has to be handled here rather than via DoubleTapped.
+            if (e.ClickCount == 2)
+            {
+                WindowState = WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
+            }
+            else
             {
                 BeginMoveDrag(e);
             }

--- a/README.md
+++ b/README.md
@@ -146,9 +146,12 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   paging — all pushed down to Postgres (`WHERE`/`ORDER BY`/`LIMIT`/`OFFSET`),
   so browsing a huge table stays as cheap as one page.
 - **Connection manager** — saved profiles with a per-connection accent color
-  (so production doesn't look like staging), SSH tunnel support, and
-  passwords held by the OS credential store (DPAPI on Windows) instead of
-  being written to disk with the profile.
+  (so production doesn't look like staging), drag-to-reorder of the saved
+  list, SSH tunnel support, and passwords held by the OS credential store
+  (DPAPI on Windows) instead of being written to disk with the profile. The
+  password field has a show/hide toggle, and the connection-string preview
+  masks the password by default (the copy button still yields the full,
+  usable string).
 - **Switch connection without restarting** — the ⇄ button next to the
   title-bar breadcrumb (or "Switch connection…" in the command palette)
   reopens the connection dialog; the current window stays fully usable until


### PR DESCRIPTION
- Results grid: drop the tunneled wheel handler from #90 - it wrote
  ScrollBar.Value directly, which the DataGrid ignores (it only reacts to
  user Scroll events), so any trackpad delta with |X| > |Y| moved the bar
  without the rows and swallowed the event. Avalonia 12's DataGrid handles
  both wheel axes natively (UpdateScroll), verified against the decompiled
  12.1.0 package.
- macOS chrome: the command bar now doubles as the title bar
  (ExtendClientAreaToDecorationsHint + 40px height hint, left padding for
  the traffic lights, empty-space drag via BeginMoveDrag); Application.Name
  + a NativeMenu give the menu bar "pgNimbus"/"About pgNimbus" instead of
  "Avalonia Application"/"About Avalonia"; the sidebar toggle icon switches
  to an SF-style sidebar.leading glyph via OnPlatform.
- Connection dialog: password fields get Fluent's reveal (eye) toggle; the
  connection-string preview masks the password with bullets (re-parse
  guard keeps the bullets from overwriting the real password; the copy
  button still copies the full usable URI); saved connections reorder by
  drag and the order persists to connections.json.
- README (connection-manager feature bullet) + CLAUDE.md (new platform
  window chrome section) updated to match.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cy4g6AxXHvGmo6Bye37sjj