### PR TITLE
Backlog: workspace restore, open/save .sql files, multiple simultaneous connections

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -181,23 +181,53 @@ public partial class App : Application
 
         var csb = new NpgsqlConnectionStringBuilder(connectionString);
 
+        // Per-connection workspace key must match the label MainViewModel stamps
+        // history with, so a workspace saved under one connection only ever
+        // restores for that same host/database.
+        var workspaceStore = new WorkspaceStore();
+        var connectionHost = csb.Host ?? "";
+        var connectionDatabase = csb.Database ?? "";
+        var workspaceKey = string.IsNullOrEmpty(connectionHost) ? null : $"{connectionHost}/{connectionDatabase}";
+
+        var viewModel = new MainViewModel(
+            engine, explainService, schemaTree, schemaService, schemaEditor, ddlService, completionProvider, notifyMonitor, activityService, importService,
+            accentColor,
+            connectionHost: connectionHost,
+            connectionDatabase: connectionDatabase,
+            autoAliasTables: SettingsStore.Load().AutoAliasTables,
+            persistAutoAliasTables: PersistAutoAliasTables,
+            safeModeEdits: SettingsStore.Load().SafeModeEdits,
+            persistSafeModeEdits: PersistSafeModeEdits,
+            wordWrapEditor: SettingsStore.Load().WordWrapEditor,
+            persistWordWrapEditor: PersistWordWrapEditor,
+            workspace: workspaceKey is null ? null : workspaceStore.GetEntry(workspaceKey));
+
         var window = new MainWindow
         {
-            DataContext = new MainViewModel(
-                engine, explainService, schemaTree, schemaService, schemaEditor, ddlService, completionProvider, notifyMonitor, activityService, importService,
-                accentColor,
-                connectionHost: csb.Host ?? "",
-                connectionDatabase: csb.Database ?? "",
-                autoAliasTables: SettingsStore.Load().AutoAliasTables,
-                persistAutoAliasTables: PersistAutoAliasTables,
-                safeModeEdits: SettingsStore.Load().SafeModeEdits,
-                persistSafeModeEdits: PersistSafeModeEdits,
-                wordWrapEditor: SettingsStore.Load().WordWrapEditor,
-                persistWordWrapEditor: PersistWordWrapEditor),
+            DataContext = viewModel,
         };
 
         window.Closed += async (_, _) =>
         {
+            // Save the workspace before anything else tears down - a failed save
+            // must never block window close / resource teardown. This fires on
+            // both a normal app exit and a "switch connection" (which closes the
+            // previous window), so the snapshot always files under the OLD
+            // connection's key - exactly what per-connection scoping wants.
+            try
+            {
+                if (workspaceKey is not null)
+                {
+                    var tabs = viewModel.Tabs.Select(t => new WorkspaceTab(t.Sql, t.TitleOverride)).ToList();
+                    var activeIndex = Math.Max(viewModel.Tabs.IndexOf(viewModel.ActiveTab), 0);
+                    workspaceStore.Save(workspaceKey, tabs, activeIndex);
+                }
+            }
+            catch
+            {
+                // Losing the workspace snapshot is not worth blocking shutdown over.
+            }
+
             // Order matters: drain the notify listener's connection back to the
             // pool first, then dispose the data source (the pool itself, which
             // otherwise leaks on every "switch connection"), then the SSH tunnel

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -141,15 +141,29 @@ public partial class App : Application
     }
 
     /// <summary>
-    /// Builds the connection-profile picker. Used both at startup (as
-    /// <see cref="IClassicDesktopStyleApplicationLifetime.MainWindow"/>, no
-    /// <paramref name="previousWindow"/>) and for "switch connection" from an
-    /// already-open <see cref="MainWindow"/> — in that case, connecting closes
-    /// <paramref name="previousWindow"/> after the new one is up, so its
-    /// resources (notify-listen connection, SSH tunnel) tear down via its own
-    /// <c>Closed</c> handler exactly as they would on a normal window close.
+    /// Builds the connection-profile picker. Used for three flows:
+    /// startup (as <see cref="IClassicDesktopStyleApplicationLifetime.MainWindow"/>,
+    /// no <paramref name="previousWindow"/>, default <paramref name="replaceMainWindow"/>),
+    /// "switch connection" from an already-open <see cref="MainWindow"/> (which
+    /// passes itself as <paramref name="previousWindow"/> and keeps the default
+    /// <paramref name="replaceMainWindow"/> so connecting closes it after the new
+    /// window is up, tearing its resources down via its own <c>Closed</c> handler
+    /// exactly as a normal window close would), and "open connection in new
+    /// window" (<paramref name="replaceMainWindow"/> = false, no
+    /// <paramref name="previousWindow"/>) which leaves every existing window —
+    /// and <see cref="IClassicDesktopStyleApplicationLifetime.MainWindow"/> itself
+    /// — untouched; the new window simply joins them. There is no explicit
+    /// <c>ShutdownMode</c> set, so Avalonia's default <c>OnLastWindowClose</c>
+    /// applies: the app keeps running until every window (whichever one that is)
+    /// has closed.
+    ///
+    /// Note: two windows connected to the same host/database each own a
+    /// separate in-memory workspace snapshot but save under the same
+    /// per-connection key on close (see <see cref="BuildMainWindow"/>) — the
+    /// one that closes last wins and overwrites the other's save. Acceptable
+    /// by design; not worth merging snapshots across windows for.
     /// </summary>
