### PR TITLE
Fix redundant double progress bar during initial schema load

### DIFF
--- a/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
@@ -23,7 +23,19 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
     /// </summary>
     public bool ShowInitialLoadingCue => IsLoading && Schemas.Count == 0;
 
-    partial void OnIsLoadingChanged(bool value) => OnPropertyChanged(nameof(ShowInitialLoadingCue));
+    /// <summary>
+    /// The thin top progress bar, shown only while *re*loading an already-populated
+    /// tree (a refresh) — the mutually-exclusive counterpart to
+    /// <see cref="ShowInitialLoadingCue"/>. On the first, empty load the centered
+    /// cue carries the loading state alone, so the two never render at once.
+    /// </summary>
+    public bool ShowRefreshLoadingBar => IsLoading && Schemas.Count > 0;
+
+    partial void OnIsLoadingChanged(bool value)
+    {
+        OnPropertyChanged(nameof(ShowInitialLoadingCue));
+        OnPropertyChanged(nameof(ShowRefreshLoadingBar));
+    }
 
     [ObservableProperty]
     private string? _errorMessage;

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -252,17 +252,20 @@
                             </TreeView.ItemTemplate>
                         </TreeView>
 
-                        <!-- Loading animation: an indeterminate bar pinned to the
-                             top while the catalog loads (visible even when the
-                             tree already has content, e.g. a refresh), plus a
-                             centered "Loading schema…" cue shown only for the
-                             first, empty load (ShowInitialLoadingCue) so it never
-                             overlays existing tree items on a refresh. Both driven
-                             by SchemaTree.IsLoading, set by RefreshAsync. -->
+                        <!-- Loading animation, two mutually-exclusive cues driven by
+                             SchemaTree.IsLoading (set by RefreshAsync): a thin
+                             indeterminate bar pinned to the top only while
+                             *re*loading an already-populated tree
+                             (ShowRefreshLoadingBar), and a centered "Loading schema…"
+                             cue shown only for the first, empty load
+                             (ShowInitialLoadingCue). Splitting them this way keeps
+                             the top bar from doubling up with the centered cue on the
+                             initial load, while still never overlaying existing tree
+                             items on a refresh. -->
                         <ProgressBar VerticalAlignment="Top" Height="2" Margin="0,-2,0,0"
                                      IsIndeterminate="True"
                                      Foreground="{DynamicResource AppAccentBrush}"
-                                     IsVisible="{Binding SchemaTree.IsLoading}" />
+                                     IsVisible="{Binding SchemaTree.ShowRefreshLoadingBar}" />
                         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center"
                                     Spacing="10" IsHitTestVisible="False"
                                     IsVisible="{Binding SchemaTree.ShowInitialLoadingCue}">


### PR DESCRIPTION
@
## Problem

On the first (empty) schema load, **two** indeterminate progress indicators showed at once — the thin bar pinned to the top of the schema panel and the centered "Loading schema…" cue below it. Both were driven by conditions that were simultaneously true on the initial load, which reads as redundant (reported from the screenshot below).

## Fix

Make the two cues mutually exclusive:

- Added `ShowRefreshLoadingBar` (`IsLoading && Schemas.Count > 0`) as the counterpart to the existing `ShowInitialLoadingCue` (`IsLoading && Schemas.Count == 0`), and bound the thin top bar to it.
- **Initial, empty load** → only the centered "Loading schema…" cue.
- **Refresh of an already-populated tree** → only the thin top bar (still never overlaying existing tree items, as before).

## Files

- `PgNimbus.App/ViewModels/SchemaTreeViewModel.cs` — new `ShowRefreshLoadingBar` property + notification on `IsLoading` change.
- `PgNimbus.App/Views/MainWindow.axaml` — top bar now binds to `ShowRefreshLoadingBar`; updated the explanatory comment.

Build passes (`dotnet build PgNimbus.App`, 0 warnings / 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@