### PR TITLE
Auto-reconnect: quietly retry once on connection loss, surface a clear transaction-lost state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,24 @@ env:
 jobs:
   build-test:
     runs-on: ubuntu-latest
+
+    # QueryEngineReconnectTests kills real backends (pg_terminate_backend) to
+    # exercise auto-reconnect end to end; PGNIMBUS_TEST_CONN below points them
+    # at this container instead of the mocks/pure-logic tests everything else
+    # uses. Mirrors the services block in benchmark.yml.
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v7
 
@@ -38,4 +56,6 @@ jobs:
       # TUnit on Microsoft.Testing.Platform — "dotnet test --project" works
       # via the test.runner opt-in in the repo-root global.json.
       - name: Test
+        env:
+          PGNIMBUS_TEST_CONN: "Host=localhost;Port=5432;Database=postgres;Username=postgres;Password=postgres"
         run: dotnet test --project PgNimbus.Core.Tests -c Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,9 @@ and wrong project memory is worse than none.
    "in transaction" indicator stays in sync no matter which path changed it.
    Auto-reconnect (2026-07): `QueryEngine` classifies a failure as connection
    loss (Postgres class-08 `SqlState`s / an admin or crash shutdown, or an
-   `NpgsqlException` wrapping a socket/IO/timeout exception) versus an
+   `NpgsqlException` wrapping a socket/IO exception — deliberately not
+   `TimeoutException`, which Npgsql also uses for command timeouts and pool
+   exhaustion where a silent re-run could double-apply work) versus an
    ordinary statement error, and on loss flushes the whole pool before
    silently retrying once on a fresh connection — runs, single-statement
    edits, and pre-commit batches all get this; a script retries only its

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,20 @@ and wrong project memory is worse than none.
    auto-rolls-back the block (so the connection never lingers in Postgres's
    aborted-transaction state), and `TransactionStateChanged` is how the App's
    "in transaction" indicator stays in sync no matter which path changed it.