-    internal static ConnectionDialog BuildConnectionDialog(IClassicDesktopStyleApplicationLifetime desktop, Window? previousWindow = null)
+    internal static ConnectionDialog BuildConnectionDialog(IClassicDesktopStyleApplicationLifetime desktop, Window? previousWindow = null, bool replaceMainWindow = true)
     {
         var viewModel = new ConnectionDialogViewModel(new ConnectionProfileStore(), CredentialStore.Create());
         var dialog = new ConnectionDialog { DataContext = viewModel };
@@ -157,10 +171,14 @@ public partial class App : Application
         viewModel.Connected += (connectionString, accentColor, tunnel) =>
         {
             var mainWindow = BuildMainWindow(connectionString, accentColor, tunnel);
-            desktop.MainWindow = mainWindow;
             mainWindow.Show();
             dialog.Close();
-            previousWindow?.Close();
+
+            if (replaceMainWindow)
+            {
+                desktop.MainWindow = mainWindow;
+                previousWindow?.Close();
+            }
         };
 
         return dialog;

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -49,6 +49,10 @@ public partial class App : Application
     private static void PersistWordWrapEditor(bool value) =>
         SettingsStore.Save(SettingsStore.Load() with { WordWrapEditor = value });
 
+    /// <summary>Remembers the command palette's recent-.sql-files list so it survives a restart.</summary>
+    private static void PersistRecentSqlFiles(IReadOnlyList<string> value) =>
+        SettingsStore.Save(SettingsStore.Load() with { RecentSqlFiles = value.ToList() });
+
     /// <summary>The saved settings snapshot, for the preferences page to initialize from.</summary>
     internal static AppSettings LoadSettings() => SettingsStore.Load();
 
@@ -200,7 +204,9 @@ public partial class App : Application
             persistSafeModeEdits: PersistSafeModeEdits,
             wordWrapEditor: SettingsStore.Load().WordWrapEditor,
             persistWordWrapEditor: PersistWordWrapEditor,
-            workspace: workspaceKey is null ? null : workspaceStore.GetEntry(workspaceKey));
+            workspace: workspaceKey is null ? null : workspaceStore.GetEntry(workspaceKey),
+            recentSqlFiles: SettingsStore.Load().RecentSqlFiles,
+            persistRecentSqlFiles: PersistRecentSqlFiles);
 
         var window = new MainWindow
         {
@@ -218,7 +224,7 @@ public partial class App : Application
             {
                 if (workspaceKey is not null)
                 {
-                    var tabs = viewModel.Tabs.Select(t => new WorkspaceTab(t.Sql, t.TitleOverride)).ToList();
+                    var tabs = viewModel.Tabs.Select(t => new WorkspaceTab(t.Sql, t.TitleOverride, t.FilePath)).ToList();
                     var activeIndex = Math.Max(viewModel.Tabs.IndexOf(viewModel.ActiveTab), 0);
                     workspaceStore.Save(workspaceKey, tabs, activeIndex);
                 }

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -44,6 +44,9 @@ public sealed partial class MainViewModel : ObservableObject
     // Raised when the user asks to connect to a different server/database;
     // MainWindow reopens the connection dialog (App.BuildConnectionDialog).
     public event Action? SwitchConnectionRequested;
+    // Raised to open another connection side by side; MainWindow opens the
+    // connection dialog additively — the current window stays connected and open.
+    public event Action? NewWindowRequested;
     // Raised to pretty-print the statement under the caret; MainWindow owns the
     // editor text (AvaloniaEdit's Text isn't bindable) so it does the rewrite.
     public event Action? FormatSqlRequested;
@@ -79,6 +82,9 @@ public sealed partial class MainViewModel : ObservableObject
 
     [RelayCommand]
     private void SwitchConnection() => SwitchConnectionRequested?.Invoke();
+
+    [RelayCommand]
+    private void OpenNewWindow() => NewWindowRequested?.Invoke();
 
     [RelayCommand]
     private void ShowPreferences() => PreferencesRequested?.Invoke();
@@ -686,6 +692,7 @@ public sealed partial class MainViewModel : ObservableObject
         yield return new PaletteItem("Toggle auto-alias tables (orders → orders o)", "Action", "a", Invoke(() => ToggleAutoAliasCommand), Hotkeys.Label("Shift+A"));
         yield return new PaletteItem("Toggle safe mode (stage grid changes, review & commit)", "Action", "⛨", Invoke(() => ToggleSafeModeCommand));
         yield return new PaletteItem("Switch connection…", "Action", "⇄", () => { SwitchConnectionRequested?.Invoke(); return Task.CompletedTask; });
+        yield return new PaletteItem("Open connection in new window…", "Action", "⧉", Invoke(() => OpenNewWindowCommand));
         yield return new PaletteItem("Toggle light/dark theme", "Action", "◐", () => { ThemeToggleRequested?.Invoke(); return Task.CompletedTask; });
         yield return new PaletteItem("Preferences…", "Action", "⚙", Invoke(() => ShowPreferencesCommand), Hotkeys.Label(","));
         yield return new PaletteItem("Keyboard shortcuts", "Action", "?", () => { ShortcutsRequested?.Invoke(); return Task.CompletedTask; }, "F1");

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -7,6 +7,7 @@ using PgNimbus.Core.Import;
 using PgNimbus.Core.Monitoring;
 using PgNimbus.Core.Query;
 using PgNimbus.Core.Schema;
+using PgNimbus.Core.Settings;
 
 namespace PgNimbus.App.ViewModels;
 
@@ -214,7 +215,8 @@ public sealed partial class MainViewModel : ObservableObject
         bool safeModeEdits = true,
         Action<bool>? persistSafeModeEdits = null,
         bool wordWrapEditor = false,
-        Action<bool>? persistWordWrapEditor = null)
+        Action<bool>? persistWordWrapEditor = null,
+        WorkspaceEntry? workspace = null)
     {
         ConnectionHost = connectionHost;
         ConnectionDatabase = connectionDatabase;
@@ -253,7 +255,27 @@ public sealed partial class MainViewModel : ObservableObject
         // auto-rollback that fires from a background query thread.
         _engine.TransactionStateChanged += OnEngineTransactionStateChanged;
 
-        AddTab();
+        // Restore the last session's tabs for this connection, if any. Browse-mode
+        // tabs (table/function "source" views opened via ShowSourceAsync etc.) are
+        // deliberately restored as their composed page SQL - i.e. plain query
+        // tabs - rather than as live browse sessions; there is no saved browse
+        // state to reconstruct from.
+        if (workspace is { Tabs.Count: > 0 })
+        {
+            foreach (var saved in workspace.Tabs)
+            {
+                var tab = NewTab();
+                tab.Sql = saved.Sql;
+                tab.TitleOverride = saved.Title;
+            }
+
+            var activeIndex = Math.Clamp(workspace.ActiveTabIndex, 0, Tabs.Count - 1);
+            ActiveTab = Tabs[activeIndex];
+        }
+        else
+        {
+            AddTab();
+        }
     }
 
     private void OnEngineTransactionStateChanged() =>

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -59,6 +59,23 @@ public sealed partial class MainViewModel : ObservableObject
     public event Action? SidebarToggleRequested;
     // Raised to open (or focus) the preferences window, which the view owns.
     public event Action? PreferencesRequested;
+    // Raised to open the "Open SQL file" picker; MainWindow owns the
+    // StorageProvider dialog and file I/O.
+    public event Action? OpenFileRequested;
+    // Raised to save the active tab's SQL to disk; true = "save as" (always
+    // prompt), false = save-in-place (prompt only when the tab has no file yet).
+    public event Action<bool>? SaveFileRequested;
+    // Raised to open a specific recent file (from the palette's "Recent file" entries).
+    public event Action<string>? OpenRecentFileRequested;
+
+    [RelayCommand]
+    private void OpenFile() => OpenFileRequested?.Invoke();
+
+    [RelayCommand]
+    private void SaveFile() => SaveFileRequested?.Invoke(false);
+
+    [RelayCommand]
+    private void SaveFileAs() => SaveFileRequested?.Invoke(true);
 
     [RelayCommand]
     private void SwitchConnection() => SwitchConnectionRequested?.Invoke();
@@ -165,6 +182,14 @@ public sealed partial class MainViewModel : ObservableObject
 
     private readonly Action<bool>? _persistWordWrapEditor;
 
+    // Most-recently-opened/saved .sql file paths, most recent first, capped at
+    // 10 — backs the palette's "Recent file" entries. Kept as a plain list
+    // (not observable) since the palette only reads it when it (re)builds its
+    // candidate set, not live.
+    private readonly List<string> _recentSqlFiles;
+
+    private readonly Action<IReadOnlyList<string>>? _persistRecentSqlFiles;
+
     // Persist and report the new state here rather than in ToggleWordWrap, so
     // the status line updates the same way whether wrap was flipped from the
     // palette command or by the toolbar toggle's direct two-way binding.
