### PR TITLE
Add compact find/replace panel with working buttons

### DIFF
--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -1,6 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:cc="clr-namespace:AvaloniaEdit.CodeCompletion;assembly=AvaloniaEdit"
+        xmlns:search="clr-namespace:AvaloniaEdit.Search;assembly=AvaloniaEdit"
         xmlns:completion="using:PgNimbus.App.Completion">
 
     <!--
@@ -161,6 +162,14 @@
         <StreamGeometry x:Key="TagIconGeometry">M5.5,7A1.5,1.5 0 0,1 4,5.5A1.5,1.5 0 0,1 5.5,4A1.5,1.5 0 0,1 7,5.5A1.5,1.5 0 0,1 5.5,7M21.41,11.58L12.41,2.58C12.05,2.22 11.55,2 11,2H4C2.89,2 2,2.89 2,4V11C2,11.55 2.22,12.05 2.59,12.41L11.58,21.41C11.95,21.77 12.45,22 13,22C13.55,22 14.05,21.77 14.41,21.41L21.41,14.41C21.78,14.05 22,13.55 22,13C22,12.44 21.77,11.94 21.41,11.58Z</StreamGeometry>
         <StreamGeometry x:Key="TableColumnIconGeometry">M10,10.02H15V21H10V10.02M17,21H20C21.1,21 22,20.1 22,19V10H17V21M20,3H5C3.9,3 3,3.9 3,5V8H22V5C22,3.9 21.1,3 20,3M3,19C3,20.1 3.9,21 5,21H8V10H3V19Z</StreamGeometry>
         <StreamGeometry x:Key="LayersIconGeometry">M12,16L19.36,10.27L21,9L12,2L3,9L4.63,10.27M12,18.54L4.62,12.81L3,14.07L12,21.07L21,14.07L19.37,12.8L12,18.54Z</StreamGeometry>
