### PR TITLE
Explain: survive PG 18 fractional row counts; text plan view with Tree toggle

### DIFF
--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -330,6 +330,12 @@
         <Setter Property="Background" Value="{StaticResource HoverBackgroundBrush}" />
         <Setter Property="Opacity" Value="1" />
     </Style>
+    <!-- Same look for plain chip Buttons acting as a segmented pair (plan Text/Tree switch),
+         where a bound "active" class marks the selected segment instead of :checked -->
+    <Style Selector="Button.chip.active">
+        <Setter Property="Background" Value="{StaticResource HoverBackgroundBrush}" />
+        <Setter Property="Opacity" Value="1" />
+    </Style>
 
     <!-- Left-nav style TabItem: pill highlight instead of the classic underline tab strip -->
     <Style Selector="TabControl">

--- a/PgNimbus.App/ViewModels/ExplainNodeViewModel.cs
+++ b/PgNimbus.App/ViewModels/ExplainNodeViewModel.cs
@@ -25,11 +25,11 @@ public sealed class ExplainNodeViewModel
 
     public double BarWidth { get; }
 
-    public string Title => Node.RelationName is { Length: > 0 } rel ? $"{Node.NodeType} on {rel}" : Node.NodeType;
+    public string Title => ExplainTextFormatter.HeaderFor(Node);
 
     public string CostLabel => $"cost={Node.StartupCost:F2}..{Node.TotalCost:F2} rows={Node.PlanRows} width={Node.PlanWidth}";
 
     public string? ActualLabel => Node.ActualTotalTimeMs is { } total
-        ? $"actual time={Node.ActualStartupTimeMs:F3}..{total:F3} ms rows={Node.ActualRows} loops={Node.ActualLoops}"
+        ? $"actual time={Node.ActualStartupTimeMs:F3}..{total:F3} ms rows={Node.ActualRows:0.##} loops={Node.ActualLoops}"
         : null;
 }

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -132,6 +132,14 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private string? _explainSummary;
 
+    /// <summary>The plan rendered in `EXPLAIN (FORMAT TEXT)` layout — the plan pane's default view.</summary>
+    [ObservableProperty]
+    private string? _explainText;
+
+    /// <summary>Plan pane mode: true = text layout (default), false = the graphical tree.</summary>
+    [ObservableProperty]
+    private bool _isPlanTextView = true;
+
     [ObservableProperty]
     private bool _isShowingPlan;
 
@@ -614,6 +622,12 @@ public sealed partial class QueryViewModel : ObservableObject
     [RelayCommand]
     private void ShowResults() => IsShowingPlan = false;
 