@@ -216,7 +241,9 @@ public sealed partial class MainViewModel : ObservableObject
         Action<bool>? persistSafeModeEdits = null,
         bool wordWrapEditor = false,
         Action<bool>? persistWordWrapEditor = null,
-        WorkspaceEntry? workspace = null)
+        WorkspaceEntry? workspace = null,
+        IReadOnlyList<string>? recentSqlFiles = null,
+        Action<IReadOnlyList<string>>? persistRecentSqlFiles = null)
     {
         ConnectionHost = connectionHost;
         ConnectionDatabase = connectionDatabase;
@@ -226,6 +253,8 @@ public sealed partial class MainViewModel : ObservableObject
         _persistSafeModeEdits = persistSafeModeEdits;
         _wordWrapEditor = wordWrapEditor;
         _persistWordWrapEditor = persistWordWrapEditor;
+        _recentSqlFiles = recentSqlFiles is null ? [] : recentSqlFiles.ToList();
+        _persistRecentSqlFiles = persistRecentSqlFiles;
         _engine = engine;
         _explainService = explainService;
         SchemaTree = schemaTree;
@@ -267,6 +296,27 @@ public sealed partial class MainViewModel : ObservableObject
                 var tab = NewTab();
                 tab.Sql = saved.Sql;
                 tab.TitleOverride = saved.Title;
+
+                // Best-effort reattach to the tab's saved file association. The
+                // restored buffer (saved.Sql, just set above) is kept as-is —
+                // AttachFile only sets the disk-comparison baseline, not Sql —
+                // so if the buffer and the file have since diverged (edited here
+                // but not saved, or the file changed elsewhere), the dirty dot
+                // honestly reflects that the moment the tab reopens. If the file
+                // is gone or unreadable, this just leaves the tab as a titled
+                // scratch tab — restore must never fail the whole session over it.
+                if (saved.FilePath is { } filePath)
+                {
+                    try
+                    {
+                        var diskContent = File.ReadAllText(filePath);
+                        tab.AttachFile(filePath, diskContent);
+                    }
+                    catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+                    {
+                        // Leave as a titled scratch tab (TitleOverride from above still applies).
+                    }
+                }
             }
 
             var activeIndex = Math.Clamp(workspace.ActiveTabIndex, 0, Tabs.Count - 1);
@@ -395,6 +445,48 @@ public sealed partial class MainViewModel : ObservableObject
         ActiveTab = tab;
         CloseTabCommand.NotifyCanExecuteChanged();
         return tab;
+    }
+
+    /// <summary>
+    /// Opens <paramref name="path"/> (already read as <paramref name="content"/>
+    /// by the caller — MainWindow owns the file I/O) into a query tab. If the
+    /// file is already open in some tab (matched by <see cref="QueryViewModel.FilePath"/>,
+    /// ordinal), that tab is made active instead of opening a duplicate.
+    /// Otherwise a brand-new tab is created — never the active one, per the
+    /// "loading a query never overwrites the active tab" rule — and recorded
+    /// as the most recent file.
+    /// </summary>
+    public QueryViewModel OpenFileTab(string path, string content)
+    {
+        var existing = Tabs.FirstOrDefault(t => string.Equals(t.FilePath, path, StringComparison.Ordinal));
+        if (existing is not null)
+        {
+            ActiveTab = existing;
+            return existing;
+        }
+
+        var tab = NewTab();
+        tab.Sql = content;
+        tab.AttachFile(path, content);
+        RecordRecentFile(path);
+        return tab;
+    }
+
+    /// <summary>
+    /// Moves <paramref name="path"/> to the front of the recent-files list
+    /// (removing any existing occurrence first), trims to the 10 most recent,
+    /// and persists the result. Called on a successful open or save.
+    /// </summary>
+    public void RecordRecentFile(string path)
+    {
+        _recentSqlFiles.RemoveAll(p => string.Equals(p, path, StringComparison.Ordinal));
+        _recentSqlFiles.Insert(0, path);
+        if (_recentSqlFiles.Count > 10)
+        {
+            _recentSqlFiles.RemoveRange(10, _recentSqlFiles.Count - 10);
+        }
+
+        _persistRecentSqlFiles?.Invoke(_recentSqlFiles);
     }
 
     /// <summary>
@@ -548,7 +640,7 @@ public sealed partial class MainViewModel : ObservableObject
     /// </summary>
     public async Task OpenCommandPaletteAsync()
     {
-        var baseItems = BuildActionItems().Concat(BuildSavedQueryItems()).ToList();
+        var baseItems = BuildActionItems().Concat(BuildRecentFileItems()).Concat(BuildSavedQueryItems()).ToList();
         CommandPalette.Open(baseItems);
 
         try
@@ -597,6 +689,9 @@ public sealed partial class MainViewModel : ObservableObject
         yield return new PaletteItem("Toggle light/dark theme", "Action", "◐", () => { ThemeToggleRequested?.Invoke(); return Task.CompletedTask; });
         yield return new PaletteItem("Preferences…", "Action", "⚙", Invoke(() => ShowPreferencesCommand), Hotkeys.Label(","));
         yield return new PaletteItem("Keyboard shortcuts", "Action", "?", () => { ShortcutsRequested?.Invoke(); return Task.CompletedTask; }, "F1");
+        yield return new PaletteItem("Open .sql file…", "Action", "↥", Invoke(() => OpenFileCommand), Hotkeys.Label("O"));
+        yield return new PaletteItem("Save tab to file", "Action", "↧", Invoke(() => SaveFileCommand), Hotkeys.Label("S"));
+        yield return new PaletteItem("Save tab as…", "Action", "↧", Invoke(() => SaveFileAsCommand), Hotkeys.Label("Shift+S"));
     }
 
     private IEnumerable<PaletteItem> BuildSavedQueryItems() =>
@@ -605,6 +700,18 @@ public sealed partial class MainViewModel : ObservableObject
             "Saved query",
             "★",
             () => { SavedQueries.LoadSavedQueryCommand.Execute(q); return Task.CompletedTask; }));
