### PR TITLE
Add connection test feature to verify credentials before saving

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: verify
+description: Build, launch, and drive pgNimbus headlessly to verify a change end-to-end (Xvfb + xdotool + ImageMagick screenshots against a local Postgres).
+---
+
+# Verifying pgNimbus changes
+
+The full sandbox bootstrap (apt packages, Xvfb, Postgres seed, launch
+command) lives in `CLAUDE.md` → "Bootstrapping a fresh Linux/CI sandbox" —
+follow it verbatim; it works as written. Extras learned from real runs:
+
+- **Connection dialog vs. main window**: launching *without* `PGNIMBUS_CONN`
+  opens `ConnectionDialog` (the login screen); setting it skips straight to
+  `MainWindow`. Pick per what you're verifying.
+- The dialog is 640×680, centered on the 1280×800 Xvfb screen → it spans
+  roughly x 320–960, y 60–740. Screenshot first (`DISPLAY=:99 import -window
+  root shot.png`), read the PNG to find exact control coordinates, then drive
+  with `xdotool mousemove <x> <y> click 1` / `xdotool type ...` /
+  `xdotool key ctrl+a Delete`.
+- Run the app in the background under `timeout 180 dotnet run --project
+  PgNimbus.App --no-build` so one launch survives several drive/screenshot
+  Bash calls.
+- `SELECT count(*) FROM pg_stat_activity WHERE application_name='pgNimbus'`
+  is a handy probe for leaked/pooled connections.
+- Ubuntu 24.04's apt Postgres is 16.x; `service postgresql start` +
+  `ALTER USER postgres PASSWORD 'postgres'` is all the seed the connection
+  dialog needs.

--- a/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
+++ b/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
@@ -96,8 +96,23 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
     [ObservableProperty]
     private string? _errorMessage;
 
+    /// <summary>Green success line (currently only "connection test succeeded"); mutually exclusive with <see cref="ErrorMessage"/>.</summary>
+    [ObservableProperty]
+    private string? _statusMessage;
+
     [ObservableProperty]
     private bool _isConnecting;
+
+    [ObservableProperty]
+    private bool _isTesting;
+
+    partial void OnErrorMessageChanged(string? value)
+    {
+        if (value is not null)
+        {
+            StatusMessage = null;
+        }
+    }
 
     /// <summary>
     /// Guards against feedback loops between the import box and the form
@@ -168,6 +183,7 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         SshPrivateKeyPath = string.Empty;
         SshPassword = string.Empty;
         ErrorMessage = null;
+        StatusMessage = null;
     }
 
     [RelayCommand]
@@ -399,6 +415,61 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         New();
     }
 
+    /// <summary>
+    /// Opens (and immediately closes) a real connection with the form's
+    /// current values — including the SSH tunnel when enabled — without
+    /// handing anything off to the main window, so credentials can be
+    /// verified before saving or connecting.
+    /// </summary>
+    [RelayCommand]
+    private async Task TestConnectionAsync()
+    {
+        if (IsTesting || IsConnecting)
+        {
+            return;
+        }
+
+        if (!TryBuildProfile(out var profile, out var error))
+        {
+            ErrorMessage = error;
+            return;
+        }
+
+        ErrorMessage = null;
+        StatusMessage = null;
+        IsTesting = true;
+
+        SshTunnel? tunnel = null;
+        try
+        {
+            string connectionString;
+            if (profile.SshTunnel is { } sshOptions)
+            {
+                tunnel = await Task.Run(() => SshTunnel.Connect(sshOptions, SshPassword, profile.Host, profile.Port));
+                connectionString = profile.BuildConnectionString(
+                    string.IsNullOrEmpty(Password) ? null : Password,
+                    (tunnel.LocalHost, tunnel.LocalPort));
+            }
+            else
+            {
+                connectionString = profile.BuildConnectionString(string.IsNullOrEmpty(Password) ? null : Password);
+            }
+
+            var serverVersion = await ConnectionTester.TestAsync(connectionString);
+            StatusMessage = $"Connection successful — PostgreSQL {serverVersion}";
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = $"Connection test failed: {ex.Message}";
+        }
+        finally
+        {
+            // Unlike Connect, the test never hands the tunnel off — always tear it down.
+            tunnel?.Dispose();
+            IsTesting = false;
+        }
+    }
+
     [RelayCommand]
     private async Task ConnectAsync()
     {
@@ -417,6 +488,7 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         }
 
         ErrorMessage = null;
+        StatusMessage = null;
         IsConnecting = true;
 
         SshTunnel? tunnel = null;