+        <!-- Find/replace bar: MDI arrow-up/arrow-down plus AvaloniaEdit's own
+             VS Code-style replace / replace-all glyphs (MIT, copied from its
+             stock SearchPanel template so the compact theme below is
+             self-contained). -->
+        <StreamGeometry x:Key="ArrowUpIconGeometry">M13,20H11V8L5.5,13.5L4.08,12.08L12,4.16L19.92,12.08L18.5,13.5L13,8V20Z</StreamGeometry>
+        <StreamGeometry x:Key="ArrowDownIconGeometry">M11,4H13V16L18.5,10.5L19.92,11.92L12,19.84L4.08,11.92L5.5,10.5L11,16V4Z</StreamGeometry>
+        <StreamGeometry x:Key="ReplaceNextIconGeometry">M3.221 3.739L5.482 6.008L7.7 3.784L7 3.084L5.988 4.091L5.98 2.491C5.97909 2.35567 6.03068 2.22525 6.12392 2.12716C6.21716 2.02908 6.3448 1.97095 6.48 1.965H8V1H6.48C6.28496 1.00026 6.09189 1.03902 5.91186 1.11405C5.73183 1.18908 5.56838 1.29892 5.43088 1.43725C5.29338 1.57558 5.18455 1.73969 5.11061 1.92018C5.03667 2.10066 4.99908 2.29396 5 2.489V4.1L3.927 3.033L3.221 3.739ZM9.89014 5.53277H9.90141C10.0836 5.84426 10.3521 6 10.707 6C11.0995 6 11.4131 5.83236 11.6479 5.49708C11.8826 5.1618 12 4.71728 12 4.16353C12 3.65304 11.8995 3.2507 11.6986 2.95652C11.4977 2.66234 11.2113 2.51525 10.8394 2.51525C10.4338 2.51525 10.1211 2.70885 9.90141 3.09604H9.89014V1H9V5.91888H9.89014V5.53277ZM9.87606 4.47177V4.13108C9.87606 3.88449 9.93427 3.6844 10.0507 3.53082C10.169 3.37724 10.3174 3.30045 10.4958 3.30045C10.6854 3.30045 10.831 3.37833 10.9324 3.53407C11.0357 3.68765 11.0873 3.9018 11.0873 4.17651C11.0873 4.50746 11.031 4.76379 10.9183 4.94549C10.8075 5.12503 10.6507 5.2148 10.4479 5.2148C10.2808 5.2148 10.1437 5.14449 10.0366 5.00389C9.92958 4.86329 9.87606 4.68592 9.87606 4.47177ZM9 12.7691C8.74433 12.923 8.37515 13 7.89247 13C7.32855 13 6.87216 12.8225 6.5233 12.4674C6.17443 12.1124 6 11.6543 6 11.0931C6 10.4451 6.18638 9.93484 6.55914 9.5624C6.93429 9.18747 7.43489 9.00001 8.06093 9.00001C8.49343 9.00001 8.80645 9.0596 9 9.17878V10.1769C8.76344 9.99319 8.4994 9.90132 8.20789 9.90132C7.88292 9.90132 7.62485 10.0006 7.43369 10.1993C7.24492 10.3954 7.15054 10.6673 7.15054 11.0149C7.15054 11.3526 7.24134 11.6183 7.42294 11.8119C7.60454 12.0031 7.85424 12.0987 8.17204 12.0987C8.454 12.0987 8.72999 12.0068 9 11.8231V12.7691ZM4 7L3 8V14L4 15H11L12 14V8L11 7H4ZM4 8H5H10H11V9V13V14H10H5H4V13V9V8Z</StreamGeometry>
+        <StreamGeometry x:Key="ReplaceAllIconGeometry">M11.6009 2.67683C11.7474 2.36708 11.9559 2.2122 12.2263 2.2122C12.4742 2.2122 12.6651 2.32987 12.7991 2.56522C12.933 2.80056 13 3.12243 13 3.53082C13 3.97383 12.9218 4.32944 12.7653 4.59766C12.6088 4.86589 12.3997 5 12.138 5C11.9014 5 11.7224 4.87541 11.6009 4.62622H11.5934V4.93511H11V1H11.5934V2.67683H11.6009ZM11.584 3.77742C11.584 3.94873 11.6197 4.09063 11.6911 4.20311C11.7624 4.3156 11.8538 4.37184 11.9653 4.37184C12.1005 4.37184 12.205 4.30002 12.2789 4.15639C12.354 4.01103 12.3915 3.80597 12.3915 3.54121C12.3915 3.32144 12.3571 3.15012 12.2883 3.02726C12.2207 2.90266 12.1236 2.84036 11.9972 2.84036C11.8782 2.84036 11.7793 2.9018 11.7005 3.02466C11.6228 3.14752 11.584 3.30759 11.584 3.50487V3.77742ZM4.11969 7.695L2 5.56781L2.66188 4.90594L3.66781 5.90625V4.39594C3.66695 4.21309 3.70219 4.03187 3.7715 3.86266C3.84082 3.69346 3.94286 3.53961 4.07176 3.40992C4.20066 3.28023 4.3539 3.17727 4.52268 3.10692C4.69146 3.03658 4.87246 3.00024 5.05531 3H7.39906V3.90469H5.05531C4.92856 3.91026 4.8089 3.96476 4.72149 4.05672C4.63408 4.14868 4.58571 4.27094 4.58656 4.39781L4.59406 5.89781L5.54281 4.95375L6.19906 5.61L4.11969 7.695ZM9.3556 4.93017H10V3.22067C10 2.40689 9.68534 2 9.05603 2C8.92098 2 8.77083 2.02421 8.6056 2.07263C8.44181 2.12104 8.3125 2.17691 8.21767 2.24022V2.90503C8.45474 2.70205 8.70474 2.60056 8.96767 2.60056C9.22917 2.60056 9.35991 2.75698 9.35991 3.06983L8.76078 3.17318C8.25359 3.25885 8 3.57914 8 4.13408C8 4.39665 8.06106 4.60708 8.18319 4.76536C8.30675 4.92179 8.47557 5 8.68966 5C8.97989 5 9.19899 4.83985 9.34698 4.51955H9.3556V4.93017ZM9.35991 3.57542V3.76816C9.35991 3.9432 9.31968 4.08845 9.23922 4.20391C9.15876 4.3175 9.0546 4.3743 8.92672 4.3743C8.83477 4.3743 8.76149 4.34264 8.7069 4.27933C8.65374 4.21415 8.62716 4.13128 8.62716 4.03073C8.62716 3.80912 8.73779 3.6797 8.95905 3.64246L9.35991 3.57542ZM7 12.9302H6.3556V12.5196H6.34698C6.19899 12.8399 5.97989 13 5.68966 13C5.47557 13 5.30675 12.9218 5.18319 12.7654C5.06106 12.6071 5 12.3966 5 12.1341C5 11.5791 5.25359 11.2588 5.76078 11.1732L6.35991 11.0698C6.35991 10.757 6.22917 10.6006 5.96767 10.6006C5.70474 10.6006 5.45474 10.702 5.21767 10.905V10.2402C5.3125 10.1769 5.44181 10.121 5.6056 10.0726C5.77083 10.0242 5.92098 10 6.05603 10C6.68534 10 7 10.4069 7 11.2207V12.9302ZM6.35991 11.7682V11.5754L5.95905 11.6425C5.73779 11.6797 5.62716 11.8091 5.62716 12.0307C5.62716 12.1313 5.65374 12.2142 5.7069 12.2793C5.76149 12.3426 5.83477 12.3743 5.92672 12.3743C6.0546 12.3743 6.15876 12.3175 6.23922 12.2039C6.31968 12.0885 6.35991 11.9432 6.35991 11.7682ZM9.26165 13C9.58343 13 9.82955 12.9423 10 12.8268V12.1173C9.81999 12.2551 9.636 12.324 9.44803 12.324C9.23616 12.324 9.06969 12.2523 8.94863 12.1089C8.82756 11.9637 8.76702 11.7644 8.76702 11.5112C8.76702 11.2505 8.82995 11.0466 8.95579 10.8994C9.08323 10.7505 9.25528 10.676 9.47192 10.676C9.66627 10.676 9.84229 10.7449 10 10.8827V10.1341C9.87097 10.0447 9.66229 10 9.37395 10C8.95659 10 8.62286 10.1406 8.37276 10.4218C8.12425 10.7011 8 11.0838 8 11.5698C8 11.9907 8.11629 12.3343 8.34887 12.6006C8.58144 12.8669 8.8857 13 9.26165 13ZM2 9L3 8H12L13 9V14L12 15H3L2 14V9ZM3 9V14H12V9H3ZM6 7L7 6H14L15 7V12L14 13V12V7H7H6Z</StreamGeometry>
         <StreamGeometry x:Key="LinkIconGeometry">M10.59,13.41C11,13.8 11,14.44 10.59,14.83C10.2,15.22 9.56,15.22 9.17,14.83C7.22,12.88 7.22,9.71 9.17,7.76V7.76L12.71,4.22C14.66,2.27 17.83,2.27 19.78,4.22C21.73,6.17 21.73,9.34 19.78,11.29L18.29,12.78C18.3,11.96 18.17,11.14 17.89,10.36L18.36,9.88C19.54,8.71 19.54,6.81 18.36,5.64C17.19,4.46 15.29,4.46 14.12,5.64L10.59,9.17C9.41,10.34 9.41,12.24 10.59,13.41M13.41,9.17C13.8,8.78 14.44,8.78 14.83,9.17C16.78,11.12 16.78,14.29 14.83,16.24V16.24L11.29,19.78C9.34,21.73 6.17,21.73 4.22,19.78C2.27,17.83 2.27,14.66 4.22,12.71L5.71,11.22C5.7,12.04 5.83,12.86 6.11,13.65L5.64,14.12C4.46,15.29 4.46,17.19 5.64,18.36C6.81,19.54 8.71,19.54 9.88,18.36L13.41,14.83C14.59,13.66 14.59,11.76 13.41,10.59C13,10.2 13,9.56 13.41,9.17Z</StreamGeometry>
 
         <!--
