### PR TITLE
Large-DB feedback: schema loading cue, resizable results, dedup fix, format + word wrap

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -45,6 +45,10 @@ public partial class App : Application
     private static void PersistSafeModeEdits(bool value) =>
         SettingsStore.Save(SettingsStore.Load() with { SafeModeEdits = value });
 
+    /// <summary>Remembers the editor's word-wrap toggle so it survives a restart.</summary>
+    private static void PersistWordWrapEditor(bool value) =>
+        SettingsStore.Save(SettingsStore.Load() with { WordWrapEditor = value });
+
     /// <summary>The saved settings snapshot, for the preferences page to initialize from.</summary>
     internal static AppSettings LoadSettings() => SettingsStore.Load();
 
@@ -187,7 +191,9 @@ public partial class App : Application
                 autoAliasTables: SettingsStore.Load().AutoAliasTables,
                 persistAutoAliasTables: PersistAutoAliasTables,
                 safeModeEdits: SettingsStore.Load().SafeModeEdits,
-                persistSafeModeEdits: PersistSafeModeEdits),
+                persistSafeModeEdits: PersistSafeModeEdits,
+                wordWrapEditor: SettingsStore.Load().WordWrapEditor,
+                persistWordWrapEditor: PersistWordWrapEditor),
         };
 
         window.Closed += async (_, _) =>

--- a/PgNimbus.App/Completion/SqlCompletionProvider.cs
+++ b/PgNimbus.App/Completion/SqlCompletionProvider.cs
@@ -584,5 +584,14 @@ public sealed class SqlCompletionProvider
     // Collapse duplicate labels, keeping the first — which, because callers
     // prepend the higher-priority items, is the better-ranked one.
     private static IReadOnlyList<SqlCompletionData> Dedupe(IEnumerable<SqlCompletionData> items) =>
-        items.GroupBy(i => i.Text, StringComparer.OrdinalIgnoreCase).Select(g => g.First()).ToList();
+        items.GroupBy(DedupeKey, StringComparer.OrdinalIgnoreCase).Select(g => g.First()).ToList();
+
+    // Tables that share a bare name across different schemas (a big DB routinely
+    // has public.users and audit.users) are distinct candidates, so they key on
+    // their schema too and both survive the collapse — otherwise only one of the
+    // two would ever be offered. In table position each still inserts its own
+    // schema-qualified form, so picking the right one resolves unambiguously.
+    // Everything else dedupes on its label alone.
+    private static string DedupeKey(SqlCompletionData item) =>
+        item.Kind == SqlCompletionKind.Table ? $"{item.Text}\u0001{item.Detail}" : item.Text;
 }

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -145,6 +145,9 @@
         <StreamGeometry x:Key="AccountMultipleIconGeometry">M16,13C15.71,13 15.38,13 15.03,13.05C16.19,13.89 17,15 17,16.5V19H23V16.5C23,14.17 18.33,13 16,13M8,13C5.67,13 1,14.17 1,16.5V19H15V16.5C15,14.17 10.33,13 8,13M8,11A3,3 0 0,0 11,8A3,3 0 0,0 8,5A3,3 0 0,0 5,8A3,3 0 0,0 8,11M16,11A3,3 0 0,0 19,8A3,3 0 0,0 16,5A3,3 0 0,0 13,8A3,3 0 0,0 16,11Z</StreamGeometry>
         <StreamGeometry x:Key="TuneIconGeometry">M3,17V19H9V17H3M3,5V7H13V5H3M13,21V19H21V17H13V15H11V21H13M7,9V11H3V13H7V15H9V9H7M21,13V11H11V13H21M15,9H17V7H21V5H17V3H15V9Z</StreamGeometry>
         <StreamGeometry x:Key="SwapHorizontalIconGeometry">M21,9L17,5V8H10V10H17V13M7,11L3,15L7,19V16H14V14H7V11Z</StreamGeometry>