+
+    // One entry per recent .sql file, most-recent-first (the order they're
+    // already kept in). The directory rides in the Shortcut slot (rendered as
+    // quiet trailing text in the palette row) since the title alone is just
+    // the file name and the full path is otherwise invisible.
+    private IEnumerable<PaletteItem> BuildRecentFileItems() =>
+        _recentSqlFiles.Select(path => new PaletteItem(
+            Path.GetFileName(path),
+            "Recent file",
+            "▢",
+            () => { OpenRecentFileRequested?.Invoke(path); return Task.CompletedTask; },
+            Path.GetDirectoryName(path)));
 
     private IEnumerable<PaletteItem> BuildTableItems(IReadOnlyList<RelationInfo> relations) =>
         relations.Select(r => new PaletteItem(

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -124,12 +124,30 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private string? _titleOverride;
 
-    /// <summary>True when the SQL has been edited since it was last run — surfaced as a dot on the tab.</summary>
+    /// <summary>
+    /// True when the tab's content diverges from its dirty baseline —
+    /// surfaced as a dot on the tab. The baseline differs by tab kind (see
+    /// <see cref="OnSqlChanged"/>): for a scratch tab (<see cref="FilePath"/>
+    /// null) it's "edited since last run"; for a file-backed tab it's
+    /// "diverges from what's on disk", independent of whether it's been run.
+    /// </summary>
     [ObservableProperty]
     private bool _isDirty;
 
-    // The SQL as of the last run; edits away from it mark the tab dirty.
+    // The SQL as of the last run; edits away from it mark a scratch tab dirty.
     private string _lastRunSql;
+
+    /// <summary>
+    /// Full local path of the file this tab is backed by, or null for a
+    /// scratch (never saved/opened-from-disk) tab. Set by <see cref="AttachFile"/>
+    /// (open, workspace restore) and <see cref="MarkSaved"/> (save/save-as).
+    /// </summary>
+    [ObservableProperty]
+    private string? _filePath;
+
+    // The buffer content as of the last load-from/save-to disk for a
+    // file-backed tab; the dirty comparison baseline while FilePath is set.
+    private string? _lastSavedSql;
 
     [ObservableProperty]
     private ExplainNodeViewModel? _explainRoot;
@@ -277,9 +295,20 @@ public sealed partial class QueryViewModel : ObservableObject
 
         if (trackAsFullRun)
         {
-            // Running clears the dirty flag: the on-screen SQL is now what produced the result.
+            // The "last run" baseline always advances, whether or not this tab
+            // is file-backed — OnSqlChanged only consults it for scratch tabs,
+            // but keeping it current means a file tab that later loses its
+            // file association (rare) still gets a sane baseline.
             _lastRunSql = executedSql;
-            IsDirty = false;
+
+            // Running a scratch tab clears its dirty flag: the on-screen SQL is
+            // now what produced the result. Running a FILE-BACKED tab does NOT
+            // save it to disk, so its dirty dot (disk-divergence) must survive
+            // the run — only Save/MarkSaved clears it.
+            if (FilePath is null)
+            {
+                IsDirty = false;
+            }
         }
 
         IsRunning = true;
@@ -754,8 +783,45 @@ public sealed partial class QueryViewModel : ObservableObject
         SelectedSql = null;
 
         IsShowingPlan = false;
-        IsDirty = !string.Equals(value, _lastRunSql, StringComparison.Ordinal);
+        // Two different dirty meanings share one flag/dot: a scratch tab (no
+        // file) is dirty when edited since its last run; a file-backed tab is
+        // dirty when it diverges from what's on disk, regardless of runs.
+        IsDirty = FilePath is null
+            ? !string.Equals(value, _lastRunSql, StringComparison.Ordinal)
+            : !string.Equals(value, _lastSavedSql, StringComparison.Ordinal);
         UpdateTabTitle();
+    }
+
+    /// <summary>
+    /// Associates this tab with a local <c>.sql</c> file whose content is
+    /// <paramref name="diskContent"/> — used both when opening a file into a
+    /// new tab and when reattaching a workspace-restored tab to its saved
+    /// file association. Sets the dirty baseline to <paramref name="diskContent"/>
+    /// but deliberately does NOT touch <see cref="Sql"/>: the caller decides
+    /// what the buffer holds (freshly read disk content on open, or the
+    /// restored workspace buffer on restore, whose divergence from disk this
+    /// then honestly reflects via <see cref="IsDirty"/>).
+    /// </summary>
+    public void AttachFile(string path, string diskContent)
+    {
+        FilePath = path;
+        _lastSavedSql = diskContent;
+        TitleOverride = Path.GetFileName(path);
+        IsDirty = !string.Equals(Sql, _lastSavedSql, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Records a successful write of the current buffer to <paramref name="path"/>
+    /// — called by save/save-as after the file write succeeds. Clears the
+    /// dirty flag (the buffer now matches disk) and renames the tab after the
+    /// file, same as a fresh open.
+    /// </summary>
+    public void MarkSaved(string path)
+    {
+        FilePath = path;
+        _lastSavedSql = Sql;
+        IsDirty = false;
+        TitleOverride = Path.GetFileName(path);
     }
 
     partial void OnBrowseChanged(TableBrowseViewModel? value)

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -320,6 +320,9 @@ public partial class MainWindow : Window
         // Ctrl/Cmd+, — the near-universal preferences shortcut.
         Add(new KeyGesture(Key.OemComma, Hotkeys.Command), () => _viewModel?.ShowPreferencesCommand);
         Add(new KeyGesture(Key.A, Hotkeys.Command | KeyModifiers.Shift), () => _viewModel?.ToggleAutoAliasCommand);
+        Add(new KeyGesture(Key.O, Hotkeys.Command), () => _viewModel?.OpenFileCommand);
+        Add(new KeyGesture(Key.S, Hotkeys.Command), () => _viewModel?.SaveFileCommand);
+        Add(new KeyGesture(Key.S, Hotkeys.Command | KeyModifiers.Shift), () => _viewModel?.SaveFileAsCommand);
 
         // The gear button's tooltip carries the shortcut, so it's set here
         // (not in XAML) to track the live Ctrl/Cmd scheme.
@@ -506,6 +509,9 @@ public partial class MainWindow : Window
             _viewModel.ActivityRequested -= ShowActivityWindow;
             _viewModel.SidebarToggleRequested -= ToggleSidebar;
             _viewModel.PreferencesRequested -= ShowPreferencesWindow;
+            _viewModel.OpenFileRequested -= OnOpenFileRequested;
+            _viewModel.SaveFileRequested -= OnSaveFileRequested;
+            _viewModel.OpenRecentFileRequested -= OnOpenRecentFileRequested;
         }
 
         _viewModel = vm;
@@ -520,6 +526,9 @@ public partial class MainWindow : Window
         _viewModel.ActivityRequested += ShowActivityWindow;
         _viewModel.SidebarToggleRequested += ToggleSidebar;
         _viewModel.PreferencesRequested += ShowPreferencesWindow;
+        _viewModel.OpenFileRequested += OnOpenFileRequested;
+        _viewModel.SaveFileRequested += OnSaveFileRequested;
+        _viewModel.OpenRecentFileRequested += OnOpenRecentFileRequested;
 
         // Warm the FK cache in the background so the grid's FK-navigation menu
         // items (which can't await) have edges to read by the time it's opened.
@@ -2119,6 +2128,164 @@ public partial class MainWindow : Window
         // The writer was snapshotted on the UI thread; do the (potentially large)
         // formatting + file write off it so the interface stays responsive.
         await Task.Run(() => write(stream));
+    }
+
+    // --- Open/save .sql files -----------------------------------------------
+    // MainViewModel raises the three events below (palette + Ctrl+O/S/Shift+S
+    // key bindings all resolve to its commands); this window owns the
+    // StorageProvider dialogs and the actual file I/O, same split as
+    // Import/Export above.
+
+    private void OnOpenFileRequested() => _ = OpenSqlFileAsync();
+
+    private void OnSaveFileRequested(bool saveAs) => _ = SaveSqlFileAsync(saveAs);
+
+    private void OnOpenRecentFileRequested(string path) => _ = OpenRecentFileAsync(path);
+
+    /// <summary>Ctrl+O / palette "Open .sql file…": pick a file and load it into a new tab (or focus it if already open).</summary>
+    private async Task OpenSqlFileAsync()
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+        if (storageProvider is null)
+        {
+            return;
+        }
+
+        var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Open SQL file",
+            AllowMultiple = false,
+            FileTypeFilter =
+            [
+                new FilePickerFileType("SQL") { Patterns = ["*.sql"] },
+                new FilePickerFileType("All files") { Patterns = ["*"] },
+            ],
+        });
+
+        if (files.Count == 0)
+        {
+            return;
+        }
+
+        var path = files[0].TryGetLocalPath();
+        if (path is null)
+        {
+            _viewModel.ActiveTab.Status = "Can't open a non-local file";
+            _viewModel.ActiveTab.HasError = true;
+            return;
+        }
+
+        try
+        {
+            var text = await File.ReadAllTextAsync(path);
+            _viewModel.OpenFileTab(path, text);
+        }
+        catch (Exception ex)
+        {
+            _viewModel.ActiveTab.Status = $"Open failed: {ex.Message}";
+            _viewModel.ActiveTab.HasError = true;
+        }
+    }
+
+    /// <summary>Palette "Recent file" entry: reload a previously opened path, leaving it in the recent list even if it's now missing.</summary>
+    private async Task OpenRecentFileAsync(string path)
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        if (!File.Exists(path))
+        {
+            _viewModel.ActiveTab.Status = $"File not found: {path}";
+            _viewModel.ActiveTab.HasError = true;
+            return;
+        }
+
+        try
+        {
+            var text = await File.ReadAllTextAsync(path);
+            _viewModel.OpenFileTab(path, text);
+        }
+        catch (Exception ex)
+        {
+            _viewModel.ActiveTab.Status = $"Open failed: {ex.Message}";
+            _viewModel.ActiveTab.HasError = true;
+        }
+    }
+
+    /// <summary>
+    /// Ctrl+S / Ctrl+Shift+S / palette "Save tab to file" / "Save tab as…":
+    /// writes the active tab's SQL to its associated file, prompting for a
+    /// location when it has none yet or <paramref name="saveAs"/> is true.
+    /// </summary>
+    private async Task SaveSqlFileAsync(bool saveAs)
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        var tab = _viewModel.ActiveTab;
+        var path = tab.FilePath;
+
+        if (path is null || saveAs)
+        {
+            var storageProvider = TopLevel.GetTopLevel(this)?.StorageProvider;
+            if (storageProvider is null)
+            {
+                return;
+            }
+
+            var suggestedName = SanitizeFileName(tab.TabTitle) + ".sql";
+            var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            {
+                Title = "Save SQL file",
+                SuggestedFileName = suggestedName,
+                DefaultExtension = "sql",
+                FileTypeChoices = [new FilePickerFileType("SQL") { Patterns = ["*.sql"] }],
+            });
+
+            if (file is null)
+            {
+                return;
+            }
+
+            path = file.TryGetLocalPath();
+            if (path is null)
+            {
+                tab.Status = "Can't save to a non-local file";
+                tab.HasError = true;
+                return;
+            }
+        }
+
+        try
+        {
+            await File.WriteAllTextAsync(path, tab.Sql);
+            tab.MarkSaved(path);
+            _viewModel.RecordRecentFile(path);
+            tab.Status = $"Saved {Path.GetFileName(path)}";
+            tab.HasError = false;
+        }
+        catch (Exception ex)
+        {
+            tab.Status = $"Save failed: {ex.Message}";
+            tab.HasError = true;
+        }
+    }
+
+    /// <summary>A usable file-name stem from a tab title: strips characters the filesystem would reject.</summary>
+    private static string SanitizeFileName(string title)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var cleaned = new string(title.Select(c => invalid.Contains(c) ? '_' : c).ToArray()).Trim();
+        return cleaned.Length == 0 ? "query" : cleaned;
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -503,6 +503,7 @@ public partial class MainWindow : Window
             _viewModel.ThemeToggleRequested -= ToggleTheme;
             _viewModel.ShortcutsRequested -= ShowShortcutsWindow;
             _viewModel.SwitchConnectionRequested -= SwitchConnection;