+   Auto-reconnect (2026-07): `QueryEngine` classifies a failure as connection
+   loss (Postgres class-08 `SqlState`s / an admin or crash shutdown, or an
+   `NpgsqlException` wrapping a socket/IO/timeout exception) versus an
+   ordinary statement error, and on loss flushes the whole pool before
+   silently retrying once on a fresh connection — runs, single-statement
+   edits, and pre-commit batches all get this; a script retries only its
+   first statement, since session state from earlier statements can't be
+   resurrected. A failure mid-stream (rows already delivered) or after a
+   batch's `COMMIT` was attempted never retries. An explicit transaction is
+   never silently re-established: a lost connection there clears
+   `_transactionConnection` without sending `ROLLBACK` (no live socket to
+   send it down) and returns a `QueryError` with `ConnectionLost`/`RolledBack`
+   set, stating plainly that the transaction is gone and nothing from it
+   committed.
 3. **PostgreSQL-first, not lowest-common-denominator.** `SchemaService` reads
    `pg_catalog` directly (not `information_schema`) so it can see materialized
    views, partitioned tables, and real Postgres semantics (e.g. primary-key

--- a/PgNimbus.Core.Tests/Query/QueryEngineReconnectTests.cs
+++ b/PgNimbus.Core.Tests/Query/QueryEngineReconnectTests.cs
@@ -1,0 +1,238 @@
+using Npgsql;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Tests.Query;
+
+/// <summary>
+/// Exercises auto-reconnect against a real Postgres server: these tests kill
+/// live backends server-side (<c>pg_terminate_backend</c>) to simulate the
+/// dead-socket condition a laptop sleep or a dropped SSH tunnel leaves
+/// behind, then assert <see cref="QueryEngine"/> quietly recovers — or, for
+/// the held transaction connection, surfaces a clear "transaction lost"
+/// state instead of hanging or throwing a raw <see cref="NpgsqlException"/>.
+///
+/// Gated on <c>PGNIMBUS_TEST_CONN</c>: unset (the default for a plain local
+/// `dotnet test`), every test in this class skips cleanly. CI's
+/// <c>postgres:17</c> service container sets it so these actually run there.
+/// </summary>
+// pg_terminate_backend kills every backend on the test database except its
+// own admin connection — that would clobber any other test hitting the same
+// database concurrently, so the whole class is serialized.
+[NotInParallel]
+public class QueryEngineReconnectTests
+{
+    private const string ScratchTable = "pgnimbus_reconnect_scratch";
+
+    private static readonly string? ConnectionString = Environment.GetEnvironmentVariable("PGNIMBUS_TEST_CONN");
+
+    private static void SkipIfNoConnection()
+    {
+        if (string.IsNullOrEmpty(ConnectionString))
+        {
+            Skip.Test("PGNIMBUS_TEST_CONN not set — no Postgres available to test auto-reconnect against.");
+        }
+    }
+
+    private static NpgsqlDataSource CreateDataSource() => NpgsqlDataSource.Create(ConnectionString!);
+
+    // The sanctioned way to simulate a dead pooled connection without
+    // actually pulling a cable or sleeping the machine: kill every backend
+    // for the test database from a separate admin connection (so the admin
+    // query itself isn't one of the backends it kills), then give Postgres a
+    // moment to actually close the sockets — pg_terminate_backend only
+    // *signals* the target backend, it doesn't block until it's gone.
+    private static async Task KillBackendsAsync()
+    {
+        await using var admin = CreateDataSource();
+        await using var connection = await admin.OpenConnectionAsync();
+        await using var command = new NpgsqlCommand(
+            """
+            SELECT pg_terminate_backend(pid)
+              FROM pg_stat_activity
+             WHERE pid <> pg_backend_pid()
+               AND datname = current_database()
+            """,
+            connection);
+        await command.ExecuteNonQueryAsync();
+        await Task.Delay(TimeSpan.FromMilliseconds(200));
+    }
+
+    private static async Task<List<object?[]>> DrainAsync(StatementResult result)
+    {
+        if (result is not ResultSet resultSet)
+        {
+            var detail = result is QueryError error ? $": {error.Message}" : string.Empty;
+            throw new InvalidOperationException($"Expected a ResultSet but got {result.GetType().Name}{detail}");
+        }
+
+        var rows = new List<object?[]>();
+        await foreach (var batch in resultSet.Batches)
+        {
+            rows.AddRange(batch.Rows);
+        }
+
+        return rows;
+    }
+
+    [Test]
+    public async Task SingleDeadPooledConnectionIsTransparentlyReconnected()
+    {
+        SkipIfNoConnection();
+
+        await using var dataSource = CreateDataSource();
+        var engine = new QueryEngine(dataSource);
+
+        // Warm exactly one pooled connection, then kill it out from under the
+        // pool. Without the feature this reproduces the bug verbatim: Npgsql
+        // hands the retry a socket that looks idle but is actually dead, and
+        // the query either throws or hangs instead of streaming a row.
+        await DrainAsync(await engine.ExecuteAsync("SELECT 1", CancellationToken.None));
+        await KillBackendsAsync();
+
+        var result = await engine.ExecuteAsync("SELECT 42", CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<ResultSet>();
+        var rows = await DrainAsync(result);
+
+        await Assert.That(rows).Count().IsEqualTo(1);
+        await Assert.That(rows[0][0]).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task TwoDeadPooledConnectionsAreBothFlushedByTheRetry()
+    {
+        SkipIfNoConnection();
+
+        await using var dataSource = CreateDataSource();
+        var engine = new QueryEngine(dataSource);
+
+        // pg_sleep keeps both connections checked out at the same time, so
+        // the pool ends up holding two distinct idle (and, after the kill,
+        // dead) connections — proof that clearing the whole pool, not just
+        // retrying once on whichever single connection Npgsql happened to
+        // hand back, is what makes the next query succeed.
+        var first = engine.ExecuteAsync("SELECT pg_sleep(0.2), 1", CancellationToken.None);
+        var second = engine.ExecuteAsync("SELECT pg_sleep(0.2), 2", CancellationToken.None);
+
+        await DrainAsync(await first);
+        await DrainAsync(await second);
+
+        await KillBackendsAsync();
+
+        var result = await engine.ExecuteAsync("SELECT 99", CancellationToken.None);
+        var rows = await DrainAsync(result);
+
+        await Assert.That(rows).Count().IsEqualTo(1);
+        await Assert.That(rows[0][0]).IsEqualTo(99);
+    }
+
+    [Test]
+    public async Task TransactionLostOnConnectionDropSurfacesClearErrorAndRecovers()
+    {
+        SkipIfNoConnection();
+
+        await using var dataSource = CreateDataSource();
+        var engine = new QueryEngine(dataSource);
+
+        var stateChanges = 0;
+        engine.TransactionStateChanged += () => Interlocked.Increment(ref stateChanges);
+
+        await engine.BeginTransactionAsync(CancellationToken.None);
+        await KillBackendsAsync();
+
+        var result = await engine.ExecuteAsync("SELECT 1", CancellationToken.None);
+
+        await Assert.That(result).IsTypeOf<QueryError>();
+        var error = (QueryError)result;
+
+        await Assert.That(error.RolledBack).IsTrue();
+        await Assert.That(error.ConnectionLost).IsTrue();
+        await Assert.That(engine.IsInTransaction).IsFalse();
+        // BEGIN fired one change, the loss fired a second.
+        await Assert.That(stateChanges).IsGreaterThanOrEqualTo(2);
+
+        // The engine reconnects on its own for the next statement — no
+        // lingering "stuck" state from the lost transaction.
+        var followUp = await engine.ExecuteAsync("SELECT 1", CancellationToken.None);
+        var rows = await DrainAsync(followUp);
+        await Assert.That(rows).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ScriptRetriesOnlyItsFirstStatementAfterConnectionLoss()
+    {
+        SkipIfNoConnection();
+
+        await using var dataSource = CreateDataSource();
+        var engine = new QueryEngine(dataSource);
+
+        await DrainAsync(await engine.ExecuteAsync("SELECT 1", CancellationToken.None));
+        await KillBackendsAsync();
+
+        var results = new List<StatementResult>();
+        await foreach (var result in engine.ExecuteScriptAsync(["SELECT 1", "SELECT 2"], null, CancellationToken.None))
+        {
+            results.Add(result);
+        }
+
+        await Assert.That(results).Count().IsEqualTo(2);
+        foreach (var result in results)
+        {
+            await Assert.That(result).IsTypeOf<MaterializedResultSet>();
+        }
+    }
+
+    [Test]
+    public async Task ExecuteNonQueryDoesNotThrowAfterConnectionLoss()
+    {
+        SkipIfNoConnection();
+
+        await using var dataSource = CreateDataSource();
+        var engine = new QueryEngine(dataSource);
+
+        await DrainAsync(await engine.ExecuteAsync("SELECT 1", CancellationToken.None));
+        await KillBackendsAsync();
+
+        // Must complete without throwing — the whole point of the retry-once
+        // is that this dead-socket case never reaches the caller as an
+        // exception.
+        await engine.ExecuteNonQueryAsync("SELECT 1", new Dictionary<string, object?>(), CancellationToken.None);
+    }
+
+    [Test]
+    public async Task ApplyBatchRetriesTheWholeBatchAfterConnectionLoss()
+    {
+        SkipIfNoConnection();
+
+        await using (var admin = CreateDataSource())
+        await using (var setup = await admin.OpenConnectionAsync())
+        {
+            await using var createTable = new NpgsqlCommand(
+                $"""CREATE TABLE IF NOT EXISTS {ScratchTable} (id integer PRIMARY KEY, val integer NOT NULL)""",
+                setup);
+            await createTable.ExecuteNonQueryAsync();
+
+            await using var seed = new NpgsqlCommand(
+                $"""INSERT INTO {ScratchTable} (id, val) VALUES (1, 0) ON CONFLICT (id) DO UPDATE SET val = 0""",
+                setup);
+            await seed.ExecuteNonQueryAsync();
+        }
+
+        await using var dataSource = CreateDataSource();
+        var engine = new QueryEngine(dataSource);
+
+        await DrainAsync(await engine.ExecuteAsync("SELECT 1", CancellationToken.None));
+        await KillBackendsAsync();
+
+        var statements = new[]
+        {
+            new ParameterizedStatement(
+                $"""UPDATE {ScratchTable} SET val = val + 1 WHERE id = @id""",
+                new Dictionary<string, object?> { ["id"] = 1 }),
+        };
+
+        var affected = await engine.ApplyBatchAsync(statements, CancellationToken.None);
+
+        await Assert.That(affected).IsEqualTo(1);
+    }
+}

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using System.Diagnostics;
+using System.Net.Sockets;
 using Npgsql;
 using Npgsql.PostgresTypes;
 
@@ -52,20 +53,43 @@ public sealed class QueryEngine
             return;
         }
 
-        var connection = await _dataSource.OpenConnectionAsync(ct);
-        try
+        // Opening the session connection can itself hit a stale pooled socket
+        // (as easily as any other rented connection), so the whole open+BEGIN
+        // is retried once on loss, after flushing the pool, same as the
+        // non-transaction execution paths below.
+        for (var attempt = 0; ; attempt++)
         {
-            await using var command = new NpgsqlCommand("BEGIN", connection);
-            await command.ExecuteNonQueryAsync(ct);
-        }
-        catch
-        {
-            await connection.DisposeAsync();
-            throw;
-        }
+            NpgsqlConnection? connection = null;
+            try
+            {
+                connection = await _dataSource.OpenConnectionAsync(ct);
+                await using var command = new NpgsqlCommand("BEGIN", connection);
+                await command.ExecuteNonQueryAsync(ct);
+            }
+            catch (Exception ex) when (attempt == 0 && IsConnectionLoss(ex))
+            {
+                if (connection is not null)
+                {
+                    await connection.DisposeAsync();
+                }
 
-        _transactionConnection = connection;
-        TransactionStateChanged?.Invoke();
+                ClearPool();
+                continue;
+            }
+            catch
+            {
+                if (connection is not null)
+                {
+                    await connection.DisposeAsync();
+                }
+
+                throw;
+            }
+
+            _transactionConnection = connection;
+            TransactionStateChanged?.Invoke();
+            return;
+        }
     }
 
     /// <summary>Commits the open transaction. A no-op if none is open.</summary>
@@ -104,7 +128,12 @@ public sealed class QueryEngine
     // every further statement errors until the block is rolled back, so rather
     // than strand the user there, undo the whole transaction and release the
     // connection. Best-effort: a rollback that itself fails still clears state.
-    private async Task AutoRollbackAsync()
+    //
+    // connectionLost skips sending the ROLLBACK itself: a dead socket has
+    // nothing listening on the other end, and the server already destroyed the
+    // transaction on its own the moment it dropped the connection, so sending
+    // one would just wait on nothing.
+    private async Task AutoRollbackAsync(bool connectionLost = false)
     {
         var connection = _transactionConnection;
         if (connection is null)
@@ -115,8 +144,11 @@ public sealed class QueryEngine
         _transactionConnection = null;
         try
         {
-            await using var command = new NpgsqlCommand("ROLLBACK", connection);
-            await command.ExecuteNonQueryAsync();
+            if (!connectionLost)
+            {
+                await using var command = new NpgsqlCommand("ROLLBACK", connection);
+                await command.ExecuteNonQueryAsync();
+            }
         }
         catch
         {
@@ -129,6 +161,55 @@ public sealed class QueryEngine
             TransactionStateChanged?.Invoke();
         }
     }
+
+    // The one message shown for every transaction lost to a dropped
+    // connection, wherever it's detected (a statement inside BEGIN…COMMIT, a
+    // script running on the transaction's connection). Deliberately doesn't
+    // repeat the underlying exception text — "the block is gone, reconnect
+    // and start over" is the whole actionable content.
+    private static QueryError TransactionLostError(TimeSpan elapsed) => new()
+    {
+        Elapsed = elapsed,
+        Message = "Connection to the server was lost. The open transaction is gone and nothing in it "
+            + "was committed. The next statement will reconnect automatically.",
+        RolledBack = true,
+        ConnectionLost = true,
+    };
+
+    // After a detected connection loss the pool may still be holding other
+    // dead sockets — every connection that sat idle across the same laptop
+    // sleep or tunnel drop — so a single retry could rent another corpse
+    // instead of a fresh session. Flushing the whole pool makes the retry
+    // deterministic: the next rent is guaranteed to open a new connection.
+    private void ClearPool() => _dataSource.Clear();
+
+    // Classifies a failure as "the server-side connection itself is gone" —
+    // the dead-socket shape a laptop sleep or a dropped SSH tunnel leaves
+    // behind — as opposed to an ordinary statement failure (syntax error,
+    // constraint violation, ...) that happened over a perfectly live
+    // connection. Only losses are safe to silently retry on a fresh
+    // connection; everything else must reach the user as-is.
+    private static bool IsConnectionLoss(Exception ex) => ex switch
+    {
+        OperationCanceledException => false,
+
+        // PostgresException derives from NpgsqlException, so it has to be
+        // matched first, or every ordinary server-side error would fall
+        // through to the NpgsqlException arm below. Class 08 ("connection
+        // exception") plus the two shutdown codes cover both a network-level
+        // drop and the server-announced kind (e.g. pg_terminate_backend on a
+        // pooled idle connection).
+        PostgresException pg => pg.SqlState is { } state &&
+            (state.StartsWith("08", StringComparison.Ordinal) ||
+             state is PostgresErrorCodes.AdminShutdown or PostgresErrorCodes.CrashShutdown),
+
+        // A non-Postgres NpgsqlException wrapping a socket-level failure — the
+        // shape a dead pooled connection takes after the peer vanished without
+        // a clean close, discovered only once a command tries to use it.
+        NpgsqlException { InnerException: IOException or SocketException or EndOfStreamException or TimeoutException } => true,
+
+        _ => false,
+    };
 
     /// <summary>
     /// Executes a parameterized statement that returns no rows (used for
@@ -152,6 +233,14 @@ public sealed class QueryEngine
             {
                 await txCommand.ExecuteNonQueryAsync(ct);
             }
+            catch (Exception ex) when (IsConnectionLoss(ex))
+            {
+                // No live socket to send ROLLBACK down — the server already
+                // destroyed the transaction itself when it dropped the
+                // connection.
+                await AutoRollbackAsync(connectionLost: true);
+                throw;
+            }
             catch (PostgresException)
             {
                 await AutoRollbackAsync();
@@ -161,15 +250,33 @@ public sealed class QueryEngine
             return;
         }
 
-        await using var connection = await _dataSource.OpenConnectionAsync(ct);
-        await using var command = new NpgsqlCommand(sql, connection);
-
-        foreach (var (name, value) in parameters)
+        // A dead socket from a stale pooled connection almost always fails on
+        // send, before the server ever saw the statement, so retrying once on
+        // a fresh connection (after flushing the pool) is safe for the common
+        // case. The residual risk — the server executed it but the
+        // acknowledgement never made it back — is accepted: callers of this
+        // method are PK-keyed UPDATE/DELETE grid edits, where a duplicate
+        // re-run is a no-op rather than a double-apply.
+        for (var attempt = 0; ; attempt++)
         {
-            command.Parameters.AddWithValue(name, value ?? DBNull.Value);
-        }
+            try
+            {
+                await using var connection = await _dataSource.OpenConnectionAsync(ct);
+                await using var command = new NpgsqlCommand(sql, connection);
 
-        await command.ExecuteNonQueryAsync(ct);
+                foreach (var (name, value) in parameters)
+                {
+                    command.Parameters.AddWithValue(name, value ?? DBNull.Value);
+                }
+
+                await command.ExecuteNonQueryAsync(ct);
+                return;
+            }
+            catch (Exception ex) when (attempt == 0 && IsConnectionLoss(ex))
+            {
+                ClearPool();
+            }
+        }
     }
 
     /// <summary>
