### PR TITLE
Inline editing for hand-typed queries, not just browse mode

### DIFF
--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -176,6 +176,7 @@
         <!-- Completion popup kind glyphs: tag / table-column / layers-triple / link-variant (MDI).
              The other kinds reuse the shared icons above (table, database, function, swap);
              CompletionKindVisuals maps kind → resource key + fixed color. -->
+        <StreamGeometry x:Key="LockIconGeometry">M12,17A2,2 0 0,0 14,15C14,13.89 13.1,13 12,13A2,2 0 0,0 10,15A2,2 0 0,0 12,17M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V10C4,8.89 4.9,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z</StreamGeometry>
         <StreamGeometry x:Key="TagIconGeometry">M5.5,7A1.5,1.5 0 0,1 4,5.5A1.5,1.5 0 0,1 5.5,4A1.5,1.5 0 0,1 7,5.5A1.5,1.5 0 0,1 5.5,7M21.41,11.58L12.41,2.58C12.05,2.22 11.55,2 11,2H4C2.89,2 2,2.89 2,4V11C2,11.55 2.22,12.05 2.59,12.41L11.58,21.41C11.95,21.77 12.45,22 13,22C13.55,22 14.05,21.77 14.41,21.41L21.41,14.41C21.78,14.05 22,13.55 22,13C22,12.44 21.77,11.94 21.41,11.58Z</StreamGeometry>
         <StreamGeometry x:Key="TableColumnIconGeometry">M10,10.02H15V21H10V10.02M17,21H20C21.1,21 22,20.1 22,19V10H17V21M20,3H5C3.9,3 3,3.9 3,5V8H22V5C22,3.9 21.1,3 20,3M3,19C3,20.1 3.9,21 5,21H8V10H3V19Z</StreamGeometry>
         <StreamGeometry x:Key="LayersIconGeometry">M12,16L19.36,10.27L21,9L12,2L3,9L4.63,10.27M12,18.54L4.62,12.81L3,14.07L12,21.07L21,14.07L19.37,12.8L12,18.54Z</StreamGeometry>

--- a/PgNimbus.App/ViewModels/EditableTableContext.cs
+++ b/PgNimbus.App/ViewModels/EditableTableContext.cs
@@ -4,9 +4,12 @@ namespace PgNimbus.App.ViewModels;
 
 /// <summary>
 /// Tracks the single table a result set maps to, so inline cell edits can be
-/// turned into targeted UPDATE statements. Cleared whenever the SQL text
-/// changes, so edits are only ever attempted against the exact query that
-/// produced this context (see <see cref="QueryViewModel"/>).
+/// turned into targeted UPDATE statements. Established two ways: browse mode
+/// knows its table up front, and a hand-typed query gets one after the run
+/// when the wire metadata maps every column onto one table (see
+/// <see cref="QueryViewModel"/>). Cleared whenever the SQL text changes or a
+/// new run starts, so edits are only ever attempted against the exact query
+/// that produced this context.
 /// <see cref="Columns"/> carries the table's per-column type metadata — it
 /// drives the grid's type-aware cell editors (enum dropdown, checkbox, date
 /// picker) and tells the UPDATE which columns need their text parsed

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -445,7 +445,7 @@ public sealed partial class MainViewModel : ObservableObject
     // Creates a query tab, wires its history hook, and makes it active.
     private QueryViewModel NewTab()
     {
-        var tab = new QueryViewModel(_engine, _explainService, GetReconcilerAsync, () => SafeModeEdits) { DefaultTitle = $"Query {Tabs.Count + 1}" };
+        var tab = new QueryViewModel(_engine, _explainService, GetReconcilerAsync, () => SafeModeEdits, _schemaService) { DefaultTitle = $"Query {Tabs.Count + 1}" };
         tab.Executed += SavedQueries.RecordExecution;
         Tabs.Add(tab);
         ActiveTab = tab;

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -251,16 +251,23 @@ public sealed partial class QueryViewModel : ObservableObject
     // every tab follows the one app-wide toggle without per-tab plumbing.
     private readonly Func<bool>? _safeMode;
 
+    // Resolves a result set's source-table metadata after a run, so hand-typed
+    // SELECTs get inline editing too (see TryEnableEditingForQueryAsync). Null
+    // in contexts that don't wire it up — editing then only exists in browse mode.
+    private readonly SchemaService? _schemaService;
+
     public QueryViewModel(
         QueryEngine engine,
         ExplainService explainService,
         Func<CancellationToken, Task<IdentifierReconciler?>>? reconcilerFactory = null,
-        Func<bool>? safeMode = null)
+        Func<bool>? safeMode = null,
+        SchemaService? schemaService = null)
     {
         _engine = engine;
         _explainService = explainService;
         _reconcilerFactory = reconcilerFactory;
         _safeMode = safeMode;
+        _schemaService = schemaService;
         _lastRunSql = Sql;
         UpdateTabTitle();
     }
@@ -326,6 +333,13 @@ public sealed partial class QueryViewModel : ObservableObject
         SelectedSection = null;
         ResultSections.Clear();
         NotifyScriptResultChanged();
+
+        // The incoming result replaces the grid, so any edit mapping from the
+        // previous result is stale (a selection/caret-statement run reaches here
+        // with Sql untouched, so OnSqlChanged alone doesn't cover this). The
+        // single-statement path re-establishes it below when the new result maps
+        // onto a table; browse re-establishes it itself after the page loads.
+        EditContext = null;
 
         var stopwatch = Stopwatch.StartNew();
 
@@ -488,6 +502,15 @@ public sealed partial class QueryViewModel : ObservableObject
                     HasError = true;
                     await TryOfferFixAsync(executedSql);
                     break;
+            }
+
+            // A hand-typed statement whose columns map cleanly onto one table
+            // gets the same inline editing browse mode has. Browse pages skip
+            // this — RunBrowseSqlAsync re-establishes their context itself, from
+            // metadata it already holds.
+            if (result is ResultSet or MaterializedResultSet && Browse is null)
+            {
+                await TryEnableEditingForQueryAsync(ct);
             }
 
             Executed?.Invoke(new QueryHistoryEntry(executedSql, DateTimeOffset.UtcNow, stopwatch.Elapsed.TotalMilliseconds, StatusSummary()));
