### PR TITLE
Safe mode: stage grid edits, deletes, and inserts for review

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -41,6 +41,10 @@ public partial class App : Application
     private static void PersistAutoAliasTables(bool value) =>
         SettingsStore.Save(SettingsStore.Load() with { AutoAliasTables = value });
 
+    /// <summary>Remembers the safe-mode (stage &amp; review grid changes) toggle so it survives a restart.</summary>
+    private static void PersistSafeModeEdits(bool value) =>
+        SettingsStore.Save(SettingsStore.Load() with { SafeModeEdits = value });
+
     /// <summary>The saved settings snapshot, for the preferences page to initialize from.</summary>
     internal static AppSettings LoadSettings() => SettingsStore.Load();
 
@@ -181,7 +185,9 @@ public partial class App : Application
                 connectionHost: csb.Host ?? "",
                 connectionDatabase: csb.Database ?? "",
                 autoAliasTables: SettingsStore.Load().AutoAliasTables,
-                persistAutoAliasTables: PersistAutoAliasTables),
+                persistAutoAliasTables: PersistAutoAliasTables,
+                safeModeEdits: SettingsStore.Load().SafeModeEdits,
+                persistSafeModeEdits: PersistSafeModeEdits),
         };
 
         window.Closed += async (_, _) =>

--- a/PgNimbus.App/ViewModels/AddRowViewModel.cs
+++ b/PgNimbus.App/ViewModels/AddRowViewModel.cs
@@ -19,11 +19,21 @@ public sealed partial class AddRowViewModel : ObservableObject
     private readonly QueryEngine _engine;
     private readonly SchemaService _schemaService;
 
+    // Safe mode's staging hook: non-null means Insert stages the row into the
+    // owning tab's pending change set (returning an error message, or null on
+    // success) instead of executing. Supplied by the view at dialog-open time.
+    private readonly Func<IReadOnlyList<PendingInsertValue>, string?>? _stageInsert;
+
     public string Schema { get; }
 
     public string Table { get; }
 
     public string QualifiedName => $"{Schema}.{Table}";
+
+    /// <summary>True when Insert stages the row for later commit instead of executing it — relabels the dialog's primary button.</summary>
+    public bool IsStaging => _stageInsert is not null;
+
+    public string InsertButtonText => IsStaging ? "Stage Row" : "Insert Row";
 
     public ObservableCollection<NewRowField> Fields { get; } = [];
 
@@ -36,12 +46,18 @@ public sealed partial class AddRowViewModel : ObservableObject
     /// <summary>Raised after a successful INSERT so the grid can refresh and the dialog can close.</summary>
     public event Action? Inserted;
 
-    public AddRowViewModel(QueryEngine engine, SchemaService schemaService, string schema, string table)
+    public AddRowViewModel(
+        QueryEngine engine,
+        SchemaService schemaService,
+        string schema,
+        string table,
+        Func<IReadOnlyList<PendingInsertValue>, string?>? stageInsert = null)
     {
         _engine = engine;
         _schemaService = schemaService;
         Schema = schema;
         Table = table;
+        _stageInsert = stageInsert;
     }
 
     public async Task LoadAsync()
@@ -78,28 +94,40 @@ public sealed partial class AddRowViewModel : ObservableObject
         IsBusy = true;
         StatusMessage = null;
 
+        // The columns that participate in the INSERT: an explicit NULL, or a
+        // typed value. Blank + not-NULL fields are omitted entirely so their
+        // defaults apply. Same shape safe mode stages, so both paths agree.
+        var values = Fields
+            .Where(f => f.IsNull || !string.IsNullOrEmpty(f.Value))
+            .Select(f => new PendingInsertValue(f.Name, f.DataType, f.IsNull ? null : f.Value))
+            .ToList();
+
+        if (_stageInsert is { } stage)
+        {
+            StatusMessage = stage(values) ?? "Row staged — commit or discard it from the status bar.";
+            IsBusy = false;
+            return;
+        }
+
         var columns = new List<string>();
         var valueExpressions = new List<string>();
         var parameters = new Dictionary<string, object?>();
-        var index = 0;
 
-        foreach (var field in Fields)
+        foreach (var value in values)
         {
-            if (field.IsNull)
+            columns.Add(SqlIdentifier.Quote(value.Column));
+            if (value.ValueText is null)
             {
-                columns.Add(SqlIdentifier.Quote(field.Name));
                 valueExpressions.Add("NULL");
             }
-            else if (!string.IsNullOrEmpty(field.Value))
+            else
             {
-                columns.Add(SqlIdentifier.Quote(field.Name));
-                var name = $"p{index++}";
+                var name = $"p{parameters.Count}";
                 // Cast the text parameter to the column's declared type so
                 // Postgres parses "42"/"2024-01-01"/... into the real type.
-                valueExpressions.Add($"CAST(@{name} AS {field.DataType})");
-                parameters[name] = field.Value;
+                valueExpressions.Add($"CAST(@{name} AS {value.DataType})");
+                parameters[name] = value.ValueText;
             }
-            // Blank + not-NULL: omit the column entirely so its default applies.
         }
 
         var target = $"{SqlIdentifier.Quote(Schema)}.{SqlIdentifier.Quote(Table)}";

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -79,6 +79,21 @@ public sealed partial class MainViewModel : ObservableObject
             : "Auto-alias tables: off";
     }
 
+    /// <summary>
+    /// Flips safe mode and reports the new state in the status bar (same
+    /// visible-confirmation rationale as <see cref="ToggleAutoAlias"/>).
+    /// Changes already staged stay staged either way — they only leave via
+    /// commit or discard.
+    /// </summary>
+    [RelayCommand]
+    private void ToggleSafeMode()
+    {
+        SafeModeEdits = !SafeModeEdits;
+        ActiveTab.Status = SafeModeEdits
+            ? "Safe mode: on — grid edits, deletes, and inserts are staged for review"
+            : "Safe mode: off — grid changes apply immediately";
+    }
+
     [RelayCommand]
     private void ShowActivity() => ActivityRequested?.Invoke();
 
@@ -126,6 +141,19 @@ public sealed partial class MainViewModel : ObservableObject
 
     partial void OnAutoAliasTablesChanged(bool value) => _persistAutoAliasTables?.Invoke(value);
 
+    /// <summary>
+    /// Safe mode: grid edits, deletes, and Add-row inserts are staged locally
+    /// for review instead of executing immediately (see
+    /// <see cref="QueryViewModel.PendingChanges"/>). Toggled from the command
+    /// palette or preferences; persisted like <see cref="AutoAliasTables"/>.
+    /// </summary>
+    [ObservableProperty]
+    private bool _safeModeEdits;
+
+    private readonly Action<bool>? _persistSafeModeEdits;
+
+    partial void OnSafeModeEditsChanged(bool value) => _persistSafeModeEdits?.Invoke(value);
+
     public MainViewModel(
         QueryEngine engine,
         ExplainService explainService,
@@ -141,12 +169,16 @@ public sealed partial class MainViewModel : ObservableObject
         string connectionHost = "",
         string connectionDatabase = "",
         bool autoAliasTables = true,
-        Action<bool>? persistAutoAliasTables = null)
+        Action<bool>? persistAutoAliasTables = null,
+        bool safeModeEdits = false,
+        Action<bool>? persistSafeModeEdits = null)
     {
         ConnectionHost = connectionHost;
         ConnectionDatabase = connectionDatabase;
         _autoAliasTables = autoAliasTables;
         _persistAutoAliasTables = persistAutoAliasTables;
+        _safeModeEdits = safeModeEdits;
+        _persistSafeModeEdits = persistSafeModeEdits;
         _engine = engine;
         _explainService = explainService;
         SchemaTree = schemaTree;
@@ -258,8 +290,8 @@ public sealed partial class MainViewModel : ObservableObject
     public AlterTableViewModel CreateAlterTableViewModel(TableNode table) =>
         new(_schemaEditor, _schemaService, table.Schema, table.Name);
 
-    public AddRowViewModel CreateAddRowViewModel(string schema, string table) =>
-        new(_engine, _schemaService, schema, table);
+    public AddRowViewModel CreateAddRowViewModel(string schema, string table, Func<IReadOnlyList<PendingInsertValue>, string?>? stageInsert = null) =>
+        new(_engine, _schemaService, schema, table, stageInsert);
 
     /// <summary>
     /// Reloads everything derived from the live catalog — the schema tree, the
@@ -290,7 +322,7 @@ public sealed partial class MainViewModel : ObservableObject
     // Creates a query tab, wires its history hook, and makes it active.
     private QueryViewModel NewTab()
     {
-        var tab = new QueryViewModel(_engine, _explainService, GetReconcilerAsync) { DefaultTitle = $"Query {Tabs.Count + 1}" };
+        var tab = new QueryViewModel(_engine, _explainService, GetReconcilerAsync, () => SafeModeEdits) { DefaultTitle = $"Query {Tabs.Count + 1}" };
         tab.Executed += SavedQueries.RecordExecution;
         Tabs.Add(tab);
         ActiveTab = tab;
@@ -492,6 +524,7 @@ public sealed partial class MainViewModel : ObservableObject
         yield return new PaletteItem("Expand SELECT * into columns", "Action", "✳", () => { ExpandStarRequested?.Invoke(); return Task.CompletedTask; });
         yield return new PaletteItem("Toggle sidebar", "Action", "◫", () => { SidebarToggleRequested?.Invoke(); return Task.CompletedTask; }, Hotkeys.Label("B"));
         yield return new PaletteItem("Toggle auto-alias tables (orders → orders o)", "Action", "a", Invoke(() => ToggleAutoAliasCommand), Hotkeys.Label("Shift+A"));
+        yield return new PaletteItem("Toggle safe mode (stage grid changes, review & commit)", "Action", "⛨", Invoke(() => ToggleSafeModeCommand));
         yield return new PaletteItem("Switch connection…", "Action", "⇄", () => { SwitchConnectionRequested?.Invoke(); return Task.CompletedTask; });
         yield return new PaletteItem("Toggle light/dark theme", "Action", "◐", () => { ThemeToggleRequested?.Invoke(); return Task.CompletedTask; });
         yield return new PaletteItem("Preferences…", "Action", "⚙", Invoke(() => ShowPreferencesCommand), Hotkeys.Label(","));

--- a/PgNimbus.App/ViewModels/PreferencesViewModel.cs
+++ b/PgNimbus.App/ViewModels/PreferencesViewModel.cs
@@ -40,6 +40,13 @@ public sealed partial class PreferencesViewModel : ObservableObject
         set => _main.AutoAliasTables = value;
     }
 
+    /// <summary>Safe mode: stage grid changes for review instead of executing them immediately. Same proxy pattern as <see cref="AutoAliasTables"/>.</summary>
+    public bool SafeModeEdits
+    {
+        get => _main.SafeModeEdits;
+        set => _main.SafeModeEdits = value;
+    }
+
     /// <summary>Unhooks from the main view-model when the window closes.</summary>
     public void Detach() => _main.PropertyChanged -= OnMainPropertyChanged;
 
@@ -48,6 +55,10 @@ public sealed partial class PreferencesViewModel : ObservableObject
         if (e.PropertyName == nameof(MainViewModel.AutoAliasTables))
         {
             OnPropertyChanged(nameof(AutoAliasTables));
+        }
+        else if (e.PropertyName == nameof(MainViewModel.SafeModeEdits))
+        {
+            OnPropertyChanged(nameof(SafeModeEdits));
         }
     }
 

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -184,14 +184,43 @@ public sealed partial class QueryViewModel : ObservableObject
     /// <summary>Raised once per <see cref="RunAsync"/> completion (success, command, error, or cancellation) so a history tracker can record it without RunAsync knowing about persistence.</summary>
     public event Action<QueryHistoryEntry>? Executed;
 
+    /// <summary>
+    /// Safe mode's staging area for this tab: grid edits, deletes, and Add-row
+    /// inserts held locally until committed as one transaction or discarded.
+    /// Null until the first change is staged; always bound to a single table
+    /// (the edit context it was created from).
+    /// </summary>
+    [ObservableProperty]
+    private PendingChangeSet? _pendingChanges;
+
+    /// <summary>Status-bar summary of the staged set ("3 staged changes · public.orders"); null when nothing is staged.</summary>
+    [ObservableProperty]
+    private string? _pendingChangesText;
+
+    public bool HasPendingChanges => PendingChanges is { IsEmpty: false };
+
+    /// <summary>
+    /// True when grid changes should be staged rather than executed: safe mode
+    /// is on, or staged changes already exist — once a set is open, later
+    /// changes keep staging even if the toggle flips, since mixing immediate
+    /// and staged writes would apply the user's changes out of order.
+    /// </summary>
+    public bool ShouldStageChanges => (_safeMode?.Invoke() ?? false) || HasPendingChanges;
+
+    // Live "is safe mode on?" probe supplied by the owner (MainViewModel), so
+    // every tab follows the one app-wide toggle without per-tab plumbing.
+    private readonly Func<bool>? _safeMode;
+
     public QueryViewModel(
         QueryEngine engine,
         ExplainService explainService,
-        Func<CancellationToken, Task<IdentifierReconciler?>>? reconcilerFactory = null)
+        Func<CancellationToken, Task<IdentifierReconciler?>>? reconcilerFactory = null,
+        Func<bool>? safeMode = null)
     {
         _engine = engine;
         _explainService = explainService;
         _reconcilerFactory = reconcilerFactory;
+        _safeMode = safeMode;
         _lastRunSql = Sql;
         UpdateTabTitle();
     }