@@ -194,6 +301,14 @@ public sealed class QueryEngine
                 {
                     affected += await txCommand.ExecuteNonQueryAsync(ct);
                 }
+                catch (Exception ex) when (IsConnectionLoss(ex))
+                {
+                    // No live socket to send ROLLBACK down — the server already
+                    // destroyed the transaction itself when it dropped the
+                    // connection.
+                    await AutoRollbackAsync(connectionLost: true);
+                    throw;
+                }
                 catch (PostgresException)
                 {
                     await AutoRollbackAsync();
@@ -204,20 +319,62 @@ public sealed class QueryEngine
             return affected;
         }
 
-        await using var connection = await _dataSource.OpenConnectionAsync(ct);
-        // Disposing an uncommitted NpgsqlTransaction rolls it back, so any
-        // failure below undoes every statement already executed.
-        await using var batchTransaction = await connection.BeginTransactionAsync(ct);
-
-        var total = 0;
-        foreach (var statement in statements)
+        // Retried once, whole batch, on a fresh connection after flushing the
+        // pool — but only while `committing` is still false. Once CommitAsync
+        // has been attempted, a loss no longer means "nothing happened": the
+        // commit may have landed server-side before the acknowledgement was
+        // lost, so re-running every statement could double-apply. That case
+        // isn't retried; it surfaces as-is.
+        for (var attempt = 0; ; attempt++)
         {
-            await using var command = CreateCommand(statement, connection, batchTransaction);
-            total += await command.ExecuteNonQueryAsync(ct);
-        }
+            NpgsqlConnection? connection = null;
+            NpgsqlTransaction? batchTransaction = null;
+            var committing = false;
+            try
+            {
+                connection = await _dataSource.OpenConnectionAsync(ct);
+                // Disposing an uncommitted NpgsqlTransaction rolls it back, so
+                // any failure below undoes every statement already executed.
+                batchTransaction = await connection.BeginTransactionAsync(ct);
 
-        await batchTransaction.CommitAsync(ct);
-        return total;
+                var total = 0;
+                foreach (var statement in statements)
+                {
+                    await using var command = CreateCommand(statement, connection, batchTransaction);
+                    total += await command.ExecuteNonQueryAsync(ct);
+                }
+
+                committing = true;
+                await batchTransaction.CommitAsync(ct);
+                return total;
+            }
+            catch (Exception ex) when (attempt == 0 && !committing && IsConnectionLoss(ex))
+            {
+                ClearPool();
+            }
+            finally
+            {
+                if (batchTransaction is not null)
+                {
+                    try
+                    {
+                        await batchTransaction.DisposeAsync();
+                    }
+                    catch
+                    {
+                        // The connection is exactly as likely to be dead as the
+                        // condition this whole method is handling — a rollback
+                        // failure here must not replace whichever exception is
+                        // already propagating out of the try block above.
+                    }
+                }
+
+                if (connection is not null)
+                {
+                    await connection.DisposeAsync();
+                }
+            }
+        }
     }
 
     private static NpgsqlCommand CreateCommand(ParameterizedStatement statement, NpgsqlConnection connection, NpgsqlTransaction? transaction)