@@ -898,6 +921,42 @@ public sealed partial class QueryViewModel : ObservableObject
     private static partial Regex TableReferenceRegex();
 
     partial void OnEditContextChanged(EditableTableContext? value) => OnPropertyChanged(nameof(IsEditable));
+
+    /// <summary>
+    /// Establishes the edit context for a hand-typed query when its result maps
+    /// cleanly onto one table: the wire metadata says every column reads a real
+    /// attribute of the same table under its real name (no expressions, aliases,
+    /// or joins mixing tables) and the full primary key is among the columns.
+    /// One catalog lookup after the rows have already rendered; best-effort —
+    /// any failure just leaves the grid read-only, exactly as before.
+    /// </summary>
+    private async Task TryEnableEditingForQueryAsync(CancellationToken ct)
+    {
+        if (_schemaService is null || EditableResultDetector.SingleSourceTableOid(_columns) is not { } tableOid)
+        {
+            return;
+        }
+
+        try
+        {
+            if (await _schemaService.GetEditableTableByOidAsync(tableOid, ct) is not { } table)
+            {
+                return;
+            }
+
+            var tableColumns = await _schemaService.GetColumnsAsync(table.Schema, table.Name, ct);
+            if (EditableResultDetector.MatchPrimaryKey(_columns, tableColumns) is { } primaryKey)
+            {
+                EditContext = new EditableTableContext(table.Schema, table.Name, primaryKey, tableColumns);
+            }
+        }
+        catch
+        {
+            // Includes cancellation: the query itself already completed and its
+            // rows are on screen, so a failed/cancelled catalog lookup must not
+            // repaint the run as failed — editing simply stays off.
+        }
+    }
 
     /// <summary>
     /// Commits an inline grid edit (the raw text typed into the cell editor)

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -81,6 +81,16 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private EditableTableContext? _editContext;
 
+    /// <summary>
+    /// Why the current result set is read-only, phrased for the status bar's
+    /// tooltip ("Results are read-only: …"). Null when the grid is editable,
+    /// when there's no grid to edit (errors, command results), or while a run
+    /// is in flight — so the status-bar segment only appears when a user could
+    /// reasonably expect to edit and can't.
+    /// </summary>
+    [ObservableProperty]
+    private string? _readOnlyHint;
+
     /// <summary>Non-null when this tab is in no-SQL "browse a table" mode (status-bar paging shown, header clicks sort server-side).</summary>
     [ObservableProperty]
     private TableBrowseViewModel? _browse;
@@ -340,6 +350,7 @@ public sealed partial class QueryViewModel : ObservableObject
         // single-statement path re-establishes it below when the new result maps
         // onto a table; browse re-establishes it itself after the page loads.
         EditContext = null;
+        ReadOnlyHint = null;
 
         var stopwatch = Stopwatch.StartNew();
 
@@ -652,6 +663,13 @@ public sealed partial class QueryViewModel : ObservableObject
         RowCountText = value.RowCountText;
         TimingText = value.TimingText;
         CapText = value.CapText;
+
+        // Script sections never get an edit context (statements share one
+        // session; results are materialized snapshots) — say so, but only for
+        // sections that actually show a grid someone might try to edit.
+        ReadOnlyHint = value.Columns.Count > 0
+            ? "multi-statement scripts run read-only — run the statement on its own to edit."
+            : null;
     }
 
     private void NotifyScriptResultChanged()
@@ -889,6 +907,13 @@ public sealed partial class QueryViewModel : ObservableObject
         {
             EditContext = new EditableTableContext(browse.Schema, browse.Name, pk, _browseColumns);
         }
+        else if (Browse is { } pkless)
+        {
+            // Browsing a view or a table without a primary key: rows show fine
+            // but can't be targeted for edits — say so instead of silently
+            // ignoring edit gestures.
+            ReadOnlyHint = $"{pkless.Schema}.{pkless.Name} has no primary key, so rows can't be targeted exactly.";
+        }
 
         return Rows.Count;
     }
@@ -928,12 +953,20 @@ public sealed partial class QueryViewModel : ObservableObject
     /// attribute of the same table under its real name (no expressions, aliases,
     /// or joins mixing tables) and the full primary key is among the columns.
     /// One catalog lookup after the rows have already rendered; best-effort —
-    /// any failure just leaves the grid read-only, exactly as before.
+    /// any failure just leaves the grid read-only. A disqualified result gets a
+    /// <see cref="ReadOnlyHint"/> instead, so the status bar can say *why*
+    /// instead of the grid silently ignoring edit gestures.
     /// </summary>
     private async Task TryEnableEditingForQueryAsync(CancellationToken ct)
     {
-        if (_schemaService is null || EditableResultDetector.SingleSourceTableOid(_columns) is not { } tableOid)
+        if (_schemaService is null)
         {
+            return;
+        }
+
+        if (EditableResultDetector.CheckSingleTable(_columns, out var tableOid) is not EditBlocker.None and var columnsBlocker)
+        {
+            ReadOnlyHint = ReadOnlyHintFor(columnsBlocker, table: null);
             return;
         }
 
@@ -941,22 +974,44 @@ public sealed partial class QueryViewModel : ObservableObject
         {
             if (await _schemaService.GetEditableTableByOidAsync(tableOid, ct) is not { } table)
             {
+                ReadOnlyHint = ReadOnlyHintFor(EditBlocker.NotAPlainTable, table: null);
                 return;
             }
 
             var tableColumns = await _schemaService.GetColumnsAsync(table.Schema, table.Name, ct);
-            if (EditableResultDetector.MatchPrimaryKey(_columns, tableColumns) is { } primaryKey)
+            if (EditableResultDetector.MatchPrimaryKey(_columns, tableColumns, out var primaryKey) is not EditBlocker.None and var matchBlocker)
             {
-                EditContext = new EditableTableContext(table.Schema, table.Name, primaryKey, tableColumns);
+                ReadOnlyHint = ReadOnlyHintFor(matchBlocker, table);
+                return;
             }
+
+            EditContext = new EditableTableContext(table.Schema, table.Name, primaryKey, tableColumns);
         }
         catch
         {
             // Includes cancellation: the query itself already completed and its
             // rows are on screen, so a failed/cancelled catalog lookup must not
-            // repaint the run as failed — editing simply stays off.
+            // repaint the run as failed — editing simply stays off, hint-less
+            // (the reason would be a guess).
         }
     }
