### PR TITLE
Postgres-native value editing: type-aware editors in the grid and Add-row dialog

### DIFF
--- a/PgNimbus.App/Converters/RowIndexConverter.cs
+++ b/PgNimbus.App/Converters/RowIndexConverter.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Avalonia.Data.Converters;
+using PgNimbus.Core.Schema;
 
 namespace PgNimbus.App.Converters;
 
@@ -23,7 +24,20 @@ public sealed class RowIndexConverter : IValueConverter
     public RowIndexConverter(int index) => _index = index;
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is object?[] row && _index < row.Length ? row[_index] ?? NullPlaceholder : null;
+        value is object?[] row && _index < row.Length
+            ? row[_index] switch
+            {
+                null => NullPlaceholder,
+                // Array columns render in Postgres's literal syntax ("{a,b}")
+                // instead of the CLR default ("System.String[]") — readable,
+                // and editable in place since the cell editor pre-fills from
+                // this text and the edit pipeline casts it back server-side.
+                // bytea (byte[]) is deliberately left alone.
+                byte[] bytes => bytes,
+                Array array => PgValueSyntax.FormatArray(array),
+                var cell => cell,
+            }
+            : null;
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/PgNimbus.App/ResultTextColumn.cs
+++ b/PgNimbus.App/ResultTextColumn.cs
@@ -2,7 +2,10 @@ using System.Diagnostics.CodeAnalysis;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
 using PgNimbus.App.Converters;
+using PgNimbus.Core.Schema;
 
 namespace PgNimbus.App;
 
@@ -12,12 +15,35 @@ namespace PgNimbus.App;
 /// reads as a marker rather than data. The display element's DataContext is
 /// the row array, so a plain style can't see the cell value - the opacity
 /// binding has to be attached per generated element.
+/// When the result maps to an editable table, the column also knows its
+/// Postgres type (via <paramref name="editorMeta"/>) and generates a
+/// type-appropriate cell editor: a dropdown of pg_enum labels for enum
+/// columns, a checkbox for booleans, a calendar picker for date/timestamp.
+/// Everything else keeps the stock TextBox. The editors are initialized from
+/// the row value here; MainWindow reads the edited value back at commit time
+/// (see its OnCellEditEnding), so none of them need a two-way binding.
 /// </summary>
 public sealed class ResultTextColumn : DataGridTextColumn
 {
     private readonly int _index;
+    private readonly ColumnDetail? _editorMeta;
 
-    public ResultTextColumn(int index) => _index = index;
+    public ResultTextColumn(int index, ColumnDetail? editorMeta = null)
+    {
+        _index = index;
+        _editorMeta = editorMeta;
+
+        if (editorMeta?.Editor is ColumnValueEditor.Boolean or ColumnValueEditor.Enum
+            or ColumnValueEditor.Date or ColumnValueEditor.Timestamp)
+        {
+            // The base class binds the column's display Binding (the row→text
+            // converter) to BindingTarget on whatever editing element we
+            // generate. The display text means nothing to these editors —
+            // their state is set from the raw row value in
+            // GenerateEditingElementDirect — so park that binding on Tag.
+            BindingTarget = Control.TagProperty;
+        }
+    }
 
     // The Binding has an empty Path - it passes the row array straight to the
     // converter and never resolves a member by name, so the reflection/dynamic
@@ -36,4 +62,85 @@ public sealed class ResultTextColumn : DataGridTextColumn
 
         return element;
     }
+
+    protected override Control GenerateEditingElementDirect(DataGridCell cell, object dataItem)
+    {
+        var value = dataItem is object?[] row && _index < row.Length ? row[_index] : null;
+
+        switch (_editorMeta?.Editor)
+        {
+            case ColumnValueEditor.Boolean:
+                // A NULL cell starts unchecked-indeterminate; committing with
+                // no click writes nothing (MainWindow skips a null IsChecked).
+                return new CheckBox
+                {
+                    IsChecked = value as bool?,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                };
+
+            case ColumnValueEditor.Enum:
+                return new ComboBox
+                {
+                    ItemsSource = _editorMeta.EnumLabels,
+                    SelectedItem = value?.ToString(),
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                };
+
+            case ColumnValueEditor.Date:
+                return new CalendarDatePicker
+                {
+                    SelectedDate = ToDateTime(value),
+                    HorizontalAlignment = HorizontalAlignment.Stretch,
+                };
+
+            case ColumnValueEditor.Timestamp:
+            {
+                var timestamp = ToDateTime(value);
+                return new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 4,
+                    Focusable = true,
+                    Children =
+                    {
+                        new CalendarDatePicker { SelectedDate = timestamp?.Date },
+                        new TextBox
+                        {
+                            Text = timestamp?.ToString("HH:mm:ss", System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+                            PlaceholderText = "HH:MM:SS",
+                            MinWidth = 84,
+                        },
+                    },
+                };
+            }
+
+            default:
+                return base.GenerateEditingElementDirect(cell, dataItem);
+        }
+    }
+
+    protected override object? PrepareCellForEdit(Control editingElement, RoutedEventArgs editingEventArgs)
+        // The TextBox path keeps the stock prepare (select-all etc.); the
+        // typed editors were fully initialized at generate time, and with
+        // one-way column bindings there is no unedited value to hand back.
+        => editingElement is TextBox ? base.PrepareCellForEdit(editingElement, editingEventArgs) : null;
+
+    protected override void CancelCellEdit(Control editingElement, object uneditedValue)
+    {
+        if (editingElement is TextBox)
+        {
+            base.CancelCellEdit(editingElement, uneditedValue);
+        }
+
+        // Typed editors never wrote into the row (their value is read only at
+        // commit), so cancelling has nothing to restore.
+    }
+
+    private static DateTime? ToDateTime(object? value) => value switch
+    {
+        DateTime dateTime => dateTime,
+        DateOnly dateOnly => dateOnly.ToDateTime(TimeOnly.MinValue),
+        DateTimeOffset dateTimeOffset => dateTimeOffset.DateTime,
+        _ => null,
+    };
 }

--- a/PgNimbus.App/ViewModels/AddRowViewModel.cs
+++ b/PgNimbus.App/ViewModels/AddRowViewModel.cs
@@ -75,6 +75,9 @@ public sealed partial class AddRowViewModel : ObservableObject
                     DataType = column.DataType,
                     NotNull = column.NotNull,
                     IsPrimaryKey = column.IsPrimaryKey,
+                    Editor = column.Editor,
+                    EnumLabels = column.EnumLabels,
+                    DomainBaseType = column.DomainBaseType,
                 });
             }
         }
@@ -93,6 +96,15 @@ public sealed partial class AddRowViewModel : ObservableObject
     {
         IsBusy = true;
         StatusMessage = null;
+
+        // Array/composite literals get their structure checked client-side
+        // before anything is sent (Postgres still parses the elements).
+        if (Fields.FirstOrDefault(f => !f.IsNull && f.HasValidationError) is { } invalid)
+        {
+            StatusMessage = $"{invalid.Name}: {invalid.ValidationError}";
+            IsBusy = false;
+            return;
+        }
 
         // The columns that participate in the INSERT: an explicit NULL, or a
         // typed value. Blank + not-NULL fields are omitted entirely so their

--- a/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
+++ b/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
@@ -56,6 +56,8 @@ public sealed partial class CellInspectorViewModel : ObservableObject
         {
             null => "NULL",
             byte[] bytes => $"\\x{Convert.ToHexString(bytes)}",
+            // Same Postgres-literal rendering the grid uses — never "System.String[]".
+            Array array => PgNimbus.Core.Schema.PgValueSyntax.FormatArray(array),
             _ => value.ToString() ?? string.Empty,
         };
 

--- a/PgNimbus.App/ViewModels/EditableTableContext.cs
+++ b/PgNimbus.App/ViewModels/EditableTableContext.cs
@@ -1,3 +1,5 @@
+using PgNimbus.Core.Schema;
+
 namespace PgNimbus.App.ViewModels;
 
 /// <summary>
@@ -5,5 +7,16 @@ namespace PgNimbus.App.ViewModels;
 /// turned into targeted UPDATE statements. Cleared whenever the SQL text
 /// changes, so edits are only ever attempted against the exact query that
 /// produced this context (see <see cref="QueryViewModel"/>).
+/// <see cref="Columns"/> carries the table's per-column type metadata — it
+/// drives the grid's type-aware cell editors (enum dropdown, checkbox, date
+/// picker) and tells the UPDATE which columns need their text parsed
+/// server-side via a cast to the declared type.
 /// </summary>
-public sealed record EditableTableContext(string Schema, string Table, IReadOnlyList<string> PrimaryKeyColumns);
+public sealed record EditableTableContext(
+    string Schema,
+    string Table,
+    IReadOnlyList<string> PrimaryKeyColumns,
+    IReadOnlyList<ColumnDetail> Columns)
+{
+    public ColumnDetail? Column(string name) => Columns.FirstOrDefault(c => c.Name == name);
+}

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -440,11 +440,11 @@ public sealed partial class MainViewModel : ObservableObject
         tab.TitleOverride = name;
 
         var columns = await _schemaService.GetColumnsAsync(schema, name, CancellationToken.None);
-        var primaryKeyColumns = columns.Where(c => c.IsPrimaryKey).Select(c => c.Name).ToList();
 
         // Open the table in no-SQL browse mode: server-side filter/sort/paging,
-        // with inline editing when the table has a primary key.
-        await tab.StartBrowseAsync(schema, name, primaryKeyColumns, initialFilter);
+        // with inline editing when the table has a primary key. The column
+        // metadata rides along so the grid can offer type-aware cell editors.
+        await tab.StartBrowseAsync(schema, name, columns, initialFilter);
     }
 
     // FK edges for grid navigation ("Follow foreign key" / "Referencing rows"