+            _viewModel.NewWindowRequested -= OpenNewWindow;
             _viewModel.FormatSqlRequested -= FormatCurrentStatement;
             _viewModel.ExpandStarRequested -= ExpandSelectStar;
             _viewModel.FindRequested -= OpenSearchPanel;
@@ -520,6 +521,7 @@ public partial class MainWindow : Window
         _viewModel.ThemeToggleRequested += ToggleTheme;
         _viewModel.ShortcutsRequested += ShowShortcutsWindow;
         _viewModel.SwitchConnectionRequested += SwitchConnection;
+        _viewModel.NewWindowRequested += OpenNewWindow;
         _viewModel.FormatSqlRequested += FormatCurrentStatement;
         _viewModel.ExpandStarRequested += ExpandSelectStar;
         _viewModel.FindRequested += OpenSearchPanel;
@@ -897,6 +899,20 @@ public partial class MainWindow : Window
 
         var dialog = App.BuildConnectionDialog(desktop, previousWindow: this);
         dialog.Show(this);
+    }
+
+    // Opens the connection dialog additively: this window stays connected and
+    // open, and a successful connect just adds another window rather than
+    // replacing anything (App.BuildConnectionDialog, replaceMainWindow: false).
+    private void OpenNewWindow()
+    {
+        if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            return;
+        }
+
+        var dialog = App.BuildConnectionDialog(desktop, replaceMainWindow: false);
+        dialog.Show();   // free-standing, NOT Show(this) — the dialog must not be owned by / pinned above the current window
     }
 
     private void ShowShortcutsWindow()

--- a/PgNimbus.App/Views/ShortcutsWindow.axaml
+++ b/PgNimbus.App/Views/ShortcutsWindow.axaml
@@ -115,6 +115,28 @@
                             <Border Classes="kbd"><TextBlock Text="PageUp" /></Border>
                         </StackPanel>
                     </Grid>
+                    <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
+                        <TextBlock Classes="what" Text="Open a .sql file" />
+                        <StackPanel Grid.Column="1" Classes="keys">
+                            <Border Classes="kbd"><TextBlock Classes="cmdKey" Text="Ctrl" /></Border>
+                            <Border Classes="kbd"><TextBlock Text="O" /></Border>
+                        </StackPanel>
+                    </Grid>
+                    <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
+                        <TextBlock Classes="what" Text="Save the active tab to a .sql file" />
+                        <StackPanel Grid.Column="1" Classes="keys">
+                            <Border Classes="kbd"><TextBlock Classes="cmdKey" Text="Ctrl" /></Border>
+                            <Border Classes="kbd"><TextBlock Text="S" /></Border>
+                        </StackPanel>
+                    </Grid>
+                    <Grid Classes="shortcutRow" ColumnDefinitions="*,Auto">
+                        <TextBlock Classes="what" Text="Save the active tab as…" />
+                        <StackPanel Grid.Column="1" Classes="keys">
+                            <Border Classes="kbd"><TextBlock Classes="cmdKey" Text="Ctrl" /></Border>
+                            <Border Classes="kbd"><TextBlock Text="Shift" /></Border>
+                            <Border Classes="kbd"><TextBlock Text="S" /></Border>
+                        </StackPanel>
+                    </Grid>
                 </StackPanel>
             </Border>
 

--- a/PgNimbus.Core.Tests/Settings/AppSettingsStoreTests.cs
+++ b/PgNimbus.Core.Tests/Settings/AppSettingsStoreTests.cs
@@ -63,4 +63,46 @@ public class AppSettingsStoreTests
             File.Delete(path);
         }
     }