@@ -363,6 +392,7 @@ public sealed partial class QueryViewModel : ObservableObject
                     CapText = truncated
                         ? $"capped at {MaxDisplayRows:N0} rows — refine the query for the full set"
                         : null;
+                    ReapplyPendingEditsToGrid();
                     break;
 
                 case MaterializedResultSet materialized:
@@ -387,6 +417,7 @@ public sealed partial class QueryViewModel : ObservableObject
                     CapText = overCap
                         ? $"capped at {MaxDisplayRows:N0} rows — refine the query for the full set"
                         : null;
+                    ReapplyPendingEditsToGrid();
                     break;
 
                 case CommandResult commandResult:
@@ -627,6 +658,8 @@ public sealed partial class QueryViewModel : ObservableObject
         ExplainCommand.NotifyCanExecuteChanged();
         ExplainAnalyzeCommand.NotifyCanExecuteChanged();
         ApplyFixCommand.NotifyCanExecuteChanged();
+        CommitPendingCommand.NotifyCanExecuteChanged();
+        DiscardPendingCommand.NotifyCanExecuteChanged();
         OnPropertyChanged(nameof(HasNoResults));
 
         if (value)
@@ -795,16 +828,6 @@ public sealed partial class QueryViewModel : ObservableObject
             return;
         }
 
-        var whereClause = string.Join(
-            " AND ",
-            context.PrimaryKeyColumns.Select((pk, n) => $"{SqlIdentifier.Quote(pk)} = @pk{n}"));
-
-        var sql = $"""
-            UPDATE {SqlIdentifier.Quote(context.Schema)}.{SqlIdentifier.Quote(context.Table)}
-            SET {SqlIdentifier.Quote(columnName)} = @value
-            WHERE {whereClause}
-            """;
-
         object? newValue;
         try
         {
@@ -817,6 +840,22 @@ public sealed partial class QueryViewModel : ObservableObject
             return;
         }
 
+        if (ShouldStageChanges)
+        {
+            StageCellValue(context, row, pkIndexes, columnIndex, columnName, newValue);
+            return;
+        }
+
+        var whereClause = string.Join(
+            " AND ",
+            context.PrimaryKeyColumns.Select((pk, n) => $"{SqlIdentifier.Quote(pk)} = @pk{n}"));
+
+        var sql = $"""
+            UPDATE {SqlIdentifier.Quote(context.Schema)}.{SqlIdentifier.Quote(context.Table)}
+            SET {SqlIdentifier.Quote(columnName)} = @value
+            WHERE {whereClause}
+            """;
+
         var parameters = new Dictionary<string, object?> { ["value"] = newValue };
         for (var n = 0; n < pkIndexes.Count; n++)
         {
@@ -826,15 +865,7 @@ public sealed partial class QueryViewModel : ObservableObject
         try
         {
             await _engine.ExecuteNonQueryAsync(sql, parameters, CancellationToken.None);
-
-            var rowIndex = Rows.IndexOf(row);
-            if (rowIndex >= 0)
-            {
-                var updated = (object?[])row.Clone();
-                updated[columnIndex] = newValue;
-                Rows[rowIndex] = updated;
-            }
-
+            ReplaceRowCell(row, columnIndex, newValue);
             Status = $"Saved {context.Schema}.{context.Table}.{columnName}";
         }
         catch (Exception ex)
@@ -883,6 +914,12 @@ public sealed partial class QueryViewModel : ObservableObject
             return;
         }
 
+        if (ShouldStageChanges)
+        {
+            StageCellValue(context, row, pkIndexes, columnIndex, columnName, null);
+            return;
+        }
+
         var whereClause = string.Join(
             " AND ",
             context.PrimaryKeyColumns.Select((pk, n) => $"{SqlIdentifier.Quote(pk)} = @pk{n}"));
@@ -902,15 +939,7 @@ public sealed partial class QueryViewModel : ObservableObject
         try
         {
             await _engine.ExecuteNonQueryAsync(sql, parameters, CancellationToken.None);
-
-            var rowIndex = Rows.IndexOf(row);
-            if (rowIndex >= 0)
-            {
-                var updated = (object?[])row.Clone();
-                updated[columnIndex] = null;
-                Rows[rowIndex] = updated;
-            }
-
+            ReplaceRowCell(row, columnIndex, null);
             Status = $"Set {context.Schema}.{context.Table}.{columnName} to NULL";
         }
         catch (Exception ex)
@@ -1000,6 +1029,12 @@ public sealed partial class QueryViewModel : ObservableObject
             return 0;
         }
 
+        if (ShouldStageChanges)
+        {
+            StageDeletes(context, pkIndexes, rows);
+            return 0;
+        }
+
         var whereClause = string.Join(
             " AND ",
             context.PrimaryKeyColumns.Select((pk, n) => $"{SqlIdentifier.Quote(pk)} = @pk{n}"));
@@ -1054,6 +1089,297 @@ public sealed partial class QueryViewModel : ObservableObject
         // out-of-band change re-runs what's on screen, independent of any live
         // highlight (unlike the user-driven RunCommand).
         Browse is { } browse ? browse.LoadAsync() : RunCoreAsync(Sql, trackAsFullRun: true);
+
+    // --- Safe mode: staged changes ------------------------------------------
+
+    /// <summary>A grid row's relationship to the staged change set, for dirty-row highlighting.</summary>
+    public enum RowStagingState
+    {
+        None,
+        Edited,
+        Deleted,
+    }
+
+    // Stages one cell's converted value and shows it in the grid without
+    // touching the database. Shared by inline edits and "Set cell to NULL".
+    private void StageCellValue(EditableTableContext context, object?[] row, IReadOnlyList<int> pkIndexes, int columnIndex, string columnName, object? newValue)
+    {
+        if (EnsurePendingSet(context, out var error) is not { } pending)
+        {
+            Status = error!;
+            HasError = true;
+            return;
+        }
+
+        try
+        {
+            pending.StageEdit(PkValuesOf(row, pkIndexes), columnName, newValue);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Status = ex.Message;
+            HasError = true;
+            return;
+        }
+
+        ReplaceRowCell(row, columnIndex, newValue);
+        NotifyPendingChangesChanged();
+        Status = $"Staged {context.Schema}.{context.Table}.{columnName} — nothing applied until you commit";
+    }
+
+    // Stages deletes for the given rows; a row already staged for deletion is
+    // unstaged instead, so Delete toggles the mark.
+    private void StageDeletes(EditableTableContext context, IReadOnlyList<int> pkIndexes, IReadOnlyList<object?[]> rows)
+    {
+        if (EnsurePendingSet(context, out var error) is not { } pending)
+        {
+            Status = error!;
+            HasError = true;
+            return;
+        }
+
+        var staged = 0;
+        var unstaged = 0;
+        foreach (var row in rows)
+        {
+            var pkValues = PkValuesOf(row, pkIndexes);
+            if (pending.IsRowDeleted(pkValues))
+            {
+                pending.UnstageDelete(pkValues);
+                unstaged++;
+            }
+            else
+            {
+                pending.StageDelete(pkValues);
+                staged++;
+            }
+        }
+
+        NotifyPendingChangesChanged();
+        Status = (staged, unstaged) switch
+        {
+            (> 0, 0) => $"Staged {staged} delete{(staged == 1 ? "" : "s")} — nothing applied until you commit",
+            (0, > 0) => $"Unstaged {unstaged} delete{(unstaged == 1 ? "" : "s")}",
+            _ => $"Staged {staged} delete{(staged == 1 ? "" : "s")}, unstaged {unstaged}",
+        };
+    }
+
+    /// <summary>
+    /// Stages an INSERT (safe mode's Add-row path). Returns an error message to
+    /// show in the dialog, or null on success.
+    /// </summary>
+    public string? TryStageInsert(IReadOnlyList<PendingInsertValue> values)
+    {
+        if (EditContext is not { } context)
+        {
+            return "Staging isn't available for this result set.";
+        }
+
+        if (EnsurePendingSet(context, out var error) is not { } pending)
+        {
+            return error;
+        }
+
+        pending.StageInsert(values);
+        NotifyPendingChangesChanged();
+        Status = "Staged 1 insert — nothing applied until you commit";
+        HasError = false;
+        return null;
+    }
+
+    private bool CanCommitPending() => HasPendingChanges && !IsRunning;
+
+    /// <summary>
+    /// Applies every staged change as one transaction, then reloads the grid
+    /// from the server. A failure applies nothing and keeps the set staged, so
+    /// the user can fix the offending change or discard.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanCommitPending))]
+    private async Task CommitPendingAsync()
+    {
+        if (PendingChanges is not { IsEmpty: false } pending)
+        {
+            return;
+        }
+
+        HasError = false;
+        var count = pending.Count;
+
+        try
+        {
+            var affected = await _engine.ApplyBatchAsync(pending.BuildStatements(), CancellationToken.None);
+            ClearPendingSet();
+            await RefreshCurrentAsync();
+            Status = $"Committed {count} staged change{(count == 1 ? "" : "s")} in one transaction — {RowLabel(affected)} affected";
+            HasError = false;
+        }
+        catch (Exception ex)
+        {
+            Status = $"Commit failed — no staged changes were applied: {ex.Message}";
+            HasError = true;
+        }
+    }
+
+    /// <summary>Drops every staged change and reloads the grid so it shows server values again.</summary>
+    [RelayCommand(CanExecute = nameof(CanCommitPending))]
+    private async Task DiscardPendingAsync()
+    {
+        if (PendingChanges is not { IsEmpty: false } pending)
+        {
+            return;
+        }
+
+        var count = pending.Count;
+        ClearPendingSet();
+        await RefreshCurrentAsync();
+        Status = $"Discarded {count} staged change{(count == 1 ? "" : "s")}";
+        HasError = false;
+    }
+
+    /// <summary>How the given grid row relates to the staged set — drives the view's dirty-row highlighting.</summary>
+    public RowStagingState GetRowStaging(object?[] row)
+    {
+        if (PendingChanges is not { IsEmpty: false } pending
+            || PendingPkIndexes(pending) is not { } pkIndexes)
+        {
+            return RowStagingState.None;
+        }
+
+        var pkValues = PkValuesOf(row, pkIndexes);
+        if (pending.IsRowDeleted(pkValues))
+        {
+            return RowStagingState.Deleted;
+        }
+
+        return pending.IsRowEdited(pkValues) ? RowStagingState.Edited : RowStagingState.None;
+    }
+
+    // Returns a per-table change set matching the edit context, creating it on
+    // first use. Staging against a different table than an existing set is
+    // refused — one set, one table, one commit.
+    private PendingChangeSet? EnsurePendingSet(EditableTableContext context, out string? error)
+    {
+        if (PendingChanges is { } existing)
+        {
+            if (!string.Equals(existing.Schema, context.Schema, StringComparison.Ordinal)
+                || !string.Equals(existing.Table, context.Table, StringComparison.Ordinal))
+            {
+                error = $"Commit or discard the staged changes for {existing.Schema}.{existing.Table} first.";
+                return null;
+            }
+
+            error = null;
+            return existing;
+        }
+
+        error = null;
+        return PendingChanges = new PendingChangeSet(context.Schema, context.Table, context.PrimaryKeyColumns);
+    }
+
+    private void ClearPendingSet()
+    {
+        PendingChanges = null;
+        NotifyPendingChangesChanged();
+    }
+
+    // Refreshes everything derived from the staged set: the status-bar summary
+    // text (whose change notification is also the view's cue to repaint row
+    // highlights) and the commit/discard availability.
+    private void NotifyPendingChangesChanged()
+    {
+        PendingChangesText = PendingChanges is { IsEmpty: false } pending
+            ? $"{pending.Count} staged change{(pending.Count == 1 ? "" : "s")} · {pending.Schema}.{pending.Table}"
+            : null;
+        // A mutation can leave the summary text equal (e.g. staging one delete
+        // while unstaging another), which the property setter would swallow —
+        // re-raise unconditionally so the view always repaints row washes.
+        OnPropertyChanged(nameof(PendingChangesText));
+        OnPropertyChanged(nameof(HasPendingChanges));
+        CommitPendingCommand.NotifyCanExecuteChanged();
+        DiscardPendingCommand.NotifyCanExecuteChanged();
+    }
+
+    // The staged set's primary-key columns as indexes into the current result's
+    // columns, or null when the result doesn't carry them all (different query
+    // on screen: no highlighting, no re-apply).
+    private List<int>? PendingPkIndexes(PendingChangeSet pending)
+    {
+        var indexes = new List<int>(pending.PrimaryKeyColumns.Count);
+        foreach (var pk in pending.PrimaryKeyColumns)
+        {
+            var index = ColumnNames.IndexOf(pk);
+            if (index < 0)
+            {
+                return null;
+            }
+
+            indexes.Add(index);
+        }
+
+        return indexes;
+    }
+
+    private static object?[] PkValuesOf(object?[] row, IReadOnlyList<int> pkIndexes)
+    {
+        var values = new object?[pkIndexes.Count];
+        for (var i = 0; i < pkIndexes.Count; i++)
+        {
+            values[i] = pkIndexes[i] < row.Length ? row[pkIndexes[i]] : null;
+        }
+
+        return values;
+    }
+
+    // After the grid reloads from the server (re-run, browse page load), the
+    // fresh rows show server values — put the staged values back on matching
+    // rows so what's on screen stays what a commit would produce.
+    private void ReapplyPendingEditsToGrid()
+    {
+        if (PendingChanges is not { IsEmpty: false } pending
+            || PendingPkIndexes(pending) is not { } pkIndexes)
+        {
+            return;
+        }
+
+        for (var r = 0; r < Rows.Count; r++)
+        {
+            var row = Rows[r];
+            if (pending.GetRowEdits(PkValuesOf(row, pkIndexes)) is not { } edits)
+            {
+                continue;
+            }
+
+            var updated = (object?[])row.Clone();
+            var changed = false;
+            foreach (var (column, value) in edits)
+            {
+                var index = ColumnNames.IndexOf(column);
+                if (index >= 0 && index < updated.Length && !Equals(updated[index], value))
+                {
+                    updated[index] = value;
+                    changed = true;
+                }
+            }
+
+            if (changed)
+            {
+                Rows[r] = updated;
+            }
+        }
+    }
+
+    // Replaces the row wholesale (mutating an array element in place doesn't
+    // raise a UI change notification) with one cell's new value.
+    private void ReplaceRowCell(object?[] row, int columnIndex, object? value)
+    {
+        var rowIndex = Rows.IndexOf(row);
+        if (rowIndex >= 0)
+        {
+            var updated = (object?[])row.Clone();
+            updated[columnIndex] = value;
+            Rows[rowIndex] = updated;
+        }
+    }
 
     /// <summary>
     /// Snapshots the current result (columns + rows) and returns a writer that

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -80,7 +80,7 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private EditableTableContext? _editContext;
 