@@ -185,6 +194,126 @@
                     </Border>
                 </ControlTemplate>
             </Setter>
+        </ControlTheme>
+
+        <!--
+            Compact find/replace bar for the SQL editor, replacing AvaloniaEdit's
+            stock SearchPanel theme (same wins-by-load-order trick as the
+            CompletionList theme above). The stock panel is oversized (265px
+            boxes, fat padding, the match counter on its own row) and its
+            find/replace/close buttons are broken: they go through AvaloniaEdit's
+            RoutedCommand, which raises the command from a static "last focused
+            element" and silently no-ops when that routing misses the panel. The
+            buttons here carry names instead of commands - MainWindow wires their
+            Click straight to the panel's FindNext/FindPrevious/Replace*/Close
+            methods on TemplateApplied. The PART_* names are the panel's template
+            contract (OnApplyTemplate): searchTextBox, replaceTextBox, Border,
+            MessageView, MessageContent must all exist.
+        -->
+        <ControlTheme x:Key="{x:Type search:SearchPanel}" TargetType="search:SearchPanel">
+            <Setter Property="Focusable" Value="True" />
+            <Setter Property="Margin" Value="0,0,18,0" />
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Border Name="PART_Border"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            Background="{DynamicResource SystemControlPageBackgroundAltHighBrush}"
+                            BorderBrush="{StaticResource CardBorderBrush}"
+                            BorderThickness="1,0,1,1"
+                            CornerRadius="0,0,8,8"
+                            BoxShadow="0 4 16 0 #38000000"
+                            Padding="6,4">
+                        <StackPanel Spacing="4">
+                            <StackPanel Orientation="Horizontal" Spacing="4">
+                                <ToggleButton Name="ReplaceToggle"
+                                              Classes="chip"
+                                              Focusable="False"
+                                              VerticalAlignment="Center"
+                                              IsChecked="{Binding IsReplaceMode, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+                                              ToolTip.Tip="Toggle replace">
+                                    <PathIcon Data="{StaticResource ChevronRightIconGeometry}" Width="10" Height="10" />
+                                </ToggleButton>
+                                <TextBox Name="PART_searchTextBox"
+                                         Width="200"
+                                         MinHeight="26"
+                                         Padding="6,3"
+                                         FontSize="12"
+                                         VerticalContentAlignment="Center"
+                                         PlaceholderText="Find"
+                                         Text="{Binding SearchPattern, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}">
+                                    <TextBox.InnerRightContent>
+                                        <StackPanel Orientation="Horizontal" Spacing="1" Margin="0,0,3,0">
+                                            <ToggleButton Classes="chip" Focusable="False" FontSize="10"
+                                                          VerticalAlignment="Center" Content="Aa"
+                                                          ToolTip.Tip="Match case"
+                                                          IsChecked="{Binding $parent[search:SearchPanel].MatchCase, Mode=TwoWay}" />
+                                            <ToggleButton Classes="chip" Focusable="False" FontSize="10"
+                                                          VerticalAlignment="Center"
+                                                          ToolTip.Tip="Whole words"
+                                                          IsChecked="{Binding $parent[search:SearchPanel].WholeWords, Mode=TwoWay}">
+                                                <TextBlock Text="ab" FontSize="10" TextDecorations="Underline" />
+                                            </ToggleButton>
+                                            <ToggleButton Classes="chip" Focusable="False" FontSize="10"
+                                                          VerticalAlignment="Center" Content=".*"
+                                                          ToolTip.Tip="Regular expression"
+                                                          IsChecked="{Binding $parent[search:SearchPanel].UseRegex, Mode=TwoWay}" />
+                                        </StackPanel>
+                                    </TextBox.InnerRightContent>
+                                </TextBox>
+                                <StackPanel Name="PART_MessageView"
+                                            Orientation="Horizontal"
+                                            IsVisible="False"
+                                            VerticalAlignment="Center">
+                                    <TextBlock Name="PART_MessageContent"
+                                               FontSize="11"
+                                               Opacity="0.6"
+                                               MinWidth="34"
+                                               Margin="2,0"
+                                               VerticalAlignment="Center" />
+                                </StackPanel>
+                                <Button Name="PART_FindPreviousButton" Classes="chip" Focusable="False"
+                                        VerticalAlignment="Center" ToolTip.Tip="Previous match (Shift+Enter)">
+                                    <PathIcon Data="{StaticResource ArrowUpIconGeometry}" Width="12" Height="12" />
+                                </Button>
+                                <Button Name="PART_FindNextButton" Classes="chip" Focusable="False"
+                                        VerticalAlignment="Center" ToolTip.Tip="Next match (Enter)">
+                                    <PathIcon Data="{StaticResource ArrowDownIconGeometry}" Width="12" Height="12" />
+                                </Button>
+                                <Button Name="PART_CloseButton" Classes="chip" Focusable="False"
+                                        VerticalAlignment="Center" ToolTip.Tip="Close (Esc)">
+                                    <PathIcon Data="{StaticResource CloseIconGeometry}" Width="12" Height="12" />
+                                </Button>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Spacing="4"
+                                        IsVisible="{Binding IsReplaceMode, RelativeSource={RelativeSource TemplatedParent}}">
+                                <TextBox Name="PART_replaceTextBox"
+                                         Width="200"
+                                         MinHeight="26"
+                                         Padding="6,3"
+                                         FontSize="12"
+                                         VerticalContentAlignment="Center"
+                                         Margin="22,0,0,0"
+                                         PlaceholderText="Replace"
+                                         Text="{Binding ReplacePattern, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}" />
+                                <Button Name="PART_ReplaceNextButton" Classes="chip" Focusable="False"
+                                        VerticalAlignment="Center" ToolTip.Tip="Replace next">
+                                    <PathIcon Data="{StaticResource ReplaceNextIconGeometry}" Width="13" Height="13" />
+                                </Button>
+                                <Button Name="PART_ReplaceAllButton" Classes="chip" Focusable="False"
+                                        VerticalAlignment="Center" ToolTip.Tip="Replace all">
+                                    <PathIcon Data="{StaticResource ReplaceAllIconGeometry}" Width="13" Height="13" />
+                                </Button>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </ControlTemplate>
+            </Setter>
+
+            <!-- Chevron points down while the replace row is expanded -->
+            <Style Selector="^/template/ ToggleButton#ReplaceToggle:checked PathIcon">
+                <Setter Property="RenderTransform" Value="rotate(90deg)" />
+            </Style>
         </ControlTheme>
         </ResourceDictionary>
     </Styles.Resources>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -5,6 +5,7 @@ using System.Xml;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
