### PR TITLE
Exclude .pdb debug symbols from the MSIX package

### DIFF
--- a/scripts/windows/build-msix.ps1
+++ b/scripts/windows/build-msix.ps1
@@ -51,7 +51,11 @@ $publisher = $Matches[1]
 $stage = Join-Path ([System.IO.Path]::GetTempPath()) ("pgnimbus-msix-" + [guid]::NewGuid())
 try {
     New-Item -ItemType Directory -Force -Path "$stage\Assets" | Out-Null
-    Copy-Item "$PublishDir\*" -Destination $stage -Recurse -Force
+    # .pdb debug symbols are dev-only (crash-dump/symbol-server use) and add
+    # tens of MB (e.g. libSkiaSharp.pdb) with no end-user benefit — same
+    # exclusion the MSI installer applies in Product.wxs.
+    Copy-Item "$PublishDir\*" -Destination $stage -Recurse -Force -Exclude '*.pdb'
+    Get-ChildItem -Path $stage -Filter '*.pdb' -Recurse | Remove-Item -Force
     Copy-Item "$AssetsDir\*.png" -Destination "$stage\Assets" -Force
     ($manifestXml -replace '\$VERSION\$', $msixVersion) | Set-Content -Path "$stage\AppxManifest.xml" -Encoding utf8NoBOM
 


### PR DESCRIPTION
## Summary
- The Microsoft Store MSIX build (`scripts/windows/build-msix.ps1`) copied the entire `dotnet publish` output verbatim into the package, including native debug symbol files (`libSkiaSharp.pdb` ~80MB, `libHarfBuzzSharp.pdb` ~20MB, plus the app's own NativeAOT `.pdb`).
- These are dev-only files (crash-dump/symbol-server use) with zero end-user benefit. The MSI installer already excludes `*.pdb` for exactly this reason (`installer/windows/Product.wxs`) — this brings the MSIX build in line with it.
- Root cause of the reported issue: the Store-installed app showed **305 MB** total usage vs **19 MB** for the direct-download MSI.

## Test plan
- [x] Validated the modified script parses cleanly (PowerShell tokenizer).
- [ ] Next tagged release: confirm the `windows-msix` CI artifact size drops to roughly MSI-parity (~20-25 MB) instead of ~300 MB.
- [ ] After that, manually re-upload the new MSIX to Partner Center to update the live Store listing (not automated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)