### PR TITLE
README overhaul: categorized features, badges, installation and quick-start sections

### DIFF
--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -91,6 +91,27 @@
         <SolidColorBrush x:Key="TabItemHeaderSelectedPipeFill" Color="Transparent" />
 
         <!--
+            Results-grid row selection. The DataGrid Fluent theme paints a
+            selected row's backing rectangle Fill from these DynamicResource
+            brushes (SystemAccentColor by default - the one selection surface
+            the fixed-brand-blue pass in #116/#119 didn't reach, which is why
+            grid rows could read grey while everything else selects blue) with
+            a separate Opacity resource per state. Brush = opaque brand accent,
+            opacity tuned so the resulting wash matches AppSelectionBrush
+            (0x28 alpha ≈ 0.157), hover a touch stronger. Unfocused states stay
+            identical to focused ones - no other selection surface in the app
+            dims on focus loss.
+        -->
+        <StaticResource x:Key="DataGridRowSelectedBackgroundBrush" ResourceKey="AppAccentBrush" />
+        <StaticResource x:Key="DataGridRowSelectedHoveredBackgroundBrush" ResourceKey="AppAccentBrush" />
+        <StaticResource x:Key="DataGridRowSelectedUnfocusedBackgroundBrush" ResourceKey="AppAccentBrush" />
+        <StaticResource x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundBrush" ResourceKey="AppAccentBrush" />
+        <x:Double x:Key="DataGridRowSelectedBackgroundOpacity">0.157</x:Double>
+        <x:Double x:Key="DataGridRowSelectedHoveredBackgroundOpacity">0.235</x:Double>
+        <x:Double x:Key="DataGridRowSelectedUnfocusedBackgroundOpacity">0.157</x:Double>
+        <x:Double x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundOpacity">0.235</x:Double>
+
+        <!--
             Modern slim scrollbars, app-wide. FluentTheme's ScrollBar is 16px
             with a near-opaque track band and end arrow buttons, drawn OVER the
             content it scrolls. The template sizes and paints every part via

--- a/README.md
+++ b/README.md
@@ -5,47 +5,160 @@
   </picture>
 </p>
 
-# pgNimbus
+<h1 align="center">pgNimbus</h1>
 
-**Project page: <https://shman4ik.github.io/pgNimbus/>**
+<p align="center">
+  <b>A blazing-fast, open-source PostgreSQL GUI client with a modern, native UI.</b><br>
+  Launches in ~100 ms. Streams results before your query finishes. Sends zero telemetry.
+</p>
 
-A fast, native-feeling, open-source **PostgreSQL** GUI client, built with **.NET
-10 + Avalonia 12**. MIT licensed. Windows is the primary target, but the
-codebase stays cross-platform-capable — no Windows-only APIs live in the core
-engine.
+<p align="center">
+  <a href="https://github.com/Shman4ik/pgNimbus/releases"><img src="https://img.shields.io/github/v/release/Shman4ik/pgNimbus?label=release" alt="Latest release"></a>
+  <a href="https://apps.microsoft.com/detail/9N6SZT42XJ24"><img src="https://img.shields.io/badge/Microsoft%20Store-install-0078D4?logo=windows" alt="Microsoft Store"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT license"></a>
+  <img src="https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet" alt=".NET 10">
+  <img src="https://img.shields.io/badge/Avalonia-12-8B44AC" alt="Avalonia 12">
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20(beta)-lightgrey" alt="Platforms">
+</p>
 
-## The market thesis
+<p align="center">
+  <a href="https://shman4ik.github.io/pgNimbus/">Website</a> ·
+  <a href="#-installation">Installation</a> ·
+  <a href="#-quick-start">Quick Start</a> ·
+  <a href="#-features">Features</a> ·
+  <a href="#-benchmarks">Benchmarks</a> ·
+  <a href="#-roadmap">Roadmap</a>
+</p>
 
-The gap in the Postgres client market: **truly fast + open source + modern
-UI**.
+---
 
-- pgAdmin and DBeaver are heavy and slow.
-- TablePlus is fast, but closed-source and paid.
-- Beekeeper Studio is open source, but Electron.
-- HeidiSQL is native and fast, but dated in its UI and MySQL-first.
+## 🎯 Why pgNimbus?
 
-pgNimbus targets HeidiSQL's speed with TablePlus's polish — PostgreSQL-first,
-from the ground up.
+The PostgreSQL client market has a gap: **truly fast + open source + modern UI**.
 
-### Differentiators
+- **pgAdmin / DBeaver** — powerful, but heavy and slow.
+- **TablePlus** — fast and polished, but closed-source and paid.
+- **Beekeeper Studio** — open source, but Electron.
+- **HeidiSQL** — native and fast, but dated and MySQL-first.
 