@@ -175,10 +176,23 @@ public partial class MainWindow : Window
         SqlEditor.AddHandler(PointerWheelChangedEvent, OnSqlEditorPointerWheel, RoutingStrategies.Tunnel);
 
         // Find & replace: AvaloniaEdit's SearchPanel handles matching,
-        // highlighting, and its own F3/Shift+F3/Esc bindings; only opening it
-        // (Ctrl/Cmd+F, Ctrl/Cmd+H — see OnKeyDown) goes through Hotkeys. Its
-        // match-highlight brush is theme-resolved in ApplySqlHighlightingTheme.
+        // highlighting, and its own Enter/Shift+Enter/Esc bindings; only
+        // opening it (Ctrl/Cmd+F, Ctrl/Cmd+H — see OnKeyDown) goes through
+        // Hotkeys. Its match-highlight brush is theme-resolved in
+        // ApplySqlHighlightingTheme. The panel wears the compact template from
+        // Theme.axaml, whose buttons are wired below by name: the stock
+        // template's RoutedCommand buttons raise their command from a static
+        // "last focused element" and silently no-op when that routing misses
+        // the panel, so the buttons call the panel's methods directly instead.
         _searchPanel = SearchPanel.Install(SqlEditor);
+        _searchPanel.TemplateApplied += (_, e) =>
+        {
+            WireSearchPanelButton(e, "PART_FindPreviousButton", p => p.FindPrevious());
+            WireSearchPanelButton(e, "PART_FindNextButton", p => p.FindNext());
+            WireSearchPanelButton(e, "PART_CloseButton", p => p.Close());
+            WireSearchPanelButton(e, "PART_ReplaceNextButton", p => p.ReplaceNext());
+            WireSearchPanelButton(e, "PART_ReplaceAllButton", p => p.ReplaceAll());
+        };
 
         // Tab-strip navigation extras: the ‹/› arrows only appear when the
         // strip overflows, and the ▾ dropdown lists every open tab with