--- a/PgNimbus.App/ViewModels/NewRowField.cs
+++ b/PgNimbus.App/ViewModels/NewRowField.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
+using PgNimbus.Core.Schema;
 
 namespace PgNimbus.App.ViewModels;
 
@@ -7,6 +9,12 @@ namespace PgNimbus.App.ViewModels;
 /// unchecked means "omit this column", so the server applies its default
 /// (serial sequences, <c>now()</c>, etc.); checking NULL inserts an explicit
 /// NULL; a non-blank value is cast to the column's declared type server-side.
+/// The input control follows the column's Postgres type (see
+/// <see cref="ColumnValueEditor"/>): enum columns get a dropdown of their
+/// pg_enum labels, booleans a checkbox, date/timestamp a calendar picker, and
+/// arrays/composites a syntax-checked text box. Every typed editor writes the
+/// canonical text into <see cref="Value"/>, so the INSERT pipeline stays
+/// text-in, CAST-server-side regardless of which control produced the value.
 /// </summary>
 public sealed partial class NewRowField : ObservableObject
 {
@@ -19,11 +27,102 @@ public sealed partial class NewRowField : ObservableObject
 
     public bool IsPrimaryKey { get; init; }
 
+    /// <summary>Which input control this column gets; classified from its base type (domains resolved).</summary>
+    public ColumnValueEditor Editor { get; init; } = ColumnValueEditor.Text;
+
+    /// <summary>The enum type's labels, in declared order, when <see cref="Editor"/> is Enum.</summary>
+    public IReadOnlyList<string> EnumLabels { get; init; } = [];
+
+    /// <summary>The resolved base type when the declared type is a domain; null otherwise.</summary>
+    public string? DomainBaseType { get; init; }
+
+    public bool IsTextEditor => Editor is ColumnValueEditor.Text or ColumnValueEditor.Array or ColumnValueEditor.Composite;
+
+    public bool IsBooleanEditor => Editor == ColumnValueEditor.Boolean;
+
+    public bool IsEnumEditor => Editor == ColumnValueEditor.Enum;
+
+    public bool IsDateEditor => Editor == ColumnValueEditor.Date;
+
+    public bool IsTimestampEditor => Editor == ColumnValueEditor.Timestamp;
+
     [ObservableProperty]
     private string _value = string.Empty;
 
     [ObservableProperty]
     private bool _isNull;
 
-    public string TypeLabel => IsPrimaryKey ? $"{DataType} · PK" : DataType;
+    // Typed editor state. Each writes through to Value; null/indeterminate
+    // means "leave blank" so the column's default still applies.
+    [ObservableProperty]
+    private bool? _boolValue;
+
+    [ObservableProperty]
+    private string? _enumChoice;
+
+    [ObservableProperty]
+    private DateTime? _dateValue;
+
+    /// <summary>Time-of-day text next to the timestamp date picker; blank means midnight.</summary>
+    [ObservableProperty]
+    private string _timeText = string.Empty;
+
+    partial void OnBoolValueChanged(bool? value) =>
+        Value = value switch { true => "true", false => "false", null => string.Empty };
+
+    partial void OnEnumChoiceChanged(string? value) => Value = value ?? string.Empty;
+
+    partial void OnDateValueChanged(DateTime? value) => ComposeDateTimeValue();
+
+    partial void OnTimeTextChanged(string value) => ComposeDateTimeValue();
+
+    private void ComposeDateTimeValue()
+    {
+        if (DateValue is not { } date)
+        {
+            Value = string.Empty;
+            return;
+        }
+
+        var datePart = date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        if (Editor == ColumnValueEditor.Date)
+        {
+            Value = datePart;
+            return;
+        }
+
+        var timePart = string.IsNullOrWhiteSpace(TimeText) ? "00:00:00" : TimeText.Trim();
+        Value = $"{datePart} {timePart}";
+    }
+
+    partial void OnValueChanged(string value)
+    {
+        OnPropertyChanged(nameof(ValidationError));
+        OnPropertyChanged(nameof(HasValidationError));
+    }
+
+    /// <summary>
+    /// Client-side syntax error for a hand-typed array/composite literal; null
+    /// when the structure is fine or the field is blank (= use the default).
+    /// Only the delimiter/quote structure is checked — element parsing stays
+    /// with Postgres via the INSERT's CAST.
+    /// </summary>
+    public string? ValidationError => string.IsNullOrEmpty(Value) ? null : Editor switch
+    {
+        ColumnValueEditor.Array => PgValueSyntax.ValidateArray(Value),
+        ColumnValueEditor.Composite => PgValueSyntax.ValidateComposite(Value),
+        _ => null,
+    };
+
+    public bool HasValidationError => ValidationError is not null;
+
+    public string TypeLabel
+    {
+        get
+        {
+            // A domain column shows what it resolves to ("posint → integer").
+            var type = DomainBaseType is { } baseType ? $"{DataType} → {baseType}" : DataType;
+            return IsPrimaryKey ? $"{type} · PK" : type;
+        }
+    }
 }

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -9,6 +9,7 @@ using CommunityToolkit.Mvvm.Input;
 using Npgsql;
 using PgNimbus.Core.Export;
 using PgNimbus.Core.Query;
+using PgNimbus.Core.Schema;
 
 namespace PgNimbus.App.ViewModels;
 
@@ -87,6 +88,10 @@ public sealed partial class QueryViewModel : ObservableObject
     // Primary-key columns of the browsed table, re-applied as the edit context
     // after each page load (composing the page SQL clears it via OnSqlChanged).
     private IReadOnlyList<string> _browsePkColumns = [];
+
+    // The browsed table's full column metadata (types, enum labels), carried
+    // into each page's edit context so the grid can offer type-aware editors.
+    private IReadOnlyList<ColumnDetail> _browseColumns = [];
 
     // Set while browse mode composes the page SQL, so OnSqlChanged doesn't treat
     // that programmatic write as a manual edit and tear browse mode down.
@@ -761,9 +766,10 @@ public sealed partial class QueryViewModel : ObservableObject
     /// the composed SQL is visible in the editor, and editing it turns the tab
     /// into a plain query.
     /// </summary>