@@ -261,81 +418,117 @@ public sealed class QueryEngine
 
         var stopwatch = Stopwatch.StartNew();
 
-        NpgsqlConnection? connection = null;
-        NpgsqlCommand? command = null;
-        NpgsqlDataReader? reader = null;
-
-        try
+        // Retried once, on a fresh connection after flushing the pool, but
+        // only for the initial phase — open, ExecuteReader, column setup.
+        // Once a ResultSet with its streaming Batches enumerable has been
+        // returned, rows may already be in the caller's hands; a failure
+        // inside StreamBatches itself is a different, untouched code path
+        // that never retries.
+        for (var attempt = 0; ; attempt++)
         {
-            connection = await _dataSource.OpenConnectionAsync(ct);
-            command = new NpgsqlCommand(sql, connection);
-            reader = await command.ExecuteReaderAsync(CommandBehavior.Default, ct);
+            NpgsqlConnection? connection = null;
+            NpgsqlCommand? command = null;
+            NpgsqlDataReader? reader = null;
 
-            if (reader.FieldCount == 0)
+            try
             {
-                var rowsAffected = reader.RecordsAffected;
-                var tag = BuildCommandTag(sql);
-
-                await reader.DisposeAsync();
-                await command.DisposeAsync();
-                await connection.DisposeAsync();
-
-                return new CommandResult
-                {
-                    Elapsed = stopwatch.Elapsed,
-                    RowsAffected = rowsAffected < 0 ? 0 : rowsAffected,
-                    CommandTag = tag,
-                };
-            }
-
-            // Columns Npgsql can't materialize as objects (unmapped composites
-            // and containers of them) are re-requested in text format — one
-            // extra round trip, and only for result sets that contain such a
-            // column. The re-execution is why callers must opt in: it would
-            // run an arbitrary statement's side effects twice.
-            if (allowTextFallback && BuildTextFallbackMask(reader) is { } textFallback)
-            {
-                await reader.DisposeAsync();
-                command.UnknownResultTypeList = textFallback;
+                connection = await _dataSource.OpenConnectionAsync(ct);
+                command = new NpgsqlCommand(sql, connection);
                 reader = await command.ExecuteReaderAsync(CommandBehavior.Default, ct);
-            }
 
-            var columns = BuildColumns(reader);
+                if (reader.FieldCount == 0)
+                {
+                    var rowsAffected = reader.RecordsAffected;
+                    var tag = BuildCommandTag(sql);
 
-            // Ownership of connection/command/reader passes to the streaming
-            // enumerable below; it disposes them once enumeration ends.
-            return new ResultSet
-            {
-                Elapsed = stopwatch.Elapsed,
-                Columns = columns,
-                Batches = StreamBatches(connection, command, reader, maxRows, ct),
-            };
-        }
-        catch (Exception ex)
-        {
-            if (reader is not null) await reader.DisposeAsync();
-            if (command is not null) await command.DisposeAsync();
-            if (connection is not null) await connection.DisposeAsync();
+                    await reader.DisposeAsync();
+                    await command.DisposeAsync();
+                    await connection.DisposeAsync();
 
-            if (ex is OperationCanceledException)
-            {
-                throw;
-            }
+                    return new CommandResult
+                    {
+                        Elapsed = stopwatch.Elapsed,
+                        RowsAffected = rowsAffected < 0 ? 0 : rowsAffected,
+                        CommandTag = tag,
+                    };
+                }
 
-            if (ex is PostgresException pg)
-            {
-                return new QueryError
+                // Columns Npgsql can't materialize as objects (unmapped composites
+                // and containers of them) are re-requested in text format — one
+                // extra round trip, and only for result sets that contain such a
+                // column. The re-execution is why callers must opt in: it would
+                // run an arbitrary statement's side effects twice.
+                if (allowTextFallback && BuildTextFallbackMask(reader) is { } textFallback)
+                {
+                    await reader.DisposeAsync();
+                    command.UnknownResultTypeList = textFallback;
+                    reader = await command.ExecuteReaderAsync(CommandBehavior.Default, ct);
+                }
+
+                var columns = BuildColumns(reader);
+
+                // Ownership of connection/command/reader passes to the streaming
+                // enumerable below; it disposes them once enumeration ends.
+                return new ResultSet
                 {
                     Elapsed = stopwatch.Elapsed,
-                    Message = pg.MessageText,
-                    SqlState = pg.SqlState,
-                    Detail = pg.Detail,
-                    Hint = pg.Hint,
-                    Position = ParsePosition(pg.Position),
+                    Columns = columns,
+                    Batches = StreamBatches(connection, command, reader, maxRows, ct),
                 };
             }
+            catch (Exception ex)
+            {
+                try
+                {
+                    if (reader is not null) await reader.DisposeAsync();
+                    if (command is not null) await command.DisposeAsync();
+                    if (connection is not null) await connection.DisposeAsync();
+                }
+                catch
+                {
+                    // The connection is already faulted (that's exactly the
+                    // condition this catch is handling in the loss case); a
+                    // cleanup failure here must not replace the exception
+                    // that's actually being classified and reported below.
+                }
 
-            return new QueryError { Elapsed = stopwatch.Elapsed, Message = ex.Message };
+                if (ex is OperationCanceledException)
+                {
+                    throw;
+                }
+
+                var isLoss = IsConnectionLoss(ex);
+                if (attempt == 0 && isLoss)
+                {
+                    ClearPool();
+                    continue;
+                }
+
+                if (isLoss)
+                {
+                    return new QueryError
+                    {
+                        Elapsed = stopwatch.Elapsed,
+                        Message = $"Connection to the server was lost and could not be re-established: {ex.Message}",
+                        ConnectionLost = true,
+                    };
+                }
+
+                if (ex is PostgresException pg)
+                {
+                    return new QueryError
+                    {
+                        Elapsed = stopwatch.Elapsed,
+                        Message = pg.MessageText,
+                        SqlState = pg.SqlState,
+                        Detail = pg.Detail,
+                        Hint = pg.Hint,
+                        Position = ParsePosition(pg.Position),
+                    };
+                }
+
+                return new QueryError { Elapsed = stopwatch.Elapsed, Message = ex.Message };
+            }
         }
     }
 