+        <!-- Editor actions: auto-fix (magic wand) for Format SQL, text-wrap for the word-wrap toggle (MDI). -->
+        <StreamGeometry x:Key="AutoFixIconGeometry">M7.5,5.6L10,7L8.6,4.5L10,2L7.5,3.4L5,2L6.4,4.5L5,7L7.5,5.6M19.5,15.4L22,14L20.6,16.5L22,19L19.5,17.6L17,19L18.4,16.5L17,14L19.5,15.4M22,2L20.6,4.5L22,7L19.5,5.6L17,7L18.4,4.5L17,2L19.5,3.4L22,2M13.34,12.78L15.78,10.34L13.66,8.22L11.22,10.66L13.34,12.78M14.37,7.29L16.71,9.63C17.1,10 17.1,10.65 16.71,11.04L5.04,22.71C4.65,23.1 4,23.1 3.63,22.71L1.29,20.37C0.9,20 0.9,19.35 1.29,18.96L12.96,7.29C13.35,6.9 14,6.9 14.37,7.29Z</StreamGeometry>
+        <StreamGeometry x:Key="WrapIconGeometry">M16.5,11H3V13H16.5A2.5,2.5 0 0,1 19,15.5A2.5,2.5 0 0,1 16.5,18H13V16L9,19L13,22V20H16.5A4.5,4.5 0 0,0 21,15.5A4.5,4.5 0 0,0 16.5,11M3,7H21V5H3V7M3,17H9V15H3V17Z</StreamGeometry>
         <StreamGeometry x:Key="CogIconGeometry">M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.21,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.21,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z</StreamGeometry>
         <!-- Custom (VS Code-style "layout sidebar left"): window frame with the
              left pane filled - reads as collapse/expand sidebar, not a menu. -->
@@ -426,10 +429,18 @@
         the ControlTheme repaints the ContentPresenter on hover anyway, and
         its default is exactly the subtle grey a quiet toolbar wants.
     -->
-    <Style Selector="Button.toolbar">
+    <Style Selector="Button.toolbar, ToggleButton.toolbar">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="Padding" Value="10,7" />
+    </Style>
+    <!-- A checked toolbar toggle (e.g. word wrap) tints its glyph with the accent
+         and keeps the subtle hover wash, so "on" reads at a glance without a fill. -->
+    <Style Selector="ToggleButton.toolbar:checked">
+        <Setter Property="Background" Value="{StaticResource HoverBackgroundBrush}" />
+    </Style>
+    <Style Selector="ToggleButton.toolbar:checked PathIcon">
+        <Setter Property="Foreground" Value="{StaticResource AppAccentBrush}" />
     </Style>
 
     <!-- Round "close chip" buttons used for tab/channel close (✕). Selectors

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -551,7 +551,7 @@ public sealed partial class MainViewModel : ObservableObject
         yield return new PaletteItem("Close tab", "Action", "✕", Invoke(() => CloseTabCommand), Hotkeys.Label("W"));
         yield return new PaletteItem("Next tab", "Action", "›", Invoke(() => NextTabCommand), Hotkeys.Label("PgDn"));
         yield return new PaletteItem("Previous tab", "Action", "‹", Invoke(() => PreviousTabCommand), Hotkeys.Label("PgUp"));
-        yield return new PaletteItem("Format SQL", "Action", "❖", Invoke(() => FormatSqlCommand), "Alt+Shift+F");
+        yield return new PaletteItem("Format SQL", "Action", "❖", Invoke(() => FormatSqlCommand), $"{Hotkeys.Label("Shift+F")} / Alt+Shift+F");
         yield return new PaletteItem("Toggle word wrap (Notepad++ style)", "Action", "↩", Invoke(() => ToggleWordWrapCommand));
         yield return new PaletteItem("Find in editor", "Action", "⌕", () => { FindRequested?.Invoke(false); return Task.CompletedTask; }, Hotkeys.Label("F"));
         yield return new PaletteItem("Find & replace in editor", "Action", "⌕", () => { FindRequested?.Invoke(true); return Task.CompletedTask; }, Hotkeys.Label("H"));

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -154,6 +154,35 @@ public sealed partial class MainViewModel : ObservableObject
 
     partial void OnSafeModeEditsChanged(bool value) => _persistSafeModeEdits?.Invoke(value);
 