+    [RelayCommand]
+    private void ShowPlanAsText() => IsPlanTextView = true;
+
+    [RelayCommand]
+    private void ShowPlanAsTree() => IsPlanTextView = false;
+
     private async Task RunExplainAsync(bool analyze)
     {
         // Own a CTS so the Cancel button (enabled by IsRunning) actually cancels
@@ -632,6 +646,7 @@ public sealed partial class QueryViewModel : ObservableObject
         {
             var result = await _explainService.ExplainAsync(Sql, analyze, ct);
             ExplainRoot = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
+            ExplainText = ExplainTextFormatter.Format(result);
             var planningFragment = result.PlanningTimeMs is { } planMs ? $"Planning: {planMs:F3} ms" : null;
             var executionFragment = result.ExecutionTimeMs is { } execMs ? $"Execution: {execMs:F3} ms" : null;
             ExplainSummary = string.Join("   ", new[] { planningFragment, executionFragment }.Where(f => f is not null));

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -706,8 +706,25 @@
                         </TextBlock>
                     </StackPanel>
                     <Grid RowDefinitions="Auto,*" IsVisible="{Binding ActiveTab.IsShowingPlan}">
-                        <TextBlock Grid.Row="0" Text="{Binding ActiveTab.ExplainSummary}" Margin="4" FontSize="12" Opacity="0.8" />
-                        <ScrollViewer Grid.Row="1">
+                        <DockPanel Grid.Row="0" Margin="4">
+                            <!-- pgAdmin-style plan view switch: raw text (default) vs graphical tree -->
+                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="2">
+                                <Button Classes="chip" Classes.active="{Binding ActiveTab.IsPlanTextView}"
+                                        Command="{Binding ActiveTab.ShowPlanAsTextCommand}"
+                                        Content="Text" FontSize="11" Padding="8,2" />
+                                <Button Classes="chip" Classes.active="{Binding !ActiveTab.IsPlanTextView}"
+                                        Command="{Binding ActiveTab.ShowPlanAsTreeCommand}"
+                                        Content="Tree" FontSize="11" Padding="8,2" />
+                            </StackPanel>
+                            <TextBlock Text="{Binding ActiveTab.ExplainSummary}" FontSize="12" Opacity="0.8"
+                                       VerticalAlignment="Center" />
+                        </DockPanel>
+                        <ScrollViewer Grid.Row="1" IsVisible="{Binding ActiveTab.IsPlanTextView}"
+                                      HorizontalScrollBarVisibility="Auto">
+                            <SelectableTextBlock Text="{Binding ActiveTab.ExplainText}" Margin="8,4"
+                                                 FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="12.5" />
+                        </ScrollViewer>
+                        <ScrollViewer Grid.Row="1" IsVisible="{Binding !ActiveTab.IsPlanTextView}">
                             <TreeView ItemsSource="{Binding ActiveTab.ExplainRoots}" Margin="4">
                                 <TreeView.ItemTemplate>
                                     <TreeDataTemplate DataType="vm:ExplainNodeViewModel" ItemsSource="{Binding Children}">

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -493,7 +493,8 @@
             </DockPanel>
 
             <!-- Files-style command bar: accent primary action, quiet icon+label secondaries -->
-            <Border Grid.Row="1" Classes="card" Padding="4" Margin="0,0,0,12" HorizontalAlignment="Left">
+            <Border Grid.Row="1" Classes="card" Classes.planOpen="{Binding ActiveTab.IsShowingPlan}"
+                    Padding="4" Margin="0,0,0,12" HorizontalAlignment="Left">
                 <Border.Resources>
                     <!--
                         Disabled buttons inside the command bar stay transparent
@@ -513,6 +514,12 @@
                          actually has to fit into. -->
                     <Style Selector="TextBlock.collapsible">
                         <Setter Property="IsVisible" Value="{Binding $parent[Grid].Bounds.Width, Converter={x:Static conv2:MinWidthVisibilityConverter.Instance}, ConverterParameter=660}" />
+                    </Style>
+                    <!-- While a plan is on screen the bar carries one extra button
+                         ("Show results"), so labels need more room before they fit —
+                         collapse them earlier or Export/Import get pushed off-pane. -->
+                    <Style Selector="Border.planOpen TextBlock.collapsible">
+                        <Setter Property="IsVisible" Value="{Binding $parent[Grid].Bounds.Width, Converter={x:Static conv2:MinWidthVisibilityConverter.Instance}, ConverterParameter=790}" />
                     </Style>
                 </Border.Styles>
                 <StackPanel Orientation="Horizontal" Spacing="2">

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -493,8 +493,7 @@
             </DockPanel>
 
             <!-- Files-style command bar: accent primary action, quiet icon+label secondaries -->
-            <Border Grid.Row="1" Classes="card" Classes.planOpen="{Binding ActiveTab.IsShowingPlan}"
-                    Padding="4" Margin="0,0,0,12" HorizontalAlignment="Left">
+            <Border Grid.Row="1" Classes="card" Padding="4" Margin="0,0,0,12" HorizontalAlignment="Left">
                 <Border.Resources>
                     <!--
                         Disabled buttons inside the command bar stay transparent
@@ -514,12 +513,6 @@
                          actually has to fit into. -->
                     <Style Selector="TextBlock.collapsible">
                         <Setter Property="IsVisible" Value="{Binding $parent[Grid].Bounds.Width, Converter={x:Static conv2:MinWidthVisibilityConverter.Instance}, ConverterParameter=660}" />
-                    </Style>
-                    <!-- While a plan is on screen the bar carries one extra button
-                         ("Show results"), so labels need more room before they fit —
-                         collapse them earlier or Export/Import get pushed off-pane. -->
-                    <Style Selector="Border.planOpen TextBlock.collapsible">
-                        <Setter Property="IsVisible" Value="{Binding $parent[Grid].Bounds.Width, Converter={x:Static conv2:MinWidthVisibilityConverter.Instance}, ConverterParameter=790}" />
                     </Style>
                 </Border.Styles>
                 <StackPanel Orientation="Horizontal" Spacing="2">
@@ -570,26 +563,21 @@
                         </StackPanel>
                     </Button>
 
-                    <!-- Group 3 — analysis: plan inspection (secondary to running) -->
+                    <!-- Group 3 — analysis: one toolbar slot for plan inspection (minimalist rule);
+                         the flyout distinguishes estimate-only from actually-executing, closing the
+                         plan lives on the plan pane itself, and both commands are in the palette too -->
                     <Rectangle Classes="statusSeparator" Margin="7,0" />
-                    <Button Classes="toolbar" Command="{Binding ActiveTab.ExplainCommand}" ToolTip.Tip="Show the query plan (EXPLAIN)">
+                    <Button Classes="toolbar" ToolTip.Tip="Query plan (EXPLAIN / EXPLAIN ANALYZE)">
                         <StackPanel Orientation="Horizontal" Spacing="7">
                             <PathIcon Data="{StaticResource FlashIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
                             <TextBlock Text="Explain" VerticalAlignment="Center" Classes="collapsible" />
                         </StackPanel>
-                    </Button>
-                    <Button Classes="toolbar" Command="{Binding ActiveTab.ExplainAnalyzeCommand}" ToolTip.Tip="Run and show the actual plan (EXPLAIN ANALYZE)">
-                        <StackPanel Orientation="Horizontal" Spacing="7">
-                            <PathIcon Data="{StaticResource GaugeIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                            <TextBlock Text="Explain Analyze" VerticalAlignment="Center" Classes="collapsible" />
-                        </StackPanel>
-                    </Button>
-                    <Button Classes="toolbar" Command="{Binding ActiveTab.ShowResultsCommand}"
-                            IsVisible="{Binding ActiveTab.IsShowingPlan}">
-                        <StackPanel Orientation="Horizontal" Spacing="7">
-                            <PathIcon Data="{StaticResource TableIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                            <TextBlock Text="Show results" VerticalAlignment="Center" Classes="collapsible" />
-                        </StackPanel>
+                        <Button.Flyout>
+                            <MenuFlyout>
+                                <MenuItem Header="Explain — estimated plan" Click="OnExplainClick" />
+                                <MenuItem Header="Explain Analyze — runs the query" Click="OnExplainAnalyzeClick" />
+                            </MenuFlyout>
+                        </Button.Flyout>
                     </Button>
 
                     <!-- Group 4 — data out: export -->
@@ -722,6 +710,12 @@
                                 <Button Classes="chip" Classes.active="{Binding !ActiveTab.IsPlanTextView}"
                                         Command="{Binding ActiveTab.ShowPlanAsTreeCommand}"
                                         Content="Tree" FontSize="11" Padding="8,2" />
+                                <!-- Fixed 18x18: in this StackPanel the taller Text/Tree chips would
+                                     otherwise stretch the ✕ chip and push its glyph off-center -->
+                                <Button Classes="chip" Command="{Binding ActiveTab.ShowResultsCommand}"
+                                        Content="✕" FontSize="10" Width="18" Height="18" Padding="0"
+                                        Margin="6,0,0,0" VerticalAlignment="Center"
+                                        ToolTip.Tip="Close the plan and show results" />
                             </StackPanel>
                             <TextBlock Text="{Binding ActiveTab.ExplainSummary}" FontSize="12" Opacity="0.8"
                                        VerticalAlignment="Center" />

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1853,6 +1853,24 @@ public partial class MainWindow : Window
         }
     }
 