+
+    // One sentence per disqualifier, completing "Results are read-only: …" —
+    // the status-bar tooltip is the only place these appear, so they say what
+    // to change (include the key, drop the alias) where that's actionable.
+    private static string ReadOnlyHintFor(EditBlocker blocker, RelationInfo? table) => blocker switch
+    {
+        EditBlocker.ComputedColumns => "some columns are expressions or system columns, not table columns.",
+        EditBlocker.MultipleTables => "the result combines columns from more than one table.",
+        EditBlocker.RepeatedColumn => "the same column appears more than once.",
+        EditBlocker.NotAPlainTable => "the source is a view, function, or another relation whose rows can't be updated by key.",
+        EditBlocker.RenamedColumns => "columns are renamed (AS …), so edits can't be mapped back to the table's real columns.",
+        EditBlocker.NoPrimaryKey => $"{TableName(table)} has no primary key, so rows can't be targeted exactly.",
+        EditBlocker.PrimaryKeyNotSelected => $"the primary key of {TableName(table)} isn't in the result — include it to edit.",
+        _ => "this result set can't be mapped back to a table.",
+    };
+
+    private static string TableName(RelationInfo? table) => table is null ? "the table" : $"{table.Schema}.{table.Name}";
 
     /// <summary>
     /// Commits an inline grid edit (the raw text typed into the cell editor)

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -821,7 +821,7 @@
                  (full text on hover), while every other segment is compact and
                  keeps its width. Long cap text truncates the same way. -->
             <Border Grid.Row="1" Classes="statusBar">
-                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
                     <TextBlock Grid.Column="0" Text="{Binding ActiveTab.Status}"
                                Classes="statusText" Classes.error="{Binding ActiveTab.HasError}"
                                TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
@@ -874,17 +874,29 @@
                                 Command="{Binding ActiveTab.ApplyFixCommand}"
                                 ToolTip.Tip="Rewrite the unquoted identifiers to match the database and run again" />
                     </StackPanel>
-                    <StackPanel Grid.Column="5" Orientation="Horizontal" Spacing="10" Margin="10,0,0,0"
+                    <!-- Why this result set can't be edited inline. A dim lock +
+                         "read-only", full reason in the tooltip — present only when
+                         there's a grid a user might try to edit and editing is off. -->
+                    <StackPanel Grid.Column="5" Orientation="Horizontal" Spacing="6" Margin="10,0,0,0"
+                                VerticalAlignment="Center"
+                                IsVisible="{Binding ActiveTab.ReadOnlyHint, Converter={x:Static conv:ObjectConverters.IsNotNull}}"
+                                ToolTip.Tip="{Binding ActiveTab.ReadOnlyHint, StringFormat='Results are read-only: {0}'}">
+                        <Rectangle Classes="statusSeparator" Margin="0,0,4,0" />
+                        <PathIcon Data="{StaticResource LockIconGeometry}" Width="10" Height="10"
+                                  Opacity="0.55" VerticalAlignment="Center" />
+                        <TextBlock Classes="statusText dim" Text="read-only" VerticalAlignment="Center" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="6" Orientation="Horizontal" Spacing="10" Margin="10,0,0,0"
                                 IsVisible="{Binding ActiveTab.RowCountStatusText, Converter={x:Static conv:ObjectConverters.IsNotNull}}">
                         <Rectangle Classes="statusSeparator" />
                         <TextBlock Classes="statusText dim" Text="{Binding ActiveTab.RowCountStatusText}" VerticalAlignment="Center" />
                     </StackPanel>
-                    <StackPanel Grid.Column="6" Orientation="Horizontal" Spacing="10" Margin="10,0,0,0"
+                    <StackPanel Grid.Column="7" Orientation="Horizontal" Spacing="10" Margin="10,0,0,0"
                                 IsVisible="{Binding ActiveTab.TimingText, Converter={x:Static conv:ObjectConverters.IsNotNull}}">
                         <Rectangle Classes="statusSeparator" />
                         <TextBlock Classes="statusText dim" Text="{Binding ActiveTab.TimingText}" VerticalAlignment="Center" />
                     </StackPanel>
-                    <StackPanel Grid.Column="7" Orientation="Horizontal" Spacing="10" Margin="10,0,0,0"
+                    <StackPanel Grid.Column="8" Orientation="Horizontal" Spacing="10" Margin="10,0,0,0"
                                 IsVisible="{Binding ActiveTab.CapText, Converter={x:Static conv:ObjectConverters.IsNotNull}}">
                         <Rectangle Classes="statusSeparator" />
                         <TextBlock Classes="statusText warn" Text="{Binding ActiveTab.CapText}" VerticalAlignment="Center"
@@ -894,7 +906,7 @@
                     <!-- Browse-mode paging: the one piece of the old browse bar that
                          couldn't move into the SQL editor. Disabled while a query is
                          in flight so a page turn can't start a second concurrent run. -->
-                    <StackPanel Grid.Column="8" Orientation="Horizontal" Spacing="8" Margin="10,0,0,0"
+                    <StackPanel Grid.Column="9" Orientation="Horizontal" Spacing="8" Margin="10,0,0,0"
                                 VerticalAlignment="Center"
                                 IsVisible="{Binding ActiveTab.IsBrowsing}"
                                 IsEnabled="{Binding !ActiveTab.IsRunning}">

--- a/PgNimbus.Core.Tests/Query/EditableResultDetectorTests.cs
+++ b/PgNimbus.Core.Tests/Query/EditableResultDetectorTests.cs
@@ -25,76 +25,86 @@ public class EditableResultDetectorTests
     [Test]
     public async Task AllColumnsFromOneTableResolveItsOid()
     {
-        var oid = EditableResultDetector.SingleSourceTableOid(
-            [Col("id", attNum: 1), Col("status", attNum: 3)]);
+        var blocker = EditableResultDetector.CheckSingleTable(
+            [Col("id", attNum: 1), Col("status", attNum: 3)], out var oid);
 
+        await Assert.That(blocker).IsEqualTo(EditBlocker.None);
         await Assert.That(oid).IsEqualTo(OrdersOid);
     }
 
     [Test]
