### PR TITLE
Restore main-window placement across sessions

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -231,6 +231,10 @@ public partial class App : Application
             DataContext = viewModel,
         };
 
+        // Restore last session's window placement before the window shows, and
+        // save it back on close - session state alongside the workspace restore.
+        WindowPlacementPersistence.Attach(window, new WindowPlacementStore());
+
         window.Closed += async (_, _) =>
         {
             // Save the workspace before anything else tears down - a failed save

--- a/PgNimbus.App/WindowPlacementPersistence.cs
+++ b/PgNimbus.App/WindowPlacementPersistence.cs
@@ -1,0 +1,122 @@
+using Avalonia;
+using Avalonia.Controls;
+using PgNimbus.Core.Settings;
+
+namespace PgNimbus.App;
+
+/// <summary>
+/// Restores and persists the main window's placement (position, size,
+/// maximized state) across sessions — the window counterpart of the
+/// workspace restore. Call <see cref="Attach"/> once from
+/// <c>App.BuildMainWindow</c>, after construction and before the window is
+/// shown, so the first frame already paints at the restored placement
+/// instead of jumping there.
+/// </summary>
+internal static class WindowPlacementPersistence
+{
+    /// <summary>
+    /// How much of the title bar must land on a live screen's working area for
+    /// a saved position to be trusted — enough to grab and drag the window
+    /// back, so a monitor unplugged since the last run can't strand it
+    /// off-screen.
+    /// </summary>
+    private const int MinVisibleDip = 48;
+
+    public static void Attach(Window window, WindowPlacementStore store)
+    {
+        Restore(window, store.Load());
+
+        // Track the last Normal-state bounds so a window closed maximized (or
+        // minimized) still saves the geometry it would restore to on
+        // unmaximize, not the maximized rect. Seeded from the just-restored
+        // (or default) placement in case the window is maximized before it is
+        // ever moved.
+        var normalPosition = window.Position;
+        var normalWidth = window.Width;
+        var normalHeight = window.Height;
+
+        window.PositionChanged += (_, e) =>
+        {
+            if (window.WindowState == WindowState.Normal)
+            {
+                normalPosition = e.Point;
+            }
+        };
+
+        window.SizeChanged += (_, e) =>
+        {
+            if (window.WindowState == WindowState.Normal)
+            {
+                normalWidth = e.NewSize.Width;
+                normalHeight = e.NewSize.Height;
+            }
+        };
+
+        window.Closing += (_, _) =>
+        {
+            // A closed-while-Normal window trusts its live geometry over the
+            // tracked one — the tracked values can lag by one event during
+            // maximize/restore transitions. Minimized never persists as a
+            // state: reopening into a hidden window would look like a hang.
+            if (window.WindowState == WindowState.Normal)
+            {
+                normalPosition = window.Position;
+                normalWidth = window.ClientSize.Width;
+                normalHeight = window.ClientSize.Height;
+            }
+
+            var maximized = window.WindowState is WindowState.Maximized or WindowState.FullScreen;
+
+            // Losing the placement is not worth blocking window close over.
+            try
+            {
+                store.Save(new WindowPlacement(normalPosition.X, normalPosition.Y, normalWidth, normalHeight, maximized));
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+            {
+            }
+        };
+    }
+
+    private static void Restore(Window window, WindowPlacement? placement)
+    {
+        if (placement is null || !double.IsFinite(placement.Width) || !double.IsFinite(placement.Height)
+            || placement.Width < 200 || placement.Height < 200)
+        {
+            return;
+        }
+
+        // Only trust the saved position if a grabbable strip of title bar
+        // still lands on some live screen: monitors get unplugged and
+        // resolutions change between runs. Position is physical pixels but
+        // Width is DIPs, so the probe converts per candidate screen's own
+        // scale (mixed-DPI setups scale each monitor differently).
+        var screens = window.Screens.All;
+        var positionUsable = screens.Any(screen =>
+        {
+            var probe = new PixelRect(
+                placement.X,
+                placement.Y,
+                Math.Max((int)(placement.Width * screen.Scaling), 1),
+                Math.Max((int)(MinVisibleDip * screen.Scaling), 1));
+            var overlap = screen.WorkingArea.Intersect(probe);
+            return overlap.Width >= (int)(MinVisibleDip * screen.Scaling) && overlap.Height > 0;
+        });
+
+        if (positionUsable)
+        {
+            window.WindowStartupLocation = WindowStartupLocation.Manual;
+            window.Position = new PixelPoint(placement.X, placement.Y);
+            window.Width = placement.Width;
+            window.Height = placement.Height;
+        }
+
+        // Maximized survives even when the saved position no longer maps to a
+        // live screen — the window then maximizes wherever the OS opens it,
+        // and unmaximize falls back to the default centered size.
+        if (placement.IsMaximized)
+        {
+            window.WindowState = WindowState.Maximized;
+        }
+    }
+}

--- a/PgNimbus.App/WindowPlacementPersistence.cs
+++ b/PgNimbus.App/WindowPlacementPersistence.cs
@@ -65,6 +65,15 @@ internal static class WindowPlacementPersistence
                 normalHeight = window.ClientSize.Height;
             }
 
+            // A window that never had explicit bounds reports NaN Width/Height
+            // (never MainWindow — its XAML sets both — but this helper takes any
+            // Window, and serializing NaN throws). No real geometry, nothing to
+            // save.
+            if (!double.IsFinite(normalWidth) || !double.IsFinite(normalHeight))
+            {
+                return;
+            }
+
             var maximized = window.WindowState is WindowState.Maximized or WindowState.FullScreen;
 
             // Losing the placement is not worth blocking window close over.
@@ -72,7 +81,7 @@ internal static class WindowPlacementPersistence
             {
                 store.Save(new WindowPlacement(normalPosition.X, normalPosition.Y, normalWidth, normalHeight, maximized));
             }
-            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+            catch
             {
             }
         };