@@ -370,20 +563,39 @@ public sealed class QueryEngine
 
         try
         {
-            foreach (var statement in statements)
+            for (var i = 0; i < statements.Count; i++)
             {
                 ct.ThrowIfCancellationRequested();
 
+                var statement = statements[i];
                 var result = await ExecuteOnConnectionAsync(connection, statement, maxRowsPerStatement, allowTextFallback: false, ct);
+
+                // A connection loss on the very first statement means nothing in
+                // the script has run yet — no session state (SET, temp tables)
+                // exists to lose — so it's safe to reconnect and retry just that
+                // one statement on a fresh connection. Any later statement is
+                // left as-is: a quiet mid-script reconnect there would silently
+                // drop whatever session state the earlier statements built up,
+                // which is worse than surfacing the error.
+                if (!inTransaction && i == 0 && result is QueryError { ConnectionLost: true })
+                {
+                    await connection.DisposeAsync();
+                    ClearPool();
+                    connection = await _dataSource.OpenConnectionAsync(ct);
+                    result = await ExecuteOnConnectionAsync(connection, statement, maxRowsPerStatement, allowTextFallback: false, ct);
+                }
 
                 if (result is QueryError error)
                 {
                     // A failed statement aborts the transaction; undo it and flag
-                    // the rollback so the last section can say so.
+                    // the rollback so the last section can say so. A connection
+                    // loss is more final than an ordinary failure — there's no
+                    // live socket for ROLLBACK, and the block is gone rather than
+                    // recoverable.
                     if (inTransaction)
                     {
-                        await AutoRollbackAsync();
-                        yield return error with { RolledBack = true };
+                        await AutoRollbackAsync(connectionLost: error.ConnectionLost);
+                        yield return error.ConnectionLost ? TransactionLostError(error.Elapsed) : error with { RolledBack = true };
                     }
                     else
                     {
@@ -433,14 +645,25 @@ public sealed class QueryEngine
         }
         catch (Exception ex)
         {
-            await AutoRollbackAsync();
-            return new QueryError { Elapsed = stopwatch.Elapsed, Message = ex.Message, RolledBack = true };
+            // A connection loss here has no live socket to send ROLLBACK down —
+            // the server already destroyed the transaction itself — so the
+            // whole block, not just this statement, is gone. That's a
+            // different, more final outcome than an ordinary in-transaction
+            // failure (which stays recoverable via the auto-rollback below,
+            // since the connection itself is still fine).
+            var lost = IsConnectionLoss(ex);
+            await AutoRollbackAsync(connectionLost: lost);
+            return lost
+                ? TransactionLostError(stopwatch.Elapsed)
+                : new QueryError { Elapsed = stopwatch.Elapsed, Message = ex.Message, RolledBack = true };
         }
 
         if (result is QueryError error)
         {
-            await AutoRollbackAsync();
-            return error with { RolledBack = true };
+            await AutoRollbackAsync(connectionLost: error.ConnectionLost);
+            return error.ConnectionLost
+                ? TransactionLostError(error.Elapsed)
+                : error with { RolledBack = true };
         }
 
         return result;
@@ -529,6 +752,7 @@ public sealed class QueryEngine
                 Detail = pg.Detail,
                 Hint = pg.Hint,
                 Position = ParsePosition(pg.Position),
+                ConnectionLost = IsConnectionLoss(pg),
             };
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -537,7 +761,11 @@ public sealed class QueryEngine
             // the shared-connection script/transaction paths turn any statement
             // failure into a QueryError rather than letting it escape and crash
             // the app. Cancellation still propagates so it reads as "Cancelled".
-            return new QueryError { Elapsed = stopwatch.Elapsed, Message = ex.Message };
+            // ConnectionLost is set here — not just left to the caller to
+            // re-derive — because it's the one signal ExecuteScriptAsync and
+            // ExecuteInTransactionAsync need to tell "the connection is gone"
+            // apart from "this statement failed".
+            return new QueryError { Elapsed = stopwatch.Elapsed, Message = ex.Message, ConnectionLost = IsConnectionLoss(ex) };
         }
         finally
         {

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -206,7 +206,12 @@ public sealed class QueryEngine
         // A non-Postgres NpgsqlException wrapping a socket-level failure — the
         // shape a dead pooled connection takes after the peer vanished without
         // a clean close, discovered only once a command tries to use it.
-        NpgsqlException { InnerException: IOException or SocketException or EndOfStreamException or TimeoutException } => true,
+        // TimeoutException is deliberately NOT here: Npgsql also wraps command
+        // timeouts (a merely slow query, possibly a write still executing
+        // server-side) and pool exhaustion in it, and silently re-running
+        // those would double-apply work and pile load onto an already
+        // struggling server.
+        NpgsqlException { InnerException: IOException or SocketException or EndOfStreamException } => true,
 
         _ => false,
     };
@@ -504,6 +509,27 @@ public sealed class QueryEngine
                     continue;
                 }
 