-    /// <summary>Non-null when this tab is in no-SQL "browse a table" mode (filter/sort/paging bar shown).</summary>
+    /// <summary>Non-null when this tab is in no-SQL "browse a table" mode (status-bar paging shown, header clicks sort server-side).</summary>
     [ObservableProperty]
     private TableBrowseViewModel? _browse;
 
@@ -92,8 +92,17 @@ public sealed partial class QueryViewModel : ObservableObject
     // that programmatic write as a manual edit and tear browse mode down.
     private bool _applyingBrowseSql;
 
-    /// <summary>Drives visibility of the browse (filter/sort/paging) bar.</summary>
+    /// <summary>Drives visibility of the status bar's paging segment.</summary>
     public bool IsBrowsing => Browse is not null;
+
+    /// <summary>
+    /// The status bar's row-count segment, suppressed in browse mode where the
+    /// paging range ("Rows 1–100") already carries the same information — one
+    /// fewer segment competing for the bar's width.
+    /// </summary>
+    public string? RowCountStatusText => IsBrowsing ? null : RowCountText;
+
+    partial void OnRowCountTextChanged(string? value) => OnPropertyChanged(nameof(RowCountStatusText));
 
     [ObservableProperty]
     private string _tabTitle = "Query";
@@ -725,12 +734,17 @@ public sealed partial class QueryViewModel : ObservableObject
         UpdateTabTitle();
     }
 
-    partial void OnBrowseChanged(TableBrowseViewModel? value) => OnPropertyChanged(nameof(IsBrowsing));
+    partial void OnBrowseChanged(TableBrowseViewModel? value)
+    {
+        OnPropertyChanged(nameof(IsBrowsing));
+        OnPropertyChanged(nameof(RowCountStatusText));
+    }
 
     /// <summary>
-    /// Enters no-SQL browse mode for a table and loads its first page. The
-    /// filter/sort/paging bar (bound to <see cref="Browse"/>) takes over from
-    /// there, re-querying the server on every change.
+    /// Enters no-SQL browse mode for a table and loads its first page. Paging
+    /// (status bar) and header-click sorting re-query the server from there;
+    /// the composed SQL is visible in the editor, and editing it turns the tab
+    /// into a plain query.
     /// </summary>
     public Task StartBrowseAsync(string schema, string name, IReadOnlyList<string> primaryKeyColumns, string? initialFilter = null)
     {
@@ -739,7 +753,7 @@ public sealed partial class QueryViewModel : ObservableObject
         if (!string.IsNullOrEmpty(initialFilter))
         {
             // A pre-seeded WHERE (e.g. following a foreign key to the referenced
-            // row) — shown in the filter box so it's visible and clearable.
+            // row) — visible in the composed SQL the editor shows.
             Browse.FilterText = initialFilter;
         }
 
@@ -1287,8 +1301,10 @@ public sealed partial class QueryViewModel : ObservableObject
     // highlights) and the commit/discard availability.
     private void NotifyPendingChangesChanged()
     {
+        // Deliberately terse — this shares one status-bar line with the
+        // metrics and paging segments; the review dialog carries the long form.
         PendingChangesText = PendingChanges is { IsEmpty: false } pending
-            ? $"{pending.Count} staged change{(pending.Count == 1 ? "" : "s")} · {pending.Schema}.{pending.Table}"
+            ? $"{pending.Count} staged · {pending.Schema}.{pending.Table}"
             : null;
         // A mutation can leave the summary text equal (e.g. staging one delete
         // while unstaging another), which the property setter would swallow —

--- a/PgNimbus.App/ViewModels/TableBrowseViewModel.cs
+++ b/PgNimbus.App/ViewModels/TableBrowseViewModel.cs
@@ -6,9 +6,12 @@ using PgNimbus.Core.Query;
 namespace PgNimbus.App.ViewModels;
 
 /// <summary>
-/// Drives no-SQL "browse a table" mode: a server-side <c>WHERE</c> filter,
-/// <c>ORDER BY</c> from clicking a column header, and <c>LIMIT</c>/<c>OFFSET</c>
-/// paging. Everything is pushed down to Postgres — no client-side slicing — so
+/// Drives no-SQL "browse a table" mode: <c>ORDER BY</c> from clicking a column
+/// header and <c>LIMIT</c>/<c>OFFSET</c> paging (the status bar's page
+/// controls), plus an optional <c>WHERE</c> predicate seeded by foreign-key
+/// navigation. There is no filter UI — the composed SQL lands in the editor,
+/// which *is* the filter box: edit it and run, and the tab becomes a plain
+/// query. Everything is pushed down to Postgres — no client-side slicing — so
 /// browsing a billion-row table stays as cheap as one page. The owning
 /// <see cref="QueryViewModel"/> supplies <see cref="_execute"/>, which composes
 /// nothing itself: it just runs the SQL this view-model builds and reports how
@@ -27,10 +30,7 @@ public sealed partial class TableBrowseViewModel : ObservableObject
 
     public string Name { get; }
 
-    /// <summary>The table being browsed, schema-qualified — shown in the browse bar.</summary>
-    public string QualifiedName => $"{Schema}.{Name}";
-
-    /// <summary>Raw SQL predicate typed into the filter box (the text after <c>WHERE</c>). Empty means no filter.</summary>
+    /// <summary>Raw SQL predicate (the text after <c>WHERE</c>), seeded by FK navigation. Empty means no filter.</summary>
     [ObservableProperty]
     private string _filterText = string.Empty;
 
@@ -46,10 +46,6 @@ public sealed partial class TableBrowseViewModel : ObservableObject
     /// <summary>"Rows 101–200" style range label for the current page.</summary>
     [ObservableProperty]
     private string _pageLabel = string.Empty;
-
-    /// <summary>"ORDER BY total ▼" style label, or null when unsorted.</summary>
-    [ObservableProperty]
-    private string? _sortLabel;
 
     [ObservableProperty]
     private bool _canGoPrevious;
@@ -103,23 +99,6 @@ public sealed partial class TableBrowseViewModel : ObservableObject
         PageLabel = count == 0
             ? (Offset > 0 ? "No more rows" : "No rows")
             : $"Rows {Offset + 1:N0}–{Offset + count:N0}";
-
-        SortLabel = SortColumn is { } col ? $"ORDER BY {col} {(SortDescending ? "▼" : "▲")}" : null;
-    }
-
-    [RelayCommand]
-    private Task ApplyFilter()
-    {
-        Offset = 0;
-        return LoadAsync();
-    }
-
-    [RelayCommand]
-    private Task ClearFilter()
-    {
-        FilterText = string.Empty;
-        Offset = 0;
-        return LoadAsync();
     }
 
     [RelayCommand(CanExecute = nameof(CanGoNext))]

--- a/PgNimbus.App/Views/AddRowDialog.axaml
+++ b/PgNimbus.App/Views/AddRowDialog.axaml
@@ -47,7 +47,7 @@
                    IsVisible="{Binding StatusMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
 
         <StackPanel Grid.Row="4" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="0,12,0,0">
-            <Button Classes="accent" Content="Insert Row" Command="{Binding InsertCommand}" IsEnabled="{Binding !IsBusy}" />
+            <Button Classes="accent" Content="{Binding InsertButtonText}" Command="{Binding InsertCommand}" IsEnabled="{Binding !IsBusy}" />
             <Button Content="Close" Click="OnCloseClick" />
         </StackPanel>
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -617,78 +617,9 @@
 
             <Border Grid.Row="3" Classes="card" Margin="0,12,0,12">
                 <DockPanel>
-                    <!-- Browse bar: server-side WHERE filter, ORDER BY (via header click), LIMIT/OFFSET paging.
-                         Disabled while a query is in flight so Apply/paging can't kick off a second concurrent run. -->
-                    <Border DockPanel.Dock="Top" IsVisible="{Binding ActiveTab.IsBrowsing}"
-                            IsEnabled="{Binding !ActiveTab.IsRunning}"
-                            BorderThickness="0,0,0,1" BorderBrush="{StaticResource CardBorderBrush}"
-                            Padding="8,7" Margin="0,0,0,4">
-                        <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto"
-                              x:DataType="vm:TableBrowseViewModel" DataContext="{Binding ActiveTab.Browse}">
-                            <TextBlock Grid.Column="0" Text="WHERE" FontFamily="Cascadia Code,Consolas,monospace"
-                                       FontSize="12" Opacity="0.55" VerticalAlignment="Center" Margin="2,0,8,0" />
-                            <TextBox Grid.Column="1" Name="BrowseFilterBox" FontSize="12"
-                                     VerticalAlignment="Center"
-                                     Text="{Binding FilterText, Mode=TwoWay}"
-                                     KeyDown="OnBrowseFilterKeyDown"
-                                     PlaceholderText="filter predicate — e.g. total &gt; 50 (Enter to apply)">
-                                <TextBox.InnerRightContent>
-                                    <Button Command="{Binding ClearFilterCommand}" Classes="chip" Margin="0,0,4,0"
-                                            VerticalAlignment="Center" ToolTip.Tip="Clear filter"
-                                            IsVisible="{Binding FilterText, Converter={x:Static conv:StringConverters.IsNotNullOrEmpty}}">
-                                        <PathIcon Data="{StaticResource CloseIconGeometry}" Width="11" Height="11" />
-                                    </Button>
-                                </TextBox.InnerRightContent>
-                            </TextBox>
-                            <!-- Column autocomplete for the WHERE predicate: only this dataset's
-                                 columns (no keywords/functions/other tables). Driven from code-behind. -->
-                            <Popup Grid.Column="1" Name="FilterCompletionPopup"
-                                   PlacementTarget="{Binding #BrowseFilterBox}"
-                                   Placement="BottomEdgeAlignedLeft"
-                                   IsLightDismissEnabled="False"
-                                   WindowManagerAddShadowHint="False">
-                                <Border Background="{DynamicResource SystemControlPageBackgroundAltHighBrush}"
-                                        BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
-                                        CornerRadius="6" BoxShadow="0 6 16 0 #40000000" Padding="2">
-                                    <!-- Non-focusable so keyboard focus stays in the filter box: arrow/Enter
-                                         keys are handled there, and clicking an item doesn't blur (and thus
-                                         auto-close) the popup before the tap is handled. -->
-                                    <ListBox Name="FilterCompletionList" MinWidth="220" MaxHeight="220"
-                                             Background="Transparent" Focusable="False"
-                                             Tapped="OnFilterCompletionTapped">
-                                        <ListBox.Styles>
-                                            <Style Selector="ListBoxItem">
-                                                <Setter Property="Focusable" Value="False" />
-                                            </Style>
-                                        </ListBox.Styles>
-                                        <ListBox.ItemTemplate>
-                                            <DataTemplate x:DataType="sys:String">
-                                                <TextBlock Text="{Binding}" FontSize="12"
-                                                           FontFamily="Cascadia Code,Consolas,monospace" />
-                                            </DataTemplate>
-                                        </ListBox.ItemTemplate>
-                                    </ListBox>
-                                </Border>
-                            </Popup>
-                            <Button Grid.Column="2" Content="Apply" Classes="toolbar" Command="{Binding ApplyFilterCommand}"
-                                    Margin="6,0,0,0" VerticalAlignment="Center" />
-                            <TextBlock Grid.Column="3" Text="{Binding SortLabel}"
-                                       IsVisible="{Binding SortLabel, Converter={x:Static conv:ObjectConverters.IsNotNull}}"
-                                       FontSize="12" Opacity="0.6" VerticalAlignment="Center" Margin="14,0,0,0" />
-                            <TextBlock Grid.Column="4" Text="{Binding PageLabel}" FontSize="12" Opacity="0.6"
-                                       VerticalAlignment="Center" Margin="14,0,6,0" />
-                            <Button Grid.Column="5" Classes="chip" Padding="5"
-                                    Command="{Binding PreviousPageCommand}" ToolTip.Tip="Previous page"
-                                    VerticalAlignment="Center">
-                                <PathIcon Data="{StaticResource ChevronLeftIconGeometry}" Width="12" Height="12" />
-                            </Button>
-                            <Button Grid.Column="6" Classes="chip" Padding="5"
-                                    Command="{Binding NextPageCommand}" ToolTip.Tip="Next page"
-                                    Margin="2,0,0,0" VerticalAlignment="Center">
-                                <PathIcon Data="{StaticResource ChevronRightIconGeometry}" Width="12" Height="12" />
-                            </Button>
-                        </Grid>
-                    </Border>
+                    <!-- No browse bar here on purpose: browse mode's WHERE/ORDER BY live in the
+                         composed SQL (visible in the editor), and its paging sits in the status
+                         bar — the results pane is the grid, nothing else (2026-07 rework). -->
 
                     <!-- Script sections: one selectable chip per statement of a multi-statement run -->
                     <Border DockPanel.Dock="Top" IsVisible="{Binding ActiveTab.IsScriptResult}"
