### PR TITLE
Benchmark publish-size: measure shipped files, not raw publish output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,10 +332,14 @@ the release pipeline don't pollute the trend history. Three moving parts:
    `customSmallerIsBetter` format — keep every metric smaller-is-better, so
    throughput is reported as stream *time*) plus `summary.md`.
    `PGNIMBUS_BENCH_SKIP_AOT=1` skips the slow AOT publish for local runs. Also
-   tracks size: the AOT exe alone (`binary_size_mb`) and the whole publish
-   dir (`publish_size_mb`, `du -sb` on the publish output) — the latter is
-   the more honest "app size" number since side-car native libs bundled
-   alongside the exe (`libSkiaSharp`, `libHarfBuzzSharp`) dwarf it.
+   tracks size: the AOT exe alone (`binary_size_mb`) and the shipped publish
+   files (`publish_size_mb` — the publish output minus `*.pdb`/`*.dbg` debug
+   symbols, mirroring the exclusion the MSI/MSIX packaging applies, so the
+   metric tracks what installers actually package rather than what publish
+   leaves on disk; the publish dir is wiped before publishing so repeated
+   local runs never count stale leftovers) — the latter is the more honest
+   "app size" number since side-car native libs bundled alongside the exe
+   (`libSkiaSharp`, `libHarfBuzzSharp`) dwarf it.
 
 Numbers are machine-relative (this sandbox: ~160 ms AOT / ~2 s JIT to first
 frame; CI runners differ) — the point is the trend per commit, not the

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -91,6 +91,27 @@
         <SolidColorBrush x:Key="TabItemHeaderSelectedPipeFill" Color="Transparent" />
 
         <!--
+            Results-grid row selection. The DataGrid Fluent theme paints a
+            selected row's backing rectangle Fill from these DynamicResource
+            brushes (SystemAccentColor by default - the one selection surface
+            the fixed-brand-blue pass in #116/#119 didn't reach, which is why
+            grid rows could read grey while everything else selects blue) with
+            a separate Opacity resource per state. Brush = opaque brand accent,
+            opacity tuned so the resulting wash matches AppSelectionBrush
+            (0x28 alpha ≈ 0.157), hover a touch stronger. Unfocused states stay
+            identical to focused ones - no other selection surface in the app
+            dims on focus loss.
+        -->
+        <StaticResource x:Key="DataGridRowSelectedBackgroundBrush" ResourceKey="AppAccentBrush" />
+        <StaticResource x:Key="DataGridRowSelectedHoveredBackgroundBrush" ResourceKey="AppAccentBrush" />
+        <StaticResource x:Key="DataGridRowSelectedUnfocusedBackgroundBrush" ResourceKey="AppAccentBrush" />
+        <StaticResource x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundBrush" ResourceKey="AppAccentBrush" />
+        <x:Double x:Key="DataGridRowSelectedBackgroundOpacity">0.157</x:Double>
+        <x:Double x:Key="DataGridRowSelectedHoveredBackgroundOpacity">0.235</x:Double>
+        <x:Double x:Key="DataGridRowSelectedUnfocusedBackgroundOpacity">0.157</x:Double>
+        <x:Double x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundOpacity">0.235</x:Double>
+
+        <!--
             Modern slim scrollbars, app-wide. FluentTheme's ScrollBar is 16px
             with a near-opaque track band and end arrow buttons, drawn OVER the
             content it scrolls. The template sizes and paints every part via

--- a/scripts/benchmarks/run-benchmarks.sh
+++ b/scripts/benchmarks/run-benchmarks.sh
@@ -10,9 +10,11 @@
 #   startup_jit_ms   launch → first rendered frame, JIT Release build
 #   startup_rss_mb   resident memory at first frame (AOT)
 #   binary_size_mb   size of the AOT executable alone
-#   publish_size_mb  total size of the AOT publish dir (exe + native deps
-#                     like libSkiaSharp/libHarfBuzzSharp) — what actually
-#                     ships, since those side-car libs dwarf the exe itself
+#   publish_size_mb  total size of the shipped files in the AOT publish dir
+#                     (exe + native deps like libSkiaSharp/libHarfBuzzSharp),
+#                     excluding *.pdb/*.dbg debug symbols — the same exclusion
+#                     the MSI (Product.wxs) and MSIX (build-msix.ps1) apply,
+#                     so this tracks what installers actually package
 #   connect_ms       first physical connection on a cold pool
 #   roundtrip_ms     SELECT 1 on a warm pooled connection (median)
 #   first_batch_ms   large SELECT: call → first streamed RowBatch (median)
@@ -81,11 +83,20 @@ JIT_BINARY=PgNimbus.App/bin/Release/net10.0/PgNimbus.App
 
 if [[ -z "${PGNIMBUS_BENCH_SKIP_AOT:-}" ]]; then
     echo "== Publishing (NativeAOT linux-x64) — this is the slow part"