+    // The Explain toolbar button is a single slot with a flyout (minimalist rule);
+    // menu items route to the active tab's commands the same way Export's do.
+    private void OnExplainClick(object? sender, RoutedEventArgs e)
+    {
+        if (_queryViewModel is { } query && query.ExplainCommand.CanExecute(null))
+        {
+            query.ExplainCommand.Execute(null);
+        }
+    }
+
+    private void OnExplainAnalyzeClick(object? sender, RoutedEventArgs e)
+    {
+        if (_queryViewModel is { } query && query.ExplainAnalyzeCommand.CanExecute(null))
+        {
+            query.ExplainAnalyzeCommand.Execute(null);
+        }
+    }
+
     private async void OnExportCsvClick(object? sender, RoutedEventArgs e)
     {
         var query = _queryViewModel;

--- a/PgNimbus.Core.Tests/Query/ExplainParsingTests.cs
+++ b/PgNimbus.Core.Tests/Query/ExplainParsingTests.cs
@@ -1,0 +1,190 @@
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Tests.Query;
+
+/// <summary>
+/// Parser + text-formatter tests over captured `EXPLAIN (FORMAT JSON)` payloads.
+/// The PG 18 sample is real output (postgres:18 docker): note the fractional
+/// "Actual Rows": 7.00 that used to crash GetInt64()-based parsing.
+/// </summary>
+public class ExplainParsingTests
+{
+    private const string Pg18AnalyzeJson = """
+        [
+          {
+            "Plan": {
+              "Node Type": "Seq Scan",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Relation Name": "t",
+              "Alias": "t",
+              "Startup Cost": 0.00,
+              "Total Cost": 41.88,
+              "Plan Rows": 850,
+              "Plan Width": 4,
+              "Actual Startup Time": 0.009,
+              "Actual Total Time": 0.009,
+              "Actual Rows": 7.00,
+              "Actual Loops": 1,
+              "Disabled": false,
+              "Filter": "(id > 3)",
+              "Rows Removed by Filter": 3
+            },
+            "Planning Time": 0.181,
+            "Triggers": [
+            ],
+            "Execution Time": 0.021
+          }
+        ]
+        """;
+
+    private const string Pg17AnalyzeJson = """
+        [
+          {
+            "Plan": {
+              "Node Type": "Result",
+              "Parallel Aware": false,
+              "Async Capable": false,
+              "Startup Cost": 0.00,
+              "Total Cost": 0.01,
+              "Plan Rows": 1,
+              "Plan Width": 4,
+              "Actual Startup Time": 0.001,
+              "Actual Total Time": 0.001,
+              "Actual Rows": 1,
+              "Actual Loops": 1
+            },
+            "Planning Time": 0.040,
+            "Triggers": [
+            ],
+            "Execution Time": 0.018
+          }
+        ]
+        """;
+
+    private const string JoinPlanJson = """
+        [
+          {
+            "Plan": {
+              "Node Type": "Hash Join",
+              "Parallel Aware": false,
+              "Join Type": "Left",
+              "Startup Cost": 1.11,
+              "Total Cost": 2.29,
+              "Plan Rows": 5,
+              "Plan Width": 30,
+              "Hash Cond": "(o.customer_id = c.id)",
+              "Plans": [
+                {
+                  "Node Type": "Seq Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Relation Name": "orders",
+                  "Alias": "o",
+                  "Startup Cost": 0.00,
+                  "Total Cost": 1.05,
+                  "Plan Rows": 5,
+                  "Plan Width": 12
+                },
+                {
+                  "Node Type": "Hash",
+                  "Parent Relationship": "Inner",
+                  "Parallel Aware": false,
+                  "Startup Cost": 1.05,
+                  "Total Cost": 1.05,
+                  "Plan Rows": 5,
+                  "Plan Width": 22,
+                  "Plans": [
+                    {
+                      "Node Type": "Index Scan",
+                      "Parent Relationship": "Outer",
+                      "Parallel Aware": false,
+                      "Scan Direction": "Forward",
+                      "Index Name": "customers_pkey",
+                      "Relation Name": "customers",
+                      "Alias": "c",
+                      "Startup Cost": 0.00,
+                      "Total Cost": 1.05,
+                      "Plan Rows": 5,
+                      "Plan Width": 22
+                    }
+                  ]
+                }
+              ]
+            },
+            "Planning Time": 0.120
+          }
+        ]
+        """;
+
+    [Test]
+    public async Task Pg18FractionalActualRowsParse()
+    {
+        var result = ExplainService.Parse(Pg18AnalyzeJson);
+
+        await Assert.That(result.Root.ActualRows).IsEqualTo(7.0);
+        await Assert.That(result.Root.PlanRows).IsEqualTo(850L);
+        await Assert.That(result.ExecutionTimeMs).IsEqualTo(0.021);
+    }
+
+    [Test]
+    public async Task Pg17IntegerActualRowsStillParse()
+    {
+        var result = ExplainService.Parse(Pg17AnalyzeJson);
+
+        await Assert.That(result.Root.ActualRows).IsEqualTo(1.0);
+        await Assert.That(result.Root.ActualLoops).IsEqualTo(1L);
+    }
+
+    [Test]
+    public async Task DetailPropertiesAreKeptStructuralOnesAreNot()
+    {
+        var root = ExplainService.Parse(Pg18AnalyzeJson).Root;
+        var keys = root.Details.Select(d => d.Key).ToList();
+
+        await Assert.That(keys).Contains("Filter");
+        await Assert.That(keys).Contains("Rows Removed by Filter");
+        // Structural / noise keys must not leak into the detail lines.
+        await Assert.That(keys).DoesNotContain("Node Type");
+        await Assert.That(keys).DoesNotContain("Parallel Aware");
+        await Assert.That(keys).DoesNotContain("Disabled");
+    }
+
+    [Test]
+    public async Task TextFormatMatchesPostgresLayout()
+    {
+        var text = ExplainTextFormatter.Format(ExplainService.Parse(Pg18AnalyzeJson));
+
+        var expected =
+            "Seq Scan on t  (cost=0.00..41.88 rows=850 width=4) (actual time=0.009..0.009 rows=7 loops=1)\n" +
+            "  Filter: (id > 3)\n" +
+            "  Rows Removed by Filter: 3\n" +
+            "Planning Time: 0.181 ms\n" +
+            "Execution Time: 0.021 ms";
+        await Assert.That(text.ReplaceLineEndings("\n")).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task TextFormatIndentsChildrenWithArrows()
+    {
+        var text = ExplainTextFormatter.Format(ExplainService.Parse(JoinPlanJson));
+
+        var expected =
+            "Hash Left Join  (cost=1.11..2.29 rows=5 width=30)\n" +
+            "  Hash Cond: (o.customer_id = c.id)\n" +
+            "  ->  Seq Scan on orders o  (cost=0.00..1.05 rows=5 width=12)\n" +
+            "  ->  Hash  (cost=1.05..1.05 rows=5 width=22)\n" +
+            "        ->  Index Scan using customers_pkey on customers c  (cost=0.00..1.05 rows=5 width=22)\n" +
+            "Planning Time: 0.120 ms";
+        await Assert.That(text.ReplaceLineEndings("\n")).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task FractionalActualRowsKeepTheirDecimals()
+    {
+        var json = Pg18AnalyzeJson.Replace("\"Actual Rows\": 7.00", "\"Actual Rows\": 7.50");
+        var text = ExplainTextFormatter.Format(ExplainService.Parse(json));
+
+        await Assert.That(text).Contains("rows=7.5 loops=1");
+    }
+}

--- a/PgNimbus.Core/Query/ExplainService.cs
+++ b/PgNimbus.Core/Query/ExplainService.cs
@@ -7,15 +7,24 @@ namespace PgNimbus.Core.Query;
 public sealed record ExplainNode(
     string NodeType,
     string? RelationName,
+    string? Alias,
     string? IndexName,
+    string? JoinType,
+    string? ScanDirection,
+    string? SubplanName,
+    string? Strategy,
+    string? PartialMode,
+    string? Operation,
+    bool ParallelAware,
     double StartupCost,
     double TotalCost,
     long PlanRows,
     int PlanWidth,
     double? ActualStartupTimeMs,
     double? ActualTotalTimeMs,
-    long? ActualRows,
+    double? ActualRows,
     long? ActualLoops,
+    IReadOnlyList<KeyValuePair<string, string>> Details,
     IReadOnlyList<ExplainNode> Children);
 
 public sealed record ExplainResult(ExplainNode Root, double? PlanningTimeMs, double? ExecutionTimeMs);
@@ -45,6 +54,12 @@ public sealed class ExplainService
         await using var command = new NpgsqlCommand(explainSql, connection);
         var json = (string)(await command.ExecuteScalarAsync(ct))!;
 
+        return Parse(json);
+    }
+
+    /// <summary>Parses the raw `EXPLAIN (FORMAT JSON)` payload. Split out from the DB round-trip for testability.</summary>
+    public static ExplainResult Parse(string json)
+    {
         using var document = JsonDocument.Parse(json);
         var planEntry = document.RootElement[0];
         var planningTime = planEntry.TryGetProperty("Planning Time", out var pt) ? pt.GetDouble() : (double?)null;
@@ -52,6 +67,21 @@ public sealed class ExplainService
 
         return new ExplainResult(ParseNode(planEntry.GetProperty("Plan")), planningTime, executionTime);
     }
+
+    /// <summary>
+    /// Node properties consumed into first-class <see cref="ExplainNode"/> fields (or deliberately
+    /// dropped as noise) — everything else lands in <see cref="ExplainNode.Details"/> so the text
+    /// view can show Filter / Sort Key / Hash Cond / … lines the way `EXPLAIN (FORMAT TEXT)` does.
+    /// </summary>
+    private static readonly HashSet<string> StructuralKeys =
+    [
+        "Node Type", "Plans",
+        "Relation Name", "Function Name", "CTE Name", "Alias", "Index Name",
+        "Join Type", "Scan Direction", "Subplan Name", "Strategy", "Partial Mode", "Operation",
+        "Parallel Aware", "Async Capable", "Parent Relationship",
+        "Startup Cost", "Total Cost", "Plan Rows", "Plan Width",
+        "Actual Startup Time", "Actual Total Time", "Actual Rows", "Actual Loops",
+    ];
 
     private static ExplainNode ParseNode(JsonElement element)
     {
@@ -64,18 +94,70 @@ public sealed class ExplainService
             }
         }
 
+        var details = new List<KeyValuePair<string, string>>();
+        foreach (var property in element.EnumerateObject())
+        {
+            if (StructuralKeys.Contains(property.Name))
+            {
+                continue;
+            }
+
+            // PG 18 stamps "Disabled": false on every node — only a true value is worth a line.
+            if (property.Name == "Disabled" && property.Value.ValueKind == JsonValueKind.False)
+            {
+                continue;
+            }
+
+            if (RenderDetailValue(property.Value) is { } rendered)
+            {
+                details.Add(new KeyValuePair<string, string>(property.Name, rendered));
+            }
+        }
+
         return new ExplainNode(
             element.GetProperty("Node Type").GetString()!,
-            element.TryGetProperty("Relation Name", out var rel) ? rel.GetString() : null,
-            element.TryGetProperty("Index Name", out var idx) ? idx.GetString() : null,
+            GetString(element, "Relation Name") ?? GetString(element, "Function Name") ?? GetString(element, "CTE Name"),
+            GetString(element, "Alias"),
+            GetString(element, "Index Name"),
+            GetString(element, "Join Type"),
+            GetString(element, "Scan Direction"),
+            GetString(element, "Subplan Name"),
+            GetString(element, "Strategy"),
+            GetString(element, "Partial Mode"),
+            GetString(element, "Operation"),
+            element.TryGetProperty("Parallel Aware", out var pa) && pa.ValueKind == JsonValueKind.True,
             element.GetProperty("Startup Cost").GetDouble(),
             element.GetProperty("Total Cost").GetDouble(),
-            element.GetProperty("Plan Rows").GetInt64(),
+            // Row counts read as double then truncated / kept fractional deliberately:
+            // PostgreSQL 18 reports actual rows averaged over loops with two decimals
+            // ("Actual Rows": 7.00) — GetInt64() throws FormatException on those.
+            (long)element.GetProperty("Plan Rows").GetDouble(),
             element.GetProperty("Plan Width").GetInt32(),
             element.TryGetProperty("Actual Startup Time", out var ast) ? ast.GetDouble() : null,
             element.TryGetProperty("Actual Total Time", out var att) ? att.GetDouble() : null,
-            element.TryGetProperty("Actual Rows", out var ar) ? ar.GetInt64() : null,
-            element.TryGetProperty("Actual Loops", out var al) ? al.GetInt64() : null,
+            element.TryGetProperty("Actual Rows", out var ar) ? ar.GetDouble() : null,
+            element.TryGetProperty("Actual Loops", out var al) ? (long)al.GetDouble() : null,
+            details,
             children);
     }