--- a/PgNimbus.App/Views/ConnectionDialog.axaml
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml
@@ -136,8 +136,12 @@
                 </Grid>
             </Border>
 
-            <TextBlock Grid.Row="10" Text="{Binding ErrorMessage}" Foreground="IndianRed" TextWrapping="Wrap"
-                       IsVisible="{Binding ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" Margin="0,0,0,8" />
+            <StackPanel Grid.Row="10">
+                <TextBlock Text="{Binding ErrorMessage}" Foreground="IndianRed" TextWrapping="Wrap"
+                           IsVisible="{Binding ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" Margin="0,0,0,8" />
+                <TextBlock Text="{Binding StatusMessage}" Foreground="MediumSeaGreen" TextWrapping="Wrap"
+                           IsVisible="{Binding StatusMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" Margin="0,0,0,8" />
+            </StackPanel>
 
             <StackPanel Grid.Row="11" Margin="0,0,0,8">
                 <TextBlock Text="Accent Color" />
@@ -178,6 +182,8 @@
         <Button Grid.Column="0" Content="New" Command="{Binding NewCommand}" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" />
         <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="20,0,0,0">
             <Button Content="Delete" Command="{Binding DeleteCommand}" />
+            <Button Content="Test" Command="{Binding TestConnectionCommand}" IsEnabled="{Binding !IsTesting}"
+                    ToolTip.Tip="Verify the connection (and SSH tunnel, if enabled) without opening it" />
             <Button Content="Save" Command="{Binding SaveCommand}" />
             <Button Classes="accent" Content="Connect" Command="{Binding ConnectCommand}" IsEnabled="{Binding !IsConnecting}" />
         </StackPanel>

--- a/PgNimbus.Core/Connections/ConnectionTester.cs
+++ b/PgNimbus.Core/Connections/ConnectionTester.cs
@@ -1,0 +1,20 @@
+using Npgsql;
+
+namespace PgNimbus.Core.Connections;
+
+/// <summary>
+/// Probes a connection string by opening (and immediately closing) a real
+/// connection. Pooling is forced off so a successful test doesn't leave an
+/// idle pooled connection behind on the server.
+/// </summary>
+public static class ConnectionTester
+{
+    /// <summary>Opens the connection and returns the server version it reports; throws on failure.</summary>
+    public static async Task<string> TestAsync(string connectionString, CancellationToken cancellationToken = default)
+    {
+        var builder = new NpgsqlConnectionStringBuilder(connectionString) { Pooling = false };
+        await using var connection = new NpgsqlConnection(builder.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        return connection.ServerVersion;
+    }
+}


### PR DESCRIPTION
## Summary
Adds a "Test" button to the connection dialog that verifies the current connection settings (including SSH tunnel if enabled) without opening a persistent connection or handing it off to the main window. This allows users to validate credentials and configuration before saving or connecting.

## Changes

- **New `ConnectionTester` utility** (`PgNimbus.Core/Connections/ConnectionTester.cs`): Opens and immediately closes a real connection with pooling disabled, returning the server version on success or throwing on failure. Keeps `Core` free of UI dependencies per architectural rule #1.

- **Connection dialog enhancements** (`ConnectionDialogViewModel.cs`):
  - Added `StatusMessage` property for green success feedback (mutually exclusive with `ErrorMessage`)
  - Added `IsTesting` flag to prevent concurrent test/connect operations
  - Added `OnErrorMessageChanged` partial to clear `StatusMessage` when an error occurs
  - Implemented `TestConnectionAsync()` command that validates the profile, establishes an SSH tunnel if configured, tests the connection, and reports the PostgreSQL version or error
  - Clears both `ErrorMessage` and `StatusMessage` on new connection and before connect/test

- **UI updates** (`ConnectionDialog.axaml`):
  - Wrapped error/status messages in a `StackPanel` to display both when needed
  - Added green `StatusMessage` TextBlock for success feedback
  - Added "Test" button between "Delete" and "Save" with tooltip explaining its purpose; disabled while testing

- **Documentation** (`.claude/skills/verify/SKILL.md`): Added verification guide for end-to-end testing with Xvfb, xdotool, and local Postgres.

## Implementation Details

The test flow mirrors the connect flow but always disposes the SSH tunnel afterward (unlike connect, which hands it off to the main window). The `ConnectionTester` forces `Pooling = false` to avoid leaving idle connections on the server after a successful test. Error messages are prefixed with "Connection test failed: " to distinguish them from validation errors.

https://claude.ai/code/session_014fdnqvJBPKiDdftkcqoVpj