-    dotnet publish PgNimbus.App -c Release -r linux-x64 -p:PublishAot=true >/dev/null
     AOT_BINARY=PgNimbus.App/bin/Release/net10.0/linux-x64/publish/PgNimbus.App
-    BINARY_SIZE_MB=$(awk "BEGIN { printf \"%.1f\", $(stat -c%s "$AOT_BINARY") / 1024 / 1024 }")
     PUBLISH_DIR=$(dirname "$AOT_BINARY")
-    PUBLISH_SIZE_BYTES=$(du -sb "$PUBLISH_DIR" | cut -f1)
+    # dotnet publish never cleans its output dir, so a repeated local run
+    # would keep (and count) files a previous build no longer produces.
+    rm -rf "$PUBLISH_DIR"
+    dotnet publish PgNimbus.App -c Release -r linux-x64 -p:PublishAot=true >/dev/null
+    BINARY_SIZE_MB=$(awk "BEGIN { printf \"%.1f\", $(stat -c%s "$AOT_BINARY") / 1024 / 1024 }")
+    # Measure what ships, not what publish leaves on disk: the MSI and MSIX
+    # both exclude debug symbols (*.pdb — see installer/windows/Product.wxs
+    # and scripts/windows/build-msix.ps1); the linux-x64 equivalent is the
+    # *.dbg file NativeAOT strips symbols into. Counting them here would
+    # make the metric miss packaging-size changes entirely.
+    PUBLISH_SIZE_BYTES=$(find "$PUBLISH_DIR" -type f ! -name '*.pdb' ! -name '*.dbg' -printf '%s\n' \
+        | awk '{ s += $1 } END { print s }')
     PUBLISH_SIZE_MB=$(awk "BEGIN { printf \"%.1f\", $PUBLISH_SIZE_BYTES / 1024 / 1024 }")
 fi
 
@@ -119,7 +130,7 @@ ROWS_PER_SEC=$(bench_value rows_per_sec)
   { "name": "Startup, launch to first frame (NativeAOT)", "unit": "ms", "value": $STARTUP_AOT_MS },
   { "name": "Memory at first frame (NativeAOT)", "unit": "MB", "value": $RSS_AOT_MB },
   { "name": "Binary size (NativeAOT)", "unit": "MB", "value": $BINARY_SIZE_MB },
-  { "name": "Publish size (NativeAOT, all files)", "unit": "MB", "value": $PUBLISH_SIZE_MB },
+  { "name": "Publish size (NativeAOT, shipped files)", "unit": "MB", "value": $PUBLISH_SIZE_MB },
 EOF
     cat <<EOF
   { "name": "Startup, launch to first frame (JIT)", "unit": "ms", "value": $STARTUP_JIT_MS },
@@ -140,7 +151,7 @@ EOF
         echo "| Startup, launch → first frame (NativeAOT) | $STARTUP_AOT_MS ms |"
         echo "| Memory at first frame (NativeAOT) | $RSS_AOT_MB MB |"
         echo "| Binary size (NativeAOT) | $BINARY_SIZE_MB MB |"
-        echo "| Publish size (NativeAOT, all files) | $PUBLISH_SIZE_MB MB |"
+        echo "| Publish size (NativeAOT, shipped files) | $PUBLISH_SIZE_MB MB |"
     }
     echo "| Startup, launch → first frame (JIT) | $STARTUP_JIT_MS ms |"
     echo "| Connect (cold pool) | $CONNECT_MS ms |"


### PR DESCRIPTION
## Problem

The `publish_size_mb` benchmark metric ran `du -sb` over the entire NativeAOT publish directory. That counts debug-symbol files - `PgNimbus.App.dbg` on linux-x64 (NativeAOT strips symbols into it by default), `*.pdb` on Windows - which the shipped packages deliberately exclude (MSI via `Product.wxs`, MSIX via `build-msix.ps1` since #113).

So the ~100MB packaging-size optimization from #113 never moved the benchmark number: the metric measured what `dotnet publish` leaves on disk, not what installers actually package.

(The benchmark does have to build its own linux-x64 binaries - startup time can''t be measured from a Windows MSI on an Ubuntu runner - so the fix is aligning the *measured file set* with what ships, not swapping in release artifacts.)

## What changed

- `publish_size_mb` now sums only installer-shipped files: `find ... ! -name '*.pdb' ! -name '*.dbg'`, mirroring the MSI/MSIX exclusion.
- The publish dir is wiped before `dotnet publish` - publish never cleans its output, so a repeated local run used to keep (and count) files a previous build no longer produces.
- Metric renamed to **"Publish size (NativeAOT, shipped files)"** since its meaning changed; per the documented convention, its gh-pages trend history restarts under the new name.
- `CLAUDE.md` benchmarks section updated in the same commit.

## Reviewer notes

- `binary_size_mb` (the exe alone) is unchanged - the exe never included symbols.
- The history restart for the renamed metric is deliberate: the old and new numbers aren''t comparable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)