### PR TITLE
Linux release artifacts: AppImage, .deb, tar.gz for x64 + arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,52 @@ jobs:
           name: macos-dmg-arm64
           path: dist/*.dmg
 
+  build-linux:
+    needs: prepare
+    strategy:
+      matrix:
+        include:
+          # arm64 is a native build — GitHub provides free arm64 runners for
+          # public repos — so no cross-compilation toolchain is involved.
+          - runner: ubuntu-latest
+            rid: linux-x64
+          - runner: ubuntu-24.04-arm
+            rid: linux-arm64
+    runs-on: ${{ matrix.runner }}
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install NativeAOT prerequisites
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y clang zlib1g-dev
+
+      - name: Publish NativeAOT (${{ matrix.rid }})
+        run: >
+          dotnet publish PgNimbus.App -c Release -r ${{ matrix.rid }}
+          --self-contained true
+          -p:PublishAot=true
+          -p:Version=${{ env.VERSION }}
+          -p:FileVersion=${{ env.VERSION }}
+          -p:InformationalVersion=${{ env.VERSION }}
+          -o publish/${{ matrix.rid }}
+
+      - name: Build tar.gz + AppImage + .deb
+        run: |
+          chmod +x scripts/linux/build-packages.sh
+          ./scripts/linux/build-packages.sh publish/${{ matrix.rid }} "$VERSION" ${{ matrix.rid }} dist
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: linux-packages-${{ matrix.rid }}
+          path: dist/*
+
   winget-manifest:
     needs: [prepare, build-windows]
     runs-on: windows-latest
@@ -222,7 +268,7 @@ jobs:
           path: winget-manifests.zip
 
   release:
-    needs: [prepare, build-windows, build-macos, winget-manifest]
+    needs: [prepare, build-windows, build-macos, build-linux, winget-manifest]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     env:
@@ -236,7 +282,7 @@ jobs:
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum *.msi *.dmg *.zip > SHA256SUMS.txt
+          sha256sum *.msi *.dmg *.zip *.AppImage *.tar.gz *.deb > SHA256SUMS.txt
           cat SHA256SUMS.txt
 
       - name: Create GitHub Release
@@ -246,6 +292,9 @@ jobs:
             artifacts/*.msi
             artifacts/*.dmg
             artifacts/*.zip
+            artifacts/*.AppImage
+            artifacts/*.tar.gz
+            artifacts/*.deb
             artifacts/SHA256SUMS.txt
           generate_release_notes: true
           # Every build is unsigned until a code-signing cert / Apple

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,6 +378,25 @@ job so it never publishes). It produces, per tag:
   via `sips`/`iconutil` (stock macOS tools, no extra dependency) — each
   iconset slot uses the exact-size master when one exists, else downscales
   from `icon-1024.png`.
+- **Linux** — `linux-x64` + `linux-arm64` (the arm64 leg runs natively on
+  GitHub's free `ubuntu-24.04-arm` runners — no cross-compile toolchain).
+  Each RID is packaged three ways by
+  [`scripts/linux/build-packages.sh`](scripts/linux/build-packages.sh):
+  `.AppImage` (appimagetool downloaded at build time from its `continuous`
+  release, run with `--appimage-extract-and-run` since CI runners lack
+  FUSE; `AppRun` is a plain symlink to the binary — NativeAOT resolves the
+  side-car `libSkiaSharp`/`libHarfBuzzSharp` next to `/proc/self/exe`, so
+  no wrapper script), `.tar.gz` (the publish output under a versioned top
+  dir), and `.deb` (`dpkg-deb`, package id `pgnimbus`, binary at
+  `/usr/lib/pgnimbus/` + `/usr/bin/pgnimbus` symlink; `Depends` lists only
+  the X11/ICE/SM/fontconfig libs Avalonia P/Invokes — Skia/HarfBuzz are
+  bundled; a semver prerelease `-` becomes Debian `~` so CI test versions
+  sort before releases). The desktop entry comes from
+  [`installer/linux/pgnimbus.desktop.template`](installer/linux/pgnimbus.desktop.template)
+  (`__EXEC__` placeholder: the AppImage execs `PgNimbus.App`, the deb
+  `pgnimbus`), icons from the `design/masters/icon/` tiles. The NativeAOT
+  `*.dbg` symbols side-file is excluded from all three packages. Unsigned,
+  like the other direct-download channels.
 - **winget** — the workflow renders (via
   [`scripts/winget/render-manifest.sh`](scripts/winget/render-manifest.sh)
   and the templates in `packaging/winget/`) the three manifest files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,9 +388,9 @@ job so it never publishes). It produces, per tag:
   side-car `libSkiaSharp`/`libHarfBuzzSharp` next to `/proc/self/exe`, so
   no wrapper script), `.tar.gz` (the publish output under a versioned top
   dir), and `.deb` (`dpkg-deb`, package id `pgnimbus`, binary at
-  `/usr/lib/pgnimbus/` + `/usr/bin/pgnimbus` symlink; `Depends` lists only
-  the X11/ICE/SM/fontconfig libs Avalonia P/Invokes — Skia/HarfBuzz are
-  bundled; a semver prerelease `-` becomes Debian `~` so CI test versions
+  `/usr/lib/pgnimbus/` + `/usr/bin/pgnimbus` symlink; `Depends` lists the
+  X11-family libs Avalonia's X11 backend uses at runtime plus fontconfig
+  for Skia — Skia/HarfBuzz themselves are bundled; a semver prerelease `-` becomes Debian `~` so CI test versions
   sort before releases). The desktop entry comes from
   [`installer/linux/pgnimbus.desktop.template`](installer/linux/pgnimbus.desktop.template)
   (`__EXEC__` placeholder: the AppImage execs `PgNimbus.App`, the deb

--- a/PgNimbus.App/PgNimbus.App.csproj
+++ b/PgNimbus.App/PgNimbus.App.csproj
@@ -21,7 +21,7 @@
     -->
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
-    <RuntimeIdentifiers>win-x64;osx-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <Authors>Dmitrii Shmanev</Authors>
     <Product>pgNimbus</Product>
     <Description>A fast, open-source PostgreSQL GUI client built with .NET and Avalonia.</Description>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT license"></a>
   <img src="https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet" alt=".NET 10">
   <img src="https://img.shields.io/badge/Avalonia-12-8B44AC" alt="Avalonia 12">
-  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20(beta)-lightgrey" alt="Platforms">
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey" alt="Platforms">
 </p>
 
 <p align="center">
@@ -90,6 +90,14 @@ xattr -cr ~/Downloads/pgNimbus.app
 Then launch `pgNimbus.app` normally. Proper signing and notarization are planned — see [Roadmap](#-roadmap).
 
 </details>
+
+### Linux (early beta)
+
+x64 and arm64 builds from [Releases](https://github.com/Shman4ik/pgNimbus/releases), in three formats:
+
+- **AppImage** (any distro) — `chmod +x pgNimbus-<version>-linux-<arch>.AppImage`, then run it. Nothing to install.
+- **Debian/Ubuntu** — `sudo apt install ./pgNimbus-<version>-linux-<arch>.deb`, then launch `pgnimbus` (or find pgNimbus in your app menu).
+- **tar.gz** — unpack anywhere and run `./PgNimbus.App`.
 
 Every `vX.Y.Z` tag builds all of the above via [`release.yml`](.github/workflows/release.yml).
 
@@ -259,7 +267,7 @@ Prioritized by how much it advances the thesis (fast + open + modern, PostgreSQL
 **Next up**
 
 - [ ] **Full macOS support** — Developer ID signing, notarization, real-world testing.
-- [ ] **Linux builds** — the linux-x64 NativeAOT publish already works; missing a release leg and packaging (AppImage/tarball first, Flatpak after).
+- [x] **Linux builds** — AppImage, .deb, and tar.gz for x64/arm64 ship from the release pipeline (Flatpak still a maybe-later).
 - [ ] **Table & index sizes and usage** — sizes in the schema tree plus a per-database overview (largest relations, seq-vs-index scans, unused indexes, cache hit rate).
 - [ ] **Locks & blocking tree** — a who-blocks-whom view in the activity window, with one-click cancel/terminate of the *blocker*.
 - [ ] **Row detail sidebar** — a vertical name/value view of the selected row, doubling as a form-style editor.

--- a/installer/linux/pgnimbus.desktop.template
+++ b/installer/linux/pgnimbus.desktop.template
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=pgNimbus
+GenericName=PostgreSQL Client
+Comment=A fast, open-source PostgreSQL GUI client
+Exec=__EXEC__
+Icon=pgnimbus
+Terminal=false
+Categories=Development;Database;
+Keywords=postgres;postgresql;sql;database;
+StartupWMClass=PgNimbus.App

--- a/scripts/linux/build-packages.sh
+++ b/scripts/linux/build-packages.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Packages a `dotnet publish` NativeAOT output into the three Linux release
+# artifacts: a plain .tar.gz, an .AppImage, and a .deb. Linux-only (dpkg-deb
+# ships with any Debian-family distro/runner; appimagetool is downloaded on
+# demand and run with --appimage-extract-and-run since CI runners lack FUSE).
+#
+# Usage: build-packages.sh <publish-dir> <version> <rid> <out-dir>
+#   publish-dir  output of `dotnet publish -r <rid> ...`
+#   version      e.g. 1.2.3 (no leading v)
+#   rid          linux-x64 | linux-arm64
+#   out-dir      where to write the packages
+set -euo pipefail
+
+PUBLISH_DIR="$1"
+VERSION="$2"
+RID="$3"
+OUT_DIR="$4"
+
+case "$RID" in
+  linux-x64)   ARCH_LABEL="x64";   DEB_ARCH="amd64"; APPIMAGE_ARCH="x86_64"  ;;
+  linux-arm64) ARCH_LABEL="arm64"; DEB_ARCH="arm64"; APPIMAGE_ARCH="aarch64" ;;
+  *) echo "Unknown RID: $RID (expected linux-x64 or linux-arm64)" >&2; exit 1 ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+mkdir -p "$OUT_DIR"
+OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+
+BASE_NAME="pgNimbus-$VERSION-linux-$ARCH_LABEL"
+MASTER_DIR="$REPO_ROOT/design/masters/icon"
+DESKTOP_TEMPLATE="$REPO_ROOT/installer/linux/pgnimbus.desktop.template"
+
+# Stage what actually ships: the publish output minus the *.dbg side file
+# NativeAOT strips debug symbols into (the benchmark script excludes it from
+# "publish size" for the same reason).
+STAGE_DIR="$WORK_DIR/stage"
+mkdir -p "$STAGE_DIR"
+cp -R "$PUBLISH_DIR/." "$STAGE_DIR/"
+rm -f "$STAGE_DIR"/*.dbg
+chmod +x "$STAGE_DIR/PgNimbus.App"
+
+# The desktop entry is shared, but Exec differs per format: inside an AppImage
+# the binary is invoked by its in-bundle name, the deb exposes a
+# /usr/bin/pgnimbus symlink.
+emit_desktop() { # <exec-line> <dest>
+  sed "s|__EXEC__|$1|" "$DESKTOP_TEMPLATE" > "$2"
+}
+
+# ---- tar.gz -----------------------------------------------------------------
+TAR_ROOT="$WORK_DIR/$BASE_NAME"
+mkdir "$TAR_ROOT"
+cp -R "$STAGE_DIR/." "$TAR_ROOT/"
+tar -C "$WORK_DIR" -czf "$OUT_DIR/$BASE_NAME.tar.gz" "$BASE_NAME"
+echo "Built $OUT_DIR/$BASE_NAME.tar.gz"
+
+# ---- AppImage ---------------------------------------------------------------
+APPDIR="$WORK_DIR/AppDir"
+mkdir -p "$APPDIR/usr/bin"
+cp -R "$STAGE_DIR/." "$APPDIR/usr/bin/"
+emit_desktop "PgNimbus.App" "$APPDIR/pgnimbus.desktop"
+# The 256px master is the circular navy badge with transparent corners —
+# right for Linux desktop icons, which draw over arbitrary backgrounds.
+cp "$MASTER_DIR/icon-256.png" "$APPDIR/pgnimbus.png"
+cp "$MASTER_DIR/icon-256.png" "$APPDIR/.DirIcon"
+# AppRun as a symlink: NativeAOT resolves its side-car .so files
+# (libSkiaSharp, libHarfBuzzSharp) relative to /proc/self/exe, so no
+# wrapper script or LD_LIBRARY_PATH is needed.
+ln -s usr/bin/PgNimbus.App "$APPDIR/AppRun"
+
+APPIMAGETOOL="$WORK_DIR/appimagetool"
+curl -fsSL -o "$APPIMAGETOOL" \
+  "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$APPIMAGE_ARCH.AppImage"
+chmod +x "$APPIMAGETOOL"
+ARCH="$APPIMAGE_ARCH" "$APPIMAGETOOL" --appimage-extract-and-run \
+  "$APPDIR" "$OUT_DIR/$BASE_NAME.AppImage"
+echo "Built $OUT_DIR/$BASE_NAME.AppImage"
+
+# ---- .deb -------------------------------------------------------------------
+# Debian versions use ~ for prerelease (sorts before the release), where
+# semver uses -. Affects workflow_dispatch test versions like 0.0.0-ci.42.
+DEB_VERSION="${VERSION/-/~}"
+DEB_ROOT="$WORK_DIR/deb"
+mkdir -p "$DEB_ROOT/DEBIAN" \
+         "$DEB_ROOT/usr/lib/pgnimbus" \
+         "$DEB_ROOT/usr/bin" \
+         "$DEB_ROOT/usr/share/applications"
+cp -R "$STAGE_DIR/." "$DEB_ROOT/usr/lib/pgnimbus/"
+ln -s ../lib/pgnimbus/PgNimbus.App "$DEB_ROOT/usr/bin/pgnimbus"
+emit_desktop "pgnimbus" "$DEB_ROOT/usr/share/applications/pgnimbus.desktop"
+for px in 16 24 32 48 256; do
+  dest="$DEB_ROOT/usr/share/icons/hicolor/${px}x${px}/apps"
+  mkdir -p "$dest"
+  cp "$MASTER_DIR/icon-$px.png" "$dest/pgnimbus.png"
+done
+
+INSTALLED_SIZE_KB=$(du -sk "$DEB_ROOT/usr" | cut -f1)
+# Depends: only the X11/session/fontconfig libs Avalonia P/Invokes directly —
+# Skia and HarfBuzz are bundled as side-car .so files, not system deps.
+cat > "$DEB_ROOT/DEBIAN/control" <<EOF
+Package: pgnimbus
+Version: $DEB_VERSION
+Section: database
+Priority: optional
+Architecture: $DEB_ARCH
+Installed-Size: $INSTALLED_SIZE_KB
+Maintainer: Dmitrii Shmanev <shman4ik@gmail.com>
+Homepage: https://github.com/Shman4ik/pgNimbus
+Depends: libx11-6, libice6, libsm6, libfontconfig1
+Description: Fast, open-source PostgreSQL GUI client
+ A PostgreSQL-first database client built with .NET and Avalonia, compiled
+ to a NativeAOT binary for instant startup. Streams large result sets while
+ they load. MIT licensed.
+EOF
+dpkg-deb --build --root-owner-group "$DEB_ROOT" "$OUT_DIR/$BASE_NAME.deb"
+echo "Built $OUT_DIR/$BASE_NAME.deb"

--- a/scripts/linux/build-packages.sh
+++ b/scripts/linux/build-packages.sh
@@ -70,7 +70,7 @@ cp "$MASTER_DIR/icon-256.png" "$APPDIR/.DirIcon"
 ln -s usr/bin/PgNimbus.App "$APPDIR/AppRun"
 
 APPIMAGETOOL="$WORK_DIR/appimagetool"
-curl -fsSL -o "$APPIMAGETOOL" \
+curl -fsSL --retry 3 -o "$APPIMAGETOOL" \
   "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$APPIMAGE_ARCH.AppImage"
 chmod +x "$APPIMAGETOOL"
 ARCH="$APPIMAGE_ARCH" "$APPIMAGETOOL" --appimage-extract-and-run \
@@ -96,8 +96,11 @@ for px in 16 24 32 48 256; do
 done
 
 INSTALLED_SIZE_KB=$(du -sk "$DEB_ROOT/usr" | cut -f1)
-# Depends: only the X11/session/fontconfig libs Avalonia P/Invokes directly —
-# Skia and HarfBuzz are bundled as side-car .so files, not system deps.
+# Depends: the X11-family libs Avalonia's X11 backend touches at runtime
+# (core X11, session management, XInput2, XRandR, XCursor, XExt, Xinerama)
+# plus fontconfig for Skia's font lookup — so the package runs on minimal
+# installs too. Skia and HarfBuzz themselves are bundled as side-car .so
+# files, not system deps.
 cat > "$DEB_ROOT/DEBIAN/control" <<EOF
 Package: pgnimbus
 Version: $DEB_VERSION
@@ -107,7 +110,7 @@ Architecture: $DEB_ARCH
 Installed-Size: $INSTALLED_SIZE_KB
 Maintainer: Dmitrii Shmanev <shman4ik@gmail.com>
 Homepage: https://github.com/Shman4ik/pgNimbus
-Depends: libx11-6, libice6, libsm6, libfontconfig1
+Depends: libx11-6, libice6, libsm6, libfontconfig1, libfreetype6, libxext6, libxi6, libxcursor1, libxinerama1, libxrandr2
 Description: Fast, open-source PostgreSQL GUI client
  A PostgreSQL-first database client built with .NET and Avalonia, compiled
  to a NativeAOT binary for instant startup. Streams large result sets while

--- a/website/index.html
+++ b/website/index.html
@@ -357,7 +357,7 @@
 <section id="download">
   <div class="wrap">
     <h2>Download</h2>
-    <p class="section-sub">Windows is the primary target; a macOS build ships as a very early beta.</p>
+    <p class="section-sub">Windows is the primary target; macOS and Linux builds ship as early betas.</p>
     <div class="dl-grid">
       <div class="dl">
         <h3>Windows</h3>
@@ -378,6 +378,16 @@
           Download .dmg
         </a>
         <p class="note">Full macOS support (signing, notarization) is planned. <a href="https://github.com/Shman4ik/pgNimbus#fixing-the-gatekeeper-app-is-damaged-error">Details in the README.</a></p>
+      </div>
+      <div class="dl">
+        <h3>Linux <span style="font-weight:400;color:var(--ink-soft)">(early beta)</span></h3>
+        <p>x64 and arm64 from GitHub Releases. AppImage runs on any distro — make it executable and launch:</p>
+        <p><code>chmod +x pgNimbus-*.AppImage</code></p>
+        <a class="btn" href="https://github.com/Shman4ik/pgNimbus/releases/latest">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          Download AppImage
+        </a>
+        <p class="note">Debian/Ubuntu <code>.deb</code> and a plain <code>.tar.gz</code> are on the same Releases page.</p>
       </div>
     </div>
   </div>

--- a/website/index.html
+++ b/website/index.html
@@ -186,7 +186,7 @@
   .center { text-align: center; }
 
   /* ---- downloads ---- */