-    public async Task ExpressionColumnDisqualifies()
+    public async Task ExpressionColumnIsComputed()
     {
         // upper(status) has no source table: OID and attnum are both 0.
-        var oid = EditableResultDetector.SingleSourceTableOid(
-            [Col("id", attNum: 1), Col("upper", tableOid: 0, attNum: 0)]);
+        var blocker = EditableResultDetector.CheckSingleTable(
+            [Col("id", attNum: 1), Col("upper", tableOid: 0, attNum: 0)], out _);
 
-        await Assert.That(oid).IsNull();
+        await Assert.That(blocker).IsEqualTo(EditBlocker.ComputedColumns);
     }
 
     [Test]
-    public async Task ColumnsFromTwoTablesDisqualify()
+    public async Task SystemColumnIsComputed()
     {
-        var oid = EditableResultDetector.SingleSourceTableOid(
-            [Col("id", attNum: 1), Col("name", tableOid: OrdersOid + 1, attNum: 1)]);
+        // SELECT ctid, id FROM orders — ctid carries the table OID but a
+        // negative attribute number.
+        var blocker = EditableResultDetector.CheckSingleTable(
+            [Col("ctid", attNum: -1), Col("id", attNum: 1)], out _);
 
-        await Assert.That(oid).IsNull();
+        await Assert.That(blocker).IsEqualTo(EditBlocker.ComputedColumns);
     }
 
     [Test]
-    public async Task RepeatedColumnDisqualifies()
+    public async Task ColumnsFromTwoTablesAreAJoin()
+    {
+        var blocker = EditableResultDetector.CheckSingleTable(
+            [Col("id", attNum: 1), Col("name", tableOid: OrdersOid + 1, attNum: 1)], out _);
+
+        await Assert.That(blocker).IsEqualTo(EditBlocker.MultipleTables);
+    }
+
+    [Test]
+    public async Task RepeatedColumnIsAmbiguous()
     {
         // SELECT id, id FROM orders — name-keyed commits would be ambiguous.
-        var oid = EditableResultDetector.SingleSourceTableOid(
-            [Col("id", attNum: 1), Col("id", attNum: 1)]);
+        var blocker = EditableResultDetector.CheckSingleTable(
+            [Col("id", attNum: 1), Col("id", attNum: 1)], out _);
 
-        await Assert.That(oid).IsNull();
-    }
-
-    [Test]
-    public async Task EmptyResultDisqualifies()
-    {
-        await Assert.That(EditableResultDetector.SingleSourceTableOid([])).IsNull();
+        await Assert.That(blocker).IsEqualTo(EditBlocker.RepeatedColumn);
     }
 
     [Test]
     public async Task FullSelectMatchesPrimaryKey()
     {
-        var pk = EditableResultDetector.MatchPrimaryKey(
+        var blocker = EditableResultDetector.MatchPrimaryKey(
             [Col("id", attNum: 1), Col("status", attNum: 3), Col("amount", attNum: 4)],
-            Orders);
+            Orders,
+            out var pk);
 
-        await Assert.That(pk).IsNotNull();
-        await Assert.That(pk!).IsEquivalentTo(["id"]);
+        await Assert.That(blocker).IsEqualTo(EditBlocker.None);
+        await Assert.That(pk).IsEquivalentTo(["id"]);
     }
 
     [Test]
     public async Task SubsetWithPrimaryKeyMatches()
     {
-        var pk = EditableResultDetector.MatchPrimaryKey(
+        var blocker = EditableResultDetector.MatchPrimaryKey(
             [Col("id", attNum: 1), Col("amount", attNum: 4)],
-            Orders);
+            Orders,
+            out _);
 
-        await Assert.That(pk).IsNotNull();
+        await Assert.That(blocker).IsEqualTo(EditBlocker.None);
     }
 
     [Test]
     public async Task MissingPrimaryKeyColumnDisqualifies()
     {
-        var pk = EditableResultDetector.MatchPrimaryKey(
+        var blocker = EditableResultDetector.MatchPrimaryKey(
             [Col("status", attNum: 3), Col("amount", attNum: 4)],
-            Orders);
+            Orders,
+            out var pk);
 
-        await Assert.That(pk).IsNull();
+        await Assert.That(blocker).IsEqualTo(EditBlocker.PrimaryKeyNotSelected);
+        await Assert.That(pk).IsEmpty();
     }
 
     [Test]
@@ -102,11 +112,12 @@ public class EditableResultDetectorTests
     {
         // SELECT id, status AS s FROM orders — the grid header says "s", but
         // every commit path keys SET clauses and PK lookups by displayed name.
-        var pk = EditableResultDetector.MatchPrimaryKey(
+        var blocker = EditableResultDetector.MatchPrimaryKey(
             [Col("id", attNum: 1), Col("s", attNum: 3)],
-            Orders);
+            Orders,
+            out _);
 
-        await Assert.That(pk).IsNull();
+        await Assert.That(blocker).IsEqualTo(EditBlocker.RenamedColumns);
     }
 
     [Test]
@@ -115,11 +126,12 @@ public class EditableResultDetectorTests
         // SELECT status AS amount, amount AS status FROM orders — names all
         // exist on the table, but each points at the wrong attribute; only the
         // attnum check catches this.
-        var pk = EditableResultDetector.MatchPrimaryKey(
+        var blocker = EditableResultDetector.MatchPrimaryKey(
             [Col("id", attNum: 1), Col("amount", attNum: 3), Col("status", attNum: 4)],
-            Orders);
+            Orders,
+            out _);
 
-        await Assert.That(pk).IsNull();
+        await Assert.That(blocker).IsEqualTo(EditBlocker.RenamedColumns);
     }
 
     [Test]
@@ -127,9 +139,9 @@ public class EditableResultDetectorTests
     {
         IReadOnlyList<ColumnDetail> heap = [TableCol("value", 1)];
 
-        var pk = EditableResultDetector.MatchPrimaryKey([Col("value", attNum: 1)], heap);
+        var blocker = EditableResultDetector.MatchPrimaryKey([Col("value", attNum: 1)], heap, out _);
 
-        await Assert.That(pk).IsNull();
+        await Assert.That(blocker).IsEqualTo(EditBlocker.NoPrimaryKey);
     }
 
     [Test]