-    public Task StartBrowseAsync(string schema, string name, IReadOnlyList<string> primaryKeyColumns, string? initialFilter = null)
+    public Task StartBrowseAsync(string schema, string name, IReadOnlyList<ColumnDetail> columns, string? initialFilter = null)
     {
-        _browsePkColumns = primaryKeyColumns;
+        _browseColumns = columns;
+        _browsePkColumns = columns.Where(c => c.IsPrimaryKey).Select(c => c.Name).ToList();
         Browse = new TableBrowseViewModel(schema, name, RunBrowseSqlAsync);
         if (!string.IsNullOrEmpty(initialFilter))
         {
@@ -788,7 +794,7 @@ public sealed partial class QueryViewModel : ObservableObject
 
         if (_browsePkColumns is { Count: > 0 } pk && Browse is { } browse)
         {
-            EditContext = new EditableTableContext(browse.Schema, browse.Name, pk);
+            EditContext = new EditableTableContext(browse.Schema, browse.Name, pk, _browseColumns);
         }
 
         return Rows.Count;
@@ -857,21 +863,54 @@ public sealed partial class QueryViewModel : ObservableObject
             return;
         }
 
+        // Postgres-native values a CLR conversion can't express — enum labels,
+        // array/composite literals (and domains over them) — travel as raw
+        // text and get parsed server-side via a cast to the declared type,
+        // the same mechanism the Add-row dialog uses for every value. A cheap
+        // client-side structure check catches malformed hand-typed literals
+        // before anything is sent.
+        var columnMeta = context.Column(columnName);
+        var castType = columnMeta?.Editor
+            is ColumnValueEditor.Enum or ColumnValueEditor.Array or ColumnValueEditor.Composite
+            ? columnMeta.DataType
+            : null;
+
         object? newValue;
-        try
+        if (castType is not null)
         {
-            newValue = ConvertEditedValue(newValueText, columnIndex);
+            var syntaxError = columnMeta!.Editor switch
+            {
+                ColumnValueEditor.Array => PgValueSyntax.ValidateArray(newValueText),
+                ColumnValueEditor.Composite => PgValueSyntax.ValidateComposite(newValueText),
+                _ => null,
+            };
+
+            if (syntaxError is not null)
+            {
+                Status = $"Invalid value for {columnName}: {syntaxError}";
+                HasError = true;
+                return;
+            }
+
+            newValue = newValueText;
         }
-        catch (Exception ex)
+        else
         {
-            Status = $"Invalid value for {columnName}: {ex.Message}";
-            HasError = true;
-            return;
+            try
+            {
+                newValue = ConvertEditedValue(newValueText, columnIndex);
+            }
+            catch (Exception ex)
+            {
+                Status = $"Invalid value for {columnName}: {ex.Message}";
+                HasError = true;
+                return;
+            }
         }
 
         if (ShouldStageChanges)
         {
-            StageCellValue(context, row, pkIndexes, columnIndex, columnName, newValue);
+            StageCellValue(context, row, pkIndexes, columnIndex, columnName, newValue, castType);
             return;
         }
 
@@ -879,9 +918,10 @@ public sealed partial class QueryViewModel : ObservableObject
             " AND ",
             context.PrimaryKeyColumns.Select((pk, n) => $"{SqlIdentifier.Quote(pk)} = @pk{n}"));
 
+        var valueExpression = castType is null ? "@value" : $"CAST(@value AS {castType})";
         var sql = $"""
             UPDATE {SqlIdentifier.Quote(context.Schema)}.{SqlIdentifier.Quote(context.Table)}
-            SET {SqlIdentifier.Quote(columnName)} = @value
+            SET {SqlIdentifier.Quote(columnName)} = {valueExpression}
             WHERE {whereClause}
             """;
 
@@ -1024,6 +1064,17 @@ public sealed partial class QueryViewModel : ObservableObject
             return TimeSpan.Parse(text, CultureInfo.InvariantCulture);
         }
 