+
+    [Test]
+    public async Task SaveThenLoad_RoundTripsRecentSqlFiles()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var store = new AppSettingsStore(path);
+            store.Save(new AppSettings { RecentSqlFiles = ["/home/user/a.sql", "/home/user/b.sql"] });
+
+            var settings = store.Load();
+
+            await Assert.That(settings.RecentSqlFiles.Count).IsEqualTo(2);
+            await Assert.That(settings.RecentSqlFiles[0]).IsEqualTo("/home/user/a.sql");
+            await Assert.That(settings.RecentSqlFiles[1]).IsEqualTo("/home/user/b.sql");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task Load_FileWithoutRecentSqlFilesProperty_LoadsAsEmptyList()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(path, """{ "Theme": "dark" }""");
+
+        try
+        {
+            var settings = new AppSettingsStore(path).Load();
+
+            await Assert.That(settings.Theme).IsEqualTo("dark");
+            await Assert.That(settings.RecentSqlFiles).IsNotNull();
+            await Assert.That(settings.RecentSqlFiles.Count).IsEqualTo(0);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }

--- a/PgNimbus.Core.Tests/Settings/WorkspaceStoreTests.cs
+++ b/PgNimbus.Core.Tests/Settings/WorkspaceStoreTests.cs
@@ -1,0 +1,121 @@
+using PgNimbus.Core.Settings;
+
+namespace PgNimbus.Core.Tests.Settings;
+
+public class WorkspaceStoreTests
+{
+    [Test]
+    public async Task GetEntry_NoFile_ReturnsNull()
+    {
+        var store = new WorkspaceStore(Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json"));
+
+        var entry = store.GetEntry("localhost/demo");
+
+        await Assert.That(entry).IsNull();
+    }
+
+    [Test]
+    public async Task GetEntry_CorruptFile_ReturnsNullAndDoesNotThrow()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(path, "not valid json {{{");
+
+        try
+        {
+            var entry = new WorkspaceStore(path).GetEntry("localhost/demo");
+
+            await Assert.That(entry).IsNull();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task SaveThenGetEntry_RoundTripsTabsAndActiveIndex()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var store = new WorkspaceStore(path);
+            var tabs = new List<WorkspaceTab>
+            {
+                new("SELECT 1;", null),
+                new("SELECT * FROM orders;", "orders · source"),
+            };
+
+            store.Save("localhost/demo", tabs, activeTabIndex: 1);
+
+            var entry = store.GetEntry("localhost/demo");
+
+            await Assert.That(entry).IsNotNull();
+            await Assert.That(entry!.Connection).IsEqualTo("localhost/demo");
+            await Assert.That(entry.ActiveTabIndex).IsEqualTo(1);
+            await Assert.That(entry.Tabs.Count).IsEqualTo(2);
+            await Assert.That(entry.Tabs[0].Sql).IsEqualTo("SELECT 1;");
+            await Assert.That(entry.Tabs[0].Title).IsNull();
+            await Assert.That(entry.Tabs[1].Sql).IsEqualTo("SELECT * FROM orders;");
+            await Assert.That(entry.Tabs[1].Title).IsEqualTo("orders · source");
+
+            var otherEntry = store.GetEntry("otherhost/otherdb");
+
+            await Assert.That(otherEntry).IsNull();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task Save_SameConnectionTwice_ReplacesEntry()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var store = new WorkspaceStore(path);
+            store.Save("localhost/demo", [new WorkspaceTab("SELECT 1;")], activeTabIndex: 0);
+            store.Save("localhost/demo", [new WorkspaceTab("SELECT 2;"), new WorkspaceTab("SELECT 3;")], activeTabIndex: 1);
+
+            var entry = store.GetEntry("localhost/demo");
+
+            await Assert.That(entry).IsNotNull();
+            await Assert.That(entry!.Tabs.Count).IsEqualTo(2);
+            await Assert.That(entry.Tabs[0].Sql).IsEqualTo("SELECT 2;");
+            await Assert.That(entry.ActiveTabIndex).IsEqualTo(1);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task Save_MoreThan20Connections_EvictsOldest()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var store = new WorkspaceStore(path);
+            for (var i = 0; i < 21; i++)
+            {
+                store.Save($"host{i}/db", [new WorkspaceTab($"SELECT {i};")], activeTabIndex: 0);
+            }
+
+            await Assert.That(store.GetEntry("host0/db")).IsNull();
+
+            for (var i = 1; i < 21; i++)
+            {
+                await Assert.That(store.GetEntry($"host{i}/db")).IsNotNull();
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/PgNimbus.Core.Tests/Settings/WorkspaceStoreTests.cs
+++ b/PgNimbus.Core.Tests/Settings/WorkspaceStoreTests.cs
@@ -94,6 +94,55 @@ public class WorkspaceStoreTests
     }
 
     [Test]
+    public async Task SaveThenGetEntry_RoundTripsFilePath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var store = new WorkspaceStore(path);
+            var tabs = new List<WorkspaceTab> { new("SELECT 1;", "query.sql", "/home/user/query.sql") };
+
+            store.Save("localhost/demo", tabs, activeTabIndex: 0);
+
+            var entry = store.GetEntry("localhost/demo");
+
+            await Assert.That(entry).IsNotNull();
+            await Assert.That(entry!.Tabs[0].FilePath).IsEqualTo("/home/user/query.sql");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task GetEntry_JsonWithoutFilePathProperty_LoadsWithNullFilePath()
+    {
+        // A workspace.json written before FilePath existed on WorkspaceTab must
+        // still deserialize — the new field falls back to its default (null)
+        // rather than failing the whole load.
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(
+            path,
+            """[{"Connection":"localhost/demo","SavedAt":"2026-01-01T00:00:00Z","Tabs":[{"Sql":"SELECT 1;","Title":null}],"ActiveTabIndex":0}]""");
+
+        try
+        {
+            var entry = new WorkspaceStore(path).GetEntry("localhost/demo");
+
+            await Assert.That(entry).IsNotNull();
+            await Assert.That(entry!.Tabs.Count).IsEqualTo(1);
+            await Assert.That(entry.Tabs[0].Sql).IsEqualTo("SELECT 1;");
+            await Assert.That(entry.Tabs[0].FilePath).IsNull();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
     public async Task Save_MoreThan20Connections_EvictsOldest()
     {
         var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");

--- a/PgNimbus.Core/Settings/AppSettings.cs
+++ b/PgNimbus.Core/Settings/AppSettings.cs
@@ -57,4 +57,15 @@ public sealed record AppSettings
     /// palette, persisted here so the choice survives a restart.
     /// </summary>
     public bool WordWrapEditor { get; set; }
+
+    /// <summary>
+    /// The most recently opened/saved <c>.sql</c> file paths, most recent
+    /// first, capped at 10 by the caller. Backs the command palette's
+    /// "Recent file" entries. <c>set</c>, not <c>init</c>, for the same
+    /// reason as every other property here — an <c>init</c> collection would
+    /// silently come back <c>null</c> (not the empty-list default) from a
+    /// settings file predating this field, since the source-generated
+    /// deserializer bypasses property initializers for init-only setters.
+    /// </summary>
+    public List<string> RecentSqlFiles { get; set; } = [];
 }

--- a/PgNimbus.Core/Settings/WorkspaceStore.cs
+++ b/PgNimbus.Core/Settings/WorkspaceStore.cs
@@ -4,8 +4,14 @@ using PgNimbus.Core.Connections;
 
 namespace PgNimbus.Core.Settings;
 
-/// <summary>A single saved tab: its SQL text and, for a titled tab (e.g. a table/function "source" tab), the title override.</summary>
-public sealed record WorkspaceTab(string Sql, string? Title = null);
+/// <summary>
+/// A single saved tab: its SQL text, for a titled tab (e.g. a table/function
+/// "source" tab) the title override, and, for a file-backed tab, the local
+/// path it's associated with. <paramref name="FilePath"/> is null for a
+/// scratch tab; a workspace.json written before this field existed still
+/// deserializes with it defaulting to null.
+/// </summary>
+public sealed record WorkspaceTab(string Sql, string? Title = null, string? FilePath = null);
 
 /// <summary>A saved snapshot of one connection's open tabs, most-recently-saved entries kept first in the store.</summary>
 public sealed record WorkspaceEntry(string Connection, DateTimeOffset SavedAt, List<WorkspaceTab> Tabs, int ActiveTabIndex = 0);

--- a/PgNimbus.Core/Settings/WorkspaceStore.cs
+++ b/PgNimbus.Core/Settings/WorkspaceStore.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PgNimbus.Core.Connections;
+
+namespace PgNimbus.Core.Settings;
+
+/// <summary>A single saved tab: its SQL text and, for a titled tab (e.g. a table/function "source" tab), the title override.</summary>
+public sealed record WorkspaceTab(string Sql, string? Title = null);
+
+/// <summary>A saved snapshot of one connection's open tabs, most-recently-saved entries kept first in the store.</summary>
+public sealed record WorkspaceEntry(string Connection, DateTimeOffset SavedAt, List<WorkspaceTab> Tabs, int ActiveTabIndex = 0);
+
+/// <summary>Persists the last <see cref="MaxEntries"/> per-connection workspaces, most recent first.</summary>
+public sealed class WorkspaceStore
+{
+    private const int MaxEntries = 20;
+
+    private readonly string _filePath;
+
+    public WorkspaceStore(string? filePath = null)
+    {
+        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "workspace.json");
+    }
+
+    private IReadOnlyList<WorkspaceEntry> Load()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return [];
+        }
+
+        // A corrupt/empty/half-written file must never block startup - fall back
+        // to an empty list rather than throwing out of the constructor path.
+        try
+        {
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize(json, WorkspaceJsonContext.Default.ListWorkspaceEntry) ?? [];
+        }
+        catch (Exception e) when (e is IOException or JsonException or UnauthorizedAccessException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>The most recently saved workspace for <paramref name="connection"/>, or null if none was ever saved.</summary>
+    public WorkspaceEntry? GetEntry(string connection) =>
+        Load().FirstOrDefault(e => string.Equals(e.Connection, connection, StringComparison.Ordinal));
+
+    /// <summary>Replaces the saved workspace for <paramref name="connection"/> with the current tabs.</summary>
+    public void Save(string connection, IReadOnlyList<WorkspaceTab> tabs, int activeTabIndex)
+    {
+        var entries = Load().ToList();
+        entries.RemoveAll(e => string.Equals(e.Connection, connection, StringComparison.Ordinal));
+        entries.Insert(0, new WorkspaceEntry(connection, DateTimeOffset.UtcNow, tabs.ToList(), activeTabIndex));
+
+        // Trim oldest-first - the list is most-recent-first, so drop from the end.
+        for (var i = entries.Count - 1; i >= 0 && entries.Count > MaxEntries; i--)
+        {
+            entries.RemoveAt(i);
+        }
+
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(entries, WorkspaceJsonContext.Default.ListWorkspaceEntry);
+        File.WriteAllText(_filePath, json);
+    }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(List<WorkspaceEntry>))]
+internal sealed partial class WorkspaceJsonContext : JsonSerializerContext;

--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   (<kbd>Ctrl</kbd>+<kbd>F</kbd> / <kbd>Ctrl</kbd>+<kbd>H</kbd>, F3 steps
   matches), and font-size zoom (<kbd>Ctrl</kbd>+wheel /
   <kbd>Ctrl</kbd>+<kbd>±</kbd>).
+- **Workspace restore** — closing the app never prompts; the next session on
+  the same connection reopens your tabs, including never-saved scratch SQL,
+  exactly as you left them.
 - **SQL formatting** — <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> (or "Format
   SQL" in the command palette) pretty-prints the statement under the cursor in a
   readable block style — clauses on their own lines, list items and JOINs one per
@@ -531,10 +534,18 @@ Everything below is what survives that filter, roughly in impact order:
   "Referencing rows" (one entry per table whose FK points here). Reuses the
   FK edges already loaded for JOIN completion; composite keys AND-join their
   filter. The most-praised "little feature" in DBeaver's HN comments.
-- [ ] **Workspace restore** — reopen the last session's tabs, including
+- [x] **Workspace restore** — reopen the last session's tabs, including
   never-saved SQL, exactly as they were — no save prompts on exit
   (Notepad++-style, called out on HN as what makes DBeaver safe to close).
   Persist per-connection alongside history in `AppSettings`-style JSON.
+  Shipped: a per-connection `workspace.json` (`WorkspaceStore`, capped at the
+  20 most-recently-used connections) snapshots every tab's SQL and title on
+  window close — including a normal exit and a "switch connection", both of
+  which fire the same `Closed` handler — and restores them, with the active
+  tab, the next time you connect to that same host/database. Browse-mode
+  tabs (table/function "source" views) restore as their composed query SQL,
+  not a live browse session; there is nothing to save/prompt for, so exit is
+  always silent.
 - [ ] **Open/save `.sql` files** — Ctrl+O / Ctrl+S on a tab, a recent-files
   list in the palette, and a dirty marker that distinguishes "unsaved
   scratch" from "file changed on disk". A top-voted Beekeeper Studio ask

--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ Every tag push (`vX.Y.Z`) builds all of the above via
 - **Workspace restore** — closing the app never prompts; the next session on
   the same connection reopens your tabs, including never-saved scratch SQL,
   exactly as you left them.
+- **Open/save `.sql` files** — <kbd>Ctrl</kbd>+<kbd>O</kbd> opens a `.sql`
+  file into a new tab (or focuses it if already open),
+  <kbd>Ctrl</kbd>+<kbd>S</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd>
+  save/save-as, and the command palette lists your 10 most recent files. A
+  file-backed tab's dirty dot means "diverges from disk" (survives a run,
+  unlike a scratch tab's "edited since run") and its file association
+  survives workspace restore.
 - **SQL formatting** — <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> (or "Format
   SQL" in the command palette) pretty-prints the statement under the cursor in a
   readable block style — clauses on their own lines, list items and JOINs one per
@@ -286,6 +293,8 @@ The highlights:
 | Cancel running query | <kbd>Esc</kbd> |
 | New / close query tab | <kbd>Ctrl</kbd>+<kbd>T</kbd> / <kbd>Ctrl</kbd>+<kbd>W</kbd> |
 | Next / previous tab | <kbd>Ctrl</kbd>+<kbd>PageDown</kbd> / <kbd>Ctrl</kbd>+<kbd>PageUp</kbd> |
+| Open a `.sql` file | <kbd>Ctrl</kbd>+<kbd>O</kbd> |
+| Save the active tab to a `.sql` file / save as | <kbd>Ctrl</kbd>+<kbd>S</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> |
 | SQL autocomplete | <kbd>Ctrl</kbd>+<kbd>Space</kbd> (also triggers while typing) |
 | Switch focus: editor ↔ results grid | <kbd>F6</kbd> |
 | Preferences | <kbd>Ctrl</kbd>+<kbd>,</kbd> |
@@ -546,10 +555,23 @@ Everything below is what survives that filter, roughly in impact order:
   tabs (table/function "source" views) restore as their composed query SQL,
   not a live browse session; there is nothing to save/prompt for, so exit is
   always silent.
-- [ ] **Open/save `.sql` files** — Ctrl+O / Ctrl+S on a tab, a recent-files
+- [x] **Open/save `.sql` files** — Ctrl+O / Ctrl+S on a tab, a recent-files
   list in the palette, and a dirty marker that distinguishes "unsaved
   scratch" from "file changed on disk". A top-voted Beekeeper Studio ask
-  (it appears twice in their top 20).
+  (it appears twice in their top 20). Shipped: `Ctrl+O` opens a `.sql` file
+  into a new tab (never the active one — same rule as saved queries/history),
+  reusing an already-open tab for the same path instead of duplicating it;
+  `Ctrl+S` / `Ctrl+Shift+S` save/save-as (via `Hotkeys.cs`, so `Cmd` on
+  macOS); the palette lists the 10 most recent files (persisted in
+  `AppSettings.RecentSqlFiles`) alongside new "Open .sql file…" / "Save tab
+  to file" / "Save tab as…" actions. The tab's dirty dot carries two
+  different meanings depending on whether it's file-backed: a scratch tab's
+  dot means "edited since last run" (cleared by running it), a file tab's dot
+  means "diverges from what's on disk" (survives a run — only a save clears
+  it). File tabs also survive workspace restore with their file association:
+  the saved buffer is kept as-is and the dot honestly reflects any
+  divergence from disk at reopen, rather than silently re-reading the file
+  over unsaved edits.
 - [ ] **Multiple simultaneous connections** — today the ⇄ switch *replaces*
   the connection; users working against dev + prod side by side want both at
   once (top-10 Beekeeper ask). Cleanest fit for the one-window shell:

--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   reopens the connection dialog; the current window stays fully usable until
   the new connection succeeds, then hands over cleanly (LISTEN subscriptions
   and SSH tunnels for the old connection are torn down).
+- **Multiple simultaneous connections** — "Open connection in new window…" in
+  the command palette opens the connection dialog additively: the current
+  window (and every other open window) stays connected, and a successful
+  connect just adds another window alongside it. Each window is fully
+  self-contained (its own pool, notify listener, SSH tunnel, and workspace
+  snapshot), so dev and prod can sit side by side — accent colors tell them
+  apart at a glance.
 - **Paste-anything connection strings** — drop whatever is on your clipboard
   into the connection dialog and it fills the form: `postgres://` URIs
   (Heroku/Supabase/Neon-style), `jdbc:postgresql://` URLs, ADO.NET/Npgsql
@@ -572,11 +579,19 @@ Everything below is what survives that filter, roughly in impact order:
   the saved buffer is kept as-is and the dot honestly reflects any
   divergence from disk at reopen, rather than silently re-reading the file
   over unsaved edits.
-- [ ] **Multiple simultaneous connections** — today the ⇄ switch *replaces*
+- [x] **Multiple simultaneous connections** — today the ⇄ switch *replaces*
   the connection; users working against dev + prod side by side want both at
   once (top-10 Beekeeper ask). Cleanest fit for the one-window shell:
   connection-per-window, with the palette able to open a profile in a new
   window. Per-connection accent colors already exist to keep them apart.
+  Shipped: "Open connection in new window…" in the command palette
+  (`App.BuildConnectionDialog`'s new `replaceMainWindow: false` mode) opens
+  the connection dialog additively instead of tearing down the current
+  window — the dialog just adds another self-contained window with its own
+  pool, notify listener, SSH tunnel, and per-connection workspace snapshot.
+  The ⇄ switch still replaces in place (unchanged); the app exits when the
+  *last* window closes, whichever that is, and accent colors keep the
+  windows visually apart on the taskbar/Alt+Tab.
 - [ ] **Auto-reconnect** — after laptop sleep or an SSH-tunnel drop, the next
   run should quietly reopen the connection instead of surfacing a broken-pipe
   error (or hanging — an HN complaint about other clients). Needs care with


### PR DESCRIPTION
Ships the three most critical actionable items from the README backlog's impact-ordered "Next" section, one commit each, each verified end-to-end headlessly (Xvfb + xdotool against a live Postgres) before landing.

## 1. Workspace restore (`9ae5606`)

Closing the window — normal exit or a connection switch — snapshots every tab's SQL, title override, and the active tab into a per-connection `workspace.json` (`WorkspaceStore`, 20 most-recently-used connections kept). The next session on the same host/database restores them exactly, including never-saved scratch SQL — no save prompts, Notepad++-style. A missing/corrupt file or a failed save never blocks startup or shutdown, matching the other stores' forgiving pattern.

## 2. Open/save `.sql` files (`fe752fb`)

Ctrl+O opens a picked `.sql` file into a new tab (focusing the existing tab if that file is already open); Ctrl+S / Ctrl+Shift+S save the active tab, prompting only when it has no file yet — all resolved through `Hotkeys` (Cmd on macOS), with palette entries and F1 cheat-sheet rows. The tab's dirty dot becomes kind-aware: scratch tabs keep the edited-since-last-run meaning, file-backed tabs show divergence from disk (a run no longer clears it — only a save does). The ten most recent files persist in settings and surface as "Recent file" palette entries. File tabs survive workspace restore via a backward-compatible `WorkspaceTab.FilePath`.

## 3. Multiple simultaneous connections (`06760d3`)

"Open connection in new window…" in the command palette opens the connection dialog additively: a successful connect adds another fully self-contained window (own pool, notify listener, SSH tunnel, per-connection workspace snapshot) instead of replacing the current one — dev and prod side by side, accent colors telling them apart. The ⇄ switch keeps its replace-in-place semantics; the app exits when the last window closes.

## Verification

- `dotnet build`: 0 warnings, 0 errors after each feature.
- `dotnet test --project PgNimbus.Core.Tests`: **341/341 passing** (337 baseline + 4 new store tests; 5 more WorkspaceStore tests were added in the first commit).
- Headless E2E per feature: tabs restored across a graceful close/relaunch; file tab dirty-dot lifecycle including a real disk-divergence catch; two windows querying `demo` and `demo2` simultaneously with independent teardown.
- README updated in each commit: backlog items flipped to `[x]` with shipped notes, Features section and shortcuts table extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U847a9g1GsRpwT7aNjPQNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01U847a9g1GsRpwT7aNjPQNU)_