+    /// <summary>
+    /// Notepad++-style word wrap in the SQL editor. Bound two-way to the editor's
+    /// <c>WordWrap</c> and to the command-bar toggle; persisted like the other
+    /// editor toggles so the choice survives a restart.
+    /// </summary>
+    [ObservableProperty]
+    private bool _wordWrapEditor;
+
+    private readonly Action<bool>? _persistWordWrapEditor;
+
+    partial void OnWordWrapEditorChanged(bool value) => _persistWordWrapEditor?.Invoke(value);
+
+    /// <summary>
+    /// Pretty-prints the statement under the caret. The rewrite itself lives in
+    /// the view (AvaloniaEdit's Text isn't bindable), so this just raises the
+    /// event — same target as the palette's "Format SQL" and the editor's
+    /// Alt+Shift+F shortcut.
+    /// </summary>
+    [RelayCommand]
+    private void FormatSql() => FormatSqlRequested?.Invoke();
+
+    /// <summary>Flips word wrap and reports the new state in the status bar.</summary>
+    [RelayCommand]
+    private void ToggleWordWrap()
+    {
+        WordWrapEditor = !WordWrapEditor;
+        ActiveTab.Status = WordWrapEditor ? "Word wrap: on" : "Word wrap: off";
+    }
+
     public MainViewModel(
         QueryEngine engine,
         ExplainService explainService,
@@ -171,7 +200,9 @@ public sealed partial class MainViewModel : ObservableObject
         bool autoAliasTables = true,
         Action<bool>? persistAutoAliasTables = null,
         bool safeModeEdits = true,
-        Action<bool>? persistSafeModeEdits = null)
+        Action<bool>? persistSafeModeEdits = null,
+        bool wordWrapEditor = false,
+        Action<bool>? persistWordWrapEditor = null)
     {
         ConnectionHost = connectionHost;
         ConnectionDatabase = connectionDatabase;
@@ -179,6 +210,8 @@ public sealed partial class MainViewModel : ObservableObject
         _persistAutoAliasTables = persistAutoAliasTables;
         _safeModeEdits = safeModeEdits;
         _persistSafeModeEdits = persistSafeModeEdits;
+        _wordWrapEditor = wordWrapEditor;
+        _persistWordWrapEditor = persistWordWrapEditor;
         _engine = engine;
         _explainService = explainService;
         SchemaTree = schemaTree;
@@ -518,7 +551,8 @@ public sealed partial class MainViewModel : ObservableObject
         yield return new PaletteItem("Close tab", "Action", "✕", Invoke(() => CloseTabCommand), Hotkeys.Label("W"));
         yield return new PaletteItem("Next tab", "Action", "›", Invoke(() => NextTabCommand), Hotkeys.Label("PgDn"));
         yield return new PaletteItem("Previous tab", "Action", "‹", Invoke(() => PreviousTabCommand), Hotkeys.Label("PgUp"));
-        yield return new PaletteItem("Format SQL", "Action", "❖", () => { FormatSqlRequested?.Invoke(); return Task.CompletedTask; }, Hotkeys.Label("Shift+F"));
+        yield return new PaletteItem("Format SQL", "Action", "❖", Invoke(() => FormatSqlCommand), "Alt+Shift+F");
+        yield return new PaletteItem("Toggle word wrap (Notepad++ style)", "Action", "↩", Invoke(() => ToggleWordWrapCommand));
         yield return new PaletteItem("Find in editor", "Action", "⌕", () => { FindRequested?.Invoke(false); return Task.CompletedTask; }, Hotkeys.Label("F"));
         yield return new PaletteItem("Find & replace in editor", "Action", "⌕", () => { FindRequested?.Invoke(true); return Task.CompletedTask; }, Hotkeys.Label("H"));
         yield return new PaletteItem("Expand SELECT * into columns", "Action", "✳", () => { ExpandStarRequested?.Invoke(); return Task.CompletedTask; });

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -164,7 +164,19 @@ public sealed partial class MainViewModel : ObservableObject
 
     private readonly Action<bool>? _persistWordWrapEditor;
 
-    partial void OnWordWrapEditorChanged(bool value) => _persistWordWrapEditor?.Invoke(value);
+    // Persist and report the new state here rather than in ToggleWordWrap, so
+    // the status line updates the same way whether wrap was flipped from the
+    // palette command or by the toolbar toggle's direct two-way binding.
+    // ActiveTab is set in the constructor, but guard anyway for a transient null
+    // during tab transitions.
+    partial void OnWordWrapEditorChanged(bool value)
+    {
+        _persistWordWrapEditor?.Invoke(value);
+        if (ActiveTab is not null)
+        {
+            ActiveTab.Status = value ? "Word wrap: on" : "Word wrap: off";
+        }
+    }
 
     /// <summary>
     /// Pretty-prints the statement under the caret. The rewrite itself lives in
@@ -175,13 +187,13 @@ public sealed partial class MainViewModel : ObservableObject
     [RelayCommand]
     private void FormatSql() => FormatSqlRequested?.Invoke();
 
-    /// <summary>Flips word wrap and reports the new state in the status bar.</summary>
+    /// <summary>
+    /// Flips word wrap. The status-line update + persistence ride on the
+    /// <see cref="OnWordWrapEditorChanged"/> hook, so the toolbar toggle (which
+    /// binds the property directly) stays consistent with this command.
+    /// </summary>
     [RelayCommand]
-    private void ToggleWordWrap()
-    {
-        WordWrapEditor = !WordWrapEditor;
-        ActiveTab.Status = WordWrapEditor ? "Word wrap: on" : "Word wrap: off";
-    }
+    private void ToggleWordWrap() => WordWrapEditor = !WordWrapEditor;
 
     public MainViewModel(
         QueryEngine engine,

--- a/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
@@ -13,6 +13,18 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
     [ObservableProperty]
     private bool _isLoading;
 
+    /// <summary>
+    /// True only during the first, empty load (no schemas yet) — drives the
+    /// centered "Loading schema…" cue. A refresh with content already loaded
+    /// keeps the tree visible and shows just the top progress bar instead, so
+    /// the cue never renders on top of existing tree items. (During a refresh
+    /// the old schemas stay in <see cref="Schemas"/> until the fetch returns,
+    /// so the count is non-zero the whole time <see cref="IsLoading"/> is set.)
+    /// </summary>
+    public bool ShowInitialLoadingCue => IsLoading && Schemas.Count == 0;
+
+    partial void OnIsLoadingChanged(bool value) => OnPropertyChanged(nameof(ShowInitialLoadingCue));
+
     [ObservableProperty]
     private string? _errorMessage;
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -635,7 +635,7 @@
                          Notepad++-style word-wrap toggle. Icon-only to stay within
                          the minimalist toolbar rule; both are in the palette too. -->
                     <Rectangle Classes="statusSeparator" Margin="7,0" />
-                    <Button Classes="toolbar" Command="{Binding FormatSqlCommand}" ToolTip.Tip="Format SQL (Alt+Shift+F)">
+                    <Button Classes="toolbar" Command="{Binding FormatSqlCommand}" ToolTip.Tip="Format SQL (Ctrl+Shift+F or Alt+Shift+F)">
                         <PathIcon Data="{StaticResource AutoFixIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
                     </Button>
                     <ToggleButton Classes="toolbar" IsChecked="{Binding WordWrapEditor, Mode=TwoWay}" ToolTip.Tip="Word wrap (Notepad++ style)">

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -255,15 +255,17 @@
                         <!-- Loading animation: an indeterminate bar pinned to the
                              top while the catalog loads (visible even when the
                              tree already has content, e.g. a refresh), plus a
-                             centered "Loading schema…" cue for the first, empty
-                             load. Bound to SchemaTree.IsLoading, set by RefreshAsync. -->
+                             centered "Loading schema…" cue shown only for the
+                             first, empty load (ShowInitialLoadingCue) so it never
+                             overlays existing tree items on a refresh. Both driven
+                             by SchemaTree.IsLoading, set by RefreshAsync. -->
                         <ProgressBar VerticalAlignment="Top" Height="2" Margin="0,-2,0,0"
                                      IsIndeterminate="True"
                                      Foreground="{DynamicResource AppAccentBrush}"
                                      IsVisible="{Binding SchemaTree.IsLoading}" />
                         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center"
                                     Spacing="10" IsHitTestVisible="False"
-                                    IsVisible="{Binding SchemaTree.IsLoading}">
+                                    IsVisible="{Binding SchemaTree.ShowInitialLoadingCue}">
                             <ProgressBar IsIndeterminate="True" Width="120" Height="4"
                                          Foreground="{DynamicResource AppAccentBrush}" />
                             <TextBlock Text="Loading schema…" FontSize="12" Opacity="0.6"

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -230,6 +230,7 @@
                     </DockPanel>
                     <!-- Sidebar content sits directly on the shell tone, Files-style - no card chrome -->
                     <Border Grid.Row="1">
+                        <Grid>
                         <TreeView Name="SchemaTreeView" ItemsSource="{Binding SchemaTree.Schemas}">
                             <TreeView.Styles>
                                 <Style Selector="TreeViewItem">
@@ -250,6 +251,25 @@
                                 </TreeDataTemplate>
                             </TreeView.ItemTemplate>
                         </TreeView>
+
+                        <!-- Loading animation: an indeterminate bar pinned to the
+                             top while the catalog loads (visible even when the
+                             tree already has content, e.g. a refresh), plus a
+                             centered "Loading schema…" cue for the first, empty
+                             load. Bound to SchemaTree.IsLoading, set by RefreshAsync. -->
+                        <ProgressBar VerticalAlignment="Top" Height="2" Margin="0,-2,0,0"
+                                     IsIndeterminate="True"
+                                     Foreground="{DynamicResource AppAccentBrush}"
+                                     IsVisible="{Binding SchemaTree.IsLoading}" />
+                        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center"
+                                    Spacing="10" IsHitTestVisible="False"
+                                    IsVisible="{Binding SchemaTree.IsLoading}">
+                            <ProgressBar IsIndeterminate="True" Width="120" Height="4"
+                                         Foreground="{DynamicResource AppAccentBrush}" />
+                            <TextBlock Text="Loading schema…" FontSize="12" Opacity="0.6"
+                                       HorizontalAlignment="Center" />
+                        </StackPanel>
+                        </Grid>
                     </Border>
                     <TextBlock Grid.Row="2" Text="{Binding SchemaTree.ErrorMessage}"
                                IsVisible="{Binding SchemaTree.ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}"
@@ -427,7 +447,17 @@
         <!-- Padding moves to the inner grid so the status bar can run flush along the layer's bottom edge -->
         <Border Grid.Column="2" Classes="layer" Padding="0">
         <Grid RowDefinitions="*,Auto">
-        <Grid Grid.Row="0" Margin="12,12,12,0" RowDefinitions="Auto,Auto,*,*">
+        <!-- Rows 3/4 (editor / results) are a resizable pair: the GridSplitter on
+             Row 3 drags the divider so the results grid can grow or shrink
+             vertically. Both panes keep a MinHeight so neither collapses. -->
+        <Grid Grid.Row="0" Margin="12,12,12,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="2*" MinHeight="80" />
+                <RowDefinition Height="12" />
+                <RowDefinition Height="3*" MinHeight="80" />
+            </Grid.RowDefinitions>
 
             <DockPanel Grid.Row="0" Margin="0,0,0,8">
                 <Button DockPanel.Dock="Right" Classes="chip" Content="+" FontSize="14" Command="{Binding AddTabCommand}" ToolTip.Tip="New query tab" />
@@ -600,17 +630,47 @@
                             <TextBlock Text="Import" VerticalAlignment="Center" Classes="collapsible" />
                         </StackPanel>
                     </Button>
+
+                    <!-- Group 5 — editor: pretty-print (also Alt+Shift+F) and the
+                         Notepad++-style word-wrap toggle. Icon-only to stay within
+                         the minimalist toolbar rule; both are in the palette too. -->
+                    <Rectangle Classes="statusSeparator" Margin="7,0" />
+                    <Button Classes="toolbar" Command="{Binding FormatSqlCommand}" ToolTip.Tip="Format SQL (Alt+Shift+F)">
+                        <PathIcon Data="{StaticResource AutoFixIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                    </Button>
+                    <ToggleButton Classes="toolbar" IsChecked="{Binding WordWrapEditor, Mode=TwoWay}" ToolTip.Tip="Word wrap (Notepad++ style)">
+                        <PathIcon Data="{StaticResource WrapIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                    </ToggleButton>
                 </StackPanel>
             </Border>
 
             <Border Grid.Row="2" Classes="card">
                 <ae:TextEditor Name="SqlEditor"
                                ShowLineNumbers="True"
+                               WordWrap="{Binding WordWrapEditor}"
                                FontFamily="Cascadia Code,Consolas,Menlo,monospace"
                                FontSize="14" />
             </Border>
 
-            <Border Grid.Row="3" Classes="card" Margin="0,12,0,12">
+            <!-- Drag to resize the editor/results split. Stretches to fill its
+                 12px row so the whole strip is a grab target; a faint centered
+                 hairline makes the divider discoverable without shouting. -->
+            <GridSplitter Grid.Row="3"
+                          HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                          ResizeDirection="Rows" ResizeBehavior="PreviousAndNext"
+                          Background="Transparent">
+                <GridSplitter.Template>
+                    <ControlTemplate>
+                        <Border Background="{TemplateBinding Background}">
+                            <Rectangle Height="2" Width="36" RadiusX="1" RadiusY="1"
+                                       VerticalAlignment="Center" HorizontalAlignment="Center"
+                                       Fill="{DynamicResource CardBorderBrush}" />
+                        </Border>
+                    </ControlTemplate>
+                </GridSplitter.Template>
+            </GridSplitter>
+
+            <Border Grid.Row="4" Classes="card" Margin="0,0,0,12">
                 <DockPanel>
                     <!-- No browse bar here on purpose: browse mode's WHERE/ORDER BY live in the
                          composed SQL (visible in the editor), and its paging sits in the status

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1326,12 +1326,17 @@ public partial class MainWindow : Window
             return;
         }
 
-        // Alt+Shift+F (the IntelliJ/VS Code convention the feedback asked for),
-        // or the legacy Ctrl/Cmd+Shift+F: pretty-print the statement the caret
-        // sits in, in place.
+        // Format the statement under the caret. All three shift-F combos fire it,
+        // regardless of the active hotkey scheme: Ctrl+Shift+F and Cmd+Shift+F
+        // (the two platform combos, as before) plus Alt+Shift+F (the
+        // IntelliJ/VS Code convention). A deliberate exception to the
+        // Hotkeys.Command routing — accepting every modifier is harmless here
+        // (nothing else binds them) and means the muscle-memory combo works
+        // whatever platform the user came from.
         if (e.Key == Key.F
-            && (e.KeyModifiers == (KeyModifiers.Alt | KeyModifiers.Shift)
-                || e.KeyModifiers == (Hotkeys.Command | KeyModifiers.Shift)))
+            && (e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift)
+                || e.KeyModifiers == (KeyModifiers.Meta | KeyModifiers.Shift)
+                || e.KeyModifiers == (KeyModifiers.Alt | KeyModifiers.Shift)))
         {
             FormatCurrentStatement();
             e.Handled = true;

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1326,8 +1326,12 @@ public partial class MainWindow : Window
             return;
         }
 