@@ -144,13 +156,15 @@ public class EditableResultDetectorTests
 
         var full = EditableResultDetector.MatchPrimaryKey(
             [Col("order_id", attNum: 1), Col("line_no", attNum: 2), Col("sku", attNum: 3)],
-            orderItems);
+            orderItems,
+            out var fullPk);
         var partial = EditableResultDetector.MatchPrimaryKey(
             [Col("order_id", attNum: 1), Col("sku", attNum: 3)],
-            orderItems);
+            orderItems,
+            out _);
 
-        await Assert.That(full).IsNotNull();
-        await Assert.That(full!).IsEquivalentTo(["order_id", "line_no"]);
-        await Assert.That(partial).IsNull();
+        await Assert.That(full).IsEqualTo(EditBlocker.None);
+        await Assert.That(fullPk).IsEquivalentTo(["order_id", "line_no"]);
+        await Assert.That(partial).IsEqualTo(EditBlocker.PrimaryKeyNotSelected);
     }
 }

--- a/PgNimbus.Core.Tests/Query/EditableResultDetectorTests.cs
+++ b/PgNimbus.Core.Tests/Query/EditableResultDetectorTests.cs
@@ -1,0 +1,156 @@
+using PgNimbus.Core.Query;
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.Core.Tests.Query;
+
+public class EditableResultDetectorTests
+{
+    private const uint OrdersOid = 16384;
+
+    private static ColumnInfo Col(string name, uint tableOid = OrdersOid, short attNum = 0) =>
+        new(name, "text", typeof(string), tableOid, attNum);
+
+    private static ColumnDetail TableCol(string name, short attNum, bool pk = false) =>
+        new(name, "text", NotNull: pk, IsPrimaryKey: pk) { AttNum = attNum };
+
+    // The orders table: id (pk, attnum 1), a dropped column left a gap at 2,
+    // status (3), amount (4).
+    private static readonly IReadOnlyList<ColumnDetail> Orders =
+    [
+        TableCol("id", 1, pk: true),
+        TableCol("status", 3),
+        TableCol("amount", 4),
+    ];
+
+    [Test]
+    public async Task AllColumnsFromOneTableResolveItsOid()
+    {
+        var oid = EditableResultDetector.SingleSourceTableOid(
+            [Col("id", attNum: 1), Col("status", attNum: 3)]);
+
+        await Assert.That(oid).IsEqualTo(OrdersOid);
+    }
+
+    [Test]
+    public async Task ExpressionColumnDisqualifies()
+    {
+        // upper(status) has no source table: OID and attnum are both 0.
+        var oid = EditableResultDetector.SingleSourceTableOid(
+            [Col("id", attNum: 1), Col("upper", tableOid: 0, attNum: 0)]);
+
+        await Assert.That(oid).IsNull();
+    }
+
+    [Test]
+    public async Task ColumnsFromTwoTablesDisqualify()
+    {
+        var oid = EditableResultDetector.SingleSourceTableOid(
+            [Col("id", attNum: 1), Col("name", tableOid: OrdersOid + 1, attNum: 1)]);
+
+        await Assert.That(oid).IsNull();
+    }
+
+    [Test]
+    public async Task RepeatedColumnDisqualifies()
+    {
+        // SELECT id, id FROM orders — name-keyed commits would be ambiguous.
+        var oid = EditableResultDetector.SingleSourceTableOid(
+            [Col("id", attNum: 1), Col("id", attNum: 1)]);
+
+        await Assert.That(oid).IsNull();
+    }
+
+    [Test]
+    public async Task EmptyResultDisqualifies()
+    {
+        await Assert.That(EditableResultDetector.SingleSourceTableOid([])).IsNull();
+    }
+
+    [Test]
+    public async Task FullSelectMatchesPrimaryKey()
+    {
+        var pk = EditableResultDetector.MatchPrimaryKey(
+            [Col("id", attNum: 1), Col("status", attNum: 3), Col("amount", attNum: 4)],
+            Orders);
+
+        await Assert.That(pk).IsNotNull();
+        await Assert.That(pk!).IsEquivalentTo(["id"]);
+    }
+
+    [Test]
+    public async Task SubsetWithPrimaryKeyMatches()
+    {
+        var pk = EditableResultDetector.MatchPrimaryKey(
+            [Col("id", attNum: 1), Col("amount", attNum: 4)],
+            Orders);
+
+        await Assert.That(pk).IsNotNull();
+    }
+
+    [Test]
+    public async Task MissingPrimaryKeyColumnDisqualifies()
+    {
+        var pk = EditableResultDetector.MatchPrimaryKey(
+            [Col("status", attNum: 3), Col("amount", attNum: 4)],
+            Orders);
+
+        await Assert.That(pk).IsNull();
+    }
+
+    [Test]
+    public async Task AliasedColumnDisqualifies()
+    {
+        // SELECT id, status AS s FROM orders — the grid header says "s", but
+        // every commit path keys SET clauses and PK lookups by displayed name.
+        var pk = EditableResultDetector.MatchPrimaryKey(
+            [Col("id", attNum: 1), Col("s", attNum: 3)],
+            Orders);
+
+        await Assert.That(pk).IsNull();
+    }
+
+    [Test]
+    public async Task SwappedAliasesDisqualify()
+    {
+        // SELECT status AS amount, amount AS status FROM orders — names all
+        // exist on the table, but each points at the wrong attribute; only the
+        // attnum check catches this.
+        var pk = EditableResultDetector.MatchPrimaryKey(
+            [Col("id", attNum: 1), Col("amount", attNum: 3), Col("status", attNum: 4)],
+            Orders);
+
+        await Assert.That(pk).IsNull();
+    }
+
+    [Test]
+    public async Task TableWithoutPrimaryKeyDisqualifies()
+    {
+        IReadOnlyList<ColumnDetail> heap = [TableCol("value", 1)];
+
+        var pk = EditableResultDetector.MatchPrimaryKey([Col("value", attNum: 1)], heap);
+
+        await Assert.That(pk).IsNull();
+    }
+
+    [Test]
+    public async Task CompositePrimaryKeyRequiresEveryColumn()
+    {
+        IReadOnlyList<ColumnDetail> orderItems =
+        [
+            TableCol("order_id", 1, pk: true),
+            TableCol("line_no", 2, pk: true),
+            TableCol("sku", 3),
+        ];
+
+        var full = EditableResultDetector.MatchPrimaryKey(
+            [Col("order_id", attNum: 1), Col("line_no", attNum: 2), Col("sku", attNum: 3)],
+            orderItems);
+        var partial = EditableResultDetector.MatchPrimaryKey(
+            [Col("order_id", attNum: 1), Col("sku", attNum: 3)],
+            orderItems);
+
+        await Assert.That(full).IsNotNull();
+        await Assert.That(full!).IsEquivalentTo(["order_id", "line_no"]);
+        await Assert.That(partial).IsNull();
+    }
+}