@@ -366,6 +380,24 @@ public partial class MainWindow : Window
         // Focus after the open has been laid out — Reactivate needs the panel's
         // TextBox realized, which isn't guaranteed synchronously on first open.
         Dispatcher.UIThread.Post(() => _searchPanel.Reactivate());
+    }
+
+    // Attaches a click handler to one of the compact search-panel template's
+    // named buttons (see the SearchPanel ControlTheme in Theme.axaml).
+    // TemplateApplied can rerun (it instantiates fresh buttons each time), so
+    // attaching here never double-subscribes.
+    private void WireSearchPanelButton(TemplateAppliedEventArgs e, string name, Action<SearchPanel> action)
+    {
+        if (e.NameScope.Find<Button>(name) is { } button)
+        {
+            button.Click += (_, _) =>
+            {
+                if (_searchPanel is { } panel)
+                {
+                    action(panel);
+                }
+            };
+        }
     }
 
     private void SetHighlightColor(string name, string hex)
@@ -1232,6 +1264,14 @@ public partial class MainWindow : Window
 
     private void OnSqlEditorKeyDown(object? sender, KeyEventArgs e)
     {
+        // The find/replace panel lives inside the TextArea, so this tunneled
+        // handler also sees keys typed into its text boxes - without this
+        // guard, Shift+Enter there runs the query instead of find-previous.
+        if (e.Source is Visual source && source.FindAncestorOfType<SearchPanel>() is not null)
+        {
+            return;
+        }
+
         if (e.Key == Key.Space && e.KeyModifiers == KeyModifiers.Control)
         {
             ShowCompletion(includeTypedChar: false);


### PR DESCRIPTION
## Summary

Replaces AvaloniaEdit's oversized stock SearchPanel with a compact, custom-themed find/replace bar that fixes broken button behavior. The stock panel's buttons route commands through a static "last focused element" that silently no-ops when routing misses the panel; the new template wires buttons directly to the panel's methods instead.

## Changes

- **Theme.axaml**: Added `search` namespace import and custom `SearchPanel` ControlTheme with:
  - Compact layout (200px text boxes, 26px min-height, match counter inline)
  - Find/replace toggle with chevron rotation animation
  - Inline match-case, whole-words, and regex toggles in the search box
  - Previous/next/close buttons in the find row; replace-next/replace-all in the replace row
  - Four new icon geometries (arrow-up, arrow-down, replace-next, replace-all) copied from AvaloniaEdit's stock template (MIT licensed)

- **MainWindow.axaml.cs**: 
  - Added `Avalonia.Controls.Primitives` using for `TemplateAppliedEventArgs`
  - Wired SearchPanel button clicks to panel methods via `TemplateApplied` event (replaces broken RoutedCommand routing)
  - Added `WireSearchPanelButton` helper to attach click handlers by button name
  - Added guard in `OnSqlEditorKeyDown` to prevent Shift+Enter in the search panel's text boxes from triggering query execution

## Implementation Details

The stock SearchPanel template's buttons use `RoutedCommand` which raises from a static "last focused element" — when focus is in the search text box, the routing chain misses the panel and commands silently no-op. The new template uses named buttons (`PART_FindPreviousButton`, etc.) that are wired in code to call the panel's public methods (`FindNext()`, `FindPrevious()`, `Replace()`, `ReplaceAll()`, `Close()`) directly, ensuring they always work regardless of focus state.

The `TemplateApplied` event fires each time the template is instantiated (including on theme changes), so wiring in that handler avoids double-subscription and keeps button handlers fresh.

https://claude.ai/code/session_01WEEzECaxS1Dpia9EJiuvbd