### PR TITLE
Unify text selection color across SQL editor and TextBox fields

### DIFF
--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -48,15 +48,19 @@
             <!-- Low-alpha accent for row/pill selection washes; reads on both themes -->
             <SolidColorBrush x:Key="AppSelectionBrush" Color="#282D7FF9" />
             <!--
-                SQL editor text-selection wash. Same fixed brand hue as the rest
-                of the app's selection surfaces (NOT AvaloniaEdit's default, which
-                is theme/OS-derived and drifted off our palette). A bit more alpha
-                than AppSelectionBrush (0x40 vs 0x28): a text run under the cursor
+                App-wide text-selection wash: the SQL editor (set on
+                TextArea.SelectionBrush in MainWindow.axaml.cs) AND every plain
+                TextBox (Style below) share this one token, so a selected
+                connection-dialog field reads the same as a selected query. Same
+                fixed brand hue as the rest of the app's selection surfaces (NOT
+                FluentTheme's/AvaloniaEdit's defaults, which are theme/OS-accent-
+                derived and drift off our palette). A bit more alpha than
+                AppSelectionBrush (0x40 vs 0x28): a text run under the cursor
                 needs to read as clearly selected even one char wide, and the
-                translucency lets the syntax-highlight colors show through. Tune
-                the alpha here to make selection stronger/weaker app-wide.
+                translucency lets underlying text colors show through. Tune the
+                alpha here to make selection stronger/weaker app-wide.
             -->
-            <SolidColorBrush x:Key="AppEditorSelectionBrush" Color="#402D7FF9" />
+            <SolidColorBrush x:Key="AppTextSelectionBrush" Color="#402D7FF9" />
 
         <CornerRadius x:Key="CardCornerRadius">8</CornerRadius>
         <CornerRadius x:Key="ControlCornerRadius">6</CornerRadius>
@@ -569,6 +573,14 @@
     <!-- Inputs: rounded to match the rest of the surface -->
     <Style Selector="TextBox, ComboBox, NumericUpDown">
         <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+    </Style>
+    <!-- Selected text in every plain TextBox (connection dialog fields, search
+         boxes, etc.) uses the same brand-blue wash as the SQL editor instead of
+         FluentTheme's OS-accent-derived default - SelectionBrush is a TextBox-only
+         property (not exposed on ComboBox/NumericUpDown), hence its own selector;
+         it still reaches the editable TextBox inside a NumericUpDown's template. -->
+    <Style Selector="TextBox">
+        <Setter Property="SelectionBrush" Value="{StaticResource AppTextSelectionBrush}" />
     </Style>
 
     <!-- Results grid: soft horizontal rules instead of a full grid -->

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -174,11 +174,12 @@ public partial class MainWindow : Window
         // TextView claims wheel events for scrolling before they'd bubble.
         SqlEditor.Options.HighlightCurrentLine = true;
         // Lock the text-selection wash to the fixed brand-blue token
-        // (AppEditorSelectionBrush in Theme.axaml) instead of AvaloniaEdit's
-        // theme/OS-derived default, so it matches the app's other selection
-        // surfaces and reads the same on both themes. SelectionBrush lives on
-        // TextArea, not TextEditor, so it can't be a XAML attribute on SqlEditor.
-        if (this.TryFindResource("AppEditorSelectionBrush", out var selectionBrush)
+        // (AppTextSelectionBrush in Theme.axaml, shared with every plain
+        // TextBox's Style setter) instead of AvaloniaEdit's theme/OS-derived
+        // default, so it matches the app's other selection surfaces and reads
+        // the same on both themes. SelectionBrush lives on TextArea, not
+        // TextEditor, so it can't be a XAML attribute on SqlEditor.
+        if (this.TryFindResource("AppTextSelectionBrush", out var selectionBrush)
             && selectionBrush is IBrush brush)
         {
             SqlEditor.TextArea.SelectionBrush = brush;


### PR DESCRIPTION
## Summary
Rename the text-selection brush token from `AppEditorSelectionBrush` to `AppTextSelectionBrush` and apply it consistently across both the SQL editor and all plain TextBox controls (connection dialog fields, search boxes, etc.). This ensures selected text reads the same brand-blue wash everywhere in the app instead of falling back to the OS-accent-derived default.

## Changes
- **Theme.axaml**: Renamed `AppEditorSelectionBrush` → `AppTextSelectionBrush` and expanded its documentation to clarify it's now an app-wide token shared by both the SQL editor and TextBox styles
- **Theme.axaml**: Added a new `TextBox` style selector that sets `SelectionBrush` to `AppTextSelectionBrush`, ensuring consistent selection appearance in connection dialogs and other input fields
- **MainWindow.axaml.cs**: Updated the resource lookup to use the renamed `AppTextSelectionBrush` token and clarified in comments that this brush is now shared with TextBox styling

## Implementation details
- The selection brush uses `#402D7FF9` (fixed brand blue with 0x40 alpha) — slightly more opaque than `AppSelectionBrush` (0x28 alpha) so a single selected character remains clearly visible
- The `SelectionBrush` property is TextBox-specific and doesn't exist on ComboBox or NumericUpDown, so it gets its own style selector; it still reaches the editable TextBox inside a NumericUpDown's template
- This change maintains the app's minimalist design principle by using a single, consistent selection token across all text input surfaces

https://claude.ai/code/session_01KSkCVWwMiHhcrBWbStD8rw