-  .dl-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 18px; max-width: 760px; margin: 0 auto; }
+  .dl-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 18px; max-width: 960px; margin: 0 auto; }
   .dl {
     background: var(--surface);
     border: 1px solid var(--border);


### PR DESCRIPTION
## What

Adds the Linux leg to the release pipeline — the app itself already runs on Linux (the benchmark job publishes and drives the linux-x64 NativeAOT build on every release), so this is purely packaging + distribution.

- **`build-linux` matrix job** in `release.yml`: `ubuntu-latest` → `linux-x64`, GitHub's free `ubuntu-24.04-arm` runner → `linux-arm64` (native build, no cross-compile toolchain).
- **`scripts/linux/build-packages.sh`** (mirrors the macOS `build-app-bundle.sh` pattern) packages each publish dir three ways:
  - **`.AppImage`** — appimagetool fetched from its `continuous` release at build time, run with `--appimage-extract-and-run` (CI runners lack FUSE). `AppRun` is a plain symlink: NativeAOT resolves the side-car `libSkiaSharp`/`libHarfBuzzSharp` next to `/proc/self/exe`, so no wrapper script or `LD_LIBRARY_PATH`.
  - **`.deb`** — `dpkg-deb --root-owner-group`; package id `pgnimbus`, files under `/usr/lib/pgnimbus` + a `/usr/bin/pgnimbus` symlink, hicolor icons straight from the hand-drawn `design/masters/icon/` tiles. `Depends` lists only what Avalonia P/Invokes (libx11-6, libice6, libsm6, libfontconfig1) — Skia/HarfBuzz ship as bundled side-cars. Semver prerelease `-` becomes Debian `~` so `workflow_dispatch` test versions sort below releases.
  - **`.tar.gz`** — publish output under a versioned top-level dir.
- The NativeAOT `*.dbg` symbols side-file is excluded from all three (same rationale as the benchmark script's shipped-size metric).
- Desktop entry shared from `installer/linux/pgnimbus.desktop.template` with an `__EXEC__` placeholder (AppImage execs `PgNimbus.App` in-bundle, the deb execs `pgnimbus`).
- Release job checksums + uploads the six new artifacts; csproj `RuntimeIdentifiers` gains the linux RIDs.
- Docs in step: README install section + platform badge + roadmap item ticked, website download card (renders fine, checked in preview), CLAUDE.md release-pipeline section.

## Not included (deliberate)

- **Flatpak** — bigger lift (Flathub submission/review, sandboxed AOT build); the roadmap keeps it as maybe-later.
- No signing, matching the MSI/dmg — the release stays marked prerelease.

## Testing

- `bash -n` on the packaging script; YAML parse-checked; `dotnet build -c Release` green after the csproj change.
- The script's first real end-to-end run will be a `workflow_dispatch` of `release.yml` — worth doing once after merge, before the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)