+                // A loss can also arrive as a PostgresException (admin/crash
+                // shutdown), so the PostgresException arm comes first: it
+                // keeps the SqlState/Detail/Hint diagnostics either way and
+                // just flags/prefixes the loss instead of flattening it into
+                // a detail-free message.
+                if (ex is PostgresException pg)
+                {
+                    return new QueryError
+                    {
+                        Elapsed = stopwatch.Elapsed,
+                        Message = isLoss
+                            ? $"Connection to the server was lost and could not be re-established: {pg.MessageText}"
+                            : pg.MessageText,
+                        SqlState = pg.SqlState,
+                        Detail = pg.Detail,
+                        Hint = pg.Hint,
+                        Position = ParsePosition(pg.Position),
+                        ConnectionLost = isLoss,
+                    };
+                }
+
                 if (isLoss)
                 {
                     return new QueryError
@@ -511,19 +537,6 @@ public sealed class QueryEngine
                         Elapsed = stopwatch.Elapsed,
                         Message = $"Connection to the server was lost and could not be re-established: {ex.Message}",
                         ConnectionLost = true,
-                    };
-                }
-
-                if (ex is PostgresException pg)
-                {
-                    return new QueryError
-                    {
-                        Elapsed = stopwatch.Elapsed,
-                        Message = pg.MessageText,
-                        SqlState = pg.SqlState,
-                        Detail = pg.Detail,
-                        Hint = pg.Hint,
-                        Position = ParsePosition(pg.Position),
                     };
                 }
 