--- a/PgNimbus.Core/Query/EditableResultDetector.cs
+++ b/PgNimbus.Core/Query/EditableResultDetector.cs
@@ -1,0 +1,90 @@
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.Core.Query;
+
+/// <summary>
+/// Decides whether an arbitrary result set maps cleanly back onto one table, so
+/// a hand-typed SELECT can get the same inline editing browse mode has. Works
+/// off the wire-protocol source metadata each <see cref="ColumnInfo"/> carries
+/// (table OID + attribute number) rather than parsing SQL — an aliased column,
+/// an expression, or a join instantly disqualifies via the metadata itself.
+/// </summary>
+public static class EditableResultDetector
+{
+    /// <summary>
+    /// The single table every result column reads a distinct real attribute of,
+    /// or null when any column is an expression/literal (no source table), the
+    /// columns span more than one table, or the same attribute appears twice
+    /// (a repeated column would make name-keyed cell commits ambiguous).
+    /// </summary>
+    public static uint? SingleSourceTableOid(IReadOnlyList<ColumnInfo> columns)
+    {
+        if (columns.Count == 0 || columns[0].TableOid == 0)
+        {
+            return null;
+        }
+
+        var oid = columns[0].TableOid;
+        var seen = new HashSet<short>();
+        foreach (var column in columns)
+        {
+            if (column.TableOid != oid || column.TableAttributeNumber <= 0 || !seen.Add(column.TableAttributeNumber))
+            {
+                return null;
+            }
+        }
+
+        return oid;
+    }
+
+    /// <summary>
+    /// The table's primary-key column names when the result can be edited
+    /// safely, null otherwise. Safe means: every result column's displayed name
+    /// is exactly the real name of the attribute it reads (no <c>AS</c> aliases —
+    /// every commit path builds SET clauses and PK lookups from displayed
+    /// names), and the table's full primary key is among the result columns
+    /// (so each row can be targeted exactly). Callers must have already
+    /// established via <see cref="SingleSourceTableOid"/> that all columns come
+    /// from the table <paramref name="tableColumns"/> describes.
+    /// </summary>
+    public static IReadOnlyList<string>? MatchPrimaryKey(
+        IReadOnlyList<ColumnInfo> resultColumns,
+        IReadOnlyList<ColumnDetail> tableColumns)
+    {
+        var byAttNum = new Dictionary<short, ColumnDetail>(tableColumns.Count);
+        foreach (var tableColumn in tableColumns)
+        {
+            byAttNum[tableColumn.AttNum] = tableColumn;
+        }
+
+        var presentAttNums = new HashSet<short>();
+        foreach (var column in resultColumns)
+        {
+            if (!byAttNum.TryGetValue(column.TableAttributeNumber, out var tableColumn)
+                || !string.Equals(tableColumn.Name, column.Name, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            presentAttNums.Add(column.TableAttributeNumber);
+        }
+
+        var primaryKey = new List<string>();
+        foreach (var tableColumn in tableColumns)
+        {
+            if (!tableColumn.IsPrimaryKey)
+            {
+                continue;
+            }
+
+            if (!presentAttNums.Contains(tableColumn.AttNum))
+            {
+                return null;
+            }
+
+            primaryKey.Add(tableColumn.Name);
+        }
+
+        return primaryKey.Count > 0 ? primaryKey : null;
+    }
+}

--- a/PgNimbus.Core/Query/EditableResultDetector.cs
+++ b/PgNimbus.Core/Query/EditableResultDetector.cs
@@ -3,6 +3,37 @@ using PgNimbus.Core.Schema;
 namespace PgNimbus.Core.Query;
 
 /// <summary>
+/// Why a result set can't be edited inline. <see cref="None"/> means it can.
+/// The other members drive the status bar's read-only hint, so each maps to
+/// one specific, user-explainable disqualifier.
+/// </summary>
+public enum EditBlocker
+{
+    None,
+
+    /// <summary>Some column isn't a plain table attribute: an expression, a literal, or a system column like ctid.</summary>
+    ComputedColumns,
+
+    /// <summary>Columns read from more than one table (a join).</summary>
+    MultipleTables,
+
+    /// <summary>The same table attribute appears more than once — name-keyed cell commits would be ambiguous.</summary>
+    RepeatedColumn,
+
+    /// <summary>The source relation isn't an ordinary/partitioned table (a view, matview, …). Assigned by the caller after the catalog lookup.</summary>
+    NotAPlainTable,
+
+    /// <summary>A column's displayed name isn't the real attribute name (an <c>AS</c> alias) — every commit path is keyed by displayed names.</summary>
+    RenamedColumns,
+
+    /// <summary>The table has no primary key, so no row can be targeted exactly.</summary>
+    NoPrimaryKey,
+
+    /// <summary>The table has a primary key, but the result doesn't include all of it.</summary>
+    PrimaryKeyNotSelected,
+}
+
+/// <summary>
 /// Decides whether an arbitrary result set maps cleanly back onto one table, so
 /// a hand-typed SELECT can get the same inline editing browse mode has. Works
 /// off the wire-protocol source metadata each <see cref="ColumnInfo"/> carries
@@ -12,45 +43,64 @@ namespace PgNimbus.Core.Query;
 public static class EditableResultDetector
 {
     /// <summary>
-    /// The single table every result column reads a distinct real attribute of,
-    /// or null when any column is an expression/literal (no source table), the
-    /// columns span more than one table, or the same attribute appears twice
-    /// (a repeated column would make name-keyed cell commits ambiguous).
+    /// Checks that every result column reads a distinct real attribute of one
+    /// table, returning that table's OID through <paramref name="tableOid"/>
+    /// (0 unless the answer is <see cref="EditBlocker.None"/>).
     /// </summary>
-    public static uint? SingleSourceTableOid(IReadOnlyList<ColumnInfo> columns)
+    public static EditBlocker CheckSingleTable(IReadOnlyList<ColumnInfo> columns, out uint tableOid)
     {
-        if (columns.Count == 0 || columns[0].TableOid == 0)
+        tableOid = 0;
+        if (columns.Count == 0)
         {
-            return null;
+            return EditBlocker.ComputedColumns;
         }
 
-        var oid = columns[0].TableOid;
+        var oid = 0u;
         var seen = new HashSet<short>();
         foreach (var column in columns)
         {
-            if (column.TableOid != oid || column.TableAttributeNumber <= 0 || !seen.Add(column.TableAttributeNumber))
+            if (column.TableOid == 0 || column.TableAttributeNumber <= 0)
             {
-                return null;
+                return EditBlocker.ComputedColumns;
+            }
+
+            if (oid == 0)
+            {
+                oid = column.TableOid;
+            }
+            else if (column.TableOid != oid)
+            {
+                return EditBlocker.MultipleTables;
+            }
+
+            if (!seen.Add(column.TableAttributeNumber))
+            {
+                return EditBlocker.RepeatedColumn;
             }
         }
 
-        return oid;
+        tableOid = oid;
+        return EditBlocker.None;
     }
 
     /// <summary>
-    /// The table's primary-key column names when the result can be edited
-    /// safely, null otherwise. Safe means: every result column's displayed name
-    /// is exactly the real name of the attribute it reads (no <c>AS</c> aliases —
-    /// every commit path builds SET clauses and PK lookups from displayed
-    /// names), and the table's full primary key is among the result columns
-    /// (so each row can be targeted exactly). Callers must have already
-    /// established via <see cref="SingleSourceTableOid"/> that all columns come
-    /// from the table <paramref name="tableColumns"/> describes.
+    /// Checks a result set against its source table's real columns: every
+    /// column's displayed name must be exactly the attribute name it reads (no
+    /// <c>AS</c> aliases — every commit path builds SET clauses and PK lookups
+    /// from displayed names), and the table's full primary key must be among
+    /// the result columns (so each row can be targeted exactly). On
+    /// <see cref="EditBlocker.None"/>, <paramref name="primaryKey"/> holds the
+    /// PK column names; empty otherwise. Callers must have already established
+    /// via <see cref="CheckSingleTable"/> that all columns come from the table
+    /// <paramref name="tableColumns"/> describes.
     /// </summary>
-    public static IReadOnlyList<string>? MatchPrimaryKey(
+    public static EditBlocker MatchPrimaryKey(
         IReadOnlyList<ColumnInfo> resultColumns,
-        IReadOnlyList<ColumnDetail> tableColumns)
+        IReadOnlyList<ColumnDetail> tableColumns,
+        out IReadOnlyList<string> primaryKey)
     {
+        primaryKey = [];
+
         var byAttNum = new Dictionary<short, ColumnDetail>(tableColumns.Count);
         foreach (var tableColumn in tableColumns)
         {
@@ -63,13 +113,14 @@ public static class EditableResultDetector
             if (!byAttNum.TryGetValue(column.TableAttributeNumber, out var tableColumn)
                 || !string.Equals(tableColumn.Name, column.Name, StringComparison.Ordinal))
             {
-                return null;
+                return EditBlocker.RenamedColumns;
             }
 
             presentAttNums.Add(column.TableAttributeNumber);
         }
 
-        var primaryKey = new List<string>();
+        var pk = new List<string>();
+        var pkMissing = false;
         foreach (var tableColumn in tableColumns)
         {
             if (!tableColumn.IsPrimaryKey)
@@ -77,14 +128,21 @@ public static class EditableResultDetector
                 continue;
             }
 
-            if (!presentAttNums.Contains(tableColumn.AttNum))
-            {
-                return null;
-            }
-
-            primaryKey.Add(tableColumn.Name);
+            pk.Add(tableColumn.Name);
+            pkMissing |= !presentAttNums.Contains(tableColumn.AttNum);
         }
 
-        return primaryKey.Count > 0 ? primaryKey : null;
+        if (pk.Count == 0)
+        {
+            return EditBlocker.NoPrimaryKey;
+        }
+
+        if (pkMissing)
+        {
+            return EditBlocker.PrimaryKeyNotSelected;
+        }
+
+        primaryKey = pk;
+        return EditBlocker.None;
     }
 }

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -865,10 +865,21 @@ public sealed class QueryEngine
 
     private static IReadOnlyList<ColumnInfo> BuildColumns(NpgsqlDataReader reader)
     {
+        // Without CommandBehavior.KeyInfo (readers here always use Default),
+        // GetColumnSchema is a pure in-memory read of the wire RowDescription —
+        // no catalog round trip. It's the one public API that exposes each
+        // column's source-table OID and attribute number, which downstream
+        // decide whether a result set maps back onto one editable table.
+        var wireSchema = reader.GetColumnSchema();
         var columns = new ColumnInfo[reader.FieldCount];
         for (var i = 0; i < reader.FieldCount; i++)
         {
-            columns[i] = new ColumnInfo(reader.GetName(i), reader.GetDataTypeName(i), reader.GetFieldType(i));
+            columns[i] = new ColumnInfo(
+                reader.GetName(i),
+                reader.GetDataTypeName(i),
+                reader.GetFieldType(i),
+                wireSchema[i].TableOID,
+                wireSchema[i].ColumnAttributeNumber ?? 0);
         }
 
         return columns;

--- a/PgNimbus.Core/Query/QueryResult.cs
+++ b/PgNimbus.Core/Query/QueryResult.cs
@@ -1,6 +1,19 @@
 namespace PgNimbus.Core.Query;
 
-public sealed record ColumnInfo(string Name, string DataTypeName, Type ClrType);
+/// <summary>
+/// One result-set column. <paramref name="TableOid"/> and
+/// <paramref name="TableAttributeNumber"/> identify the base-table attribute the
+/// column reads straight through (from the wire-protocol RowDescription — no
+/// extra round trip); both are 0 for expressions, literals, and anything else
+/// that isn't a plain table column. That's what lets the app decide whether an
+/// arbitrary SELECT's rows map cleanly onto one editable table.
+/// </summary>
+public sealed record ColumnInfo(
+    string Name,
+    string DataTypeName,
+    Type ClrType,
+    uint TableOid = 0,
+    short TableAttributeNumber = 0);
 
 public sealed record RowBatch(IReadOnlyList<object?[]> Rows);
 

--- a/PgNimbus.Core/Schema/SchemaService.cs
+++ b/PgNimbus.Core/Schema/SchemaService.cs
@@ -31,6 +31,14 @@ public sealed record ColumnDetail(string Name, string DataType, bool NotNull, bo
 
     /// <summary>The base type a domain column resolves to (e.g. "integer" for a domain over integer); null when the declared type isn't a domain.</summary>
     public string? DomainBaseType { get; init; }
+
+    /// <summary>
+    /// pg_attribute.attnum — the column's stable positional identity within its
+    /// table (gaps where columns were dropped). Matches the attribute number the
+    /// wire protocol reports per result column, which is what lets a result set
+    /// be checked against the table's real columns without trusting names.
+    /// </summary>
+    public short AttNum { get; init; }
 }
 
 public sealed record TableColumn(string Table, string Column, string DataType);
@@ -221,7 +229,8 @@ public sealed class SchemaService
                     (SELECT array_agg(e.enumlabel ORDER BY e.enumsortorder)
                      FROM pg_catalog.pg_enum e
                      WHERE e.enumtypid = bt.oid)
-                END AS enum_labels
+                END AS enum_labels,
+                c.attnum
             FROM cols c
             JOIN base b ON b.attnum = c.attnum
             JOIN pg_catalog.pg_type bt ON bt.oid = b.type_oid
@@ -249,10 +258,43 @@ public sealed class SchemaService
                     reader.GetString(4)),
                 DomainBaseType = reader.IsDBNull(7) ? null : reader.GetString(7),
                 EnumLabels = reader.IsDBNull(8) ? [] : reader.GetFieldValue<string[]>(8),
+                AttNum = reader.GetInt16(9),
             });
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Resolves a pg_class OID (as the wire protocol reports per result column)
+    /// to its schema-qualified name — but only for relations whose rows can be
+    /// UPDATEd by primary key directly: ordinary and partitioned tables. Views,
+    /// materialized views, and anything else return null, so a result set that
+    /// reads through them never gets offered inline editing.
+    /// </summary>
+    public async Task<RelationInfo?> GetEditableTableByOidAsync(uint tableOid, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT n.nspname, c.relname, c.relkind::text
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.oid = @oid
+              AND c.relkind IN ('r', 'p')
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        // uint has no implicit Npgsql parameter mapping — the oid type must be named.
+        command.Parameters.Add(new NpgsqlParameter<uint>("oid", NpgsqlTypes.NpgsqlDbType.Oid) { TypedValue = tableOid });
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        if (!await reader.ReadAsync(ct))
+        {
+            return null;
+        }
+
+        var kind = reader.GetString(2) == "p" ? RelationKind.PartitionedTable : RelationKind.Table;
+        return new RelationInfo(reader.GetString(0), reader.GetString(1), kind);
     }
 
     /// <summary>Functions, procedures, aggregates, and window functions in a schema, with identity arguments and result type.</summary>