@@ -802,13 +733,20 @@
         </Grid>
 
             <!-- Files-style segmented status bar: message · rows · timing · cap warning -->
+            <!-- The bar is a Grid, not a StackPanel, so it can never overflow the
+                 window: the message sits in the lone star column and truncates
+                 (full text on hover), while every other segment is compact and
+                 keeps its width. Long cap text truncates the same way. -->
             <Border Grid.Row="1" Classes="statusBar">
-                <StackPanel Orientation="Horizontal" Spacing="10">
-                    <TextBlock Text="{Binding ActiveTab.Status}"
+                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                    <TextBlock Grid.Column="0" Text="{Binding ActiveTab.Status}"
                                Classes="statusText" Classes.error="{Binding ActiveTab.HasError}"
-                               TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
+                               TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
+                               HorizontalAlignment="Left"
+                               ToolTip.Tip="{Binding ActiveTab.Status}" />
                     <!-- Running indicator: indeterminate bar + live elapsed tick while a query is in flight -->
-                    <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center"
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center"
+                                Margin="10,0,0,0"
                                 IsVisible="{Binding ActiveTab.IsRunning}">
                         <Rectangle Classes="statusSeparator" />
                         <ProgressBar IsIndeterminate="True" Width="90" Height="4"
@@ -816,7 +754,8 @@
                         <TextBlock Classes="statusText dim" Text="{Binding ActiveTab.RunningElapsedText}" VerticalAlignment="Center" />
                     </StackPanel>
                     <!-- Persistent "in transaction" indicator: an explicit BEGIN block is open -->
-                    <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center"
+                    <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center"
+                                Margin="10,0,0,0"
                                 IsVisible="{Binding IsInTransaction}"
                                 ToolTip.Tip="A transaction is open — statements run inside it until you commit or roll back">
                         <Rectangle Classes="statusSeparator" />
@@ -827,14 +766,15 @@
                     <!-- Safe mode's staged-changes segment: count + review/commit + discard.
                          Contextual like the fix affordance below — only present while
                          something is staged, so the bar stays clean otherwise. -->
-                    <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center"
+                    <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center"
+                                Margin="10,0,0,0"
                                 IsVisible="{Binding ActiveTab.HasPendingChanges}"
                                 ToolTip.Tip="Safe mode: these changes are staged locally — nothing has been sent to the database yet">
                         <Rectangle Classes="statusSeparator" />
                         <Ellipse Width="8" Height="8" Fill="{DynamicResource AppAccentBrush}" VerticalAlignment="Center" />
                         <TextBlock Classes="statusText" FontWeight="SemiBold"
                                    Text="{Binding ActiveTab.PendingChangesText}" VerticalAlignment="Center" />
-                        <Button Classes="accent" FontSize="11" Padding="10,3" Content="Review &amp; commit…"
+                        <Button Classes="accent" FontSize="11" Padding="10,3" Content="Review…"
                                 Click="OnReviewPendingClick"
                                 ToolTip.Tip="Show the generated SQL, then commit everything as one transaction" />
                         <Button FontSize="11" Padding="10,3" Content="Discard"
@@ -842,7 +782,8 @@
                                 ToolTip.Tip="Drop all staged changes and reload from the server" />
                     </StackPanel>
                     <!-- "Did you mean the quoted form?" fix, offered after a failed unquoted-identifier run -->
-                    <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center"
+                    <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center"
+                                Margin="10,0,0,0"
                                 IsVisible="{Binding ActiveTab.FixSuggestionSql, Converter={x:Static conv:ObjectConverters.IsNotNull}}">
                         <Rectangle Classes="statusSeparator" />
                         <TextBlock Classes="statusText" Text="{Binding ActiveTab.FixSuggestionText}" VerticalAlignment="Center" />
@@ -850,22 +791,42 @@
                                 Command="{Binding ActiveTab.ApplyFixCommand}"
                                 ToolTip.Tip="Rewrite the unquoted identifiers to match the database and run again" />
                     </StackPanel>
-                    <StackPanel Orientation="Horizontal" Spacing="10"
-                                IsVisible="{Binding ActiveTab.RowCountText, Converter={x:Static conv:ObjectConverters.IsNotNull}}">
+                    <StackPanel Grid.Column="5" Orientation="Horizontal" Spacing="10" Margin="10,0,0,0"
+                                IsVisible="{Binding ActiveTab.RowCountStatusText, Converter={x:Static conv:ObjectConverters.IsNotNull}}">
                         <Rectangle Classes="statusSeparator" />
-                        <TextBlock Classes="statusText dim" Text="{Binding ActiveTab.RowCountText}" VerticalAlignment="Center" />
+                        <TextBlock Classes="statusText dim" Text="{Binding ActiveTab.RowCountStatusText}" VerticalAlignment="Center" />
                     </StackPanel>
-                    <StackPanel Orientation="Horizontal" Spacing="10"
+                    <StackPanel Grid.Column="6" Orientation="Horizontal" Spacing="10" Margin="10,0,0,0"
                                 IsVisible="{Binding ActiveTab.TimingText, Converter={x:Static conv:ObjectConverters.IsNotNull}}">
                         <Rectangle Classes="statusSeparator" />
                         <TextBlock Classes="statusText dim" Text="{Binding ActiveTab.TimingText}" VerticalAlignment="Center" />
                     </StackPanel>
-                    <StackPanel Orientation="Horizontal" Spacing="10"
+                    <StackPanel Grid.Column="7" Orientation="Horizontal" Spacing="10" Margin="10,0,0,0"
                                 IsVisible="{Binding ActiveTab.CapText, Converter={x:Static conv:ObjectConverters.IsNotNull}}">
                         <Rectangle Classes="statusSeparator" />
-                        <TextBlock Classes="statusText warn" Text="{Binding ActiveTab.CapText}" VerticalAlignment="Center" />
+                        <TextBlock Classes="statusText warn" Text="{Binding ActiveTab.CapText}" VerticalAlignment="Center"
+                                   MaxWidth="320" TextTrimming="CharacterEllipsis"
+                                   ToolTip.Tip="{Binding ActiveTab.CapText}" />
                     </StackPanel>
-                </StackPanel>
+                    <!-- Browse-mode paging: the one piece of the old browse bar that
+                         couldn't move into the SQL editor. Disabled while a query is
+                         in flight so a page turn can't start a second concurrent run. -->
+                    <StackPanel Grid.Column="8" Orientation="Horizontal" Spacing="8" Margin="10,0,0,0"
+                                VerticalAlignment="Center"
+                                IsVisible="{Binding ActiveTab.IsBrowsing}"
+                                IsEnabled="{Binding !ActiveTab.IsRunning}">
+                        <Rectangle Classes="statusSeparator" />
+                        <TextBlock Classes="statusText dim" Text="{Binding ActiveTab.Browse.PageLabel}" VerticalAlignment="Center" />
+                        <Button Classes="chip" Padding="4" VerticalAlignment="Center"
+                                Command="{Binding ActiveTab.Browse.PreviousPageCommand}" ToolTip.Tip="Previous page">
+                            <PathIcon Data="{StaticResource ChevronLeftIconGeometry}" Width="11" Height="11" />
+                        </Button>
+                        <Button Classes="chip" Padding="4" VerticalAlignment="Center"
+                                Command="{Binding ActiveTab.Browse.NextPageCommand}" ToolTip.Tip="Next page">
+                            <PathIcon Data="{StaticResource ChevronRightIconGeometry}" Width="11" Height="11" />
+                        </Button>
+                    </StackPanel>
+                </Grid>
             </Border>
 
         </Grid>

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -824,6 +824,23 @@
                         <TextBlock Text="In transaction" Classes="statusText" Foreground="#D9822B"
                                    FontWeight="SemiBold" VerticalAlignment="Center" />
                     </StackPanel>
+                    <!-- Safe mode's staged-changes segment: count + review/commit + discard.
+                         Contextual like the fix affordance below — only present while
+                         something is staged, so the bar stays clean otherwise. -->
+                    <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center"
+                                IsVisible="{Binding ActiveTab.HasPendingChanges}"
+                                ToolTip.Tip="Safe mode: these changes are staged locally — nothing has been sent to the database yet">
+                        <Rectangle Classes="statusSeparator" />
+                        <Ellipse Width="8" Height="8" Fill="{DynamicResource AppAccentBrush}" VerticalAlignment="Center" />
+                        <TextBlock Classes="statusText" FontWeight="SemiBold"
+                                   Text="{Binding ActiveTab.PendingChangesText}" VerticalAlignment="Center" />
+                        <Button Classes="accent" FontSize="11" Padding="10,3" Content="Review &amp; commit…"
+                                Click="OnReviewPendingClick"
+                                ToolTip.Tip="Show the generated SQL, then commit everything as one transaction" />
+                        <Button FontSize="11" Padding="10,3" Content="Discard"
+                                Click="OnDiscardPendingClick"
+                                ToolTip.Tip="Drop all staged changes and reload from the server" />
+                    </StackPanel>
                     <!-- "Did you mean the quoted form?" fix, offered after a failed unquoted-identifier run -->
                     <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center"
                                 IsVisible="{Binding ActiveTab.FixSuggestionSql, Converter={x:Static conv:ObjectConverters.IsNotNull}}">

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -150,6 +150,10 @@ public partial class MainWindow : Window
         ResultsGrid.PreparingCellForEdit += OnPreparingCellForEdit;
         ResultsGrid.KeyDown += OnResultsGridKeyDown;
         ResultsGrid.Sorting += OnResultsGridSorting;
+        // Safe mode's dirty-row wash: rows are tinted as the grid realizes
+        // them; already-realized rows are re-tinted whenever the staged set
+        // changes (see RefreshPendingRowHighlights).
+        ResultsGrid.LoadingRow += (_, e) => ApplyRowStaging(e.Row);
 
         // The FK-navigation items are composed per-cell just before the grid
         // context menu shows (their targets depend on which cell was pressed).
@@ -519,6 +523,9 @@ public partial class MainWindow : Window
 
         ResultsGrid.ItemsSource = query.Rows;
         RebuildColumns(query);
+        // The new tab's staged set (if any) tints different rows than the old
+        // tab's — repaint once its rows have realized.
+        Dispatcher.UIThread.Post(RefreshPendingRowHighlights, DispatcherPriority.Background);
     }
 
     private void OnColumnNamesChanged(object? sender, NotifyCollectionChangedEventArgs e) => RebuildColumns(_queryViewModel!);
@@ -1047,6 +1054,39 @@ public partial class MainWindow : Window
         }
 
         await _queryViewModel.CommitCellEditAsync(row, columnIndex, text);
+    }
+
+    // --- Safe mode: dirty-row highlighting ---------------------------------
+
+    // Translucent washes so grid lines and the selection state stay readable
+    // in both themes: amber = staged edit, red = staged delete.
+    private static readonly IBrush StagedEditRowBrush = new SolidColorBrush(Color.Parse("#38D9822B"));
+    private static readonly IBrush StagedDeleteRowBrush = new SolidColorBrush(Color.Parse("#38E03131"));
+
+    private void ApplyRowStaging(DataGridRow row)
+    {
+        var staging = _queryViewModel is { } query && row.DataContext is object?[] values
+            ? query.GetRowStaging(values)
+            : QueryViewModel.RowStagingState.None;
+
+        // Always assign: rows are recycled, so a formerly staged row must be
+        // washed back to the theme's transparent default.
+        row.Background = staging switch
+        {
+            QueryViewModel.RowStagingState.Edited => StagedEditRowBrush,
+            QueryViewModel.RowStagingState.Deleted => StagedDeleteRowBrush,
+            _ => Brushes.Transparent,
+        };
+    }
+
+    // Re-tints every realized row; newly realized ones are handled by the
+    // grid's LoadingRow hook. Called whenever the staged set changes.
+    private void RefreshPendingRowHighlights()
+    {
+        foreach (var row in ResultsGrid.GetVisualDescendants().OfType<DataGridRow>())
+        {
+            ApplyRowStaging(row);
+        }
     }
 
     // Auto-close pairs. Decided here — before the character lands — because a