@@ -577,11 +590,36 @@ public sealed class QueryEngine
                 // left as-is: a quiet mid-script reconnect there would silently
                 // drop whatever session state the earlier statements built up,
                 // which is worse than surfacing the error.
-                if (!inTransaction && i == 0 && result is QueryError { ConnectionLost: true })
+                if (!inTransaction && i == 0 && result is QueryError { ConnectionLost: true } firstLoss)
                 {
                     await connection.DisposeAsync();
                     ClearPool();
-                    connection = await _dataSource.OpenConnectionAsync(ct);
+
+                    // The reconnect open can itself fail (server fully down);
+                    // that must become a yielded QueryError like every other
+                    // script failure, not an exception escaping the enumerable.
+                    // yield isn't legal inside a catch, hence the local.
+                    QueryError? reconnectFailure = null;
+                    try
+                    {
+                        connection = await _dataSource.OpenConnectionAsync(ct);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        reconnectFailure = new QueryError
+                        {
+                            Elapsed = firstLoss.Elapsed,
+                            Message = $"Connection to the server was lost and could not be re-established: {ex.Message}",
+                            ConnectionLost = true,
+                        };
+                    }
+
+                    if (reconnectFailure is not null)
+                    {
+                        yield return reconnectFailure;
+                        yield break;
+                    }
+
                     result = await ExecuteOnConnectionAsync(connection, statement, maxRowsPerStatement, allowTextFallback: false, ct);
                 }
 

--- a/PgNimbus.Core/Query/QueryResult.cs
+++ b/PgNimbus.Core/Query/QueryResult.cs
@@ -61,4 +61,14 @@ public sealed record QueryError : StatementResult
     /// engine auto-rolled it back — the block is gone, so the UI can say so.
     /// </summary>
     public bool RolledBack { get; init; }
+
+    /// <summary>
+    /// True when this failure is the server-side connection itself going away
+    /// (dead socket after a laptop sleep, a dropped SSH tunnel, or the server
+    /// terminating the backend) rather than an ordinary statement failure. The
+    /// engine already retried once on a fresh connection before surfacing
+    /// this — a second loss means the caller should treat the connection (and,
+    /// if one was open, the transaction on it) as gone rather than retry again.
+    /// </summary>
+    public bool ConnectionLost { get; init; }
 }

--- a/README.md
+++ b/README.md
@@ -604,10 +604,12 @@ Everything below is what survives that filter, roughly in impact order:
   the held transaction connection: an open transaction can't be silently
   re-established, so that path surfaces a clear "transaction lost" state.
   Shipped: `QueryEngine` classifies a failure as connection loss (Postgres
-  class-08 `SqlState`s, an admin/crash shutdown, or a socket/IO/timeout
-  exception under the hood) versus an ordinary statement error, and on loss
-  flushes the whole connection pool — not just the one dead socket — before
-  silently retrying once on a fresh connection. Runs, single-row edits, and
+  class-08 `SqlState`s, an admin/crash shutdown, or a socket/IO exception
+  under the hood — deliberately not a command timeout, where the statement
+  may still be executing server-side) versus an ordinary statement error,
+  and on loss flushes the whole connection pool — not just the one dead
+  socket — before silently retrying once on a fresh connection. Runs,
+  single-row edits, and
   safe-mode batches (retried only if the loss happened before `COMMIT` was
   attempted) all get this; a multi-statement script retries only its first
   statement, since a mid-script reconnect can't resurrect `SET`s or temp

--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ Every tag push (`vX.Y.Z`) builds all of the above via
 - **Streaming, cancellable results** — the first screenful renders before the
   full result set arrives, backed by a virtualized grid with inline cell
   editing and CSV/JSON export.
