### PR TITLE
Enable auto-alias tables and safe-mode edits by default

### DIFF
--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -170,7 +170,7 @@ public sealed partial class MainViewModel : ObservableObject
         string connectionDatabase = "",
         bool autoAliasTables = true,
         Action<bool>? persistAutoAliasTables = null,
-        bool safeModeEdits = false,
+        bool safeModeEdits = true,
         Action<bool>? persistSafeModeEdits = null)
     {
         ConnectionHost = connectionHost;

--- a/PgNimbus.App/Views/PreferencesWindow.axaml
+++ b/PgNimbus.App/Views/PreferencesWindow.axaml
@@ -4,8 +4,8 @@
         x:Class="PgNimbus.App.Views.PreferencesWindow"
         x:DataType="vm:PreferencesViewModel"
         Title="pgNimbus — Preferences"
-        Width="520" Height="430"
-        MinWidth="440" MinHeight="360"
+        Width="560" Height="560"
+        MinWidth="440" MinHeight="520"
         WindowStartupLocation="CenterOwner"
         FontFamily="{StaticResource InterFont}">
 

--- a/PgNimbus.Core.Tests/Settings/AppSettingsStoreTests.cs
+++ b/PgNimbus.Core.Tests/Settings/AppSettingsStoreTests.cs
@@ -12,7 +12,7 @@ public class AppSettingsStoreTests
         var settings = store.Load();
 
         await Assert.That(settings.Theme).IsEqualTo("system");
-        await Assert.That(settings.AutoAliasTables).IsFalse();
+        await Assert.That(settings.AutoAliasTables).IsTrue();
     }
 
     [Test]
@@ -23,8 +23,9 @@ public class AppSettingsStoreTests
         // added after this file was written would silently load as null/false if
         // AppSettings ever regressed from set to init accessors. Theme carries
         // that guard — a file omitting it must still fall back to "system", not
-        // null. ShowAdvancedSchemaObjects and AutoAliasTables default to false,
-        // so they can't detect the regression; they're checked for completeness.
+        // null. AutoAliasTables also defaults to true, so it doubles as a guard;
+        // ShowAdvancedSchemaObjects defaults to false and is checked for
+        // completeness only.
         var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
         await File.WriteAllTextAsync(path, """{ "ShowAdvancedSchemaObjects": true }""");
 
@@ -34,7 +35,7 @@ public class AppSettingsStoreTests
 
             await Assert.That(settings.Theme).IsEqualTo("system");
             await Assert.That(settings.ShowAdvancedSchemaObjects).IsTrue();
-            await Assert.That(settings.AutoAliasTables).IsFalse();
+            await Assert.That(settings.AutoAliasTables).IsTrue();
         }
         finally
         {

--- a/PgNimbus.Core/Settings/AppSettings.cs
+++ b/PgNimbus.Core/Settings/AppSettings.cs
@@ -28,19 +28,19 @@ public sealed record AppSettings
     /// <summary>
     /// Whether accepting a table from completion after FROM/JOIN also appends a
     /// short alias (<c>public.orders</c> → <c>public.orders o</c>), so the
-    /// <c>o.</c> member-access flow is available immediately. Off by default;
-    /// opt in from the completion preferences toggle.
+    /// <c>o.</c> member-access flow is available immediately. On by default;
+    /// opt out from the completion preferences toggle.
     /// </summary>
-    public bool AutoAliasTables { get; set; }
+    public bool AutoAliasTables { get; set; } = true;
 
     /// <summary>
     /// Safe mode: grid cell edits, row deletes, and Add-row inserts are staged
     /// locally (dirty rows highlighted in the grid) instead of executing
     /// immediately; the generated SQL is reviewed and committed as one
-    /// transaction — or discarded. Off by default; toggled from the command
+    /// transaction — or discarded. On by default; toggled from the command
     /// palette or the preferences page.
     /// </summary>
-    public bool SafeModeEdits { get; set; }
+    public bool SafeModeEdits { get; set; } = true;
 
     /// <summary>
     /// Which modifier the app's command shortcuts use: <c>"auto"</c> (Cmd on


### PR DESCRIPTION
## Summary
Changes the default behavior for two user-preference settings from opt-in to opt-out, making both auto-alias tables and safe-mode edits enabled by default while allowing users to disable them from the preferences page.

## Changes
- **AppSettings.cs**: Set `AutoAliasTables` and `SafeModeEdits` to default to `true` instead of `false`
  - Updated XML documentation to reflect "On by default; opt out" instead of "Off by default; opt in"
- **AppSettingsStoreTests.cs**: Updated test assertions to expect `true` for `AutoAliasTables` in default/fallback scenarios
  - Clarified test comments: `AutoAliasTables` now serves as a regression guard (like `Theme`) since it defaults to `true`
- **MainViewModel.cs**: Updated constructor parameter default for `safeModeEdits` from `false` to `true`
- **PreferencesWindow.axaml**: Increased window dimensions to accommodate the expanded preferences UI
  - Width: 520 → 560, Height: 430 → 560
  - MinHeight: 360 → 520

## Rationale
These features improve the user experience by default: auto-aliasing tables enables immediate member-access completion (e.g., `o.` after selecting `public.orders`), and safe-mode edits prevent accidental data loss by staging grid edits locally for review before commit. Users who prefer the previous behavior can opt out via the preferences toggle.

https://claude.ai/code/session_01SKfytFhrRoUBSFsMeRFp1N