@@ -1828,15 +1868,20 @@ public partial class MainWindow : Window
 
     // "Add row…" - opens the insert dialog for the mapped table; on a successful
     // insert the grid refreshes (browse page reload, or a re-run of the query).
+    // In safe mode the dialog stages the INSERT into the tab's pending set
+    // instead of executing it.
     private async void OnAddRowClick(object? sender, RoutedEventArgs e)
     {
-        if (_viewModel is null || _queryViewModel?.EditContext is not { } context)
+        if (_viewModel is null || _queryViewModel is not { EditContext: { } context } query)
         {
             return;
         }
 
-        var addRowViewModel = _viewModel.CreateAddRowViewModel(context.Schema, context.Table);
-        addRowViewModel.Inserted += () => _ = _queryViewModel.RefreshCurrentAsync();
+        var addRowViewModel = _viewModel.CreateAddRowViewModel(
+            context.Schema,
+            context.Table,
+            query.ShouldStageChanges ? query.TryStageInsert : null);
+        addRowViewModel.Inserted += () => _ = query.RefreshCurrentAsync();
 
         var dialog = new AddRowDialog { DataContext = addRowViewModel };
         await dialog.ShowDialog(this);
@@ -1845,9 +1890,12 @@ public partial class MainWindow : Window
     private async void OnDeleteRowsClick(object? sender, RoutedEventArgs e) => await DeleteSelectedRowsAsync();
 
     // Confirms, then deletes the selected rows via primary-key-keyed DELETEs.
+    // In safe mode there's nothing to confirm — the delete is only staged
+    // (and Delete on an already-staged row unstages it), reversible until
+    // the set is committed.
     private async Task DeleteSelectedRowsAsync()
     {
-        if (_queryViewModel is not { IsEditable: true })
+        if (_queryViewModel is not { IsEditable: true } query)
         {
             return;
         }
@@ -1858,11 +1906,57 @@ public partial class MainWindow : Window
             return;
         }
 
+        if (query.ShouldStageChanges)
+        {
+            await query.DeleteRowsAsync(rows);
+            return;
+        }
+
         var noun = rows.Count == 1 ? "this row" : $"these {rows.Count} rows";
         var confirm = new ConfirmDialog($"Delete {noun}? This can't be undone.", "Delete");
         if (await confirm.ShowDialog<bool>(this))
         {
-            await _queryViewModel.DeleteRowsAsync(rows);
+            await query.DeleteRowsAsync(rows);
+        }
+    }
+
+    // "Review & commit…" on the staged-changes status segment: show the
+    // generated SQL, then commit it all as one transaction or discard it all.
+    private async void OnReviewPendingClick(object? sender, RoutedEventArgs e)
+    {
+        if (_queryViewModel is not { } query || query.PendingChanges is not { IsEmpty: false } pending)
+        {
+            return;
+        }
+
+        var dialog = new PendingChangesDialog(query.PendingChangesText ?? "Staged changes", pending.BuildScript(), pending.Count);
+        var result = await dialog.ShowDialog<PendingChangesDialog.Result>(this);
+        switch (result)
+        {
+            case PendingChangesDialog.Result.Commit:
+                await query.CommitPendingCommand.ExecuteAsync(null);
+                break;
+            case PendingChangesDialog.Result.Discard:
+                await query.DiscardPendingCommand.ExecuteAsync(null);
+                break;
+        }
+    }
+
+    // Status-bar "Discard": one confirm (it drops real staged work), then
+    // clears the set and reloads server values.
+    private async void OnDiscardPendingClick(object? sender, RoutedEventArgs e)
+    {
+        if (_queryViewModel is not { HasPendingChanges: true } query)
+        {
+            return;
+        }
+
+        var count = query.PendingChanges!.Count;
+        var noun = count == 1 ? "1 staged change" : $"{count} staged changes";
+        var confirm = new ConfirmDialog($"Discard {noun}? The database hasn't been touched.", "Discard");
+        if (await confirm.ShowDialog<bool>(this))
+        {
+            await query.DiscardPendingCommand.ExecuteAsync(null);
         }
     }
 
@@ -2049,6 +2143,17 @@ public partial class MainWindow : Window
         if (e.PropertyName == nameof(QueryViewModel.Rows))
         {
             ResultsGrid.ItemsSource = _queryViewModel.Rows;
+            // Rows realize after this returns; re-tint once they exist so a
+            // reloaded page keeps its staged-row washes.
+            Dispatcher.UIThread.Post(RefreshPendingRowHighlights, DispatcherPriority.Background);
+            return;
+        }
+
+        // Every staged-set mutation re-raises this (even when the summary text
+        // is unchanged), making it the one repaint cue for row washes.
+        if (e.PropertyName == nameof(QueryViewModel.PendingChangesText))
+        {
+            RefreshPendingRowHighlights();
             return;
         }
 

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -42,10 +42,6 @@ public partial class MainWindow : Window
     // Closer promised by OnSqlTextEntering's InsertPair verdict, written by
     // OnSqlTextEntered once the opener is in the document. '\0' = none pending.
     private char _pendingAutoCloser;
-    // Set while an accepted filter-completion writes back into the box, so the
-    // resulting TextChanged doesn't immediately re-open the popup on the word we
-    // just inserted.
-    private bool _suppressFilterCompletion;
     private ShortcutsWindow? _shortcutsWindow;
     private IHighlightingDefinition? _sqlHighlighting;
     // AvaloniaEdit's stock find/replace panel, installed on the SQL editor;
@@ -212,19 +208,11 @@ public partial class MainWindow : Window
         HistoryList.DoubleTapped += (_, e) => OnQueryListDoubleTapped(e,
             item => _viewModel?.SavedQueries.LoadHistoryEntryCommand.Execute(item as QueryHistoryEntry));
 
-        // Column autocomplete inside the browse WHERE box (see the popup in XAML).
-        BrowseFilterBox.TextChanged += OnBrowseFilterTextChanged;
-        BrowseFilterBox.LostFocus += (_, _) => CloseFilterCompletion();
-
         // On Windows, popups are native always-on-top windows, and one left
         // open while the user Alt+Tabs (or clicks) into another program keeps
         // floating above that program. Close every popup we own the moment
         // this window stops being the foreground one.
-        Deactivated += (_, _) =>
-        {
-            _completionWindow?.Close();
-            CloseFilterCompletion();
-        };
+        Deactivated += (_, _) => _completionWindow?.Close();
 
         DataContextChanged += (_, _) =>
         {
@@ -1737,135 +1725,6 @@ public partial class MainWindow : Window
         }
     }
 