--- a/PgNimbus.Core.Tests/Settings/WindowPlacementStoreTests.cs
+++ b/PgNimbus.Core.Tests/Settings/WindowPlacementStoreTests.cs
@@ -1,0 +1,85 @@
+using PgNimbus.Core.Settings;
+
+namespace PgNimbus.Core.Tests.Settings;
+
+public class WindowPlacementStoreTests
+{
+    [Test]
+    public async Task Load_NoFile_ReturnsNull()
+    {
+        var store = new WindowPlacementStore(Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json"));
+
+        var placement = store.Load();
+
+        await Assert.That(placement).IsNull();
+    }
+
+    [Test]
+    public async Task Load_CorruptFile_ReturnsNullAndDoesNotThrow()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+        await File.WriteAllTextAsync(path, "not valid json {{{");
+
+        try
+        {
+            var placement = new WindowPlacementStore(path).Load();
+
+            await Assert.That(placement).IsNull();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task SaveThenLoad_RoundTripsPlacement()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var store = new WindowPlacementStore(path);
+
+            store.Save(new WindowPlacement(X: -120, Y: 42, Width: 1280.5, Height: 900, IsMaximized: true));
+
+            var placement = store.Load();
+
+            await Assert.That(placement).IsNotNull();
+            await Assert.That(placement!.X).IsEqualTo(-120);
+            await Assert.That(placement.Y).IsEqualTo(42);
+            await Assert.That(placement.Width).IsEqualTo(1280.5);
+            await Assert.That(placement.Height).IsEqualTo(900);
+            await Assert.That(placement.IsMaximized).IsTrue();
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task Save_Twice_KeepsOnlyTheLatest()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"pgnimbus-{Guid.NewGuid():N}.json");
+
+        try
+        {
+            var store = new WindowPlacementStore(path);
+            store.Save(new WindowPlacement(0, 0, 1100, 800, IsMaximized: false));
+            store.Save(new WindowPlacement(200, 100, 1440, 960, IsMaximized: false));
+
+            var placement = store.Load();
+
+            await Assert.That(placement).IsNotNull();
+            await Assert.That(placement!.X).IsEqualTo(200);
+            await Assert.That(placement.Y).IsEqualTo(100);
+            await Assert.That(placement.Width).IsEqualTo(1440);
+            await Assert.That(placement.Height).IsEqualTo(960);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/PgNimbus.Core/Settings/WindowPlacementStore.cs
+++ b/PgNimbus.Core/Settings/WindowPlacementStore.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using PgNimbus.Core.Connections;
+
+namespace PgNimbus.Core.Settings;
+
+/// <summary>
+/// The main window's last known placement. <see cref="X"/>/<see cref="Y"/> are
+/// physical screen pixels (Avalonia's <c>Window.Position</c> space) while
+/// <see cref="Width"/>/<see cref="Height"/> are DIPs (<c>Window.Width</c>/
+/// <c>Height</c> space) — that split mirrors Avalonia's own API, so the App
+/// round-trips values without converting. Kept as plain numbers so
+/// <c>PgNimbus.Core</c> stays free of UI-framework types; validating the
+/// placement against the live monitor layout is the App's job on restore.
+/// When <see cref="IsMaximized"/> is true, the other fields still hold the
+/// last <em>normal</em> bounds — what the window should return to on
+/// unmaximize — not the maximized rect.
+/// </summary>
+public sealed record WindowPlacement(int X, int Y, double Width, double Height, bool IsMaximized);
+
+/// <summary>
+/// Persists the main window's placement across sessions (<c>window.json</c>,
+/// next to <c>workspace.json</c> — window geometry is session state like the
+/// restored workspace, not a user preference like <see cref="AppSettings"/>).
+/// One placement for the whole app: with several main windows open, the last
+/// one to close wins, same as the workspace store's per-connection snapshots.
+/// </summary>
+public sealed class WindowPlacementStore
+{
+    private readonly string _filePath;
+
+    public WindowPlacementStore(string? filePath = null)
+    {
+        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "window.json");
+    }
+
+    /// <summary>The saved placement, or null if none was ever saved (or the file is unreadable).</summary>
+    public WindowPlacement? Load()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return null;
+        }
+
+        // A corrupt/empty/half-written file must never block startup - fall back
+        // to "no saved placement" rather than throwing out of the startup path.
+        try
+        {
+            var json = File.ReadAllText(_filePath);
+            return JsonSerializer.Deserialize(json, WindowPlacementJsonContext.Default.WindowPlacement);
+        }
+        catch (Exception e) when (e is IOException or JsonException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    public void Save(WindowPlacement placement)
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(placement, WindowPlacementJsonContext.Default.WindowPlacement);
+        File.WriteAllText(_filePath, json);
+    }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(WindowPlacement))]
+internal sealed partial class WindowPlacementJsonContext : JsonSerializerContext;