+        // Npgsql is strict about DateTime.Kind: timestamptz only accepts Utc,
+        // timestamp only accepts non-Utc. A parsed string is Unspecified, so
+        // stamp the kind the column expects (a bare "2026-07-15 12:00" edited
+        // into a timestamptz cell is taken as UTC — what the grid displays).
+        if (underlying == typeof(DateTime))
+        {
+            var parsed = DateTime.Parse(text, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+            var isTimestampTz = _columns[columnIndex].DataTypeName.Contains("with time zone", StringComparison.OrdinalIgnoreCase);
+            return DateTime.SpecifyKind(parsed, isTimestampTz ? DateTimeKind.Utc : DateTimeKind.Unspecified);
+        }
+
         if (typeof(IConvertible).IsAssignableFrom(underlying))
         {
             return Convert.ChangeType(text, underlying, CultureInfo.InvariantCulture);
@@ -1131,7 +1182,7 @@ public sealed partial class QueryViewModel : ObservableObject
 
     // Stages one cell's converted value and shows it in the grid without
     // touching the database. Shared by inline edits and "Set cell to NULL".
-    private void StageCellValue(EditableTableContext context, object?[] row, IReadOnlyList<int> pkIndexes, int columnIndex, string columnName, object? newValue)
+    private void StageCellValue(EditableTableContext context, object?[] row, IReadOnlyList<int> pkIndexes, int columnIndex, string columnName, object? newValue, string? castType = null)
     {
         if (EnsurePendingSet(context, out var error) is not { } pending)
         {
@@ -1142,7 +1193,7 @@ public sealed partial class QueryViewModel : ObservableObject
 
         try
         {
-            pending.StageEdit(PkValuesOf(row, pkIndexes), columnName, newValue);
+            pending.StageEdit(PkValuesOf(row, pkIndexes), columnName, newValue, castType);
         }
         catch (InvalidOperationException ex)
         {

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -323,8 +323,12 @@ public sealed partial class QueryViewModel : ObservableObject
 
             // Ask for one row past the cap: receiving it proves the result was
             // actually cut short, so an exactly-at-the-cap result isn't
-            // mislabeled as truncated.
-            var result = await _engine.ExecuteAsync(executedSql, ct, MaxDisplayRows + 1);
+            // mislabeled as truncated. The composite-column text fallback
+            // re-executes the statement, so it's only enabled for browse-mode
+            // pages (app-composed SELECTs, side-effect-free by construction) —
+            // never for hand-written SQL, where a second execution would apply
+            // an INSERT … RETURNING (or any volatile call) twice.
+            var result = await _engine.ExecuteAsync(executedSql, ct, MaxDisplayRows + 1, allowTextFallback: IsBrowsing);
 
             switch (result)
             {

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -1069,14 +1069,23 @@ public sealed partial class QueryViewModel : ObservableObject
         }
 
         // Npgsql is strict about DateTime.Kind: timestamptz only accepts Utc,
-        // timestamp only accepts non-Utc. A parsed string is Unspecified, so
-        // stamp the kind the column expects (a bare "2026-07-15 12:00" edited
-        // into a timestamptz cell is taken as UTC — what the grid displays).
+        // timestamp (without time zone) only accepts non-Utc. The two column
+        // flavors also interpret the text differently, so handle them apart.
         if (underlying == typeof(DateTime))
         {
-            var parsed = DateTime.Parse(text, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
             var isTimestampTz = _columns[columnIndex].DataTypeName.Contains("with time zone", StringComparison.OrdinalIgnoreCase);
-            return DateTime.SpecifyKind(parsed, isTimestampTz ? DateTimeKind.Utc : DateTimeKind.Unspecified);
+            if (isTimestampTz)
+            {
+                // timestamptz: an offset-less value is taken as UTC (what the
+                // grid displays), an offset-bearing one as its real instant.
+                return DateTime.Parse(text, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            }
+
+            // timestamp without time zone: Postgres stores the wall-clock time
+            // as written and ignores any offset. DateTimeOffset.DateTime yields
+            // exactly that typed wall clock — timezone-independent — which we
+            // then mark Unspecified for Npgsql.
+            return DateTime.SpecifyKind(DateTimeOffset.Parse(text, CultureInfo.InvariantCulture).DateTime, DateTimeKind.Unspecified);
         }
 
         if (typeof(IConvertible).IsAssignableFrom(underlying))

--- a/PgNimbus.App/Views/AddRowDialog.axaml
+++ b/PgNimbus.App/Views/AddRowDialog.axaml
@@ -31,9 +31,38 @@
                                     <TextBlock Text="{Binding TypeLabel}" Opacity="0.55" FontSize="10"
                                                TextTrimming="CharacterEllipsis" />
                                 </StackPanel>
-                                <TextBox Grid.Column="1" Text="{Binding Value, Mode=TwoWay}"
-                                         IsEnabled="{Binding !IsNull}" FontSize="12"
-                                         VerticalAlignment="Center" PlaceholderText="default" />
+                                <!-- One editor per Postgres type family; each writes canonical
+                                     text into Value, so the INSERT path is identical no matter
+                                     which control produced it. -->
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center"
+                                            IsEnabled="{Binding !IsNull}">
+                                    <TextBox Text="{Binding Value, Mode=TwoWay}" FontSize="12"
+                                             PlaceholderText="default"
+                                             IsVisible="{Binding IsTextEditor}" />
+                                    <CheckBox IsChecked="{Binding BoolValue, Mode=TwoWay}"
+                                              IsThreeState="True" Content="{Binding Value}" FontSize="12"
+                                              IsVisible="{Binding IsBooleanEditor}" />
+                                    <ComboBox ItemsSource="{Binding EnumLabels}"
+                                              SelectedItem="{Binding EnumChoice, Mode=TwoWay}"
+                                              PlaceholderText="default" FontSize="12"
+                                              HorizontalAlignment="Stretch"
+                                              IsVisible="{Binding IsEnumEditor}" />
+                                    <CalendarDatePicker SelectedDate="{Binding DateValue, Mode=TwoWay}"
+                                                        PlaceholderText="default" FontSize="12"
+                                                        HorizontalAlignment="Stretch"
+                                                        IsVisible="{Binding IsDateEditor}" />
+                                    <Grid ColumnDefinitions="*,6,88" IsVisible="{Binding IsTimestampEditor}">
+                                        <CalendarDatePicker Grid.Column="0"
+                                                            SelectedDate="{Binding DateValue, Mode=TwoWay}"
+                                                            PlaceholderText="default" FontSize="12"
+                                                            HorizontalAlignment="Stretch" />
+                                        <TextBox Grid.Column="2" Text="{Binding TimeText, Mode=TwoWay}"
+                                                 PlaceholderText="HH:MM:SS" FontSize="12" />
+                                    </Grid>
+                                    <TextBlock Text="{Binding ValidationError}" FontSize="10"
+                                               Foreground="#E03131" TextWrapping="Wrap" Margin="2,2,0,0"
+                                               IsVisible="{Binding HasValidationError}" />
+                                </StackPanel>
                                 <CheckBox Grid.Column="2" IsChecked="{Binding IsNull, Mode=TwoWay}"
                                           Content="NULL" FontSize="11" Margin="8,0,0,0" VerticalAlignment="Center" />
                             </Grid>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1,6 +1,7 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Xml;
 using Avalonia;
 using Avalonia.Controls;
@@ -1052,12 +1053,43 @@ public partial class MainWindow : Window
     private void OnCellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
     {
         // Column bindings are one-way (see RebuildColumns), so the grid never
-        // mutates Row's array elements itself - the edited text has to be
-        // read directly off the editing TextBox here, before it's torn down.
+        // mutates Row's array elements itself - the edited value has to be
+        // read directly off the editing element here, before it's torn down.
         // (DataGridCellEditEndedEventArgs doesn't expose EditingElement.)
         _pendingEditRow = e.Row.DataContext as object?[];
         _pendingEditColumnIndex = e.Column.DisplayIndex;
-        _pendingEditText = (e.EditingElement as TextBox)?.Text;
+        _pendingEditText = ReadEditedValueText(e.EditingElement);
+    }
+
+    /// <summary>
+    /// The committed value of a cell editor as the canonical text the edit
+    /// pipeline expects — the typed editors ResultTextColumn generates for
+    /// enum/boolean/date/timestamp columns all reduce to text here, so
+    /// CommitCellEditAsync stays a single text-in path. Null means "no value
+    /// chosen" (an untouched picker/dropdown), which skips the commit.
+    /// </summary>
+    private static string? ReadEditedValueText(Control? editingElement) => editingElement switch
+    {
+        TextBox textBox => textBox.Text,
+        CheckBox checkBox => checkBox.IsChecked switch { true => "true", false => "false", null => null },
+        ComboBox comboBox => comboBox.SelectedItem as string,
+        CalendarDatePicker datePicker =>
+            datePicker.SelectedDate?.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        StackPanel timestampEditor => ReadTimestampEditorText(timestampEditor),
+        _ => null,
+    };
+
+    // The timestamp editor is a date picker + time TextBox; no date picked
+    // means no value, a blank time means midnight.
+    private static string? ReadTimestampEditorText(StackPanel editor)
+    {
+        if (editor.Children.OfType<CalendarDatePicker>().FirstOrDefault()?.SelectedDate is not { } date)
+        {
+            return null;
+        }
+
+        var time = editor.Children.OfType<TextBox>().FirstOrDefault()?.Text?.Trim();
+        return $"{date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} {(string.IsNullOrEmpty(time) ? "00:00:00" : time)}";
     }
 
     private async void OnCellEditEnded(object? sender, DataGridCellEditEndedEventArgs e)
@@ -2076,6 +2108,15 @@ public partial class MainWindow : Window
             return;
         }
 
+        // The edit context lands after the rows do (a browse page sets it once
+        // the run completes), and it carries the per-column type metadata the
+        // type-aware cell editors need — so the columns must be rebuilt again.
+        if (e.PropertyName == nameof(QueryViewModel.EditContext))
+        {
+            RebuildColumns(_queryViewModel);
+            return;
+        }
+
         if (e.PropertyName != nameof(QueryViewModel.Sql))
         {
             return;
@@ -2180,9 +2221,22 @@ public partial class MainWindow : Window
 
         for (var i = 0; i < query.ColumnNames.Count; i++)
         {
-            ResultsGrid.Columns.Add(new ResultTextColumn(i)
+            // In browse mode the edit context knows each column's Postgres
+            // type — the column uses it to generate a type-aware cell editor
+            // (enum dropdown, checkbox, date picker) instead of a TextBox.
+            var editorMeta = query.EditContext?.Column(query.ColumnNames[i]);
+
+            ResultsGrid.Columns.Add(new ResultTextColumn(i, editorMeta)
             {
                 Header = query.ColumnNames[i],
+                // Avalonia 12's DataGrid infers "read-only" from a column's
+                // binding path — and a pathless converter binding (the
+                // AOT-safe pattern used here) has none, which silently made
+                // every column uneditable after the 11→12 upgrade. An explicit
+                // false skips that inference; the getter still ORs in the
+                // grid-level IsReadOnly, so non-editable result sets stay
+                // locked via the grid binding.
+                IsReadOnly = false,
                 // Empty path + converter instead of "[i]": indexer paths
                 // resolve via reflection, which trips NativeAOT/trimming.
                 Binding = new Binding

--- a/PgNimbus.Core.Tests/Query/PendingChangeSetTests.cs
+++ b/PgNimbus.Core.Tests/Query/PendingChangeSetTests.cs
@@ -48,6 +48,43 @@ public class PendingChangeSetTests
     }
 
     [Test]
+    public async Task EditWithCastTypeWrapsTheParameterServerSide()
+    {
+        var set = NewSet();
+        set.StageEdit([42], "mood", "happy", "mood");
+        set.StageEdit([42], "tags", "{a,b}", "text[]");
+
+        var statement = set.BuildStatements()[0];
+
+        await Assert.That(statement.Sql).IsEqualTo(
+            """UPDATE "public"."orders" SET "mood" = CAST(@v0 AS mood), "tags" = CAST(@v1 AS text[]) WHERE "id" = @pk0""");
+        await Assert.That(statement.Parameters["v0"]).IsEqualTo("happy");
+    }
+
+    [Test]
+    public async Task ScriptRendersCastEditsAsCastLiterals()
+    {
+        var set = NewSet();
+        set.StageEdit([1], "mood", "happy", "mood");
+
+        await Assert.That(set.BuildScript()).Contains(
+            """UPDATE "public"."orders" SET "mood" = CAST('happy' AS mood) WHERE "id" = 1;""");
+    }
+
+    [Test]
+    public async Task RecastingACellReplacesItsEarlierCastType()
+    {
+        var set = NewSet();
+        set.StageEdit([1], "mood", "happy", "mood");
+        set.StageEdit([1], "mood", null);
+
+        // The re-staged plain value (e.g. an explicit NULL) must not keep the
+        // superseded edit's cast.
+        await Assert.That(set.BuildStatements()[0].Sql).Contains("\"mood\" = @v0");
+        await Assert.That(set.BuildStatements()[0].Parameters["v0"]).IsNull();
+    }
+
+    [Test]
     public async Task EditsToDifferentColumnsOfOneRowShareOneUpdate()
     {
         var set = NewSet();

--- a/PgNimbus.Core.Tests/Schema/ColumnValueEditorClassifierTests.cs
+++ b/PgNimbus.Core.Tests/Schema/ColumnValueEditorClassifierTests.cs
@@ -1,0 +1,49 @@
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.Core.Tests.Schema;
+
+public class ColumnValueEditorClassifierTests
+{
+    [Test]
+    [Arguments('e', 'E', "mood", ColumnValueEditor.Enum)]
+    [Arguments('c', 'C', "address", ColumnValueEditor.Composite)]
+    [Arguments('b', 'A', "_int4", ColumnValueEditor.Array)]
+    [Arguments('b', 'B', "bool", ColumnValueEditor.Boolean)]
+    [Arguments('b', 'D', "date", ColumnValueEditor.Date)]
+    [Arguments('b', 'D', "timestamp", ColumnValueEditor.Timestamp)]
+    [Arguments('b', 'D', "timestamptz", ColumnValueEditor.Timestamp)]
+    public async Task ClassifiesDedicatedEditors(char typtype, char typcategory, string typname, ColumnValueEditor expected)
+    {
+        await Assert.That(ColumnValueEditorClassifier.Classify(typtype, typcategory, typname)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments('b', 'S', "text")]
+    [Arguments('b', 'N', "int4")]
+    [Arguments('b', 'N', "numeric")]
+    [Arguments('b', 'U', "uuid")]
+    [Arguments('b', 'U', "jsonb")]
+    [Arguments('b', 'D', "time")]     // no seconds-capable picker — stays text
+    [Arguments('b', 'T', "interval")]
+    [Arguments('r', 'R', "int4range")]
+    public async Task EverythingElseStaysText(char typtype, char typcategory, string typname)
+    {
+        await Assert.That(ColumnValueEditorClassifier.Classify(typtype, typcategory, typname)).IsEqualTo(ColumnValueEditor.Text);
+    }
+
+    [Test]
+    public async Task EnumWinsOverCategory()
+    {
+        // An enum's typcategory is 'E', but typtype alone must decide — a
+        // hypothetical mismatch should still land on the enum editor.
+        await Assert.That(ColumnValueEditorClassifier.Classify('e', 'X', "whatever")).IsEqualTo(ColumnValueEditor.Enum);
+    }
+
+    [Test]
+    public async Task ArrayOfEnumsIsAnArrayNotAnEnum()
+    {
+        // "_mood" (mood[]) is typtype 'b', typcategory 'A' — the array editor
+        // (text + validation) applies, not the element type's dropdown.
+        await Assert.That(ColumnValueEditorClassifier.Classify('b', 'A', "_mood")).IsEqualTo(ColumnValueEditor.Array);
+    }
+}

--- a/PgNimbus.Core.Tests/Schema/PgValueSyntaxTests.cs
+++ b/PgNimbus.Core.Tests/Schema/PgValueSyntaxTests.cs
@@ -1,0 +1,95 @@
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.Core.Tests.Schema;
+
+public class PgValueSyntaxTests
+{
+    [Test]
+    [Arguments("{}")]
+    [Arguments("{1,2,3}")]
+    [Arguments(" {1,2,3} ")]
+    [Arguments("{{1,2},{3,4}}")]
+    [Arguments("""{"a b","c,d"}""")]
+    [Arguments("""{"say \"hi\""}""")]
+    [Arguments("""{"do""ble"}""")]
+    [Arguments("""{"(1,x)","(2,y)"}""")]
+    [Arguments("[1:3]={1,2,3}")]
+    public async Task AcceptsWellFormedArrays(string text)
+    {
+        await Assert.That(PgValueSyntax.ValidateArray(text)).IsNull();
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments("1,2,3")]
+    [Arguments("{1,2,3")]
+    [Arguments("{1,2}}")]
+    [Arguments("{1,2} extra")]
+    [Arguments("""{"unterminated}""")]
+    [Arguments("[1:3]{1,2,3}")]
+    public async Task RejectsMalformedArrays(string text)
+    {
+        await Assert.That(PgValueSyntax.ValidateArray(text)).IsNotNull();
+    }
+
+    [Test]
+    [Arguments("()")]
+    [Arguments("(1,abc)")]
+    [Arguments("(1,,3)")]
+    [Arguments("""(1,"a,b")""")]
+    [Arguments("""("{1,2}",x)""")]
+    [Arguments("((1,2),3)")]
+    public async Task AcceptsWellFormedComposites(string text)
+    {
+        await Assert.That(PgValueSyntax.ValidateComposite(text)).IsNull();
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments("1,abc")]
+    [Arguments("(1,abc")]
+    [Arguments("(1))")]
+    [Arguments("(1) tail")]
+    [Arguments("""("open)""")]
+    public async Task RejectsMalformedComposites(string text)
+    {
+        await Assert.That(PgValueSyntax.ValidateComposite(text)).IsNotNull();
+    }
+
+    [Test]
+    public async Task FormatsClrArraysAsPostgresLiterals()
+    {
+        await Assert.That(PgValueSyntax.FormatArray(new[] { 1, 2, 3 })).IsEqualTo("{1,2,3}");
+        await Assert.That(PgValueSyntax.FormatArray(new[] { "new", "sale" })).IsEqualTo("{new,sale}");
+        await Assert.That(PgValueSyntax.FormatArray(new[] { true, false })).IsEqualTo("{t,f}");
+        await Assert.That(PgValueSyntax.FormatArray(new[] { new[] { 1 }, new[] { 2 } })).IsEqualTo("{{1},{2}}");
+        await Assert.That(PgValueSyntax.FormatArray(new string?[] { "a", null })).IsEqualTo("{a,NULL}");
+    }
+
+    [Test]
+    public async Task QuotesArrayElementsTheWayPostgresWould()
+    {
+        await Assert.That(PgValueSyntax.FormatArray(new[] { "a b", "c,d" })).IsEqualTo("""{"a b","c,d"}""");
+        await Assert.That(PgValueSyntax.FormatArray(new[] { "" })).IsEqualTo("""{""}""");
+        await Assert.That(PgValueSyntax.FormatArray(new[] { "null" })).IsEqualTo("""{"null"}""");
+        await Assert.That(PgValueSyntax.FormatArray(new[] { "say \"hi\"" })).IsEqualTo("""{"say \"hi\""}""");
+        await Assert.That(PgValueSyntax.FormatArray(new[] { @"back\slash" })).IsEqualTo("""{"back\\slash"}""");
+    }
+
+    [Test]
+    public async Task FormattedArraysPassTheirOwnValidation()
+    {
+        var formatted = PgValueSyntax.FormatArray(new[] { "plain", "with space", "with,comma", "with\"quote" });
+
+        await Assert.That(PgValueSyntax.ValidateArray(formatted)).IsNull();
+    }
+
+    [Test]
+    public async Task BracesInsideCompositesAndParensInsideArraysAreOrdinaryCharacters()
+    {
+        // Only the literal's own delimiter pair is structural — Postgres
+        // treats the other pair as plain data when unquoted.
+        await Assert.That(PgValueSyntax.ValidateComposite("({1,x)")).IsNull();
+        await Assert.That(PgValueSyntax.ValidateArray("{(1,x}")).IsNull();
+    }
+}

--- a/PgNimbus.Core/Query/PendingChangeSet.cs
+++ b/PgNimbus.Core/Query/PendingChangeSet.cs
@@ -68,8 +68,12 @@ public sealed class PendingChangeSet
     /// Stages one cell's new value, replacing any earlier staged value for the
     /// same cell. Rejects primary-key columns (the key is what targets the
     /// UPDATE) and rows already staged for deletion.
+    /// <paramref name="castType"/> is the column's declared type for values
+    /// that must be parsed server-side (enum labels, array/composite literals
+    /// staged as raw text) — the built UPDATE wraps the parameter in
+    /// <c>CAST(@p AS type)</c>, matching how staged INSERT values execute.
     /// </summary>
-    public void StageEdit(object?[] pkValues, string column, object? value)
+    public void StageEdit(object?[] pkValues, string column, object? value, string? castType = null)
     {
         var key = MakeKey(pkValues);
 
@@ -92,11 +96,11 @@ public sealed class PendingChangeSet
         var index = row.Cells.FindIndex(c => c.Column == column);
         if (index >= 0)
         {
-            row.Cells[index] = (column, value);
+            row.Cells[index] = (column, value, castType);
         }
         else
         {
-            row.Cells.Add((column, value));
+            row.Cells.Add((column, value, castType));
         }
     }
 
@@ -132,7 +136,9 @@ public sealed class PendingChangeSet
     public IReadOnlyList<(string Column, object? Value)>? GetRowEdits(object?[] pkValues)
     {
         var key = MakeKey(pkValues);
-        return _edits.FirstOrDefault(e => e.Key.Equals(key))?.Cells;
+        return _edits.FirstOrDefault(e => e.Key.Equals(key))?.Cells
+            .Select(c => (c.Column, c.Value))
+            .ToList();
     }
 
     public void Clear()
@@ -158,7 +164,8 @@ public sealed class PendingChangeSet
             var sets = new List<string>(row.Cells.Count);
             for (var i = 0; i < row.Cells.Count; i++)
             {
-                sets.Add($"{SqlIdentifier.Quote(row.Cells[i].Column)} = @v{i}");
+                var expression = row.Cells[i].CastType is { } cast ? $"CAST(@v{i} AS {cast})" : $"@v{i}";
+                sets.Add($"{SqlIdentifier.Quote(row.Cells[i].Column)} = {expression}");
                 parameters[$"v{i}"] = row.Cells[i].Value;
             }
 
@@ -194,7 +201,11 @@ public sealed class PendingChangeSet
 
         foreach (var row in ActiveEdits)
         {
-            var sets = row.Cells.Select(c => $"{SqlIdentifier.Quote(c.Column)} = {SqlLiteral.Format(c.Value)}");
+            var sets = row.Cells.Select(c =>
+            {
+                var literal = c.CastType is { } cast ? $"CAST({SqlLiteral.Format(c.Value)} AS {cast})" : SqlLiteral.Format(c.Value);
+                return $"{SqlIdentifier.Quote(c.Column)} = {literal}";
+            });
             script.Append("UPDATE ").Append(QualifiedTable)
                   .Append(" SET ").Append(string.Join(", ", sets))
                   .Append(" WHERE ").Append(WherePkScript(row.Key)).AppendLine(";");
@@ -293,7 +304,7 @@ public sealed class PendingChangeSet
     {
         public RowKey Key { get; } = key;
 
-        public List<(string Column, object? Value)> Cells { get; } = [];
+        public List<(string Column, object? Value, string? CastType)> Cells { get; } = [];
     }
 
     // Structural equality over the primary-key values, so a row keeps its

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -241,7 +241,14 @@ public sealed class QueryEngine
     /// unbounded SELECT would still pull every row over the wire. An explicit
     /// backend cancel makes the drain a no-op.
     /// </param>
-    public async Task<StatementResult> ExecuteAsync(string sql, CancellationToken ct, int? maxRows = null)
+    /// <param name="allowTextFallback">
+    /// Permits re-executing the statement with unreadable columns (unmapped
+    /// composites) re-requested in text format. Only safe for statements known
+    /// to be side-effect-free — the app-composed browse-mode SELECTs — never
+    /// for arbitrary user SQL, where a second execution would apply an
+    /// <c>INSERT … RETURNING</c> (or any volatile call) twice.
+    /// </param>
+    public async Task<StatementResult> ExecuteAsync(string sql, CancellationToken ct, int? maxRows = null, bool allowTextFallback = false)
     {
         // Inside a transaction the statement runs on the shared session
         // connection and its result is fully materialized: a lazily-streaming
@@ -249,7 +256,7 @@ public sealed class QueryEngine
         // in the transaction until the grid finished consuming it.
         if (_transactionConnection is not null)
         {
-            return await ExecuteInTransactionAsync(sql, maxRows, ct);
+            return await ExecuteInTransactionAsync(sql, maxRows, allowTextFallback, ct);
         }
 
         var stopwatch = Stopwatch.StartNew();
@@ -284,8 +291,9 @@ public sealed class QueryEngine
             // Columns Npgsql can't materialize as objects (unmapped composites
             // and containers of them) are re-requested in text format — one
             // extra round trip, and only for result sets that contain such a
-            // column.
-            if (BuildTextFallbackMask(reader) is { } textFallback)
+            // column. The re-execution is why callers must opt in: it would
+            // run an arbitrary statement's side effects twice.
+            if (allowTextFallback && BuildTextFallbackMask(reader) is { } textFallback)
             {
                 await reader.DisposeAsync();
                 command.UnknownResultTypeList = textFallback;
@@ -366,7 +374,7 @@ public sealed class QueryEngine
             {
                 ct.ThrowIfCancellationRequested();
 
-                var result = await ExecuteOnConnectionAsync(connection, statement, maxRowsPerStatement, ct);
+                var result = await ExecuteOnConnectionAsync(connection, statement, maxRowsPerStatement, allowTextFallback: false, ct);
 
                 if (result is QueryError error)
                 {
@@ -404,7 +412,7 @@ public sealed class QueryEngine
     // its result (see ExecuteAsync for why streaming is avoided here). A failure
     // auto-rolls-back the transaction and comes back flagged so the UI can note
     // that the block is gone.
-    private async Task<StatementResult> ExecuteInTransactionAsync(string sql, int? maxRows, CancellationToken ct)
+    private async Task<StatementResult> ExecuteInTransactionAsync(string sql, int? maxRows, bool allowTextFallback, CancellationToken ct)
     {
         var connection = _transactionConnection!;
         var stopwatch = Stopwatch.StartNew();
@@ -415,7 +423,7 @@ public sealed class QueryEngine
             // ExecuteOnConnectionAsync converts PostgresExceptions to QueryError
             // but lets other failures (e.g. a dropped connection) escape; ExecuteAsync
             // promises never to throw those, so translate them here too.
-            result = await ExecuteOnConnectionAsync(connection, sql, maxRows, ct);
+            result = await ExecuteOnConnectionAsync(connection, sql, maxRows, allowTextFallback, ct);
         }
         catch (OperationCanceledException)
         {
@@ -446,6 +454,7 @@ public sealed class QueryEngine
         NpgsqlConnection connection,
         string sql,
         int? maxRows,
+        bool allowTextFallback,
         CancellationToken ct)
     {
         var stopwatch = Stopwatch.StartNew();
@@ -468,8 +477,9 @@ public sealed class QueryEngine
                 };
             }
 
-            // Same unmapped-composite text fallback as ExecuteAsync.
-            if (BuildTextFallbackMask(reader) is { } textFallback)
+            // Same opt-in unmapped-composite text fallback as ExecuteAsync
+            // (script statements always pass false — they're arbitrary SQL).
+            if (allowTextFallback && BuildTextFallbackMask(reader) is { } textFallback)
             {
                 await reader.DisposeAsync();
                 command.UnknownResultTypeList = textFallback;

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using System.Diagnostics;
 using Npgsql;
+using Npgsql.PostgresTypes;
 
 namespace PgNimbus.Core.Query;
 
@@ -280,6 +281,17 @@ public sealed class QueryEngine
                 };
             }
 
+            // Columns Npgsql can't materialize as objects (unmapped composites
+            // and containers of them) are re-requested in text format — one
+            // extra round trip, and only for result sets that contain such a
+            // column.
+            if (BuildTextFallbackMask(reader) is { } textFallback)
+            {
+                await reader.DisposeAsync();
+                command.UnknownResultTypeList = textFallback;
+                reader = await command.ExecuteReaderAsync(CommandBehavior.Default, ct);
+            }
+
             var columns = BuildColumns(reader);
 
             // Ownership of connection/command/reader passes to the streaming
@@ -456,6 +468,14 @@ public sealed class QueryEngine
                 };
             }
 
+            // Same unmapped-composite text fallback as ExecuteAsync.
+            if (BuildTextFallbackMask(reader) is { } textFallback)
+            {
+                await reader.DisposeAsync();
+                command.UnknownResultTypeList = textFallback;
+                reader = await command.ExecuteReaderAsync(CommandBehavior.Default, ct);
+            }
+
             var columns = BuildColumns(reader);
             var fieldCount = reader.FieldCount;
             var rows = new List<object?[]>();
@@ -529,6 +549,42 @@ public sealed class QueryEngine
                 }
             }
         }
+    }
+
+    // Npgsql can't read an unmapped composite type (or an array/domain/range
+    // over one) as a plain object — GetValue throws "Reading as 'System.Object'
+    // is not supported…". Without a fallback, one composite column makes the
+    // whole table unbrowsable. Such columns are re-requested in the text wire
+    // format instead, so their values arrive as Postgres literals ("(10,20,cm)")
+    // — exactly the shape the grid displays and the composite editor
+    // validates and casts back on edit.
+    private static bool NeedsTextFormat(PostgresType type) => type switch
+    {
+        PostgresCompositeType => true,
+        PostgresArrayType array => NeedsTextFormat(array.Element),
+        PostgresDomainType domain => NeedsTextFormat(domain.BaseType),
+        PostgresRangeType range => NeedsTextFormat(range.Subtype),
+        PostgresMultirangeType multirange => NeedsTextFormat(multirange.Subrange),
+        _ => false,
+    };
+
+    /// <summary>
+    /// A per-column "request as text" mask for <see cref="NpgsqlCommand.UnknownResultTypeList"/>,
+    /// or null when every column materializes fine as-is (the common case — no
+    /// re-execution then).
+    /// </summary>
+    private static bool[]? BuildTextFallbackMask(NpgsqlDataReader reader)
+    {
+        bool[]? mask = null;
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            if (NeedsTextFormat(reader.GetPostgresType(i)))
+            {
+                (mask ??= new bool[reader.FieldCount])[i] = true;
+            }
+        }
+
+        return mask;
     }
 
     private static IReadOnlyList<ColumnInfo> BuildColumns(NpgsqlDataReader reader)

--- a/PgNimbus.Core/Schema/ColumnValueEditor.cs
+++ b/PgNimbus.Core/Schema/ColumnValueEditor.cs
@@ -1,0 +1,56 @@
+namespace PgNimbus.Core.Schema;
+
+/// <summary>
+/// Which input affordance a column's values call for, classified from the
+/// column's *base* Postgres type — domains are resolved through
+/// <c>pg_type.typbasetype</c> first, so a domain over an enum still gets the
+/// enum dropdown. Anything without a dedicated editor (text, numerics, uuid,
+/// json, ranges, …) stays <see cref="Text"/>: those already round-trip fine
+/// through a plain text box.
+/// </summary>
+public enum ColumnValueEditor
+{
+    Text,
+
+    /// <summary>boolean — a checkbox.</summary>
+    Boolean,
+
+    /// <summary>An enum type — a dropdown of its pg_enum labels.</summary>
+    Enum,
+
+    /// <summary>date — a calendar picker.</summary>
+    Date,
+
+    /// <summary>timestamp / timestamptz — a calendar picker plus a time-of-day field.</summary>
+    Timestamp,
+
+    /// <summary>Any array type — free text with client-side literal validation.</summary>
+    Array,
+
+    /// <summary>A composite (row) type — free text with client-side literal validation.</summary>
+    Composite,
+}
+
+public static class ColumnValueEditorClassifier
+{
+    /// <summary>
+    /// Maps a base type's pg_type identity to an editor.
+    /// <paramref name="typtype"/> and <paramref name="typcategory"/> are
+    /// pg_type.typtype/typcategory of the *resolved* base type (never 'd' —
+    /// domains are walked to their base before classification);
+    /// <paramref name="typname"/> is its pg_type.typname.
+    /// </summary>
+    public static ColumnValueEditor Classify(char typtype, char typcategory, string typname) => typtype switch
+    {
+        'e' => ColumnValueEditor.Enum,
+        'c' => ColumnValueEditor.Composite,
+        _ when typcategory == 'A' => ColumnValueEditor.Array,
+        _ => typname switch
+        {
+            "bool" => ColumnValueEditor.Boolean,
+            "date" => ColumnValueEditor.Date,
+            "timestamp" or "timestamptz" => ColumnValueEditor.Timestamp,
+            _ => ColumnValueEditor.Text,
+        },
+    };
+}

--- a/PgNimbus.Core/Schema/PgValueSyntax.cs
+++ b/PgNimbus.Core/Schema/PgValueSyntax.cs
@@ -1,0 +1,181 @@
+using System.Globalization;
+using System.Text;
+
+namespace PgNimbus.Core.Schema;
+
+/// <summary>
+/// Cheap client-side syntax checks for the two Postgres literal shapes users
+/// type by hand — arrays (<c>{1,2,3}</c>) and composites (<c>(1,abc)</c>) — so
+/// a structurally malformed value is caught in the editor instead of surfacing
+/// as a server error after the statement fires. Postgres remains the real
+/// parser: these verify only the delimiter/quote structure, never element
+/// types or counts.
+/// </summary>
+public static class PgValueSyntax
+{
+    /// <summary>Error message for a malformed array literal, or null when the structure is fine.</summary>
+    public static string? ValidateArray(string text)
+    {
+        var trimmed = text.Trim();
+
+        // An optional dimension prefix ("[1:3]={…}") is legal input — skip it.
+        if (trimmed.StartsWith('['))
+        {
+            var eq = trimmed.IndexOf('=');
+            if (eq < 0)
+            {
+                return "An array dimension prefix ('[…]') must be followed by '='.";
+            }
+
+            trimmed = trimmed[(eq + 1)..].TrimStart();
+        }
+
+        return Validate(trimmed, '{', '}', "An array");
+    }
+
+    /// <summary>Error message for a malformed composite (row) literal, or null when the structure is fine.</summary>
+    public static string? ValidateComposite(string text) => Validate(text.Trim(), '(', ')', "A composite");
+
+    /// <summary>
+    /// Renders a CLR array (what Npgsql materializes an array column as) in
+    /// Postgres's own literal syntax — <c>{a,b,c}</c>, elements quoted by the
+    /// server's rules — so the grid shows a readable, *editable* value instead
+    /// of "System.String[]", and an F2 edit round-trips through
+    /// <c>CAST(text AS type[])</c> unchanged.
+    /// </summary>
+    public static string FormatArray(Array array)
+    {
+        var sb = new StringBuilder();
+        AppendArray(sb, array);
+        return sb.ToString();
+    }
+
+    private static void AppendArray(StringBuilder sb, Array array)
+    {
+        sb.Append('{');
+        var first = true;
+        foreach (var item in array)
+        {
+            if (!first)
+            {
+                sb.Append(',');
+            }
+
+            first = false;
+            AppendElement(sb, item);
+        }
+
+        sb.Append('}');
+    }
+
+    private static void AppendElement(StringBuilder sb, object? value)
+    {
+        switch (value)
+        {
+            case null or DBNull:
+                sb.Append("NULL");
+                return;
+            case Array nested:
+                AppendArray(sb, nested);
+                return;
+        }
+
+        var text = value switch
+        {
+            bool b => b ? "t" : "f",
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? string.Empty,
+        };
+
+        // Postgres quotes an element when the bare form would be ambiguous:
+        // empty, the word NULL, or containing a delimiter/quote/backslash/space.
+        var needsQuoting = text.Length == 0
+            || text.Equals("NULL", StringComparison.OrdinalIgnoreCase)
+            || text.AsSpan().ContainsAny(QuotedElementChars);
+
+        if (needsQuoting)
+        {
+            sb.Append('"').Append(text.Replace("\\", "\\\\").Replace("\"", "\\\"")).Append('"');
+        }
+        else
+        {
+            sb.Append(text);
+        }
+    }
+
+    private static readonly System.Buffers.SearchValues<char> QuotedElementChars =
+        System.Buffers.SearchValues.Create("{},\"\\ \t\n\r");
+
+    private static string? Validate(string trimmed, char open, char close, string kind)
+    {
+        if (trimmed.Length == 0 || trimmed[0] != open)
+        {
+            return $"{kind} literal must start with '{open}' (e.g. {(open == '{' ? "{1,2,3}" : "(1,abc)")}).";
+        }
+
+        var depth = 0;
+        var inQuotes = false;
+
+        for (var i = 0; i < trimmed.Length; i++)
+        {
+            var ch = trimmed[i];
+
+            if (inQuotes)
+            {
+                // Inside a double-quoted element: backslash escapes the next
+                // character, "" is an embedded quote, a lone " closes it.
+                if (ch == '\\')
+                {
+                    i++;
+                }
+                else if (ch == '"')
+                {
+                    if (i + 1 < trimmed.Length && trimmed[i + 1] == '"')
+                    {
+                        i++;
+                    }
+                    else
+                    {
+                        inQuotes = false;
+                    }
+                }
+
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inQuotes = true;
+            }
+            else if (ch == open)
+            {
+                depth++;
+            }
+            else if (ch == close)
+            {
+                depth--;
+                if (depth == 0 && i != trimmed.Length - 1)
+                {
+                    return $"Unexpected text after the closing '{close}'.";
+                }
+
+                if (depth < 0)
+                {
+                    return $"Unbalanced '{close}'.";
+                }
+            }
+        }
+
+        if (inQuotes)
+        {
+            return "Unterminated double-quoted section.";
+        }
+
+        if (depth != 0)
+        {
+            return $"{kind} literal must end with '{close}'.";
+        }
+
+        return null;
+    }
+}

--- a/PgNimbus.Core/Schema/SchemaService.cs
+++ b/PgNimbus.Core/Schema/SchemaService.cs
@@ -16,7 +16,22 @@ public sealed record TableInfo(string Name, RelationKind Kind);
 
 public sealed record RelationInfo(string Schema, string Name, RelationKind Kind);
 
-public sealed record ColumnDetail(string Name, string DataType, bool NotNull, bool IsPrimaryKey);
+public sealed record ColumnDetail(string Name, string DataType, bool NotNull, bool IsPrimaryKey)
+{
+    /// <summary>
+    /// The input affordance the column's values call for (enum dropdown,
+    /// checkbox, date picker, …), classified from the column's base type with
+    /// domains resolved. <see cref="ColumnValueEditor.Text"/> when nothing
+    /// more specific applies.
+    /// </summary>
+    public ColumnValueEditor Editor { get; init; } = ColumnValueEditor.Text;
+
+    /// <summary>The enum type's labels in declared order when <see cref="Editor"/> is <see cref="ColumnValueEditor.Enum"/>; empty otherwise.</summary>
+    public IReadOnlyList<string> EnumLabels { get; init; } = [];
+
+    /// <summary>The base type a domain column resolves to (e.g. "integer" for a domain over integer); null when the declared type isn't a domain.</summary>
+    public string? DomainBaseType { get; init; }
+}
 
 public sealed record TableColumn(string Table, string Column, string DataType);
 
@@ -153,25 +168,64 @@ public sealed class SchemaService
 
     public async Task<IReadOnlyList<ColumnDetail>> GetColumnsAsync(string schema, string table, CancellationToken ct)
     {
+        // Besides name/type/nullability/PK, each column carries what its
+        // values need for type-aware editing: the base type's pg_type identity
+        // (domains walked to their base via typbasetype, so a domain over an
+        // enum still classifies as an enum) and, for enums, the pg_enum labels.
         const string sql = """
+            WITH RECURSIVE cols AS (
+                SELECT
+                    a.attnum,
+                    a.attname,
+                    format_type(a.atttypid, a.atttypmod) AS data_type,
+                    a.attnotnull,
+                    COALESCE(pk.is_primary_key, false) AS is_primary_key,
+                    a.atttypid
+                FROM pg_catalog.pg_attribute a
+                JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+                JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                LEFT JOIN (
+                    SELECT con.conrelid, unnest(con.conkey) AS attnum, true AS is_primary_key
+                    FROM pg_catalog.pg_constraint con
+                    WHERE con.contype = 'p'
+                ) pk ON pk.conrelid = a.attrelid AND pk.attnum = a.attnum
+                WHERE n.nspname = @schema
+                  AND c.relname = @table
+                  AND a.attnum > 0
+                  AND NOT a.attisdropped
+            ),
+            walk AS (
+                SELECT c.attnum, c.atttypid AS type_oid, 0 AS depth
+                FROM cols c
+                UNION ALL
+                SELECT w.attnum, t.typbasetype, w.depth + 1
+                FROM walk w
+                JOIN pg_catalog.pg_type t ON t.oid = w.type_oid
+                WHERE t.typbasetype <> 0
+            ),
+            base AS (
+                SELECT DISTINCT ON (attnum) attnum, type_oid
+                FROM walk
+                ORDER BY attnum, depth DESC
+            )
             SELECT
-                a.attname,
-                format_type(a.atttypid, a.atttypmod) AS data_type,
-                a.attnotnull,
-                COALESCE(pk.is_primary_key, false) AS is_primary_key
-            FROM pg_catalog.pg_attribute a
-            JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
-            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-            LEFT JOIN (
-                SELECT con.conrelid, unnest(con.conkey) AS attnum, true AS is_primary_key
-                FROM pg_catalog.pg_constraint con
-                WHERE con.contype = 'p'
-            ) pk ON pk.conrelid = a.attrelid AND pk.attnum = a.attnum
-            WHERE n.nspname = @schema
-              AND c.relname = @table
-              AND a.attnum > 0
-              AND NOT a.attisdropped
-            ORDER BY a.attnum
+                c.attname,
+                c.data_type,
+                c.attnotnull,
+                c.is_primary_key,
+                bt.typname,
+                bt.typtype::text,
+                bt.typcategory::text,
+                CASE WHEN c.atttypid <> bt.oid THEN format_type(bt.oid, NULL) END AS domain_base_type,
+                CASE WHEN bt.typtype = 'e' THEN
+                    (SELECT array_agg(e.enumlabel ORDER BY e.enumsortorder)
+                     FROM pg_catalog.pg_enum e
+                     WHERE e.enumtypid = bt.oid)
+                END AS enum_labels
+            FROM cols c
+            JOIN base b ON b.attnum = c.attnum
+            JOIN pg_catalog.pg_type bt ON bt.oid = b.type_oid
+            ORDER BY c.attnum
             """;
 
         await using var connection = await _dataSource.OpenConnectionAsync(ct);
@@ -187,7 +241,15 @@ public sealed class SchemaService
                 reader.GetString(0),
                 reader.GetString(1),
                 reader.GetBoolean(2),
-                reader.GetBoolean(3)));
+                reader.GetBoolean(3))
+            {
+                Editor = ColumnValueEditorClassifier.Classify(
+                    reader.GetString(5)[0],
+                    reader.GetString(6)[0],
+                    reader.GetString(4)),
+                DomainBaseType = reader.IsDBNull(7) ? null : reader.GetString(7),
+                EnumLabels = reader.IsDBNull(8) ? [] : reader.GetFieldValue<string[]>(8),
+            });
         }
 
         return results;

--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   cast to its real type server-side, blanks fall back to defaults),
   "Delete selected row(s)" with a confirmation, and "Set cell to NULL" (the
   gesture inline editing can't express), all keyed on the primary key.
+- **Postgres-native value editing** — cell editors (grid and Add-row dialog)
+  follow the column's type: `enum` columns get a dropdown of their `pg_enum`
+  labels, `boolean` a checkbox, `date`/`timestamp` a calendar picker, arrays
+  and composites are syntax-checked client-side before anything is sent, and
+  domains resolve to their base type (a domain over an enum still gets the
+  dropdown). Array cells display as Postgres literals (`{a,b}`), and tables
+  with composite-typed columns browse fine — those columns are fetched in
+  text format, since Npgsql can't materialize an unmapped composite.
 - **Safe mode (pending-changes review)** — a toggle (command palette or
   preferences) that stages grid edits, deletes, and Add-row inserts locally
   instead of firing them at the server: dirty rows are highlighted (amber =
@@ -541,13 +549,23 @@ Everything below is what survives that filter, roughly in impact order:
   error (or hanging — an HN complaint about other clients). Needs care with
   the held transaction connection: an open transaction can't be silently
   re-established, so that path surfaces a clear "transaction lost" state.
-- [ ] **Postgres-native value editing** — the grid and Add-row dialog treat
+- [x] **Postgres-native value editing** — the grid and Add-row dialog treat
   every column as text today. Make the editors type-aware: `enum` columns get
   a dropdown of `pg_enum` labels, `boolean` a checkbox, `date/timestamp` a
   picker, arrays and composites get validation, domains resolve to their base
   type. DataGrip's missing array support was a stated deal-breaker on HN, and
   ENUM dropdowns / user-defined types are open TablePlus asks — exactly the
-  "PostgreSQL-first, not lowest-common-denominator" differentiator.
+  "PostgreSQL-first, not lowest-common-denominator" differentiator. Shipped:
+  `SchemaService` classifies each column from its base `pg_type` (domains
+  walked through `typbasetype`, so a domain over an enum still gets the
+  dropdown), enum/boolean/date/timestamp cells get typed editors in both the
+  grid (F2) and the dialog, array/composite literals are structure-checked
+  client-side and cast to the declared type server-side (staged edits
+  included — the safe-mode review shows the `CAST`), arrays render as `{a,b}`
+  literals, and composite columns fall back to text-format fetch so such
+  tables browse at all. Also un-broke inline editing itself: Avalonia 12
+  treats pathless-binding columns as read-only, which had silently disabled
+  every cell editor since the 11→12 upgrade.
 - [ ] **Table & index sizes and usage** — sizes in the schema tree (tooltip or
   detail column) and a per-database overview: largest tables/indexes
   (`pg_total_relation_size`), seq-vs-index scan counts, unused indexes, cache


### PR DESCRIPTION
SchemaService now classifies every column from its base pg_type (domains
walked through typbasetype, so a domain over an enum still counts as an
enum) and carries pg_enum labels. On top of that metadata:

- Grid (F2) and Add-row editors follow the column's type: enum columns get
  a dropdown of their pg_enum labels, booleans a checkbox, date/timestamp a
  calendar picker (+ time-of-day field for timestamps).
- Array and composite literals are structure-checked client-side
  (PgValueSyntax) before anything is sent; the UPDATE casts the raw text to
  the declared type server-side, same as the Add-row INSERT always has.
  Staged (safe-mode) edits carry the cast too, and the review script shows
  it (CAST('happy' AS mood)).
- Array cells render as Postgres literals ({a,b}) instead of
  "System.String[]", in the grid and the cell inspector, so they are
  readable and editable in place.
- Tables with composite-typed columns browse at all now: Npgsql can't
  materialize an unmapped composite as object, so QueryEngine re-requests
  such columns in text format (one extra round trip, only when needed).
- Fixed inline cell editing being silently dead since the Avalonia 11→12
  upgrade: DataGrid now infers "read-only" from a column's binding path,
  and the grid's AOT-safe pathless converter bindings have none — an
  explicit IsReadOnly=false restores editing while the grid-level
  IsReadOnly binding still gates it.
- ConvertEditedValue stamps DateTime.Kind per column flavor (Utc for
  timestamptz, Unspecified for timestamp) — Npgsql rejects mismatched kinds.

Verified end-to-end under Xvfb against Postgres 16: enum dropdown, boolean
checkbox, and date picker edits round-tripped through safe-mode staging into
the database; Add-row staged an enum + validated array insert.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015xvkUT4twxeC2Bpf3RC7yt