-    // Keys in the browse filter box: while the column-completion popup is open it
-    // owns arrow/Enter/Tab/Esc; otherwise Enter applies the WHERE predicate
-    // (re-query from page 1).
-    private void OnBrowseFilterKeyDown(object? sender, KeyEventArgs e)
-    {
-        if (FilterCompletionPopup.IsOpen)
-        {
-            switch (e.Key)
-            {
-                case Key.Down:
-                    MoveFilterCompletionSelection(+1);
-                    e.Handled = true;
-                    return;
-                case Key.Up:
-                    MoveFilterCompletionSelection(-1);
-                    e.Handled = true;
-                    return;
-                case Key.Enter:
-                case Key.Tab:
-                    AcceptFilterCompletion();
-                    e.Handled = true;
-                    return;
-                case Key.Escape:
-                    CloseFilterCompletion();
-                    e.Handled = true;
-                    return;
-            }
-        }
-
-        if (e.Key == Key.Enter && _queryViewModel?.Browse is { } browse)
-        {
-            browse.ApplyFilterCommand.Execute(null);
-            e.Handled = true;
-        }
-    }
-
-    // Offers the current dataset's columns as the user types an identifier in the
-    // WHERE box — and nothing else (no keywords, functions, or other tables), so
-    // the suggestions are exactly the columns a predicate here can reference.
-    private void OnBrowseFilterTextChanged(object? sender, TextChangedEventArgs e)
-    {
-        if (_suppressFilterCompletion || _queryViewModel is null)
-        {
-            return;
-        }
-
-        var text = BrowseFilterBox.Text ?? string.Empty;
-        var (start, end) = CurrentWordBounds(text, BrowseFilterBox.CaretIndex);
-        var word = text[start..end];
-        if (word.Length == 0)
-        {
-            CloseFilterCompletion();
-            return;
-        }
-
-        var matches = _queryViewModel.ColumnNames
-            .Where(c => c.Contains(word, StringComparison.OrdinalIgnoreCase))
-            .OrderByDescending(c => c.StartsWith(word, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-        // Nothing worth showing: no match, or the only match is already fully typed.
-        if (matches.Count == 0 || (matches.Count == 1 && string.Equals(matches[0], word, StringComparison.OrdinalIgnoreCase)))
-        {
-            CloseFilterCompletion();
-            return;
-        }
-
-        FilterCompletionList.ItemsSource = matches;
-        FilterCompletionList.SelectedIndex = 0;
-        FilterCompletionPopup.IsOpen = true;
-    }
-
-    private void OnFilterCompletionTapped(object? sender, TappedEventArgs e) => AcceptFilterCompletion();
-
-    private void MoveFilterCompletionSelection(int delta)
-    {
-        var count = FilterCompletionList.ItemCount;
-        if (count == 0)
-        {
-            return;
-        }
-
-        var index = FilterCompletionList.SelectedIndex + delta;
-        FilterCompletionList.SelectedIndex = (index % count + count) % count;
-        if (FilterCompletionList.SelectedItem is { } selected)
-        {
-            FilterCompletionList.ScrollIntoView(selected);
-        }
-    }
-
-    // Replaces the identifier under the caret with the chosen column (quoted only
-    // if Postgres needs it) and drops the popup.
-    private void AcceptFilterCompletion()
-    {
-        if (!FilterCompletionPopup.IsOpen || FilterCompletionList.SelectedItem is not string column)
-        {
-            return;
-        }
-
-        var text = BrowseFilterBox.Text ?? string.Empty;
-        var (start, end) = CurrentWordBounds(text, BrowseFilterBox.CaretIndex);
-        var insert = SqlIdentifier.QuoteIfNeeded(column);
-        var newText = string.Concat(text.AsSpan(0, start), insert, text.AsSpan(end));
-
-        _suppressFilterCompletion = true;
-        BrowseFilterBox.Text = newText;
-        BrowseFilterBox.CaretIndex = start + insert.Length;
-        _suppressFilterCompletion = false;
-
-        CloseFilterCompletion();
-    }
-
-    private void CloseFilterCompletion() => FilterCompletionPopup.IsOpen = false;
-
-    // Bounds of the identifier the caret sits in (empty span when not on one).
-    private static (int Start, int End) CurrentWordBounds(string text, int caret)
-    {
-        var end = Math.Clamp(caret, 0, text.Length);
-        var start = end;
-        while (start > 0 && IsIdentChar(text[start - 1]))
-        {
-            start--;
-        }
-
-        return (start, end);
-
-        static bool IsIdentChar(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '$';
-    }
-
     // "Add row…" - opens the insert dialog for the mapped table; on a successful
     // insert the grid refreshes (browse page reload, or a re-run of the query).
     // In safe mode the dialog stages the INSERT into the tab's pending set
@@ -1929,7 +1788,9 @@ public partial class MainWindow : Window
             return;
         }
 
-        var dialog = new PendingChangesDialog(query.PendingChangesText ?? "Staged changes", pending.BuildScript(), pending.Count);
+        // Long-form summary here; the status bar's text is deliberately terse.
+        var summary = $"{pending.Count} staged change{(pending.Count == 1 ? "" : "s")} · {pending.Schema}.{pending.Table}";
+        var dialog = new PendingChangesDialog(summary, pending.BuildScript(), pending.Count);
         var result = await dialog.ShowDialog<PendingChangesDialog.Result>(this);
         switch (result)
         {

--- a/PgNimbus.App/Views/PendingChangesDialog.axaml
+++ b/PgNimbus.App/Views/PendingChangesDialog.axaml
@@ -1,0 +1,33 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="PgNimbus.App.Views.PendingChangesDialog"
+        Title="pgNimbus — Staged changes"
+        Width="620" Height="460"
+        MinWidth="460" MinHeight="280"
+        WindowStartupLocation="CenterOwner"
+        FontFamily="{StaticResource InterFont}">
+
+    <Grid RowDefinitions="Auto,Auto,*,Auto" Margin="16">
+
+        <TextBlock Grid.Row="0" Name="SummaryText" FontWeight="SemiBold" FontSize="14" Margin="0,0,0,4" />
+
+        <TextBlock Grid.Row="1" FontSize="11" Opacity="0.55" TextWrapping="Wrap" Margin="0,0,0,10"
+                   Text="This SQL runs as one transaction when you commit — everything applies, or nothing does. Values are shown inline for review; execution is parameterized." />
+
+        <Border Grid.Row="2" Classes="card" Padding="8">
+            <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+                <SelectableTextBlock Name="SqlText"
+                                     FontFamily="Cascadia Code,Consolas,Menlo,monospace"
+                                     FontSize="12" />
+            </ScrollViewer>
+        </Border>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button Name="CommitButton" Classes="accent" Content="Commit" Click="OnCommitClick" />
+            <Button Content="Discard all" Foreground="#E03131" Click="OnDiscardClick" />
+            <Button Content="Cancel" Click="OnCancelClick" />
+        </StackPanel>
+
+    </Grid>
+
+</Window>

--- a/PgNimbus.App/Views/PendingChangesDialog.axaml.cs
+++ b/PgNimbus.App/Views/PendingChangesDialog.axaml.cs
@@ -1,0 +1,39 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace PgNimbus.App.Views;
+
+/// <summary>
+/// Safe mode's pre-commit review: shows the staged change set as a readable
+/// SQL script, then commits it all as one transaction, discards it all, or
+/// does nothing. Shown via <c>ShowDialog&lt;PendingChangesDialog.Result&gt;</c>;
+/// closing the window without choosing counts as Cancel.
+/// </summary>
+public partial class PendingChangesDialog : Window
+{
+    public enum Result
+    {
+        Cancel,
+        Commit,
+        Discard,
+    }
+
+    public PendingChangesDialog()
+    {
+        InitializeComponent();
+        ThemedWindowChrome.Attach(this);
+    }
+
+    public PendingChangesDialog(string summary, string sqlScript, int changeCount) : this()
+    {
+        SummaryText.Text = summary;
+        SqlText.Text = sqlScript;
+        CommitButton.Content = changeCount == 1 ? "Commit 1 change" : $"Commit {changeCount} changes";
+    }
+
+    private void OnCommitClick(object? sender, RoutedEventArgs e) => Close(Result.Commit);
+
+    private void OnDiscardClick(object? sender, RoutedEventArgs e) => Close(Result.Discard);
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e) => Close(Result.Cancel);
+}

--- a/PgNimbus.App/Views/PreferencesWindow.axaml
+++ b/PgNimbus.App/Views/PreferencesWindow.axaml
@@ -53,6 +53,19 @@
                 </Grid>
             </Border>
 
+            <TextBlock Classes="sectionHeader" Text="DATA EDITING" Margin="4,10,4,4" />
+            <Border Classes="card" Padding="14,12">
+                <Grid ColumnDefinitions="*,Auto">
+                    <StackPanel Spacing="2" Margin="0,0,16,0">
+                        <TextBlock Classes="label" Text="Safe mode (stage &amp; review changes)" />
+                        <TextBlock Classes="hint" Text="Grid edits, deletes, and Add-row inserts are staged locally and highlighted; review the generated SQL, then commit everything as one transaction — or discard" />
+                    </StackPanel>
+                    <ToggleSwitch Grid.Column="1" VerticalAlignment="Center"
+                                  OnContent="" OffContent=""
+                                  IsChecked="{Binding SafeModeEdits}" />
+                </Grid>
+            </Border>
+
             <TextBlock Classes="sectionHeader" Text="KEYBOARD" Margin="4,10,4,4" />
             <Border Classes="card" Padding="14,12">
                 <Grid ColumnDefinitions="*,Auto">

--- a/PgNimbus.Core.Tests/Query/PendingChangeSetTests.cs
+++ b/PgNimbus.Core.Tests/Query/PendingChangeSetTests.cs
@@ -1,0 +1,223 @@
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Tests.Query;
+
+public class PendingChangeSetTests
+{
+    private static PendingChangeSet NewSet(params string[] pkColumns) =>
+        new("public", "orders", pkColumns.Length == 0 ? ["id"] : pkColumns);
+
+    [Test]
+    public async Task StartsEmpty()
+    {
+        var set = NewSet();
+
+        await Assert.That(set.IsEmpty).IsTrue();
+        await Assert.That(set.Count).IsEqualTo(0);
+        await Assert.That(set.BuildStatements()).IsEmpty();
+        await Assert.That(set.BuildScript()).IsEmpty();
+    }
+
+    [Test]
+    public async Task EditBuildsPrimaryKeyTargetedUpdate()
+    {
+        var set = NewSet();
+        set.StageEdit([42], "status", "shipped");
+
+        var statements = set.BuildStatements();
+
+        await Assert.That(statements).Count().IsEqualTo(1);
+        await Assert.That(statements[0].Sql)
+            .IsEqualTo("""UPDATE "public"."orders" SET "status" = @v0 WHERE "id" = @pk0""");
+        await Assert.That(statements[0].Parameters["v0"]).IsEqualTo("shipped");
+        await Assert.That(statements[0].Parameters["pk0"]).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task RepeatedEditsToSameCellCoalesce()
+    {
+        var set = NewSet();
+        set.StageEdit([1], "status", "packed");
+        set.StageEdit([1], "status", "shipped");
+
+        var statements = set.BuildStatements();
+
+        await Assert.That(set.Count).IsEqualTo(1);
+        await Assert.That(statements).Count().IsEqualTo(1);
+        await Assert.That(statements[0].Parameters["v0"]).IsEqualTo("shipped");
+    }
+
+    [Test]
+    public async Task EditsToDifferentColumnsOfOneRowShareOneUpdate()
+    {
+        var set = NewSet();
+        set.StageEdit([1], "status", "shipped");
+        set.StageEdit([1], "total", 99.5m);
+
+        var statements = set.BuildStatements();
+
+        await Assert.That(set.Count).IsEqualTo(1);
+        await Assert.That(statements).Count().IsEqualTo(1);
+        await Assert.That(statements[0].Sql)
+            .IsEqualTo("""UPDATE "public"."orders" SET "status" = @v0, "total" = @v1 WHERE "id" = @pk0""");
+    }
+
+    [Test]
+    public async Task RowIdentityIsStructuralAcrossGridReloads()
+    {
+        var set = NewSet("region", "id");
+        set.StageEdit(["eu", 7], "status", "shipped");
+
+        // A fresh array with equal values (a reloaded page) is the same row.
+        await Assert.That(set.IsRowEdited(["eu", 7])).IsTrue();
+        await Assert.That(set.GetRowEdits(["eu", 7])).IsNotNull();
+        await Assert.That(set.IsRowEdited(["us", 7])).IsFalse();
+    }
+
+    [Test]
+    public async Task CompositeKeyBuildsAndJoinedWhere()
+    {
+        var set = NewSet("region", "id");
+        set.StageDelete(["eu", 7]);
+
+        var statements = set.BuildStatements();
+
+        await Assert.That(statements[0].Sql)
+            .IsEqualTo("""DELETE FROM "public"."orders" WHERE "region" = @pk0 AND "id" = @pk1""");
+        await Assert.That(statements[0].Parameters["pk0"]).IsEqualTo("eu");
+        await Assert.That(statements[0].Parameters["pk1"]).IsEqualTo(7);
+    }
+
+    [Test]
+    public async Task PrimaryKeyColumnsCannotBeEdited()
+    {
+        var set = NewSet();
+
+        await Assert.That(() => set.StageEdit([1], "id", 2)).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task DeleteSupersedesRowEditsUntilUnstaged()
+    {
+        var set = NewSet();
+        set.StageEdit([1], "status", "shipped");
+        set.StageDelete([1]);
+
+        // While the delete is staged, the row's edits don't count or execute…
+        await Assert.That(set.Count).IsEqualTo(1);
+        await Assert.That(set.BuildStatements()).Count().IsEqualTo(1);
+        await Assert.That(set.BuildStatements()[0].Sql).StartsWith("DELETE");
+
+        // …and editing it is refused outright.
+        await Assert.That(() => set.StageEdit([1], "total", 5)).Throws<InvalidOperationException>();
+
+        // Unstaging the delete brings the edits back.
+        await Assert.That(set.UnstageDelete([1])).IsTrue();
+        await Assert.That(set.Count).IsEqualTo(1);
+        await Assert.That(set.BuildStatements()[0].Sql).StartsWith("UPDATE");
+    }
+
+    [Test]
+    public async Task StatementsOrderUpdatesThenDeletesThenInserts()
+    {
+        var set = NewSet();
+        set.StageInsert([new PendingInsertValue("status", "text", "new")]);
+        set.StageDelete([2]);
+        set.StageEdit([1], "status", "shipped");
+
+        var kinds = set.BuildStatements().Select(s => s.Sql.Split(' ')[0]).ToList();
+
+        await Assert.That(string.Join('|', kinds)).IsEqualTo("UPDATE|DELETE|INSERT");
+    }
+
+    [Test]
+    public async Task InsertCastsTypedValuesAndInlinesNulls()
+    {
+        var set = NewSet();
+        set.StageInsert(
+        [
+            new PendingInsertValue("total", "numeric(10,2)", "99.50"),
+            new PendingInsertValue("note", "text", null),
+        ]);
+
+        var statement = set.BuildStatements()[0];
+
+        await Assert.That(statement.Sql).IsEqualTo(
+            """INSERT INTO "public"."orders" ("total", "note") VALUES (CAST(@p0 AS numeric(10,2)), NULL)""");
+        await Assert.That(statement.Parameters["p0"]).IsEqualTo("99.50");
+    }
+
+    [Test]
+    public async Task EmptyInsertUsesDefaultValues()
+    {
+        var set = NewSet();
+        set.StageInsert([]);
+
+        await Assert.That(set.BuildStatements()[0].Sql)
+            .IsEqualTo("""INSERT INTO "public"."orders" DEFAULT VALUES""");
+    }
+
+    [Test]
+    public async Task ScriptRendersLiteralsForReview()
+    {
+        var set = new PendingChangeSet("public", "people", ["id"]);
+        set.StageEdit([1], "name", "O'Brien");
+        set.StageEdit([1], "active", true);
+        set.StageDelete([2]);
+        set.StageInsert([new PendingInsertValue("name", "text", "new 'guy'")]);
+
+        var script = set.BuildScript();
+
+        await Assert.That(script).Contains(
+            """UPDATE "public"."people" SET "name" = 'O''Brien', "active" = true WHERE "id" = 1;""");
+        await Assert.That(script).Contains("""DELETE FROM "public"."people" WHERE "id" = 2;""");
+        await Assert.That(script).Contains(
+            """INSERT INTO "public"."people" ("name") VALUES (CAST('new ''guy''' AS text));""");
+    }
+
+    [Test]
+    public async Task ScriptRendersNullAndNumericLiterals()
+    {
+        var set = NewSet();
+        set.StageEdit([1], "note", null);
+        set.StageEdit([1], "total", 12.5m);
+
+        var script = set.BuildScript();
+
+        await Assert.That(script).Contains("\"note\" = NULL, \"total\" = 12.5");
+    }
+
+    [Test]
+    public async Task ClearEmptiesEverything()
+    {
+        var set = NewSet();
+        set.StageEdit([1], "status", "x");
+        set.StageDelete([2]);
+        set.StageInsert([]);
+
+        set.Clear();
+
+        await Assert.That(set.IsEmpty).IsTrue();
+        await Assert.That(set.BuildStatements()).IsEmpty();
+    }
+
+    [Test]
+    public async Task MismatchedKeyLengthIsRejected()
+    {
+        var set = NewSet("region", "id");
+
+        await Assert.That(() => set.StageDelete([1])).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task QuotedIdentifiersSurviveRoundTrip()
+    {
+        var set = new PendingChangeSet("Games", "Spell Book", ["Id"]);
+        set.StageEdit([1], "Mana Cost", 3);
+
+        var sql = set.BuildStatements()[0].Sql;
+
+        await Assert.That(sql).IsEqualTo(
+            """UPDATE "Games"."Spell Book" SET "Mana Cost" = @v0 WHERE "Id" = @pk0""");
+    }
+}

--- a/PgNimbus.Core.Tests/Query/SqlLiteralTests.cs
+++ b/PgNimbus.Core.Tests/Query/SqlLiteralTests.cs
@@ -1,0 +1,49 @@
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Tests.Query;
+
+public class SqlLiteralTests
+{
+    [Test]
+    public async Task NullRendersAsKeyword()
+    {
+        await Assert.That(SqlLiteral.Format(null)).IsEqualTo("NULL");
+    }
+
+    [Test]
+    public async Task StringsQuoteAndDoubleEmbeddedQuotes()
+    {
+        await Assert.That(SqlLiteral.Format("O'Brien")).IsEqualTo("'O''Brien'");
+    }
+
+    [Test]
+    public async Task BooleansRenderBare()
+    {
+        await Assert.That(SqlLiteral.Format(true)).IsEqualTo("true");
+        await Assert.That(SqlLiteral.Format(false)).IsEqualTo("false");
+    }
+
+    [Test]
+    public async Task NumbersUseInvariantCulture()
+    {
+        await Assert.That(SqlLiteral.Format(42)).IsEqualTo("42");
+        await Assert.That(SqlLiteral.Format(12.5m)).IsEqualTo("12.5");
+        await Assert.That(SqlLiteral.Format(0.25)).IsEqualTo("0.25");
+    }
+
+    [Test]
+    public async Task DatesAndTimesRenderIsoQuoted()
+    {
+        await Assert.That(SqlLiteral.Format(new DateOnly(2026, 7, 14))).IsEqualTo("'2026-07-14'");
+        await Assert.That(SqlLiteral.Format(new DateTime(2026, 7, 14, 8, 30, 0))).IsEqualTo("'2026-07-14 08:30:00'");
+        await Assert.That(SqlLiteral.Format(new TimeOnly(8, 30, 15))).IsEqualTo("'08:30:15'");
+    }
+
+    [Test]
+    public async Task OtherTypesFallBackToQuotedText()
+    {
+        var guid = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+        await Assert.That(SqlLiteral.Format(guid)).IsEqualTo("'11111111-2222-3333-4444-555555555555'");
+    }
+}

--- a/PgNimbus.Core/Query/ParameterizedStatement.cs
+++ b/PgNimbus.Core/Query/ParameterizedStatement.cs
@@ -1,0 +1,4 @@
+namespace PgNimbus.Core.Query;
+
+/// <summary>A single SQL statement plus the parameter values it executes with.</summary>
+public sealed record ParameterizedStatement(string Sql, IReadOnlyDictionary<string, object?> Parameters);

--- a/PgNimbus.Core/Query/PendingChangeSet.cs
+++ b/PgNimbus.Core/Query/PendingChangeSet.cs
@@ -1,0 +1,336 @@
+using System.Text;
+
+namespace PgNimbus.Core.Query;
+
+/// <summary>
+/// One column's value in a staged INSERT. <see cref="ValueText"/> is the raw
+/// text the user typed — it executes as a parameter cast to the column's
+/// declared type server-side (<c>CAST(@p AS numeric(10,2))</c>), so Postgres
+/// does the parsing; null means an explicit SQL NULL. Columns the user left
+/// blank aren't staged at all, so their defaults apply.
+/// </summary>
+public sealed record PendingInsertValue(string Column, string DataType, string? ValueText);
+
+/// <summary>
+/// Safe mode's staging area: cell edits, row deletes, and row inserts against
+/// a single table, held locally instead of executing one by one. Edits and
+/// deletes are keyed by the row's primary-key values (captured before any
+/// staging, and stable because primary-key columns can't be edited), so
+/// repeated edits to a cell coalesce. A delete supersedes the row's staged
+/// edits without discarding them: while the delete is staged the edits are
+/// excluded from <see cref="Count"/> and the built statements, and un-staging
+/// the delete brings them back.
+/// <see cref="BuildStatements"/> turns the set into parameterized statements
+/// for one-transaction execution; <see cref="BuildScript"/> renders the same
+/// changes as a human-readable SQL script for review before committing.
+/// </summary>
+public sealed class PendingChangeSet
+{
+    public string Schema { get; }
+
+    public string Table { get; }
+
+    public IReadOnlyList<string> PrimaryKeyColumns { get; }
+
+    // Ordered lists, not dictionaries: the review script and the executed
+    // batch must list changes in the order they were staged, and the set stays
+    // human-sized (it's hand-staged), so linear lookups are fine.
+    private readonly List<EditedRow> _edits = [];
+    private readonly List<RowKey> _deletes = [];
+    private readonly List<IReadOnlyList<PendingInsertValue>> _inserts = [];
+
+    public PendingChangeSet(string schema, string table, IReadOnlyList<string> primaryKeyColumns)
+    {
+        if (primaryKeyColumns.Count == 0)
+        {
+            throw new ArgumentException("Staged changes need primary-key columns to target rows.", nameof(primaryKeyColumns));
+        }
+
+        Schema = schema;
+        Table = table;
+        PrimaryKeyColumns = primaryKeyColumns;
+    }
+
+    /// <summary>
+    /// Total staged changes: edited rows (however many cells each, and not
+    /// counting rows whose staged delete supersedes their edits) + deletes +
+    /// inserts.
+    /// </summary>
+    public int Count => ActiveEdits.Count() + _deletes.Count + _inserts.Count;
+
+    // Edited rows whose edits would actually execute — a staged delete on the
+    // same row wins while it's staged.
+    private IEnumerable<EditedRow> ActiveEdits => _edits.Where(e => !_deletes.Contains(e.Key));
+
+    public bool IsEmpty => Count == 0;
+
+    /// <summary>
+    /// Stages one cell's new value, replacing any earlier staged value for the
+    /// same cell. Rejects primary-key columns (the key is what targets the
+    /// UPDATE) and rows already staged for deletion.
+    /// </summary>
+    public void StageEdit(object?[] pkValues, string column, object? value)
+    {
+        var key = MakeKey(pkValues);
+
+        if (PrimaryKeyColumns.Contains(column))
+        {
+            throw new ArgumentException($"Primary key column {column} can't be edited.", nameof(column));
+        }
+
+        if (_deletes.Contains(key))
+        {
+            throw new InvalidOperationException("This row is staged for deletion — press Delete on it again to unstage the delete first.");
+        }
+
+        var row = _edits.FirstOrDefault(e => e.Key.Equals(key));
+        if (row is null)
+        {
+            _edits.Add(row = new EditedRow(key));
+        }
+
+        var index = row.Cells.FindIndex(c => c.Column == column);
+        if (index >= 0)
+        {
+            row.Cells[index] = (column, value);
+        }
+        else
+        {
+            row.Cells.Add((column, value));
+        }
+    }
+
+    /// <summary>
+    /// Stages a row delete. Any staged edits for the row are kept but dormant
+    /// (the DELETE supersedes them) until the delete is unstaged. A no-op if
+    /// already staged.
+    /// </summary>
+    public void StageDelete(object?[] pkValues)
+    {
+        var key = MakeKey(pkValues);
+        if (!_deletes.Contains(key))
+        {
+            _deletes.Add(key);
+        }
+    }
+
+    /// <summary>Removes a staged delete. Returns false when the row wasn't staged.</summary>
+    public bool UnstageDelete(object?[] pkValues) => _deletes.Remove(MakeKey(pkValues));
+
+    /// <summary>Stages an INSERT. An empty value list means "all defaults" (<c>INSERT … DEFAULT VALUES</c>).</summary>
+    public void StageInsert(IReadOnlyList<PendingInsertValue> values) => _inserts.Add(values);
+
+    public bool IsRowDeleted(object?[] pkValues) => _deletes.Contains(MakeKey(pkValues));
+
+    public bool IsRowEdited(object?[] pkValues)
+    {
+        var key = MakeKey(pkValues);
+        return _edits.Any(e => e.Key.Equals(key));
+    }
+
+    /// <summary>The staged (column, value) pairs for a row, or null when none are staged — used to re-apply staged values after the grid reloads from the server.</summary>
+    public IReadOnlyList<(string Column, object? Value)>? GetRowEdits(object?[] pkValues)
+    {
+        var key = MakeKey(pkValues);
+        return _edits.FirstOrDefault(e => e.Key.Equals(key))?.Cells;
+    }
+
+    public void Clear()
+    {
+        _edits.Clear();
+        _deletes.Clear();
+        _inserts.Clear();
+    }
+
+    /// <summary>
+    /// The staged changes as parameterized statements, one per edited row
+    /// (all of a row's cells in one UPDATE), delete, and insert. Ordered
+    /// UPDATEs → DELETEs → INSERTs so a "delete this row, insert its
+    /// replacement" pair can reuse a key within the one transaction.
+    /// </summary>
+    public IReadOnlyList<ParameterizedStatement> BuildStatements()
+    {
+        var statements = new List<ParameterizedStatement>(Count);
+
+        foreach (var row in ActiveEdits)
+        {
+            var parameters = new Dictionary<string, object?>();
+            var sets = new List<string>(row.Cells.Count);
+            for (var i = 0; i < row.Cells.Count; i++)
+            {
+                sets.Add($"{SqlIdentifier.Quote(row.Cells[i].Column)} = @v{i}");
+                parameters[$"v{i}"] = row.Cells[i].Value;
+            }
+
+            statements.Add(new ParameterizedStatement(
+                $"UPDATE {QualifiedTable} SET {string.Join(", ", sets)} WHERE {WherePkClause(row.Key, parameters)}",
+                parameters));
+        }
+
+        foreach (var key in _deletes)
+        {
+            var parameters = new Dictionary<string, object?>();
+            statements.Add(new ParameterizedStatement(
+                $"DELETE FROM {QualifiedTable} WHERE {WherePkClause(key, parameters)}",
+                parameters));
+        }
+
+        foreach (var insert in _inserts)
+        {
+            statements.Add(BuildInsertStatement(insert));
+        }
+
+        return statements;
+    }
+
+    /// <summary>
+    /// The staged changes rendered as a readable SQL script (values inlined as
+    /// literals) for pre-commit review. Display only — execution always goes
+    /// through the parameterized <see cref="BuildStatements"/>.
+    /// </summary>
+    public string BuildScript()
+    {
+        var script = new StringBuilder();
+
+        foreach (var row in ActiveEdits)
+        {
+            var sets = row.Cells.Select(c => $"{SqlIdentifier.Quote(c.Column)} = {SqlLiteral.Format(c.Value)}");
+            script.Append("UPDATE ").Append(QualifiedTable)
+                  .Append(" SET ").Append(string.Join(", ", sets))
+                  .Append(" WHERE ").Append(WherePkScript(row.Key)).AppendLine(";");
+        }
+
+        foreach (var key in _deletes)
+        {
+            script.Append("DELETE FROM ").Append(QualifiedTable)
+                  .Append(" WHERE ").Append(WherePkScript(key)).AppendLine(";");
+        }
+
+        foreach (var insert in _inserts)
+        {
+            script.AppendLine(RenderInsertScript(insert));
+        }
+
+        return script.ToString();
+    }
+
+    private string QualifiedTable => $"{SqlIdentifier.Quote(Schema)}.{SqlIdentifier.Quote(Table)}";
+
+    // "pk0 = @pk0 AND pk1 = @pk1", adding the key's values to the statement's
+    // parameter dictionary as it goes.
+    private string WherePkClause(RowKey key, Dictionary<string, object?> parameters)
+    {
+        var clauses = new List<string>(PrimaryKeyColumns.Count);
+        for (var i = 0; i < PrimaryKeyColumns.Count; i++)
+        {
+            clauses.Add($"{SqlIdentifier.Quote(PrimaryKeyColumns[i])} = @pk{i}");
+            parameters[$"pk{i}"] = key.Values[i];
+        }
+
+        return string.Join(" AND ", clauses);
+    }
+
+    private string WherePkScript(RowKey key) =>
+        string.Join(" AND ", PrimaryKeyColumns.Select((pk, i) => $"{SqlIdentifier.Quote(pk)} = {SqlLiteral.Format(key.Values[i])}"));
+
+    private ParameterizedStatement BuildInsertStatement(IReadOnlyList<PendingInsertValue> values)
+    {
+        if (values.Count == 0)
+        {
+            return new ParameterizedStatement($"INSERT INTO {QualifiedTable} DEFAULT VALUES", new Dictionary<string, object?>());
+        }
+
+        var parameters = new Dictionary<string, object?>();
+        var columns = new List<string>(values.Count);
+        var expressions = new List<string>(values.Count);
+        foreach (var value in values)
+        {
+            columns.Add(SqlIdentifier.Quote(value.Column));
+            if (value.ValueText is null)
+            {
+                expressions.Add("NULL");
+            }
+            else
+            {
+                var name = $"p{parameters.Count}";
+                // Cast the text parameter to the column's declared type so
+                // Postgres parses "42"/"2024-01-01"/… into the real type.
+                expressions.Add($"CAST(@{name} AS {value.DataType})");
+                parameters[name] = value.ValueText;
+            }
+        }
+
+        return new ParameterizedStatement(
+            $"INSERT INTO {QualifiedTable} ({string.Join(", ", columns)}) VALUES ({string.Join(", ", expressions)})",
+            parameters);
+    }
+
+    private string RenderInsertScript(IReadOnlyList<PendingInsertValue> values)
+    {
+        if (values.Count == 0)
+        {
+            return $"INSERT INTO {QualifiedTable} DEFAULT VALUES;";
+        }
+
+        var columns = string.Join(", ", values.Select(v => SqlIdentifier.Quote(v.Column)));
+        var expressions = string.Join(", ", values.Select(v =>
+            v.ValueText is null ? "NULL" : $"CAST({SqlLiteral.Quote(v.ValueText)} AS {v.DataType})"));
+        return $"INSERT INTO {QualifiedTable} ({columns}) VALUES ({expressions});";
+    }
+
+    private RowKey MakeKey(object?[] pkValues)
+    {
+        if (pkValues.Length != PrimaryKeyColumns.Count)
+        {
+            throw new ArgumentException(
+                $"Expected {PrimaryKeyColumns.Count} primary-key value(s), got {pkValues.Length}.", nameof(pkValues));
+        }
+
+        return new RowKey(pkValues);
+    }
+
+    private sealed class EditedRow(RowKey key)
+    {
+        public RowKey Key { get; } = key;
+
+        public List<(string Column, object? Value)> Cells { get; } = [];
+    }
+
+    // Structural equality over the primary-key values, so a row keeps its
+    // identity across grid reloads (fresh arrays, equal values).
+    private readonly struct RowKey(object?[] values) : IEquatable<RowKey>
+    {
+        public object?[] Values { get; } = values;
+
+        public bool Equals(RowKey other)
+        {
+            if (Values.Length != other.Values.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < Values.Length; i++)
+            {
+                if (!Equals(Values[i], other.Values[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override bool Equals(object? obj) => obj is RowKey other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            foreach (var value in Values)
+            {
+                hash.Add(value);
+            }
+
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -171,6 +171,65 @@ public sealed class QueryEngine
         await command.ExecuteNonQueryAsync(ct);
     }
 
+    /// <summary>
+    /// Executes a batch of parameterized statements atomically — safe mode's
+    /// "commit everything as one transaction". On its own dedicated connection
+    /// the batch runs inside <c>BEGIN…COMMIT</c>; any failure rolls the whole
+    /// batch back (nothing is applied) and the exception propagates to the
+    /// caller. Inside an explicit user transaction the statements run on the
+    /// held session connection instead, joining the open block — atomicity
+    /// then comes from that block, and a failure auto-rolls it back like any
+    /// other in-transaction statement. Returns the total rows affected.
+    /// </summary>
+    public async Task<int> ApplyBatchAsync(IReadOnlyList<ParameterizedStatement> statements, CancellationToken ct)
+    {
+        if (_transactionConnection is { } tx)
+        {
+            var affected = 0;
+            foreach (var statement in statements)
+            {
+                await using var txCommand = CreateCommand(statement, tx, transaction: null);
+                try
+                {
+                    affected += await txCommand.ExecuteNonQueryAsync(ct);
+                }
+                catch (PostgresException)
+                {
+                    await AutoRollbackAsync();
+                    throw;
+                }
+            }
+
+            return affected;
+        }
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        // Disposing an uncommitted NpgsqlTransaction rolls it back, so any
+        // failure below undoes every statement already executed.
+        await using var batchTransaction = await connection.BeginTransactionAsync(ct);
+
+        var total = 0;
+        foreach (var statement in statements)
+        {
+            await using var command = CreateCommand(statement, connection, batchTransaction);
+            total += await command.ExecuteNonQueryAsync(ct);
+        }
+
+        await batchTransaction.CommitAsync(ct);
+        return total;
+    }
+
+    private static NpgsqlCommand CreateCommand(ParameterizedStatement statement, NpgsqlConnection connection, NpgsqlTransaction? transaction)
+    {
+        var command = new NpgsqlCommand(statement.Sql, connection, transaction);
+        foreach (var (name, value) in statement.Parameters)
+        {
+            command.Parameters.AddWithValue(name, value ?? DBNull.Value);
+        }
+
+        return command;
+    }
+
     /// <param name="sql">The statement to execute.</param>
     /// <param name="ct">Cancels the execution mid-flight.</param>
     /// <param name="maxRows">

--- a/PgNimbus.Core/Query/SqlLiteral.cs
+++ b/PgNimbus.Core/Query/SqlLiteral.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+
+namespace PgNimbus.Core.Query;
+
+/// <summary>
+/// Renders a CLR value as a PostgreSQL literal for *display* — the review
+/// script safe mode shows before committing staged changes. Execution never
+/// interpolates these strings: the staged statements run parameterized, so a
+/// value this formatter renders imperfectly (an exotic composite, say) can at
+/// worst mislead the preview, never break or inject into the real statement.
+/// </summary>
+public static class SqlLiteral
+{
+    public static string Format(object? value) => value switch
+    {
+        null => "NULL",
+        bool b => b ? "true" : "false",
+        sbyte or byte or short or ushort or int or uint or long or ulong =>
+            ((IFormattable)value).ToString(null, CultureInfo.InvariantCulture),
+        float f => f.ToString("R", CultureInfo.InvariantCulture),
+        double d => d.ToString("R", CultureInfo.InvariantCulture),
+        decimal m => m.ToString(CultureInfo.InvariantCulture),
+        string s => Quote(s),
+        DateTime dt => Quote(dt.ToString("yyyy-MM-dd HH:mm:ss.FFFFFF", CultureInfo.InvariantCulture)),
+        DateTimeOffset dto => Quote(dto.ToString("yyyy-MM-dd HH:mm:ss.FFFFFFzzz", CultureInfo.InvariantCulture)),
+        DateOnly d => Quote(d.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+        TimeOnly t => Quote(t.ToString("HH:mm:ss.FFFFFF", CultureInfo.InvariantCulture)),
+        _ => Quote(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty),
+    };
+
+    /// <summary>Single-quotes a string, doubling embedded quotes (<c>'</c> → <c>''</c>).</summary>
+    public static string Quote(string text) => $"'{text.Replace("'", "''")}'";
+}

--- a/PgNimbus.Core/Settings/AppSettings.cs
+++ b/PgNimbus.Core/Settings/AppSettings.cs
@@ -34,6 +34,15 @@ public sealed record AppSettings
     public bool AutoAliasTables { get; set; }
 
     /// <summary>
+    /// Safe mode: grid cell edits, row deletes, and Add-row inserts are staged
+    /// locally (dirty rows highlighted in the grid) instead of executing
+    /// immediately; the generated SQL is reviewed and committed as one
+    /// transaction — or discarded. Off by default; toggled from the command
+    /// palette or the preferences page.
+    /// </summary>
+    public bool SafeModeEdits { get; set; }
+
+    /// <summary>
     /// Which modifier the app's command shortcuts use: <c>"auto"</c> (Cmd on
     /// macOS, Ctrl elsewhere — the default), <c>"windows"</c> (always Ctrl), or
     /// <c>"mac"</c> (always Cmd). A plain string for the same reason as

--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   cast to its real type server-side, blanks fall back to defaults),
   "Delete selected row(s)" with a confirmation, and "Set cell to NULL" (the
   gesture inline editing can't express), all keyed on the primary key.
+- **Safe mode (pending-changes review)** — a toggle (command palette or
+  preferences) that stages grid edits, deletes, and Add-row inserts locally
+  instead of firing them at the server: dirty rows are highlighted (amber =
+  edited, red = marked for deletion, and <kbd>Delete</kbd> toggles the mark),
+  a status-bar segment counts what's staged, "Review & commit…" shows the
+  exact generated SQL, and committing applies everything as **one
+  transaction** — or discard it all and nothing was ever sent. Built for the
+  "inline edit on production" nerves.
 - **Cell inspector** — double-click a cell (or "Inspect cell…" on the grid
   context menu) to read the full value of a long `text`/`jsonb` cell in an
   overlay: JSON pretty-printed, word wrap on by default with a toggle, and a
@@ -494,13 +502,18 @@ Postico/DataGrip users single out. Multi-database support dominates those
 trackers and is deliberately out of scope — PostgreSQL-first *is* the thesis.
 Everything below is what survives that filter, roughly in impact order:
 
-- [ ] **Pending-changes review ("safe mode")** — stage grid edits, inserts,
+- [x] **Pending-changes review ("safe mode")** — stage grid edits, inserts,
   and deletes locally, highlight the dirty cells/rows, show the generated SQL
   for review, then commit everything as one transaction (or discard). Today
   each inline edit fires immediately, which is scary on production; a staged
-  mode is TablePlus's single most-praised trust feature. The transaction
-  machinery (held session connection, auto-rollback) is most of the plumbing
-  already.
+  mode is TablePlus's single most-praised trust feature. Shipped as an
+  opt-in toggle (palette/preferences, persisted): staged rows get amber/red
+  washes, Delete toggles a row's staged-delete mark, a delete supersedes the
+  row's staged edits until unstaged, and the review dialog shows literal SQL
+  while execution stays parameterized through one `BEGIN…COMMIT` batch
+  (joining the explicit transaction instead when one is open). Once anything
+  is staged, later changes keep staging even if the toggle flips off —
+  mixing immediate and staged writes would apply changes out of order.
 - [x] **Follow a foreign key from the grid** — right-clicking a browse-mode
   cell whose column is an FK offers "Follow *col* → *parent table*" (jumps to
   the referenced row in a new filtered browse tab), and a key cell offers

--- a/README.md
+++ b/README.md
@@ -141,10 +141,13 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>) reloads the schema tree,
   autocomplete cache, and command-palette table list from the server, so
   objects created or altered elsewhere appear without reconnecting.
-- **No-SQL table browsing** — previewing a table opens a browse bar with a
-  `WHERE` filter, `ORDER BY` from clicking a column header, and prev/next
-  paging — all pushed down to Postgres (`WHERE`/`ORDER BY`/`LIMIT`/`OFFSET`),
-  so browsing a huge table stays as cheap as one page.
+- **No-SQL table browsing** — previewing a table opens it paged, with
+  `ORDER BY` from clicking a column header and prev/next paging in the
+  status bar — all pushed down to Postgres (`ORDER BY`/`LIMIT`/`OFFSET`),
+  so browsing a huge table stays as cheap as one page. The composed SQL
+  sits right in the editor, which doubles as the filter: add a `WHERE`
+  there and run (there's deliberately no separate filter box — you already
+  have a SQL editor).
 - **Follow foreign keys from the grid** — right-click an FK cell while
   browsing to jump to the row it references ("Follow customer_id →
   public.customers"), or a key cell to list the rows referencing it


### PR DESCRIPTION
Implements safe mode — a new app-wide toggle that stages grid cell edits, row deletes, and Add-row inserts locally for review before committing them as a single transaction, instead of executing them immediately.

## Summary

Safe mode adds a safety net for data modifications: when enabled, any grid change (cell edit, row delete, or new row insert) is held locally in a `PendingChangeSet` rather than executed immediately. Users can review all staged changes as a readable SQL script in a pre-commit dialog, then commit them atomically or discard them entirely. Once changes are staged, the mode stays active for that tab even if the toggle flips, preventing accidental mixing of immediate and staged writes.

## Key changes

- **`PendingChangeSet` (new)** — Core staging container for a single table's edits, deletes, and inserts. Tracks changes by primary key so repeated edits to the same cell coalesce. Builds both parameterized statements (for atomic execution) and a human-readable SQL script (for review). Deletes supersede a row's staged edits while active but keep them dormant for unstaging.

- **`QueryViewModel` safe-mode integration** — Added `PendingChanges`, `PendingChangesText`, `ShouldStageChanges`, and `HasPendingChanges` properties. Modified `CommitCellEditAsync`, `SetCellNullAsync`, and `DeleteRowsAsync` to check `ShouldStageChanges` and stage changes instead of executing them. Added `CommitPendingCommand` and `DiscardPendingCommand` for batch operations. Tracks row staging state (`RowStagingState` enum) for dirty-row highlighting.

- **`MainViewModel` safe-mode toggle** — New `SafeModeEdits` property and `ToggleSafeMode` command. Passes a `Func<bool>` probe to each `QueryViewModel` so tabs follow the app-wide toggle without per-tab plumbing.

- **`PendingChangesDialog` (new)** — Pre-commit review window showing the staged SQL script and change summary. User chooses Commit, Discard, or Cancel.

- **Dirty-row highlighting** — Grid rows are tinted (amber for edits, red for deletes) via `ApplyRowStaging` and `RefreshPendingRowHighlights`. Rows are re-tinted whenever the staged set changes.

- **`AddRowViewModel` staging hook** — When safe mode is on, the Add Row dialog stages the INSERT instead of executing it. Dialog button relabels to "Stage Row" vs "Insert Row".

- **Status bar updates** — `RowCountStatusText` is suppressed in browse mode (where the paging range already shows row counts), reducing visual clutter. `PendingChangesText` shows a summary like "3 staged changes · public.orders".

- **`QueryEngine.ApplyBatchAsync` (new)** — Executes a batch of parameterized statements atomically. Inside an explicit transaction, statements run on the held session connection; otherwise they run on a dedicated connection wrapped in `BEGIN…COMMIT`. Any failure rolls back the entire batch.

- **Utility classes** — `SqlLiteral` (renders CLR values as SQL literals for display), `ParameterizedStatement` (SQL + parameters record), and comprehensive test suites for `PendingChangeSet` and `SqlLiteral`.

- **UI/UX** — Removed the browse-mode WHERE filter box and its column-autocomplete popup (the composed SQL in the editor is now the filter interface). Added safe-mode toggle to Preferences. Updated README to reflect the simplified browse UI.

## Implementation notes

- Primary-key columns are captured before staging so they remain stable across grid reloads and can't be edited (they target the UPDATE/DELETE).
- Row identity is structural (based on primary-key values), so a reloaded page with the same rows re-applies staged edits automatically via `ReapplyPendingEditsToGrid`.
- The staged set persists until explicitly committed or discarded, even if the safe-mode toggle flips, preventing accidental loss of user changes.
- All staged statements execute parameterized (never interpolated), so the review script's literal rendering

https://claude.ai/code/session_01WvTHc6BpW8DyXCneywGuRg