-1. **Native performance** — launch-to-window in the ~100 ms range as a
-   NativeAOT binary. Not a one-off claim: startup, memory, and query-engine
-   numbers are measured on every release — see [Benchmarks](#benchmarks).
-2. **PostgreSQL-first** — deep `pg_catalog` introspection (materialized views,
-   real types, primary-key flags, and EXPLAIN visualization); never the
-   lowest-common-denominator SQL dialect.
-3. **Keyboard-first** — run, cancel, and navigate without touching the mouse.
-4. **Streaming results** — the first screenful renders before the full result
-   set arrives, backed by a virtualized grid for large results.
+pgNimbus delivers HeidiSQL's speed with TablePlus's polish — **PostgreSQL-first, from the ground up**. Built with .NET 10 + Avalonia 12, compiled to a NativeAOT binary, MIT licensed.
 
-## See it in action
+## 🎬 See It in Action
 
 | Instant launch (NativeAOT) | SQL completion that predicts the next move |
 | --- | --- |
 | ![pgNimbus launching from a cold NativeAOT process to a fully rendered main window in well under a second](docs/screenshots/cold-start.gif) | ![Typing FROM + a partial table name, JOIN with an FK-ranked table suggestion, then ON auto-completing the full join condition](docs/screenshots/completion-demo.gif) |
 
-## Screenshots
+## 📦 Installation
+
+### Microsoft Store (recommended)
+
+The Store package is signed and auto-updated — no SmartScreen warnings.
+
+**[Get pgNimbus on the Microsoft Store →](https://apps.microsoft.com/detail/9N6SZT42XJ24)**
+
+### WinGet
+
+```powershell
+winget install pgNimbus --source msstore
+```
+
+### Direct download (MSI)
+
+Grab `pgNimbus-<version>-win-x64.msi` from [Releases](https://github.com/Shman4ik/pgNimbus/releases) — a per-user installer, no admin rights needed.
+
+> [!NOTE]
+> The direct MSI is unsigned, so SmartScreen will warn on first run — click **More info → Run anyway**, or prefer the Store/WinGet path above.
+
+### macOS (early beta)
+
+`pgNimbus-<version>-macos-arm64.dmg` from [Releases](https://github.com/Shman4ik/pgNimbus/releases) (Apple Silicon only). The beta is unsigned and unnotarized, so Gatekeeper shows a misleading *"pgNimbus is damaged"* dialog on first launch.
+
+<details>
+<summary>Fixing the Gatekeeper "App is damaged" error</summary>
+
+The file is safe — this is standard macOS behavior for unsigned apps. Clear the quarantine flag once per downloaded update:
+
+```bash
+# If you moved the app to the Applications folder:
+xattr -cr /Applications/pgNimbus.app
+
+# If the app is still in your Downloads folder:
+xattr -cr ~/Downloads/pgNimbus.app
+```
+
+Then launch `pgNimbus.app` normally. Proper signing and notarization are planned — see [Roadmap](#-roadmap).
+
+</details>
+
+Every `vX.Y.Z` tag builds all of the above via [`release.yml`](.github/workflows/release.yml).
+
+## 🚀 Quick Start
+
+1. **Launch pgNimbus** — the connection dialog opens first.
+2. **Paste any connection string** into the box at the top; the form fills itself. All common syntaxes work:
+
+   ```text
+   postgres://alice:s3cret@db.example.com:5433/appdb?sslmode=require
+   jdbc:postgresql://db.example.com:5433/appdb?user=alice&ssl=true
+   Host=db.example.com;Port=5433;Database=appdb;Username=alice;Password=s3cret
+   host=db.example.com port=5433 dbname=appdb user=alice sslmode=require
+   PGPASSWORD=s3cret psql -h db.example.com -p 5433 -U alice appdb
+   ```
+
+3. **Connect** — your password goes to the OS credential store (DPAPI on Windows), never to disk.
+4. **Run a query** with <kbd>Ctrl</kbd>+<kbd>Enter</kbd>, jump anywhere with the command palette (<kbd>Ctrl</kbd>+<kbd>K</kbd>), and press <kbd>F1</kbd> for the full shortcut cheat sheet.
+
+For scripted or repeated local testing, set `PGNIMBUS_CONN` (same formats as the paste box) to skip the dialog entirely:
+
+```bash
+export PGNIMBUS_CONN="postgres://postgres:secret@localhost:5432/mydb"
+dotnet run --project PgNimbus.App
+```
+
+## ✨ Features
+
+### ⚡ Fast & Dependable
+
+- **~100 ms launch-to-window** as a NativeAOT binary — measured on every release, not asserted ([Benchmarks](#-benchmarks)).
+- **Streaming, cancellable results** — the first screenful renders before the full result set arrives, backed by a virtualized grid; <kbd>Esc</kbd> genuinely stops a query mid-flight.
+- **Auto-reconnect** — a connection dropped by laptop sleep or an SSH-tunnel hiccup quietly reopens on the next run. An open explicit transaction is never silently re-established; it surfaces a clear "connection lost, nothing committed" state instead.
+- **Workspace restore** — closing the app never prompts; the next session reopens your tabs, including never-saved scratch SQL, exactly as you left them.
+- **Zero telemetry** — no analytics, no crash reporting, no update pings. The only connections the app opens are the ones you configure ([Privacy](#-privacy)).
+
+### ✏️ A Smarter SQL Editor
+
+- **Schema-aware autocomplete** — schema-qualified tables after `FROM`/`JOIN`, scoped columns in `WHERE`/`ON`/`ORDER BY`, `alias.` member access, CTE output columns (including `SELECT *` bodies resolved through the catalog), and user-defined functions with signature tooltips.
+- **FK-aware JOIN magic** — after `JOIN`, tables connected by a foreign key rank first; after `ON`, the complete join condition (`oi.order_id = o.id`) is the top, one-keystroke suggestion.
+- **SQL formatting** — <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> pretty-prints the statement under the cursor; a token round-trip self-check guarantees only whitespace ever changes.
+- **Script execution** — run several `;`-separated statements on one connection (`BEGIN…COMMIT`, `SET`, and temp tables carry across), each with its own result section and timing, stopping at the first error.
+- **Multi-tab editor** with find & replace, current-line and bracket highlighting, font-size zoom, and `SELECT *` expansion into an explicit column list.
+- **Open/save `.sql` files** — <kbd>Ctrl</kbd>+<kbd>O</kbd>/<kbd>Ctrl</kbd>+<kbd>S</kbd>, a recent-files list in the palette, and a dirty marker that distinguishes "unsaved scratch" from "diverges from disk".
+- **Query history** — searchable, pinnable, scoped per connection; entries open in a new tab.
+- **Command palette** — <kbd>Ctrl</kbd>+<kbd>K</kbd> fuzzy-jumps to any table, saved query, or action without touching the mouse.
+
+### 🧮 Data Editing Without Fear
+
+- **Safe mode (pending-changes review)** — stage grid edits, inserts, and deletes locally: dirty rows are highlighted (amber = edited, red = delete), "Review & commit…" shows the exact generated SQL, and everything applies as **one transaction** — or gets discarded with nothing ever sent. Built for the "inline edit on production" nerves.
+- **No-SQL table browsing** — paged browsing with click-to-sort headers, all pushed down to Postgres (`ORDER BY`/`LIMIT`/`OFFSET`), so a huge table stays as cheap as one page. The composed SQL sits in the editor and doubles as the filter — add a `WHERE` and run.
+- **Follow foreign keys from the grid** — right-click an FK cell to jump to the row it references, or a key cell to list all referencing rows, each hop opening a pre-filtered browse tab.
+- **Full grid CRUD** — inline cell editing, an "Add row" dialog with server-side type casts, delete with confirmation, and "Set cell to NULL". Hand-typed `SELECT`s become editable too whenever the wire metadata proves it's safe.
+- **Postgres-native value editors** — `enum` columns get a dropdown of their `pg_enum` labels, `boolean` a checkbox, `date`/`timestamp` a calendar picker; arrays and composites are syntax-checked before anything is sent, and domains resolve to their base type.
+- **Transaction control** — an explicit **Begin/Commit/Rollback** flow on one held connection, with a status-bar indicator and automatic rollback on failure so you're never stranded in an aborted-transaction state.
+- **Cell inspector** — double-click any cell to read the full value in an overlay, with JSON pretty-printed and one-click copy.
+- **Import & export** — CSV/JSON import streamed via `COPY` with type inference; copy results as TSV, CSV, JSON, Markdown table, or `INSERT` statements.
+
+### 🐘 PostgreSQL-First Tooling
+
+- **Real `pg_catalog` introspection** — the schema tree sees materialized views, partitioned tables, and true primary-key flags; never the lowest-common-denominator `information_schema`.
+- **DDL reconstruction** — a "Source (DDL)" action rebuilds an object's `CREATE TABLE`/`CREATE VIEW` — columns, defaults, identity, constraints, partition key, indexes — into a new tab; an "Alter Table" UI covers no-SQL column changes.
+- **EXPLAIN visualization** — a graphical plan tree for `EXPLAIN` and `EXPLAIN ANALYZE` with per-node cost and timing, not just raw text.
+- **Server activity dashboard** — a live `pg_stat_activity` view with per-backend **cancel statement** and **terminate session**, so a runaway query is one click to stop.
+- **LISTEN/NOTIFY monitor** — subscribe to channels and watch notifications arrive live.
+- **Connection manager** — saved profiles with per-connection accent colors (so production never looks like staging), SSH tunnels, and passwords held by the OS credential store — never written to disk.
+- **Multiple simultaneous connections** — open profiles in separate self-contained windows (own pool, listener, tunnel, workspace), so dev and prod sit side by side; or switch the current window's connection without restarting.
+
+## 📸 Screenshots
 
 | Query editor + results (light) | Query editor + results (dark) |
 | --- | --- |
@@ -59,648 +172,114 @@ from the ground up.
 | --- | --- |
 | ![Server activity window showing a live backend and its wait event](docs/screenshots/server-activity.png) | ![Connection dialog with saved profiles and paste-anything import](docs/screenshots/connection-dialog.png) |
 
-Keyboard shortcuts cheat sheet (<kbd>F1</kbd>):
+## ⌨️ Keyboard Shortcuts
 
-<img src="docs/screenshots/shortcuts.png" alt="Keyboard shortcuts cheat sheet" width="360">
-
-## Download
-
-### Windows
-
-The **Microsoft Store is the preferred way to install** on Windows: the Store
-signs the package with its own trusted certificate (no SmartScreen warnings)
-and keeps it updated automatically.
-
-- **Microsoft Store** — [pgNimbus on the Microsoft Store](https://apps.microsoft.com/detail/9N6SZT42XJ24).
-- **winget** — Store apps are installable through winget's built-in
-  `msstore` source:
-
-  ```text
-  winget install pgNimbus --source msstore
-  ```
-
-- **Direct download** — `pgNimbus-<version>-win-x64.msi` from
-  [Releases](https://github.com/Shman4ik/pgNimbus/releases), a per-user
-  installer (no admin rights needed). The direct MSI is unsigned, so Windows
-  SmartScreen will warn on first run — click "More info" → "Run anyway".
-  Prefer the Store/winget path above if you can.
-
-### macOS (very early beta)
-
-The macOS build is a **very early beta**: it's produced by the same CI
-pipeline but has seen far less real-world testing than Windows, and full
-macOS support (signing, notarization, broader testing) is planned for
-later. If you want to try it anyway:
-
-- `pgNimbus-<version>-macos-arm64.dmg` from
-  [Releases](https://github.com/Shman4ik/pgNimbus/releases) (Apple Silicon
-  only; GitHub retired hosted Intel macOS runners in December 2025, and
-  Apple hasn't sold an Intel Mac since 2023).
-
-#### Fixing the Gatekeeper "App is damaged" error
-
-Because the beta binary is currently unsigned and unnotarized, macOS
-Gatekeeper will block it on the first launch, showing a misleading security
-warning:
-
-> *"pgNimbus" is damaged and can't be opened. You should move it to the
-> Trash.*
-
-This is standard macOS behavior for unsigned apps. The file is completely
-safe. To fix this and open the app, you need to clear the quarantine flag
-via Terminal:
-
-1. Drag `pgNimbus.app` from the DMG into your **Applications** folder (or
-   keep it in `Downloads`).
-2. Open **Terminal** (`Terminal.app`) and run the corresponding command:
-
-   ```bash
-   # If you moved the app to the Applications folder:
-   xattr -cr /Applications/pgNimbus.app
-
-   # If the app is still in your Downloads folder:
-   xattr -cr ~/Downloads/pgNimbus.app
-   ```
-
-3. Launch `pgNimbus.app` normally — the warning is gone for good (each
-   downloaded update needs the command once).
-
-Every tag push (`vX.Y.Z`) builds all of the above via
-[`.github/workflows/release.yml`](.github/workflows/release.yml) — see
-[CLAUDE.md](CLAUDE.md) for how the pipeline is put together.
-
-## Features
-
-- **Schema tree sidebar** — schemas → tables/views → columns, reading
-  `pg_catalog` directly (materialized views, partitioned tables, real
-  primary-key flags), with an "Alter Table" UI for no-SQL column add/rename/drop
-  and a **"Source (DDL)"** action that reconstructs an object's
-  `CREATE TABLE`/`CREATE VIEW` — columns, defaults, identity, constraints,
-  partition key, and secondary indexes — into a new editor tab.
-- **Refresh database & schema** — a sidebar refresh button (or
-  <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>) reloads the schema tree,
-  autocomplete cache, and command-palette table list from the server, so
-  objects created or altered elsewhere appear without reconnecting.
-- **No-SQL table browsing** — previewing a table opens it paged, with
-  `ORDER BY` from clicking a column header and prev/next paging in the
-  status bar — all pushed down to Postgres (`ORDER BY`/`LIMIT`/`OFFSET`),
-  so browsing a huge table stays as cheap as one page. The composed SQL
-  sits right in the editor, which doubles as the filter: add a `WHERE`
-  there and run (there's deliberately no separate filter box — you already
-  have a SQL editor).
-- **Follow foreign keys from the grid** — right-click an FK cell while
-  browsing to jump to the row it references ("Follow customer_id →
-  public.customers"), or a key cell to list the rows referencing it
-  ("Referencing rows"), each hop opening the target table in a new
-  pre-filtered browse tab.
-- **Connection manager** — saved profiles with a per-connection accent color
-  (so production doesn't look like staging), drag-to-reorder of the saved
-  list, SSH tunnel support, and passwords held by the OS credential store
-  (DPAPI on Windows) instead of being written to disk with the profile. The
-  password field has a show/hide toggle, and the connection-string preview
-  masks the password by default (the copy button still yields the full,
-  usable string).
-- **Switch connection without restarting** — the ⇄ button next to the
-  title-bar breadcrumb (or "Switch connection…" in the command palette)
-  reopens the connection dialog; the current window stays fully usable until
-  the new connection succeeds, then hands over cleanly (LISTEN subscriptions
-  and SSH tunnels for the old connection are torn down).
-- **Multiple simultaneous connections** — "Open connection in new window…" in
-  the command palette opens the connection dialog additively: the current
-  window (and every other open window) stays connected, and a successful
-  connect just adds another window alongside it. Each window is fully
-  self-contained (its own pool, notify listener, SSH tunnel, and workspace
-  snapshot), so dev and prod can sit side by side — accent colors tell them
-  apart at a glance.
-- **Paste-anything connection strings** — drop whatever is on your clipboard
-  into the connection dialog and it fills the form: `postgres://` URIs
-  (Heroku/Supabase/Neon-style), `jdbc:postgresql://` URLs, ADO.NET/Npgsql
-  `Key=Value;` strings, libpq `host=… dbname=…` keyword strings, and even
-  full `psql` command lines (including `PGPASSWORD=… psql -h …` prefixes).
-- **Command palette** — press <kbd>Ctrl</kbd>+<kbd>K</kbd> (or
-  <kbd>Ctrl</kbd>+<kbd>P</kbd>) to fuzzy-jump to any table, saved query, or
-  action from one keyboard-driven control.
-- **Keyboard shortcuts cheat sheet** — press <kbd>F1</kbd> (or the `?`
-  title-bar button) for an overview of every binding.
-- **Preferences page** — theme (system/light/dark), editor behavior
-  (auto-alias on completion), and the shortcut modifier (Ctrl/Cmd,
-  auto-detected per platform) on one page, opened via the gear title-bar
-  button, <kbd>Ctrl</kbd>+<kbd>,</kbd>, or "Preferences…" in the command
-  palette; every change applies immediately.
-- **Multi-tab query editor** — schema-aware SQL autocomplete (schema-qualified
-  tables after `FROM`/`JOIN`, `FROM`-scoped columns in `WHERE`/`ON`/`ORDER BY`,
-  columns with their data types elsewhere, `alias.` member access, CTE names
-  *and their output columns* — `cte.` completes what the CTE's SELECT list
-  yields, with `SELECT *` bodies resolved through the catalog,
-  common built-in functions *and the schema's own user-defined
-  functions/procedures/aggregates*, inserted as calls with the argument list
-  and return type shown as a tooltip in place of a separate parameter-hints
-  popup), saved queries,
-  run history, current-line and matching-bracket highlighting, find & replace
-  (<kbd>Ctrl</kbd>+<kbd>F</kbd> / <kbd>Ctrl</kbd>+<kbd>H</kbd>, F3 steps
-  matches), and font-size zoom (<kbd>Ctrl</kbd>+wheel /
-  <kbd>Ctrl</kbd>+<kbd>±</kbd>).
-- **Workspace restore** — closing the app never prompts; the next session on
-  the same connection reopens your tabs, including never-saved scratch SQL,
-  exactly as you left them.
-- **Open/save `.sql` files** — <kbd>Ctrl</kbd>+<kbd>O</kbd> opens a `.sql`
-  file into a new tab (or focuses it if already open),
-  <kbd>Ctrl</kbd>+<kbd>S</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd>
-  save/save-as, and the command palette lists your 10 most recent files. A
-  file-backed tab's dirty dot means "diverges from disk" (survives a run,
-  unlike a scratch tab's "edited since run") and its file association
-  survives workspace restore.
-- **SQL formatting** — <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> (or "Format
-  SQL" in the command palette) pretty-prints the statement under the cursor in a
-  readable block style — clauses on their own lines, list items and JOINs one per
-  line, `AND`/`OR` stacked, subqueries indented, keywords upper-cased — replacing
-  just that statement so the rest of a multi-statement script is left alone. A
-  self-check guarantees it never alters a query's tokens, only its whitespace.
-- **Run a whole script** — execute several `;`-separated statements at once on a
-  single connection (so `BEGIN…COMMIT`, `SET`, and temp tables carry across
-  them); each statement gets its own selectable result section with per-statement
-  timing, and the run stops at the first error (psql `ON_ERROR_STOP` style).
-- **Transaction control** — an explicit **Begin** toolbar button opens a
-  transaction that every statement (and inline grid edit) then runs inside on
-  one held connection; **Commit**/**Rollback** end it, a status-bar "in
-  transaction" indicator shows while it's open, and a failed statement
-  auto-rolls-back the block so you're never stranded in Postgres's
-  aborted-transaction state.
-- **Streaming, cancellable results** — the first screenful renders before the
-  full result set arrives, backed by a virtualized grid with inline cell
-  editing and CSV/JSON export.
-- **Auto-reconnect** — a connection dropped by a laptop sleep or an SSH-tunnel
-  hiccup quietly reopens on the next run instead of throwing a broken-pipe
-  error, with the whole pool flushed first so no other stale socket gets
-  rented next. An open explicit transaction is the one exception: it can't be
-  silently re-established, so that surfaces a clear "connection lost, nothing
-  committed" state instead.
-- **Grid CRUD** — beyond inline cell edits: an "Add row" dialog (each column
-  cast to its real type server-side, blanks fall back to defaults),
-  "Delete selected row(s)" with a confirmation, and "Set cell to NULL" (the
-  gesture inline editing can't express), all keyed on the primary key.
-  Editing isn't limited to browse mode: a hand-typed `SELECT` becomes
-  editable too whenever the wire metadata proves every column reads a real
-  column of one table under its own name and the full primary key is in the
-  result — expressions, aliases, joins, and views stay read-only.
-- **Postgres-native value editing** — cell editors (grid and Add-row dialog)
-  follow the column's type: `enum` columns get a dropdown of their `pg_enum`
-  labels, `boolean` a checkbox, `date`/`timestamp` a calendar picker, arrays
-  and composites are syntax-checked client-side before anything is sent, and
-  domains resolve to their base type (a domain over an enum still gets the
-  dropdown). Array cells display as Postgres literals (`{a,b}`), and tables
-  with composite-typed columns browse fine — those columns are fetched in
-  text format, since Npgsql can't materialize an unmapped composite.
-- **Safe mode (pending-changes review)** — a toggle (command palette or
-  preferences) that stages grid edits, deletes, and Add-row inserts locally
-  instead of firing them at the server: dirty rows are highlighted (amber =
-  edited, red = marked for deletion, and <kbd>Delete</kbd> toggles the mark),
-  a status-bar segment counts what's staged, "Review & commit…" shows the
-  exact generated SQL, and committing applies everything as **one
-  transaction** — or discard it all and nothing was ever sent. Built for the
-  "inline edit on production" nerves.
-- **Cell inspector** — double-click a cell (or "Inspect cell…" on the grid
-  context menu) to read the full value of a long `text`/`jsonb` cell in an
-  overlay: JSON pretty-printed, word wrap on by default with a toggle, and a
-  one-click copy.
-- **EXPLAIN visualization** — a graphical plan tree for `EXPLAIN` and
-  `EXPLAIN ANALYZE`, not just raw text output.
-- **Server activity dashboard** — a live `pg_stat_activity` view (state, wait
-  events, running statement) with per-backend **cancel statement** and
-  **terminate session** actions, so a runaway query is one click to stop.
-- **CSV/JSON import** — load a file into a new or existing table with
-  delimiter/header detection and per-column type inference, streamed via
-  `COPY`.
-- **Query history search & pinning** — history is searchable, pinnable, and
-  scoped per connection; entries open in a new tab.
-- **Copy results as…** — <kbd>Ctrl</kbd>+<kbd>C</kbd> copies selected rows as
-  TSV; the grid context menu adds CSV, JSON, Markdown table, and
-  `INSERT`-statement formats.
-- **LISTEN/NOTIFY monitor** — subscribe to channels and watch notifications
-  arrive live.
-
-## Privacy
-
-pgNimbus sends **zero telemetry**. No usage analytics, no crash reporting,
-no update pings, no "anonymous statistics" — nothing. The only network
-connections the app ever opens are the ones you configure: your PostgreSQL
-servers and, if you use them, your SSH tunnel hosts. Queries, schemas,
-credentials, and history never leave your machine (passwords live in the OS
-credential store, everything else in local JSON files under your user
-profile). The code is MIT-licensed and open — you can verify all of this
-rather than take it on faith.
-
-## Keyboard shortcuts
-
-Press <kbd>F1</kbd> in the app for the full cheat sheet. On macOS,
-<kbd>Cmd</kbd> takes the place of <kbd>Ctrl</kbd> automatically (except SQL
-autocomplete, which stays on <kbd>Ctrl</kbd>+<kbd>Space</kbd> — Cmd+Space is
-Spotlight); the modifier can also be forced either way from Preferences.
-The highlights:
+Press <kbd>F1</kbd> in the app for the full cheat sheet. On macOS, <kbd>Cmd</kbd> takes the place of <kbd>Ctrl</kbd> automatically (except autocomplete, which stays on <kbd>Ctrl</kbd>+<kbd>Space</kbd> — Cmd+Space is Spotlight). The highlights:
 
 | Action | Shortcut |
 | --- | --- |
-| Command palette (jump to table / query / action) | <kbd>Ctrl</kbd>+<kbd>K</kbd> or <kbd>Ctrl</kbd>+<kbd>P</kbd> |
-| Refresh database & schema | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> |
-| Collapse / show the sidebar | <kbd>Ctrl</kbd>+<kbd>B</kbd> |
-| Run query | <kbd>Ctrl</kbd>+<kbd>Enter</kbd> or <kbd>F5</kbd> |
-| Run just the statement under the cursor | <kbd>Shift</kbd>+<kbd>Enter</kbd> |
-| Format the statement under the cursor | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> |
-| Find / find & replace in the editor | <kbd>Ctrl</kbd>+<kbd>F</kbd> / <kbd>Ctrl</kbd>+<kbd>H</kbd> |
+| Command palette | <kbd>Ctrl</kbd>+<kbd>K</kbd> or <kbd>Ctrl</kbd>+<kbd>P</kbd> |
+| Run query / run statement under cursor | <kbd>Ctrl</kbd>+<kbd>Enter</kbd> / <kbd>Shift</kbd>+<kbd>Enter</kbd> |
 | Cancel running query | <kbd>Esc</kbd> |
+| Format statement under cursor | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>F</kbd> |
+| Find / find & replace | <kbd>Ctrl</kbd>+<kbd>F</kbd> / <kbd>Ctrl</kbd>+<kbd>H</kbd> |
 | New / close query tab | <kbd>Ctrl</kbd>+<kbd>T</kbd> / <kbd>Ctrl</kbd>+<kbd>W</kbd> |
-| Next / previous tab | <kbd>Ctrl</kbd>+<kbd>PageDown</kbd> / <kbd>Ctrl</kbd>+<kbd>PageUp</kbd> |
-| Open a `.sql` file | <kbd>Ctrl</kbd>+<kbd>O</kbd> |
-| Save the active tab to a `.sql` file / save as | <kbd>Ctrl</kbd>+<kbd>S</kbd> / <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> |
+| Open / save a `.sql` file | <kbd>Ctrl</kbd>+<kbd>O</kbd> / <kbd>Ctrl</kbd>+<kbd>S</kbd> |
 | SQL autocomplete | <kbd>Ctrl</kbd>+<kbd>Space</kbd> (also triggers while typing) |
+| Refresh database & schema | <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> |
+| Toggle sidebar | <kbd>Ctrl</kbd>+<kbd>B</kbd> |
 | Switch focus: editor ↔ results grid | <kbd>F6</kbd> |
+| Edit selected result cell | <kbd>F2</kbd> |
 | Preferences | <kbd>Ctrl</kbd>+<kbd>,</kbd> |
-| Edit selected result cell | <kbd>F2</kbd>, then <kbd>Enter</kbd> to commit / <kbd>Esc</kbd> to cancel |
-| Inspect a result cell (full value, pretty-printed JSON) | Double-click, or "Inspect cell…" on the grid context menu |
-| Keyboard shortcuts window | <kbd>F1</kbd> |
+| Shortcuts cheat sheet | <kbd>F1</kbd> |
 
-## Architecture
+## 📊 Benchmarks
 
-```
-pgNimbus/
-├── PgNimbus.sln
-├── PgNimbus.Core/                # Engine. Zero Avalonia/UI dependencies.
-│   ├── Connections/ConnectionProfile.cs
-│   ├── Query/QueryResult.cs
-│   ├── Query/QueryEngine.cs
-│   └── Schema/SchemaService.cs
-├── PgNimbus.App/                 # Avalonia MVVM front-end.
-│   ├── ViewModels/QueryViewModel.cs
-│   ├── Views/MainWindow.axaml(.cs)
-│   ├── App.axaml(.cs)
-│   └── Program.cs
-├── PgNimbus.Core.Tests/          # TUnit tests for the engine.
-└── PgNimbus.Benchmarks/          # Query-engine benchmarks (see Benchmarks).
-```
-
-`PgNimbus.Core` is a plain class library that depends only on `Npgsql`. It
-knows nothing about Avalonia or any UI framework, which keeps the engine
-reusable for a future CLI or test harness. `PgNimbus.App` is the Avalonia
-MVVM shell built on top of it, using CommunityToolkit.Mvvm source generators.
-
-## Building and running
-
-Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download).
-
-```bash
-dotnet build
-
-dotnet run --project PgNimbus.App
-```
-
-### Connecting to a database
-
-On launch, pgNimbus opens a connection dialog where you can create and save
-connection profiles (host, port, database, credentials, optional SSH tunnel,
-accent color) — saved profiles never store the password, only the OS
-credential store does.
-
-The **paste box at the top of the dialog** accepts a connection string in any
-common syntax and fills the form from it — only the fields the string
-mentions are overwritten:
-
-```text
-postgres://alice:s3cret@db.example.com:5433/appdb?sslmode=require
-jdbc:postgresql://db.example.com:5433/appdb?user=alice&ssl=true
-Host=db.example.com;Port=5433;Database=appdb;Username=alice;Password=s3cret
-host=db.example.com port=5433 dbname=appdb user=alice sslmode=require
-PGPASSWORD=s3cret psql -h db.example.com -p 5433 -U alice appdb
-```
-
-For scripted or repeated local testing, you can skip the dialog entirely by
-setting `PGNIMBUS_CONN`, which opens straight to the main window. It accepts
-the same formats as the paste box:
-
-```bash
-export PGNIMBUS_CONN="postgres://postgres:secret@localhost:5432/mydb"
-dotnet run --project PgNimbus.App
-```
-
-### Publishing a NativeAOT build
-
-```bash
-dotnet publish PgNimbus.App -c Release -r win-x64 -p:PublishAot=true    # Windows
-dotnet publish PgNimbus.App -c Release -r linux-x64 -p:PublishAot=true  # Linux (needs clang + zlib1g-dev)
-```
-
-The linux-x64 AOT binary is exercised as part of development: the query grid,
-EXPLAIN visualization, and profile stores all work under AOT (JSON persistence
-uses source-generated serializer contexts, and the results grid binds columns
-via converters instead of reflection paths, both of which trimming/AOT
-require).
-
-## Benchmarks
-
-"Fast" is the thesis, so it's measured, not asserted. The
-[Benchmarks workflow](.github/workflows/benchmark.yml) runs as part of the
-release pipeline (so every tagged build is measured) and on demand via
-`workflow_dispatch`:
+"Fast" is the thesis, so it's **measured, not asserted**. The [benchmark workflow](.github/workflows/benchmark.yml) runs on every tagged release and tracks:
 
 | Metric | What it proves |
 | --- | --- |
-| Startup, launch → first frame (NativeAOT and JIT) | The app is on screen in the ~100 ms range as an AOT binary — measured from OS process start to the first rendered frame, median of 7 runs |
+| Startup, launch → first frame (NativeAOT and JIT) | On screen in the ~100 ms range — measured from OS process start to first rendered frame |
 | Memory at first frame, AOT binary size | The footprint stays "native app", not "Electron app" |
-| Connect (cold pool) / round-trip (`SELECT 1`, warm) | Interactive latency of the query path |
-| First row batch of a 100 000-row `SELECT` | Streaming works: the first screenful arrives long before the full result |
-| Full 100 000-row stream (rows/s) | Sustained throughput of the `IAsyncEnumerable<RowBatch>` engine path |
+| Connect (cold pool) / `SELECT 1` round-trip | Interactive latency of the query path |
+| First row batch / full stream of a 100 000-row `SELECT` | Streaming delivers the first screenful long before the full result |
 
-Each run writes the numbers to the workflow's job summary and a
-`bench-results` artifact; tagged releases also append to the historical
-charts at <https://shman4ik.github.io/pgNimbus/dev/bench/>, so a regression
-shows up as a visible step in the graph of the release that introduced it.
-(Shared CI runners are noisy — read trends and big jumps, not single-percent
-wiggles.)
+Historical charts live at **<https://shman4ik.github.io/pgNimbus/dev/bench/>** — a regression shows up as a visible step in the release that introduced it.
 
-To run the suite locally (Linux, needs Xvfb and a reachable PostgreSQL):
+<details>
+<summary>Running the suite locally</summary>
+
+Linux, needs Xvfb and a reachable PostgreSQL:
 
 ```bash
 PGNIMBUS_BENCH_CONN="Host=localhost;Database=postgres;Username=postgres;Password=postgres" \
     scripts/benchmarks/run-benchmarks.sh          # add PGNIMBUS_BENCH_SKIP_AOT=1 to skip the slow AOT publish
 ```
 
-Two small pieces make it work: `PGNIMBUS_STARTUP_PROBE=1` makes the app print
-launch-to-first-frame time and RSS and exit
-([`StartupProbe.cs`](PgNimbus.App/StartupProbe.cs)), and the
-[`PgNimbus.Benchmarks`](PgNimbus.Benchmarks/Program.cs) console project
-measures the query engine through the same streaming API the UI uses.
+Two pieces make it work: `PGNIMBUS_STARTUP_PROBE=1` makes the app print launch-to-first-frame time and RSS and exit ([`StartupProbe.cs`](PgNimbus.App/StartupProbe.cs)), and the [`PgNimbus.Benchmarks`](PgNimbus.Benchmarks/Program.cs) console project measures the query engine through the same streaming API the UI uses.
 
-## Backlog
+</details>
 
-Prioritized by how much they advance the thesis (fast + open + modern,
-PostgreSQL-first). Contributions welcome — these are intentionally scoped as
-individually shippable pieces. Shipped items graduate from this list into
-[Features](#features) above.
+## 🏗️ Architecture
 
-### Now — release blockers
+```
+pgNimbus/
+├── PgNimbus.Core/         # Engine. Depends only on Npgsql — zero UI dependencies.
+├── PgNimbus.App/          # Avalonia MVVM front-end (CommunityToolkit.Mvvm).
+├── PgNimbus.Core.Tests/   # TUnit tests for the engine.
+└── PgNimbus.Benchmarks/   # Query-engine benchmarks.
+```
 
-- [x] **Microsoft Store certification** — done: the listing is
-  [live on the Microsoft Store](https://apps.microsoft.com/detail/9N6SZT42XJ24)
-  and is the trusted, SmartScreen-clean install path on Windows (the Store
-  re-signs the package with its own certificate); `winget install` works
-  through the built-in `msstore` source. Buying an Authenticode cert for the
-  direct MSI is deliberately *not* planned — the Store covers the trust story
-  for $0; the direct MSI stays as an unsigned convenience download.
-- [ ] **winget-pkgs submission** — manifests are generated and validated per
-  release, but the first manual `winget-pkgs` PR (which registers the
-  `pgNimbus.pgNimbus` identifier for the classic community source) hasn't
-  been made yet. Lower priority now that the `msstore` source already covers
-  `winget install`.
-- [ ] **Full macOS support** — the current `.dmg` is a very early beta:
-  arm64-only, unsigned/unnotarized, lightly tested. Proper support (Apple
-  Developer ID signing + notarization, real-world testing) is planned for
-  later and needs an Apple developer account.
+`PgNimbus.Core` is a plain class library that knows nothing about Avalonia, keeping the engine reusable for a future CLI or test harness. Results stream as `IAsyncEnumerable<RowBatch>` with real mid-flight cancellation.
 
-### Polish
+### Building from source
 
-- [ ] **Mica/acrylic backdrop on Windows** — the two-tone shell is ready for
-  it; deliberately deferred until it can be verified on a real Windows
-  desktop (transparency fallbacks can't be seen headless).
-- [ ] **Verify results-grid trackpad scrolling on a real mac** — the fix
-  (horizontal wheel deltas are fed to the grid's horizontal scrollbar on
-  hover, no click-into-grid needed) is implemented but was exercised on
-  Windows only; needs a pass with an actual macOS trackpad, ideally as part
-  of a broader macOS input/gesture sweep.
-- [ ] **Per-action hotkey remapping** — the Ctrl/Cmd scheme switch
-  (Preferences → Keyboard, `Hotkeys.cs`) is the foundation; the next step is
-  letting users rebind individual actions, persisted in `AppSettings`, with
-  conflict detection and a reset-to-defaults.
-- [x] **State the privacy guarantee** — the [Privacy](#privacy) section
-  above pledges zero telemetry and zero network traffic beyond the database
-  and SSH hosts you configure. It was already true; now it's stated where
-  users look for it
-  ([Show HN: DB Pro](https://news.ycombinator.com/item?id=46078571)).
+Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download).
 
-### SQL editor — completion that predicts the next move
+```bash
+dotnet build
+dotnet run --project PgNimbus.App
+```
 
-Findings from a hands-on Windows testing session (2026-07-09) against a live
-multi-schema database. The context-aware core (clause detection, alias/CTE
-resolution, `qualifier.` member access, auto-open after FROM/JOIN) all works —
-these are the gaps between "correct" and "feels like magic", roughly in
-impact order:
+Publishing a NativeAOT build:
 
-- [x] **First-keystroke preselection (bug — fix first)** — the popup opened
-  by the first typed letter shows the *unfiltered* list with nothing
-  selected, so `f` → Enter inserts nothing instead of `FROM`; filtering and
-  preselection only kick in from the second character. Apply the initial
-  character as the filter when the window opens.
-- [x] **FK-aware JOIN magic** — the flagship. After `JOIN`, rank tables
-  connected by a foreign key to the statement's tables first (today it's the
-  same flat catalog dump as `FROM`); after `ON `, auto-open and offer the
-  complete join condition (`oi.order_id = o.id`) as the top, one-keystroke
-  item. Needs FK edges (`pg_constraint contype = 'f'`) in the completion
-  catalog — the same data the ER-diagram backlog item wants.
-- [x] **Fuzzy matching + smarter ranking** — filtering is strict-prefix:
-  `dr` offers only `DROP` and never finds `daily_revenue`; `ord` preselects
-  `order_items` when `orders` is at least as likely. Reuse the command
-  palette's `FuzzyMatcher` (subsequence + word-boundary + adjacency bonuses)
-  in the completion list, breaking ties by exact-prefix, then shorter name,
-  then recency of use. Requires replacing the stock AvaloniaEdit
-  `CompletionList` filter.
-- [x] **Auto-open in more predictable spots** — the list opens by itself
-  only after FROM/JOIN/INTO/UPDATE today. `WHERE `, `ON `, `AND `/`OR `,
-  `SELECT ` and a comma inside a select list are just as predictable (the
-  statement's own columns are already scoped and floated there) but
-  currently require Ctrl+Space.
-- [x] **Auto-alias on table accept** — accepting `sales.orders` after
-  FROM/JOIN could also insert a short alias (`o`, dedup as `o2`…) so the
-  `o.` member-access flow is immediately available; make it a setting.
-- [x] **Auto-close pairs** — `(`, `'`, `"` should insert their closer with
-  type-over on the closing character; today `coalesce()` from a completion
-  accept is the only paired insert in the editor.
-- [x] **Completion popup visual polish** — stock AvaloniaEdit look: no kind
-  icons, no type column. Give items a kind glyph + color (table / column /
-  function / keyword / schema / alias / CTE), right-align the column data
-  type that's currently buried in the description panel, and restyle the
-  card (radius, shadow, padding) to match the Files-style shell in both
-  themes.
-- [x] **CTE output columns** — `WITH recent AS (SELECT id, total FROM orders)`
-  followed by `recent.` used to complete nothing; now the CTE's declared
-  column list or SELECT-list aliases complete like a table's columns
-  (`SELECT *` bodies resolve through the source tables' catalog columns,
-  chained/recursive CTEs included), and WHERE over a CTE narrows to them.
-- [x] **`SELECT *` expansion** — "Expand SELECT * into columns" in the
-  command palette replaces the statement's `*` / `alias.*` with the explicit
-  column list of its FROM tables (qualified by alias when the statement joins
-  more than one; CTEs resolve through their derived output columns).
-  All-or-nothing: an unresolvable table means no rewrite, never a wrong one.
-  Deliberately palette-only — no popup item on every typed `*`.
+```bash
+dotnet publish PgNimbus.App -c Release -r win-x64 -p:PublishAot=true    # Windows
+dotnet publish PgNimbus.App -c Release -r linux-x64 -p:PublishAot=true  # Linux (needs clang + zlib1g-dev)
+```
 
-### Next — the gaps users of competing tools keep hitting
+## 🔒 Privacy
 
-Sourced from a research pass (2026-07) over what people praise, request, and
-abandon tools over: Hacker News client threads
-([Good UI for PostgreSQL?](https://news.ycombinator.com/item?id=33776831),
-[What PostgreSQL client do you use?](https://news.ycombinator.com/item?id=23208181),
-[Show HN: DB Pro](https://news.ycombinator.com/item?id=46078571)), the
-top-👍 issues on the TablePlus and Beekeeper Studio trackers, and what
-Postico/DataGrip users single out. Multi-database support dominates those
-trackers and is deliberately out of scope — PostgreSQL-first *is* the thesis.
-Everything below is what survives that filter, roughly in impact order:
+pgNimbus sends **zero telemetry**. No usage analytics, no crash reporting, no update pings, no "anonymous statistics" — nothing. The only network connections the app ever opens are the ones you configure: your PostgreSQL servers and, if you use them, your SSH tunnel hosts. Queries, schemas, credentials, and history never leave your machine (passwords live in the OS credential store, everything else in local JSON files under your user profile). The code is MIT-licensed and open — verify it rather than take it on faith.
 
-- [x] **Pending-changes review ("safe mode")** — stage grid edits, inserts,
-  and deletes locally, highlight the dirty cells/rows, show the generated SQL
-  for review, then commit everything as one transaction (or discard). Today
-  each inline edit fires immediately, which is scary on production; a staged
-  mode is TablePlus's single most-praised trust feature. Shipped as an
-  opt-in toggle (palette/preferences, persisted): staged rows get amber/red
-  washes, Delete toggles a row's staged-delete mark, a delete supersedes the
-  row's staged edits until unstaged, and the review dialog shows literal SQL
-  while execution stays parameterized through one `BEGIN…COMMIT` batch
-  (joining the explicit transaction instead when one is open). Once anything
-  is staged, later changes keep staging even if the toggle flips off —
-  mixing immediate and staged writes would apply changes out of order.
-- [x] **Follow a foreign key from the grid** — right-clicking a browse-mode
-  cell whose column is an FK offers "Follow *col* → *parent table*" (jumps to
-  the referenced row in a new filtered browse tab), and a key cell offers
-  "Referencing rows" (one entry per table whose FK points here). Reuses the
-  FK edges already loaded for JOIN completion; composite keys AND-join their
-  filter. The most-praised "little feature" in DBeaver's HN comments.
-- [x] **Workspace restore** — reopen the last session's tabs, including
-  never-saved SQL, exactly as they were — no save prompts on exit
-  (Notepad++-style, called out on HN as what makes DBeaver safe to close).
-  Persist per-connection alongside history in `AppSettings`-style JSON.
-  Shipped: a per-connection `workspace.json` (`WorkspaceStore`, capped at the
-  20 most-recently-used connections) snapshots every tab's SQL and title on
-  window close — including a normal exit and a "switch connection", both of
-  which fire the same `Closed` handler — and restores them, with the active
-  tab, the next time you connect to that same host/database. Browse-mode
-  tabs (table/function "source" views) restore as their composed query SQL,
-  not a live browse session; there is nothing to save/prompt for, so exit is
-  always silent.
-- [x] **Open/save `.sql` files** — Ctrl+O / Ctrl+S on a tab, a recent-files
-  list in the palette, and a dirty marker that distinguishes "unsaved
-  scratch" from "file changed on disk". A top-voted Beekeeper Studio ask
-  (it appears twice in their top 20). Shipped: `Ctrl+O` opens a `.sql` file
-  into a new tab (never the active one — same rule as saved queries/history),
-  reusing an already-open tab for the same path instead of duplicating it;
-  `Ctrl+S` / `Ctrl+Shift+S` save/save-as (via `Hotkeys.cs`, so `Cmd` on
-  macOS); the palette lists the 10 most recent files (persisted in
-  `AppSettings.RecentSqlFiles`) alongside new "Open .sql file…" / "Save tab
-  to file" / "Save tab as…" actions. The tab's dirty dot carries two
-  different meanings depending on whether it's file-backed: a scratch tab's
-  dot means "edited since last run" (cleared by running it), a file tab's dot
-  means "diverges from what's on disk" (survives a run — only a save clears
-  it). File tabs also survive workspace restore with their file association:
-  the saved buffer is kept as-is and the dot honestly reflects any
-  divergence from disk at reopen, rather than silently re-reading the file
-  over unsaved edits.
-- [x] **Multiple simultaneous connections** — today the ⇄ switch *replaces*
-  the connection; users working against dev + prod side by side want both at
-  once (top-10 Beekeeper ask). Cleanest fit for the one-window shell:
-  connection-per-window, with the palette able to open a profile in a new
-  window. Per-connection accent colors already exist to keep them apart.
-  Shipped: "Open connection in new window…" in the command palette
-  (`App.BuildConnectionDialog`'s new `replaceMainWindow: false` mode) opens
-  the connection dialog additively instead of tearing down the current
-  window — the dialog just adds another self-contained window with its own
-  pool, notify listener, SSH tunnel, and per-connection workspace snapshot.
-  The ⇄ switch still replaces in place (unchanged); the app exits when the
-  *last* window closes, whichever that is, and accent colors keep the
-  windows visually apart on the taskbar/Alt+Tab.
-- [x] **Auto-reconnect** — after laptop sleep or an SSH-tunnel drop, the next
-  run should quietly reopen the connection instead of surfacing a broken-pipe
-  error (or hanging — an HN complaint about other clients). Needs care with
-  the held transaction connection: an open transaction can't be silently
-  re-established, so that path surfaces a clear "transaction lost" state.
-  Shipped: `QueryEngine` classifies a failure as connection loss (Postgres
-  class-08 `SqlState`s, an admin/crash shutdown, or a socket/IO exception
-  under the hood — deliberately not a command timeout, where the statement
-  may still be executing server-side) versus an ordinary statement error,
-  and on loss flushes the whole connection pool — not just the one dead
-  socket — before silently retrying once on a fresh connection. Runs,
-  single-row edits, and
-  safe-mode batches (retried only if the loss happened before `COMMIT` was
-  attempted) all get this; a multi-statement script retries only its first
-  statement, since a mid-script reconnect can't resurrect `SET`s or temp
-  tables the earlier statements built up. The one path that never retries is
-  an explicit transaction: there's no live socket left to send `ROLLBACK`
-  down, so the engine tears down its client-side state instead and returns a
-  `QueryError` that plainly says the connection (and the transaction on it)
-  is gone and nothing from it was committed — the next statement reconnects
-  on its own.
-- [x] **Postgres-native value editing** — the grid and Add-row dialog treat
-  every column as text today. Make the editors type-aware: `enum` columns get
-  a dropdown of `pg_enum` labels, `boolean` a checkbox, `date/timestamp` a
-  picker, arrays and composites get validation, domains resolve to their base
-  type. DataGrip's missing array support was a stated deal-breaker on HN, and
-  ENUM dropdowns / user-defined types are open TablePlus asks — exactly the
-  "PostgreSQL-first, not lowest-common-denominator" differentiator. Shipped:
-  `SchemaService` classifies each column from its base `pg_type` (domains
-  walked through `typbasetype`, so a domain over an enum still gets the
-  dropdown), enum/boolean/date/timestamp cells get typed editors in both the
-  grid (F2) and the dialog, array/composite literals are structure-checked
-  client-side and cast to the declared type server-side (staged edits
-  included — the safe-mode review shows the `CAST`), arrays render as `{a,b}`
-  literals, and composite columns fall back to text-format fetch so such
-  tables browse at all. Also un-broke inline editing itself: Avalonia 12
-  treats pathless-binding columns as read-only, which had silently disabled
-  every cell editor since the 11→12 upgrade.
-- [ ] **Table & index sizes and usage** — sizes in the schema tree (tooltip or
-  detail column) and a per-database overview: largest tables/indexes
-  (`pg_total_relation_size`), seq-vs-index scan counts, unused indexes, cache
-  hit rate (`pg_stat_user_tables`/`_indexes`, `pg_statio_*`). "No list of
-  tables or indexes with their sizes and usage" is a direct HN complaint
-  about DataGrip; pgAdmin buries it. Read-only `pg_catalog` queries — squarely
-  in `SchemaService`/`ActivityService` territory.
-- [ ] **Locks & blocking tree** — extend the server-activity window with a
-  who-blocks-whom view (`pg_locks` joined to `pg_stat_activity`, or
-  `pg_blocking_pids()`), so a stuck migration is a one-click
-  cancel/terminate of the *blocker*. The signal plumbing
-  (`CancelBackendAsync`/`TerminateBackendAsync`) already exists.
-- [ ] **Row detail sidebar** — a vertical name/value view of the selected row
-  (Postico's much-loved "row sidebar"), for tables too wide to read as a grid
-  row; doubles as a form-style editor and complements the cell inspector.
-- [x] **Find & replace in the editor** — <kbd>Ctrl</kbd>+<kbd>F</kbd> /
-  <kbd>Ctrl</kbd>+<kbd>H</kbd> (via `Hotkeys.cs`, so Cmd on macOS) open
-  AvaloniaEdit's SearchPanel over the SQL editor, seeded with the current
-  selection; F3/Shift+F3 step matches, match highlights are theme-tinted, and
-  both actions are in the command palette.
-- [ ] **Linux builds** — the linux-x64 NativeAOT publish already works (it's
-  how the app is exercised in CI sandboxes and benchmarks); what's missing is
-  a release-pipeline leg and packaging. Flatpak is the #2 top-voted Beekeeper
-  Studio request, and HeidiSQL adding native Linux builds in late 2025 shows
-  the demand; start with an AppImage or tarball from `release.yml`, Flatpak
-  after.
+## 🗺️ Roadmap
 
-### Later — bigger bets
+Prioritized by how much it advances the thesis (fast + open + modern, PostgreSQL-first). Contributions welcome — items are intentionally scoped as individually shippable pieces; shipped items graduate into [Features](#-features) above.
 
-- [ ] **ER diagram** — auto-laid-out foreign-key graph of a schema, exportable
-  as SVG.
-- [ ] **EXPLAIN plan diffing** — run the same query twice (e.g. before/after an
-  index) and diff the plan trees node-by-node.
-- [ ] **Backup/restore UI** — `pg_dump`/`pg_restore` orchestration with
-  progress streaming.
-- [ ] **AI, privacy-first** — the 2026 table stakes in every competitor is a
-  schema-aware assistant; the differentiator for an OSS client is doing it
-  without a data-leak worry: bring-your-own-key (or local model), explicit
-  opt-in, nothing leaves the machine otherwise. Two shapes, possibly both:
-  an in-app "explain this query / write this query" assistant fed the same
-  completion catalog, and/or a built-in MCP server exposing the current
-  connection so Claude Code / Cursor / VS Code can query it (TablePlus has an
-  open ask for exactly this).
-- [ ] **Vim keybindings in the editor** — the single most-upvoted
-  editor-related request on TablePlus's tracker (180+ 👍); a modal-editing
-  layer over AvaloniaEdit, opt-in from Preferences.
-- [ ] **Parameterized queries** — recognize `:name` / `$1` placeholders and
-  prompt for values on run (remembering the last ones), so shared saved
-  queries stop being edit-before-every-run.
-- [ ] **Quick chart of a result set** — one click from a result grid to a
-  bar/line/scatter view of two chosen columns; DataGrip's inline charts get
-  cited as the reason analysts stay there.
-- [ ] **PostGIS geometry viewer** — render `geometry`/`geography` cells on a
-  map/canvas the way the cell inspector renders JSON; the one PostGIS
-  feature HN users single out pgAdmin and DBeaver for having.
-- [ ] **Notebook mode** — mixed SQL + Markdown documents with inline result
-  snapshots, saved as shareable files.
-- [ ] **Plugin/extension API** — a stable surface for community panels
-  (initially: custom result visualizers).
-- [ ] **Localization** — externalize UI strings; ship Russian and German first.
+**Next up**
 
-## License
+- [ ] **Full macOS support** — Developer ID signing, notarization, real-world testing.
+- [ ] **Linux builds** — the linux-x64 NativeAOT publish already works; missing a release leg and packaging (AppImage/tarball first, Flatpak after).
+- [ ] **Table & index sizes and usage** — sizes in the schema tree plus a per-database overview (largest relations, seq-vs-index scans, unused indexes, cache hit rate).
+- [ ] **Locks & blocking tree** — a who-blocks-whom view in the activity window, with one-click cancel/terminate of the *blocker*.
+- [ ] **Row detail sidebar** — a vertical name/value view of the selected row, doubling as a form-style editor.
+- [ ] **winget-pkgs submission** — manifests are generated and validated per release; the first manual community-source PR is pending (the `msstore` source already covers `winget install`).
+- [ ] **Windows polish** — Mica/acrylic backdrop; per-action hotkey remapping.
+
+**Bigger bets**
+
+- [ ] **ER diagram** — auto-laid-out foreign-key graph of a schema, exportable as SVG.
+- [ ] **EXPLAIN plan diffing** — run a query before/after an index and diff the plan trees node-by-node.
+- [ ] **Backup/restore UI** — `pg_dump`/`pg_restore` orchestration with progress streaming.
+- [ ] **AI, privacy-first** — bring-your-own-key or local model, explicit opt-in, nothing leaves the machine otherwise; possibly an in-app assistant and/or a built-in MCP server exposing the current connection.
+- [ ] **Vim keybindings** — opt-in modal editing over AvaloniaEdit.
+- [ ] **Parameterized queries** — recognize `:name` / `$1` placeholders and prompt for values on run.
+- [ ] **Quick chart of a result set** — one click from grid to a bar/line/scatter view.
+- [ ] **PostGIS geometry viewer** — render `geometry`/`geography` cells on a map.
+- [ ] **Notebook mode** — mixed SQL + Markdown documents with inline result snapshots.
+- [ ] **Plugin/extension API** — a stable surface for community panels.
+- [ ] **Localization** — externalize UI strings; Russian and German first.
+
+## 📄 License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## What changed

A full restructure of `README.md` for GitHub presentation (~700 lines -> ~280), with no substantive claims lost:

- **Hero + badges** - centered wordmark, one-line pitch, and a badge row (release, Microsoft Store, MIT, .NET 10, Avalonia 12, platforms), plus a quick-nav link row.
- **Installation section** - three Windows channels (Microsoft Store recommended, WinGet via `msstore`, direct MSI with a SmartScreen `> [!NOTE]` callout) plus the macOS beta, with the Gatekeeper `xattr` fix collapsed into `<details>`. No portable ZIP exists, so the third channel is the per-user MSI.
- **Quick Start section** - launch -> paste-anything connection string (all five syntaxes shown) -> connect -> core shortcuts, plus the `PGNIMBUS_CONN` tip.
- **Features regrouped into 4 categories** - Fast & Dependable / A Smarter SQL Editor / Data Editing Without Fear / PostgreSQL-First Tooling, replacing the flat 25-bullet list.
- **Prose rewritten** in tighter, benefit-led English throughout; emoji section headers.
- **Backlog -> Roadmap** - completed `[x]` items and their long "Shipped:" narratives are dropped (they graduated into Features per the README's own convention, and the detail survives in git history); only unshipped items remain, split into "Next up" and "Bigger bets".
- Benchmarks keeps its metrics table and charts link with local-run instructions in `<details>`; Architecture, Privacy, and the shortcuts table are condensed but preserved.

## Why

The old README front-loaded a very long flat feature list and a 270-line backlog before a visitor ever saw how to install the app. This version leads with what sells (speed, demo GIFs, install paths) and keeps the deep detail reachable.

## Reviewer notes

- The badge URLs use shields.io (external images render fine on GitHub); the Store badge links to the live listing `9N6SZT42XJ24`.
- Worth a skim of the Roadmap section to confirm nothing dropped there is something you still wanted visible in the README rather than only in git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)