-        // Ctrl/Cmd+Shift+F: pretty-print the statement the caret sits in, in place.
-        if (e.Key == Key.F && e.KeyModifiers == (Hotkeys.Command | KeyModifiers.Shift))
+        // Alt+Shift+F (the IntelliJ/VS Code convention the feedback asked for),
+        // or the legacy Ctrl/Cmd+Shift+F: pretty-print the statement the caret
+        // sits in, in place.
+        if (e.Key == Key.F
+            && (e.KeyModifiers == (KeyModifiers.Alt | KeyModifiers.Shift)
+                || e.KeyModifiers == (Hotkeys.Command | KeyModifiers.Shift)))
         {
             FormatCurrentStatement();
             e.Handled = true;

--- a/PgNimbus.App/Views/ShortcutsWindow.axaml
+++ b/PgNimbus.App/Views/ShortcutsWindow.axaml
@@ -72,7 +72,7 @@
                     <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
                         <TextBlock Classes="what" Text="Format the statement under the cursor" />
                         <StackPanel Grid.Column="1" Classes="keys">
-                            <Border Classes="kbd"><TextBlock Classes="cmdKey" Text="Ctrl" /></Border>
+                            <Border Classes="kbd"><TextBlock Text="Alt" /></Border>
                             <Border Classes="kbd"><TextBlock Text="Shift" /></Border>
                             <Border Classes="kbd"><TextBlock Text="F" /></Border>
                         </StackPanel>

--- a/PgNimbus.App/Views/ShortcutsWindow.axaml
+++ b/PgNimbus.App/Views/ShortcutsWindow.axaml
@@ -72,6 +72,10 @@
                     <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
                         <TextBlock Classes="what" Text="Format the statement under the cursor" />
                         <StackPanel Grid.Column="1" Classes="keys">
+                            <Border Classes="kbd"><TextBlock Classes="cmdKey" Text="Ctrl" /></Border>
+                            <Border Classes="kbd"><TextBlock Text="Shift" /></Border>
+                            <Border Classes="kbd"><TextBlock Text="F" /></Border>
+                            <TextBlock Classes="combo" Text="or" />
                             <Border Classes="kbd"><TextBlock Text="Alt" /></Border>
                             <Border Classes="kbd"><TextBlock Text="Shift" /></Border>
                             <Border Classes="kbd"><TextBlock Text="F" /></Border>

--- a/PgNimbus.Core/Settings/AppSettings.cs
+++ b/PgNimbus.Core/Settings/AppSettings.cs
@@ -49,4 +49,12 @@ public sealed record AppSettings
     /// <see cref="Theme"/>; the App maps it to key modifiers.
     /// </summary>
     public string HotkeyScheme { get; set; } = "auto";
+
+    /// <summary>
+    /// Notepad++-style word wrap in the SQL editor: long lines wrap to the pane
+    /// width instead of scrolling horizontally. Off by default (the classic
+    /// no-wrap editor); toggled from the editor command bar or the command
+    /// palette, persisted here so the choice survives a restart.
+    /// </summary>
+    public bool WordWrapEditor { get; set; }
 }


### PR DESCRIPTION
Five improvements from production-database feedback:

1. Schema loading animation — the sidebar now shows an indeterminate
   progress bar (top hairline + centered "Loading schema…" cue) bound to
   SchemaTree.IsLoading while the catalog loads, so a slow first connect or
   refresh no longer looks frozen.

2. Results pane is vertically resizable — a GridSplitter between the editor
   and results cards lets the grid grow or shrink; both panes keep a
   MinHeight so neither collapses. A faint centered hairline makes the
   divider discoverable.

3. Duplicate table names across schemas — completion deduped by bare name,
   so public.users and analytics.users collapsed to a single entry. Tables
   now key on schema too, so both survive and each inserts its own
   schema-qualified form.

4. Format SQL on Alt+Shift+F (the IntelliJ/VS Code convention) plus a small
   magic-wand command-bar button; the legacy Ctrl/Cmd+Shift+F still works.
   Palette label and F1 cheat sheet updated to match.

5. Notepad++-style word wrap — a command-bar toggle (and palette command)
   wraps long editor lines to the pane width instead of scrolling
   horizontally; persisted in AppSettings so the choice survives a restart.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TUMbSWRXtr1KaowiLiX43G