--- a/README.md
+++ b/README.md
@@ -239,6 +239,10 @@ Every tag push (`vX.Y.Z`) builds all of the above via
   cast to its real type server-side, blanks fall back to defaults),
   "Delete selected row(s)" with a confirmation, and "Set cell to NULL" (the
   gesture inline editing can't express), all keyed on the primary key.
+  Editing isn't limited to browse mode: a hand-typed `SELECT` becomes
+  editable too whenever the wire metadata proves every column reads a real
+  column of one table under its own name and the full primary key is in the
+  result — expressions, aliases, joins, and views stay read-only.
 - **Postgres-native value editing** — cell editors (grid and Add-row dialog)
   follow the column's type: `enum` columns get a dropdown of their `pg_enum`
   labels, `boolean` a checkbox, `date`/`timestamp` a calendar picker, arrays


### PR DESCRIPTION
## Why

Typing `SELECT * FROM orders` left the results grid read-only — inline editing only worked when a table was opened through browse mode, which felt broken ("почему редактирование не работает, если просто набить запрос").

## How

The edit context is now also established after a plain query run, from metadata the wire protocol already sends: each result column carries its source-table OID and attribute number in the RowDescription, at **zero extra round trips** (`GetColumnSchema()` without `CommandBehavior.KeyInfo` never touches the server).

- **Core** — `ColumnInfo` gains `TableOid`/`TableAttributeNumber`; `ColumnDetail` gains `AttNum`; `SchemaService.GetEditableTableByOidAsync` resolves an OID back to a schema-qualified name for ordinary/partitioned tables only (views/matviews never qualify).
- **Core** — `EditableResultDetector` holds the safety rules, unit-tested (12 tests): one source table; every column a **distinct real attribute under its real name** — matched by attnum, not name, so `SELECT status AS amount, amount AS status` can't slip through and corrupt data; the **full primary key** present in the result.
- **App** — after a successful single-statement run outside browse mode, one best-effort catalog lookup builds the same `EditableTableContext` browse uses, so cell edits, Add row, delete rows, Set-NULL, and safe-mode staging all work unchanged. Nice side effect: `INSERT … RETURNING *` results are editable too.
- **Fix in passing** — the context is now cleared at the start of every run; previously a selection/caret-statement run in a browse tab kept the stale browse context aimed at a different result set.

## Verification

- 359 Core tests pass (12 new).
- Live against the seeded Docker Postgres via DevTools MCP: typed `SELECT * FROM orders` → grid editable → F2 edit staged (safe mode, "1 staged · public.orders") → commit → value landed in the table (checked via psql). `SELECT id, total AS t FROM orders` stays read-only.
- Root-caused one landmine along the way: `AddWithValue(uint)` has no implicit Npgsql mapping (throws), so the OID parameter is passed as an explicit `NpgsqlDbType.Oid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)