+
+    private static string? GetString(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    /// <summary>Scalar-ish JSON values render as text; objects (and arrays of them) are skipped as noise.</summary>
+    private static string? RenderDetailValue(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.String => value.GetString(),
+        JsonValueKind.Number => value.GetRawText(),
+        JsonValueKind.True => "true",
+        JsonValueKind.False => "false",
+        JsonValueKind.Array when value.GetArrayLength() > 0 && value.EnumerateArray().All(IsScalar) =>
+            string.Join(", ", value.EnumerateArray().Select(item => RenderDetailValue(item)!)),
+        _ => null,
+    };
+
+    private static bool IsScalar(JsonElement value) =>
+        value.ValueKind is JsonValueKind.String or JsonValueKind.Number or JsonValueKind.True or JsonValueKind.False;
 }

--- a/PgNimbus.Core/Query/ExplainTextFormatter.cs
+++ b/PgNimbus.Core/Query/ExplainTextFormatter.cs
@@ -1,0 +1,165 @@
+using System.Globalization;
+using System.Text;
+
+namespace PgNimbus.Core.Query;
+
+/// <summary>
+/// Renders a parsed <see cref="ExplainResult"/> in the classic
+/// `EXPLAIN (FORMAT TEXT)` layout — node headers with cost/actual figures,
+/// indented detail lines, `-&gt;` arrows for children — without a second server
+/// round-trip (an EXPLAIN ANALYZE re-run would execute the query again).
+/// </summary>
+public static class ExplainTextFormatter
+{
+    public static string Format(ExplainResult result)
+    {
+        var sb = new StringBuilder();
+        AppendNode(sb, result.Root, textIndent: 0, isRoot: true);
+        if (result.PlanningTimeMs is { } planning)
+        {
+            sb.AppendLine(Invariant($"Planning Time: {planning:F3} ms"));
+        }
+
+        if (result.ExecutionTimeMs is { } execution)
+        {
+            sb.AppendLine(Invariant($"Execution Time: {execution:F3} ms"));
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// The node's text-format display name ("Parallel Hash Left Join",
+    /// "Index Scan using orders_pkey on orders o") — also the tree view's title,
+    /// so both plan views name nodes identically.
+    /// </summary>
+    public static string HeaderFor(ExplainNode node)
+    {
+        var name = node.NodeType;
+
+        // Joins fold their join type into the name the way explain.c does:
+        // "Hash Join" + Left → "Hash Left Join"; "Nested Loop" + Anti → "Nested Loop Anti Join".
+        if (node.JoinType is { } joinType && joinType != "Inner")
+        {
+            name = name == "Nested Loop"
+                ? $"Nested Loop {joinType} Join"
+                : name.Replace(" Join", $" {joinType} Join");
+        }
+
+        if (name == "Aggregate" && node.Strategy is { } strategy)
+        {
+            name = strategy switch
+            {
+                "Sorted" => "GroupAggregate",
+                "Hashed" => "HashAggregate",
+                "Mixed" => "MixedAggregate",
+                _ => "Aggregate",
+            };
+        }
+
+        if (node.PartialMode is { } partialMode && partialMode != "Simple")
+        {
+            name = $"{partialMode} {name}";
+        }
+
+        // ModifyTable displays as its operation: "Insert on orders".
+        if (name == "ModifyTable" && node.Operation is { } operation)
+        {
+            name = operation;
+        }
+
+        if (node.ParallelAware)
+        {
+            name = $"Parallel {name}";
+        }
+
+        if (node.IndexName is { } index)
+        {
+            if (node.NodeType == "Bitmap Index Scan")
+            {
+                name += $" on {index}";
+            }
+            else
+            {
+                if (node.ScanDirection == "Backward")
+                {
+                    name += " Backward";
+                }
+
+                name += $" using {index}";
+                if (Target(node) is { } indexTarget)
+                {
+                    name += $" on {indexTarget}";
+                }
+            }
+        }
+        else if (Target(node) is { } target)
+        {
+            name += $" on {target}";
+        }
+
+        return name;
+    }
+
+    /// <summary>Scan target with its alias when aliased: "orders o"; null for non-scan nodes.</summary>
+    private static string? Target(ExplainNode node)
+    {
+        if (node.RelationName is not { } relation)
+        {
+            return null;
+        }
+
+        return node.Alias is { } alias && alias != relation ? $"{relation} {alias}" : relation;
+    }
+
+    private static void AppendNode(StringBuilder sb, ExplainNode node, int textIndent, bool isRoot)
+    {
+        var line = new StringBuilder();
+        if (!isRoot)
+        {
+            line.Append(' ', textIndent - 4).Append("->  ");
+        }
+
+        line.Append(HeaderFor(node));
+        line.Append(Invariant($"  (cost={node.StartupCost:F2}..{node.TotalCost:F2} rows={node.PlanRows} width={node.PlanWidth})"));
+
+        if (node.ActualLoops == 0)
+        {
+            line.Append(" (never executed)");
+        }
+        else if (node.ActualRows is { } actualRows)
+        {
+            line.Append(" (actual");
+            if (node.ActualTotalTimeMs is { } totalTime)
+            {
+                line.Append(Invariant($" time={node.ActualStartupTimeMs ?? 0:F3}..{totalTime:F3}"));
+            }
+
+            // "0.##" instead of PG 18's fixed two decimals: integral counts stay
+            // clean ("rows=7"), fractional per-loop averages keep theirs ("rows=7.50").
+            line.Append(Invariant($" rows={actualRows:0.##} loops={node.ActualLoops})"));
+        }
+
+        sb.AppendLine(line.ToString());
+
+        var detailIndent = new string(' ', textIndent + 2);
+        foreach (var (key, value) in node.Details)
+        {
+            sb.Append(detailIndent).Append(key).Append(": ").AppendLine(value);
+        }
+
+        foreach (var child in node.Children)
+        {
+            // Subplans announce themselves on their own line above the arrow,
+            // at the parent's detail indent — same as text-format EXPLAIN.
+            if (child.SubplanName is { } subplan)
+            {
+                sb.Append(detailIndent).AppendLine(subplan);
+            }
+
+            AppendNode(sb, child, textIndent + 6, isRoot: false);
+        }
+    }
+
+    private static string Invariant(FormattableString value) => value.ToString(CultureInfo.InvariantCulture);
+}


### PR DESCRIPTION
## Bug: EXPLAIN ANALYZE failed on PostgreSQL 18

PostgreSQL 18 reports EXPLAIN ANALYZE actual row counts averaged over loops with two decimals (`"Actual Rows": 7.00` in FORMAT JSON — verified against a real `postgres:18` container; `postgres:17` still emits integers). `ExplainService` parsed them with `JsonElement.GetInt64()`, which throws `FormatException` on any fractional number, so **every** EXPLAIN ANALYZE against a PG 18 server (e.g. current Neon) failed with the opaque status *"Explain failed: One of the identified items was in an invalid format."* Plain EXPLAIN kept working only because it has no `Actual *` fields.

Row counts now parse as `double` (kept fractional for actual rows, truncated for plan rows) and render with trailing zeros trimmed (`rows=7`, `rows=7.5`).

## Feature: text-format plan view, pgAdmin-style toggle

The plan pane now defaults to the classic `EXPLAIN (FORMAT TEXT)` layout — node headers with cost/actual figures, indented detail lines (`Filter`, `Sort Key`, `Hash Cond`, …), `->` arrows for children, Planning/Execution Time footers — with a chip toggle to the existing graphical tree, plus a ✕ chip that closes the plan back to results.

The text is rendered client-side by the new `ExplainTextFormatter` from the same FORMAT JSON payload, deliberately avoiding a second server round-trip: re-running EXPLAIN ANALYZE for FORMAT TEXT would execute the query a second time. To feed it, `ExplainNode` keeps the detail properties it used to drop plus header qualifiers (join type, alias, scan direction, aggregate strategy, ModifyTable operation), and the tree view titles nodes with the same header logic (`Index Scan using idx on t`, `Hash Left Join`), so both views name nodes identically.

## Toolbar: one Explain slot instead of three plan buttons

Per the minimalist-toolbar rule, Explain / Explain Analyze / Show results no longer occupy three toolbar slots. A single **Explain** button opens a flyout (same pattern as Export) with "Explain — estimated plan" and "Explain Analyze — runs the query"; closing the plan is the ✕ chip on the plan pane itself. Both commands remain in the command palette. This also made the interim collapse-threshold override for the extra button unnecessary (reverted within this PR).

## Verification

- 6 new tests in `ExplainParsingTests` over captured PG 17/PG 18 JSON (fractional parse, detail retention, exact text layout incl. nested-join indentation); full Core suite: 249 passed.
- Live-verified the Debug build against `postgres:18` in Docker: the Explain flyout opens with real input, Explain Analyze renders the text plan (Sort → Seq Scan with Filter / Rows Removed by Filter), the Text/Tree toggle switches views, plain Explain unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)