### PR DESCRIPTION
## What

Saves and restores the main window's placement — position, size, and maximized state — across sessions, completing the session-restore story (workspace tabs already come back; now the window does too).

## How

- **`PgNimbus.Core/Settings/WindowPlacementStore.cs`** — `WindowPlacement` record + store persisting to `window.json` next to `workspace.json` (window geometry is session state like the restored workspace, not a preference, so it deliberately does not live in `AppSettings`). Same corrupt-file tolerance as `WorkspaceStore`: a bad file means "no saved placement", never a startup crash. `X`/`Y` are physical pixels and `Width`/`Height` are DIPs, mirroring Avalonia's own `Position` vs `Width`/`Height` split so the App round-trips without conversion.
- **`PgNimbus.App/WindowPlacementPersistence.cs`** — `Attach(window, store)` called from `BuildMainWindow` after construction and before `Show()`, so the first frame already paints at the restored placement (no jump). Restores position only if a grabbable strip of title bar (48 DIPs, converted per candidate screen's own scale for mixed-DPI setups) still lands on a live screen's working area — a monitor unplugged since the last run can't strand the window off-screen; the window then opens at the OS default. Maximized survives independently of position validity. While running, it tracks the last Normal-state bounds so closing maximized saves what unmaximize should return to, not the maximized rect; minimized never persists as a state.

With several main windows open they share the one placement and the last to close wins — same accepted trade-off as the per-connection workspace snapshots.

## Verified

- 4 new `WindowPlacementStore` unit tests; full suite: 351 passed, 0 failed.
- Live end-to-end on Windows (Win32 `GetWindowRect` probes against the running app): exact position+size restore; move-then-close saves the new position; maximized restores maximized and closing maximized keeps the normal bounds; an off-screen placement (`99999,99999`) falls back to the default position and self-heals on next close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)