+- **Auto-reconnect** — a connection dropped by a laptop sleep or an SSH-tunnel
+  hiccup quietly reopens on the next run instead of throwing a broken-pipe
+  error, with the whole pool flushed first so no other stale socket gets
+  rented next. An open explicit transaction is the one exception: it can't be
+  silently re-established, so that surfaces a clear "connection lost, nothing
+  committed" state instead.
 - **Grid CRUD** — beyond inline cell edits: an "Add row" dialog (each column
   cast to its real type server-side, blanks fall back to defaults),
   "Delete selected row(s)" with a confirmation, and "Set cell to NULL" (the
@@ -592,11 +598,25 @@ Everything below is what survives that filter, roughly in impact order:
   The ⇄ switch still replaces in place (unchanged); the app exits when the
   *last* window closes, whichever that is, and accent colors keep the
   windows visually apart on the taskbar/Alt+Tab.
-- [ ] **Auto-reconnect** — after laptop sleep or an SSH-tunnel drop, the next
+- [x] **Auto-reconnect** — after laptop sleep or an SSH-tunnel drop, the next
   run should quietly reopen the connection instead of surfacing a broken-pipe
   error (or hanging — an HN complaint about other clients). Needs care with
   the held transaction connection: an open transaction can't be silently
   re-established, so that path surfaces a clear "transaction lost" state.
+  Shipped: `QueryEngine` classifies a failure as connection loss (Postgres
+  class-08 `SqlState`s, an admin/crash shutdown, or a socket/IO/timeout
+  exception under the hood) versus an ordinary statement error, and on loss
+  flushes the whole connection pool — not just the one dead socket — before
+  silently retrying once on a fresh connection. Runs, single-row edits, and
+  safe-mode batches (retried only if the loss happened before `COMMIT` was
+  attempted) all get this; a multi-statement script retries only its first
+  statement, since a mid-script reconnect can't resurrect `SET`s or temp
+  tables the earlier statements built up. The one path that never retries is
+  an explicit transaction: there's no live socket left to send `ROLLBACK`
+  down, so the engine tears down its client-side state instead and returns a
+  `QueryError` that plainly says the connection (and the transaction on it)
+  is gone and nothing from it was committed — the next statement reconnects
+  on its own.
 - [x] **Postgres-native value editing** — the grid and Add-row dialog treat
   every column as text today. Make the editors type-aware: `enum` columns get
   a dropdown of `pg_enum` labels, `boolean` a checkbox, `date/timestamp` a


### PR DESCRIPTION
Ships the **Auto-reconnect** backlog item (top unchecked entry in the impact-ordered "Next" list): after a laptop sleep or an SSH-tunnel drop, the next run quietly reopens the connection instead of surfacing a broken-pipe error — and the held-transaction path surfaces a clear "transaction lost" state instead of a raw socket error.

## What changed

**`PgNimbus.Core/Query/QueryEngine.cs`**
- New connection-loss classifier: Postgres class-08 `SQLSTATE`s or `57P01`/`57P02` (admin/crash shutdown — the shape a killed backend takes), or an `NpgsqlException` wrapping a socket/IO/timeout failure. Ordinary statement errors (syntax, constraints) are never classified as loss.
- On loss, the whole pool is flushed (`NpgsqlDataSource.Clear()`) before a single retry on a fresh connection — after a sleep *every* idle pooled socket is dead, so retrying without the flush could just rent the next corpse.
- Retry-once applies to: `ExecuteAsync`'s initial phase (never mid-stream — rows may already be in the caller's hands), non-transaction `ExecuteNonQueryAsync` (grid edits), `ApplyBatchAsync` (only while nothing was committed; a loss during `COMMIT` is ambiguous and surfaces as-is), a script's **first** statement only (a mid-script reconnect would silently drop `SET`s/temp tables), and `BeginTransactionAsync`.
- The explicit transaction is the deliberate exception: it can't be silently re-established. A loss clears the engine's transaction state **without** sending `ROLLBACK` down the dead socket, fires `TransactionStateChanged` (so the App's indicator syncs), and returns a `QueryError` stating the block is gone and nothing from it was committed.

**`PgNimbus.Core/Query/QueryResult.cs`** — new `QueryError.ConnectionLost` flag so callers (and the script path internally) can tell "the connection is gone" apart from "this statement failed".

**Tests** — `QueryEngineReconnectTests.cs`: six integration tests that kill real backends via `pg_terminate_backend` and assert recovery (single dead socket, two concurrently-warmed dead sockets proving the pool flush, transaction-lost + follow-up recovery, script first-statement retry, non-query edit, batch apply). Gated on `PGNIMBUS_TEST_CONN` (skip cleanly when unset) and serialized with `[NotInParallel]` since they kill the database's backends.

**CI** — `ci.yml` gains a `postgres:17` service container and sets `PGNIMBUS_TEST_CONN`, so the new tests actually run on every PR.

**Docs** — README feature bullet + backlog item flipped to shipped with the usual "Shipped:" note; CLAUDE.md hard rule 2 documents the auto-reconnect contract.

## Verification

- `dotnet build -c Debug` / `-c Release`: clean, 0 warnings.
- `dotnet test` with live Postgres 16: **347/347 passed** (all 6 new tests exercised for real).
- `dotnet test` without a database: 341 passed, 6 skipped cleanly.

## Not in scope (follow-ups)

- Re-establishing a dropped **SSH tunnel** itself (App-owned `SshTunnel`); a loss through a dead tunnel now fails with the clear could-not-re-establish message instead of a raw broken pipe.
- `SchemaService`/refresh paths — the pool flush from a failed run already heals subsequent operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9vEZzGKuMpdgKNyu1CJVu

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9vEZzGKuMpdgKNyu1CJVu)_