### PR TITLE
Tab drag-reorder, app menu, and a centered command-palette Search pill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,9 @@ and wrong project memory is worse than none.
    serializes `Tabs` in collection order). The ☰ button (top-left, 2026-07)
    opens the one discoverable menu for file/tab-level commands: New tab,
    Open .sql / Open recent, Save / Save as, Close tab, Switch connection,
-   New window. The command bar's centered "Search" pill (VS Code-style,
-   same date) opens the command palette — the palette's one visible entry
-   point besides Ctrl+K/P. Both deliberately duplicate palette entries
+   New window, Preferences. The command bar's centered "Search" pill
+   (VS Code-style, same date) opens the command palette — the palette's
+   one visible entry point besides Ctrl+K/P. Both deliberately duplicate palette entries
    (discoverability);
    that doesn't loosen rule 1 — new always-visible controls still default
    to no, and new secondary actions go to the palette first, not this menu.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,16 @@ and wrong project memory is worse than none.
    modes, 2026-07). Apply the same rule to any new list-like UI.
 3. **Loading a query never overwrites the active tab.** Saved queries,
    history entries, and generated DDL all open in a *new* tab.
-4. **No hardcoded Ctrl gestures.** Every command shortcut resolves through
+4. **Tabs drag-reorder; the ☰ app menu is the file-command home.** The query
+   tab strip reorders by dragging (live, browser-style — pointer handlers in
+   `MainWindow.axaml.cs`; the order persists via the workspace snapshot, which
+   serializes `Tabs` in collection order). The ☰ button (top-left, 2026-07)
+   opens the one discoverable menu for file/tab-level commands: New tab,
+   Open .sql / Open recent, Save / Save as, Close tab, Switch connection,
+   New window. It deliberately duplicates palette entries (discoverability);
+   that doesn't loosen rule 1 — new always-visible controls still default
+   to no, and new secondary actions go to the palette first, not this menu.
+5. **No hardcoded Ctrl gestures.** Every command shortcut resolves through
    `PgNimbus.App/Hotkeys.cs` (Ctrl vs Cmd, per platform or the persisted
    scheme preference): MainWindow builds its `KeyBindings` in code, palette
    labels use `Hotkeys.Label`, and the F1 cheat sheet relabels its `cmdKey`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,10 @@ and wrong project memory is worse than none.
    serializes `Tabs` in collection order). The ☰ button (top-left, 2026-07)
    opens the one discoverable menu for file/tab-level commands: New tab,
    Open .sql / Open recent, Save / Save as, Close tab, Switch connection,
-   New window. It deliberately duplicates palette entries (discoverability);
+   New window. The command bar's centered "Search" pill (VS Code-style,
+   same date) opens the command palette — the palette's one visible entry
+   point besides Ctrl+K/P. Both deliberately duplicate palette entries
+   (discoverability);
    that doesn't loosen rule 1 — new always-visible controls still default
    to no, and new secondary actions go to the palette first, not this menu.
 5. **No hardcoded Ctrl gestures.** Every command shortcut resolves through

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -170,6 +170,8 @@
         <StreamGeometry x:Key="ChevronLeftIconGeometry">M15.41,16.58L10.83,12L15.41,7.41L14,6L8,12L14,18L15.41,16.58Z</StreamGeometry>
         <StreamGeometry x:Key="ChevronRightIconGeometry">M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z</StreamGeometry>
         <StreamGeometry x:Key="MenuDownIconGeometry">M7,10L12,15L17,10H7Z</StreamGeometry>
+        <!-- App menu (☰): file/tab-level commands live behind this one button (MDI "menu") -->
+        <StreamGeometry x:Key="MenuIconGeometry">M3,6H21V8H3V6M3,11H21V13H3V11M3,16H21V18H3V16Z</StreamGeometry>
         <StreamGeometry x:Key="PinIconGeometry">M16,12V4H17V2H7V4H8V12L6,14V16H11.2V22H12.8V16H18V14L16,12Z</StreamGeometry>
         <StreamGeometry x:Key="ImportIconGeometry">M2,12H4V17H20V12H22V17A2,2 0 0,1 20,19H4A2,2 0 0,1 2,17V12M12,2L6.46,7.46L7.88,8.88L11,5.75V15H13V5.75L16.13,8.88L17.55,7.45L12,2Z</StreamGeometry>
         <StreamGeometry x:Key="ClipboardIconGeometry">M19,20H5V4H7V7H17V4H19M12,2A1,1 0 0,1 13,3A1,1 0 0,1 12,4A1,1 0 0,1 11,3A1,1 0 0,1 12,2M19,2H14.82C14.4,0.84 13.3,0 12,0C10.7,0 9.6,0.84 9.18,2H5A2,2 0 0,0 3,4V20A2,2 0 0,0 5,22H19A2,2 0 0,0 21,20V4A2,2 0 0,0 19,2Z</StreamGeometry>

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -521,6 +521,25 @@
         <Setter Property="Background" Value="{StaticResource HoverBackgroundBrush}" />
         <Setter Property="Opacity" Value="1" />
     </Style>
+    <!-- The command bar's centered palette opener (VS Code-style search pill):
+         a quiet card-toned capsule that reads as a search field but is a
+         Button. Hover is pinned at the template part - Fluent repaints
+         PART_ContentPresenter's background on :pointerover otherwise. -->
+    <Style Selector="Button.searchpill">
+        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="10,0" />
+        <Setter Property="MinHeight" Value="24" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Button.searchpill:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource HoverBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+    </Style>
+
     <!-- Checked state for chip-styled ToggleButtons (e.g. cell inspector's Wrap
          toggle): the app's brand-blue selection wash, same as the toolbar toggle.
          Fluent paints the checked fill on PART_ContentPresenter via its ControlTheme,

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -196,6 +196,9 @@ public sealed partial class MainViewModel : ObservableObject
 
     private readonly Action<IReadOnlyList<string>>? _persistRecentSqlFiles;
 
+    /// <summary>The recent .sql files, most recent first — read by the app menu's "Open recent" submenu (the palette reads <see cref="_recentSqlFiles"/> directly).</summary>
+    public IReadOnlyList<string> RecentSqlFiles => _recentSqlFiles;
+
     // Persist and report the new state here rather than in ToggleWordWrap, so
     // the status line updates the same way whether wrap was flipped from the
     // palette command or by the toolbar toggle's direct two-way binding.
@@ -451,6 +454,26 @@ public sealed partial class MainViewModel : ObservableObject
         ActiveTab = tab;
         CloseTabCommand.NotifyCanExecuteChanged();
         return tab;
+    }
+
+    /// <summary>
+    /// Moves <paramref name="tab"/> to <paramref name="newIndex"/> (clamped) —
+    /// the tab strip's drag-reorder. The moved tab stays active, and the new
+    /// order persists naturally: the workspace snapshot serializes
+    /// <see cref="Tabs"/> in collection order.
+    /// </summary>
+    public void MoveTab(QueryViewModel tab, int newIndex)
+    {
+        var oldIndex = Tabs.IndexOf(tab);
+        newIndex = Math.Clamp(newIndex, 0, Tabs.Count - 1);
+        if (oldIndex < 0 || newIndex == oldIndex)
+        {
+            return;
+        }
+
+        Tabs.Move(oldIndex, newIndex);
+        // Re-assert: a collection Move can churn the ListBox's selection.
+        ActiveTab = tab;
     }
 
     /// <summary>

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -136,6 +136,31 @@
         <Border Name="CommandBar" DockPanel.Dock="Top" Height="40" Padding="16,0"
                 BorderThickness="0,0,0,1" BorderBrush="{StaticResource CardBorderBrush}">
             <DockPanel>
+                <!-- App menu (☰): the discoverable home for file/tab commands
+                     (open/save/recent live nowhere else visible — the palette
+                     has them, but only for those who know to look). Shortcut
+                     labels are set in BuildKeyBindings so they track the live
+                     Ctrl/Cmd scheme; the Open Recent submenu is rebuilt on
+                     every open from the current recent-files list. -->
+                <Button Name="AppMenuButton" DockPanel.Dock="Left" Classes="chip" Padding="5"
+                        Margin="0,0,4,0" VerticalAlignment="Center" ToolTip.Tip="Menu">
+                    <PathIcon Data="{StaticResource MenuIconGeometry}" Width="14" Height="14" />
+                    <Button.Flyout>
+                        <MenuFlyout Placement="BottomEdgeAlignedLeft">
+                            <MenuItem Name="MenuNewTab" Header="New query tab" Command="{Binding AddTabCommand}" />
+                            <MenuItem Name="MenuOpenFile" Header="Open .sql file…" Command="{Binding OpenFileCommand}" />
+                            <MenuItem Name="MenuOpenRecent" Header="Open recent" />
+                            <Separator />
+                            <MenuItem Name="MenuSaveFile" Header="Save" Command="{Binding SaveFileCommand}" />
+                            <MenuItem Name="MenuSaveFileAs" Header="Save as…" Command="{Binding SaveFileAsCommand}" />
+                            <Separator />
+                            <MenuItem Name="MenuCloseTab" Header="Close tab" Command="{Binding CloseTabCommand}" />
+                            <Separator />
+                            <MenuItem Header="Switch connection…" Command="{Binding SwitchConnectionCommand}" />
+                            <MenuItem Header="Open connection in new window…" Command="{Binding OpenNewWindowCommand}" />
+                        </MenuFlyout>
+                    </Button.Flyout>
+                </Button>
                 <Button Name="SidebarToggleButton" DockPanel.Dock="Left" Classes="chip" Padding="5"
                         Margin="0,0,10,0" VerticalAlignment="Center"
                         Click="OnToggleSidebarClick" ToolTip.Tip="Toggle sidebar (Ctrl+B)">

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -163,6 +163,8 @@
                                 <Separator />
                                 <MenuItem Header="Switch connection…" Command="{Binding SwitchConnectionCommand}" />
                                 <MenuItem Header="Open connection in new window…" Command="{Binding OpenNewWindowCommand}" />
+                                <Separator />
+                                <MenuItem Name="MenuPreferences" Header="Preferences…" Command="{Binding ShowPreferencesCommand}" />
                             </MenuFlyout>
                         </Button.Flyout>
                     </Button>

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -135,71 +135,91 @@
              empty space drag the window. -->
         <Border Name="CommandBar" DockPanel.Dock="Top" Height="40" Padding="16,0"
                 BorderThickness="0,0,0,1" BorderBrush="{StaticResource CardBorderBrush}">
-            <DockPanel>
-                <!-- App menu (☰): the discoverable home for file/tab commands
-                     (open/save/recent live nowhere else visible — the palette
-                     has them, but only for those who know to look). Shortcut
-                     labels are set in BuildKeyBindings so they track the live
-                     Ctrl/Cmd scheme; the Open Recent submenu is rebuilt on
-                     every open from the current recent-files list. -->
-                <Button Name="AppMenuButton" DockPanel.Dock="Left" Classes="chip" Padding="5"
-                        Margin="0,0,4,0" VerticalAlignment="Center" ToolTip.Tip="Menu">
-                    <PathIcon Data="{StaticResource MenuIconGeometry}" Width="14" Height="14" />
-                    <Button.Flyout>
-                        <MenuFlyout Placement="BottomEdgeAlignedLeft">
-                            <MenuItem Name="MenuNewTab" Header="New query tab" Command="{Binding AddTabCommand}" />
-                            <MenuItem Name="MenuOpenFile" Header="Open .sql file…" Command="{Binding OpenFileCommand}" />
-                            <MenuItem Name="MenuOpenRecent" Header="Open recent" />
-                            <Separator />
-                            <MenuItem Name="MenuSaveFile" Header="Save" Command="{Binding SaveFileCommand}" />
-                            <MenuItem Name="MenuSaveFileAs" Header="Save as…" Command="{Binding SaveFileAsCommand}" />
-                            <Separator />
-                            <MenuItem Name="MenuCloseTab" Header="Close tab" Command="{Binding CloseTabCommand}" />
-                            <Separator />
-                            <MenuItem Header="Switch connection…" Command="{Binding SwitchConnectionCommand}" />
-                            <MenuItem Header="Open connection in new window…" Command="{Binding OpenNewWindowCommand}" />
-                        </MenuFlyout>
-                    </Button.Flyout>
-                </Button>
-                <Button Name="SidebarToggleButton" DockPanel.Dock="Left" Classes="chip" Padding="5"
-                        Margin="0,0,10,0" VerticalAlignment="Center"
-                        Click="OnToggleSidebarClick" ToolTip.Tip="Toggle sidebar (Ctrl+B)">
-                    <PathIcon Data="{OnPlatform Default={StaticResource SidebarToggleIconGeometry}, macOS={StaticResource SidebarToggleMacIconGeometry}}" Width="14" Height="14" />
-                </Button>
-                <Border DockPanel.Dock="Left" Width="10" Height="10" CornerRadius="5" Margin="0,0,10,0"
-                        VerticalAlignment="Center"
-                        Background="{Binding AccentColor, Converter={x:Static conv2:HexToBrushConverter.Instance}}" />
-                <Button DockPanel.Dock="Right" Classes="chip" Content="?" FontSize="13" VerticalAlignment="Center"
-                        Click="OnShowShortcutsClick" ToolTip.Tip="Keyboard shortcuts (F1)" />
-                <!-- Tooltip is set in code (BuildKeyBindings) so its shortcut
-                     label tracks the live Ctrl/Cmd scheme. -->
-                <Button Name="PreferencesButton" DockPanel.Dock="Right" Classes="chip" Padding="5"
-                        Margin="0,0,4,0" VerticalAlignment="Center"
-                        Click="OnShowPreferencesClick">
-                    <PathIcon Data="{StaticResource CogIconGeometry}" Width="14" Height="14" />
-                </Button>
-                <Button Name="ThemeToggleButton" DockPanel.Dock="Right" Classes="chip" Padding="5"
-                        Margin="0,0,4,0" VerticalAlignment="Center"
-                        Click="OnToggleThemeClick" ToolTip.Tip="Toggle light/dark theme">
-                    <PathIcon Name="ThemeIcon" Data="{StaticResource WeatherNightIconGeometry}" Width="14" Height="14" />
-                </Button>
-                <Button DockPanel.Dock="Right" Classes="chip" Padding="5"
-                        Margin="0,0,4,0" VerticalAlignment="Center"
-                        Click="OnShowActivityClick" ToolTip.Tip="Server activity (pg_stat_activity)">
-                    <PathIcon Data="{StaticResource PulseIconGeometry}" Width="14" Height="14" />
-                </Button>
-                <StackPanel Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
+            <!-- Auto | * | Auto: left cluster, the centered search pill, right
+                 cluster. The pill stretches up to its MaxWidth and centers in
+                 the middle column, VS Code-style; on a narrow window it
+                 shrinks instead of overlapping the clusters. -->
+            <Grid ColumnDefinitions="Auto,*,Auto">
+                <StackPanel Grid.Column="0" Orientation="Horizontal" VerticalAlignment="Center">
+                    <!-- App menu (☰): the discoverable home for file/tab commands
+                         (open/save/recent live nowhere else visible — the palette
+                         has them, but only for those who know to look). Shortcut
+                         labels are set in BuildKeyBindings so they track the live
+                         Ctrl/Cmd scheme; the Open Recent submenu is rebuilt on
+                         every open from the current recent-files list. -->
+                    <Button Name="AppMenuButton" Classes="chip" Padding="5"
+                            Margin="0,0,4,0" VerticalAlignment="Center" ToolTip.Tip="Menu">
+                        <PathIcon Data="{StaticResource MenuIconGeometry}" Width="14" Height="14" />
+                        <Button.Flyout>
+                            <MenuFlyout Placement="BottomEdgeAlignedLeft">
+                                <MenuItem Name="MenuNewTab" Header="New query tab" Command="{Binding AddTabCommand}" />
+                                <MenuItem Name="MenuOpenFile" Header="Open .sql file…" Command="{Binding OpenFileCommand}" />
+                                <MenuItem Name="MenuOpenRecent" Header="Open recent" />
+                                <Separator />
+                                <MenuItem Name="MenuSaveFile" Header="Save" Command="{Binding SaveFileCommand}" />
+                                <MenuItem Name="MenuSaveFileAs" Header="Save as…" Command="{Binding SaveFileAsCommand}" />
+                                <Separator />
+                                <MenuItem Name="MenuCloseTab" Header="Close tab" Command="{Binding CloseTabCommand}" />
+                                <Separator />
+                                <MenuItem Header="Switch connection…" Command="{Binding SwitchConnectionCommand}" />
+                                <MenuItem Header="Open connection in new window…" Command="{Binding OpenNewWindowCommand}" />
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+                    <Button Name="SidebarToggleButton" Classes="chip" Padding="5"
+                            Margin="0,0,10,0" VerticalAlignment="Center"
+                            Click="OnToggleSidebarClick" ToolTip.Tip="Toggle sidebar (Ctrl+B)">
+                        <PathIcon Data="{OnPlatform Default={StaticResource SidebarToggleIconGeometry}, macOS={StaticResource SidebarToggleMacIconGeometry}}" Width="14" Height="14" />
+                    </Button>
+                    <Border Width="10" Height="10" CornerRadius="5" Margin="0,0,10,0"
+                            VerticalAlignment="Center"
+                            Background="{Binding AccentColor, Converter={x:Static conv2:HexToBrushConverter.Instance}}" />
                     <TextBlock Text="pgNimbus" FontWeight="SemiBold" FontSize="14" VerticalAlignment="Center" />
                     <!-- Files-style breadcrumb: where am I connected -->
-                    <TextBlock Text="{Binding ConnectionHost}" FontSize="12" Opacity="0.75" VerticalAlignment="Center" Margin="10,0,0,0" />
-                    <TextBlock Text="›" FontSize="12" Opacity="0.45" VerticalAlignment="Center" />
+                    <TextBlock Text="{Binding ConnectionHost}" FontSize="12" Opacity="0.75" VerticalAlignment="Center" Margin="16,0,0,0" />
+                    <TextBlock Text="›" FontSize="12" Opacity="0.45" VerticalAlignment="Center" Margin="6,0" />
                     <TextBlock Text="{Binding ConnectionDatabase}" FontSize="12" Opacity="0.75" VerticalAlignment="Center" />
-                    <Button Classes="chip" Padding="5" VerticalAlignment="Center" Margin="4,0,0,0"
+                    <Button Classes="chip" Padding="5" VerticalAlignment="Center" Margin="10,0,0,0"
                             Click="OnSwitchConnectionClick" ToolTip.Tip="Switch connection">
                         <PathIcon Data="{StaticResource SwapHorizontalIconGeometry}" Width="12" Height="12" />
                     </Button>
                 </StackPanel>
-            </DockPanel>
+
+                <!-- Opens the command palette; the shortcut caption is set in
+                     BuildKeyBindings to track the live Ctrl/Cmd scheme. -->
+                <Button Grid.Column="1" Name="PaletteSearchButton" Classes="searchpill"
+                        HorizontalAlignment="Stretch" VerticalAlignment="Center"
+                        MaxWidth="300" Margin="16,0"
+                        Click="OnPaletteSearchButtonClick">
+                    <Grid ColumnDefinitions="Auto,*,Auto">
+                        <PathIcon Grid.Column="0" Data="{StaticResource MagnifyIconGeometry}" Width="11" Height="11" Opacity="0.55" VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="1" Text="Search" FontSize="12" Opacity="0.55" Margin="7,0,0,0" VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="2" Name="PaletteSearchShortcut" FontSize="11" Opacity="0.4" VerticalAlignment="Center" />
+                    </Grid>
+                </Button>
+
+                <StackPanel Grid.Column="2" Orientation="Horizontal" VerticalAlignment="Center">
+                    <Button Classes="chip" Padding="5"
+                            Margin="0,0,4,0" VerticalAlignment="Center"
+                            Click="OnShowActivityClick" ToolTip.Tip="Server activity (pg_stat_activity)">
+                        <PathIcon Data="{StaticResource PulseIconGeometry}" Width="14" Height="14" />
+                    </Button>
+                    <Button Name="ThemeToggleButton" Classes="chip" Padding="5"
+                            Margin="0,0,4,0" VerticalAlignment="Center"
+                            Click="OnToggleThemeClick" ToolTip.Tip="Toggle light/dark theme">
+                        <PathIcon Name="ThemeIcon" Data="{StaticResource WeatherNightIconGeometry}" Width="14" Height="14" />
+                    </Button>
+                    <!-- Tooltip is set in code (BuildKeyBindings) so its shortcut
+                         label tracks the live Ctrl/Cmd scheme. -->
+                    <Button Name="PreferencesButton" Classes="chip" Padding="5"
+                            Margin="0,0,4,0" VerticalAlignment="Center"
+                            Click="OnShowPreferencesClick">
+                        <PathIcon Data="{StaticResource CogIconGeometry}" Width="14" Height="14" />
+                    </Button>
+                    <Button Classes="chip" Content="?" FontSize="13" VerticalAlignment="Center"
+                            Click="OnShowShortcutsClick" ToolTip.Tip="Keyboard shortcuts (F1)" />
+                </StackPanel>
+            </Grid>
         </Border>
 
     <Grid Name="ContentGrid" Margin="16">

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -193,7 +193,7 @@
                         Click="OnPaletteSearchButtonClick">
                     <Grid ColumnDefinitions="Auto,*,Auto">
                         <PathIcon Grid.Column="0" Data="{StaticResource MagnifyIconGeometry}" Width="11" Height="11" Opacity="0.55" VerticalAlignment="Center" />
-                        <TextBlock Grid.Column="1" Text="Search" FontSize="12" Opacity="0.55" Margin="7,0,0,0" VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="1" Text="Search tables, queries, actions…" FontSize="12" Opacity="0.55" Margin="7,0,0,0" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
                         <TextBlock Grid.Column="2" Name="PaletteSearchShortcut" FontSize="11" Opacity="0.4" VerticalAlignment="Center" />
                     </Grid>
                 </Button>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -224,6 +224,21 @@ public partial class MainWindow : Window
             tabFlyout.Opened += (_, _) => OpenTabList();
         }
 
+        // Drag a tab along the strip to reorder it. Pressed is tunneled so the
+        // drag candidate is noted before the ListBoxItem handles selection;
+        // moves/releases bubble up from the item that holds the pointer capture.
+        TabsList.AddHandler(PointerPressedEvent, OnTabStripPointerPressed, RoutingStrategies.Tunnel);
+        TabsList.PointerMoved += OnTabStripPointerMoved;
+        TabsList.PointerReleased += (_, _) => EndTabDrag();
+        TabsList.PointerCaptureLost += (_, _) => EndTabDrag();
+
+        // The ☰ app menu's "Open recent" submenu reflects the list as of the
+        // moment the menu opens, not app start.
+        if (AppMenuButton.Flyout is MenuFlyout appMenu)
+        {
+            appMenu.Opened += (_, _) => RebuildRecentFilesMenu();
+        }
+
         TabSearchBox.TextChanged += (_, _) => FilterTabList();
         TabSearchBox.KeyDown += OnTabSearchKeyDown;
         TabSearchList.Tapped += (_, e) =>
@@ -332,6 +347,14 @@ public partial class MainWindow : Window
         // The gear button's tooltip carries the shortcut, so it's set here
         // (not in XAML) to track the live Ctrl/Cmd scheme.
         ToolTip.SetTip(PreferencesButton, $"Preferences ({Hotkeys.Label(",")})");
+
+        // Same for the ☰ menu's shortcut captions: display-only gestures whose
+        // Ctrl/Cmd side must match the bindings built just above.
+        MenuNewTab.InputGesture = new KeyGesture(Key.T, Hotkeys.Command);
+        MenuOpenFile.InputGesture = new KeyGesture(Key.O, Hotkeys.Command);
+        MenuSaveFile.InputGesture = new KeyGesture(Key.S, Hotkeys.Command);
+        MenuSaveFileAs.InputGesture = new KeyGesture(Key.S, Hotkeys.Command | KeyModifiers.Shift);
+        MenuCloseTab.InputGesture = new KeyGesture(Key.W, Hotkeys.Command);
 
         void Add(KeyGesture gesture, Func<System.Windows.Input.ICommand?> resolve) =>
             KeyBindings.Add(new KeyBinding { Gesture = gesture, Command = new DelegatedCommand(resolve) });
@@ -587,6 +610,121 @@ public partial class MainWindow : Window
         if (sender is Button { Tag: QueryViewModel tab })
         {
             _viewModel?.CloseTabCommand.Execute(tab);
+        }
+    }
+
+    // --- Tab-strip drag reorder -------------------------------------------
+
+    // The tab a press armed for dragging; the drag activates only once the
+    // pointer travels past DragThreshold with the button down, so a plain
+    // click stays a tab switch.
+    private QueryViewModel? _tabDragCandidate;
+    private Point _tabDragOrigin;
+    private bool _tabDragActive;
+
+    private void OnTabStripPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(TabsList).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        // A press on the tab's ✕ chip is a close click, never a drag.
+        if (e.Source is Visual source && source.FindAncestorOfType<Button>(includeSelf: true) is not null)
+        {
+            return;
+        }
+
+        var item = (e.Source as Visual)?.FindAncestorOfType<ListBoxItem>(includeSelf: true);
+        if (item?.DataContext is QueryViewModel tab)
+        {
+            _tabDragCandidate = tab;
+            _tabDragOrigin = e.GetPosition(TabsList);
+            _tabDragActive = false;
+        }
+    }
+
+    private void OnTabStripPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_tabDragCandidate is not { } tab || _viewModel is null)
+        {
+            return;
+        }
+
+        var position = e.GetPosition(TabsList);
+        if (!_tabDragActive)
+        {
+            if (Math.Abs(position.X - _tabDragOrigin.X) < DragThreshold
+                && Math.Abs(position.Y - _tabDragOrigin.Y) < DragThreshold)
+            {
+                return;
+            }
+
+            _tabDragActive = true;
+            SetDraggedTabOpacity(0.55);
+        }
+
+        // Live reorder, browser-style: the dragged tab lands after every tab
+        // whose center the pointer has passed. Centers are measured excluding
+        // the dragged tab itself so a move doesn't immediately re-trigger.
+        var targetIndex = 0;
+        for (var i = 0; i < _viewModel.Tabs.Count; i++)
+        {
+            if (ReferenceEquals(_viewModel.Tabs[i], tab)
+                || TabsList.ContainerFromIndex(i) is not { } container
+                || container.TranslatePoint(default, TabsList) is not { } topLeft)
+            {
+                continue;
+            }
+
+            if (position.X > topLeft.X + container.Bounds.Width / 2)
+            {
+                targetIndex++;
+            }
+        }
+
+        if (targetIndex != _viewModel.Tabs.IndexOf(tab))
+        {
+            _viewModel.MoveTab(tab, targetIndex);
+            SetDraggedTabOpacity(0.55);
+        }
+
+        // Dragging against an overflowed strip's edge scrolls it, so a tab can
+        // travel further than the visible span in one gesture.
+        if (_tabsScrollViewer is { } scroller)
+        {
+            const double edge = 24;
+            if (position.X < edge)
+            {
+                scroller.Offset = scroller.Offset.WithX(Math.Max(0, scroller.Offset.X - 8));
+            }
+            else if (position.X > TabsList.Bounds.Width - edge)
+            {
+                scroller.Offset = scroller.Offset.WithX(scroller.Offset.X + 8);
+            }
+        }
+    }
+
+    private void EndTabDrag()
+    {
+        if (_tabDragActive)
+        {
+            SetDraggedTabOpacity(1);
+        }
+
+        _tabDragCandidate = null;
+        _tabDragActive = false;
+    }
+
+    // The faded "in flight" look rides on the item's container, which can be
+    // re-realized across a collection Move — hence re-applied after each one.
+    private void SetDraggedTabOpacity(double opacity)
+    {
+        if (_tabDragCandidate is { } tab && _viewModel is not null
+            && _viewModel.Tabs.IndexOf(tab) is var index and >= 0
+            && TabsList.ContainerFromIndex(index) is { } container)
+        {
+            container.Opacity = opacity;
         }
     }
 
@@ -2183,6 +2321,34 @@ public partial class MainWindow : Window
     // key bindings all resolve to its commands); this window owns the
     // StorageProvider dialogs and the actual file I/O, same split as
     // Import/Export above.
+
+    /// <summary>
+    /// Rebuilds the ☰ menu's "Open recent" submenu from the live recent-files
+    /// list — called every time the menu opens. Headers are TextBlocks, not
+    /// strings, so an underscore in a file name isn't eaten as an access key;
+    /// the full path rides in the tooltip since the item shows only the name.
+    /// </summary>
+    private void RebuildRecentFilesMenu()
+    {
+        MenuOpenRecent.Items.Clear();
+        if (_viewModel is not { RecentSqlFiles.Count: > 0 } viewModel)
+        {
+            MenuOpenRecent.Items.Add(new MenuItem
+            {
+                Header = new TextBlock { Text = "No recent files" },
+                IsEnabled = false,
+            });
+            return;
+        }
+
+        foreach (var path in viewModel.RecentSqlFiles)
+        {
+            var item = new MenuItem { Header = new TextBlock { Text = Path.GetFileName(path) } };
+            ToolTip.SetTip(item, path);
+            item.Click += (_, _) => _ = OpenRecentFileAsync(path);
+            MenuOpenRecent.Items.Add(item);
+        }
+    }
 
     private void OnOpenFileRequested() => _ = OpenSqlFileAsync();
 

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -355,6 +355,7 @@ public partial class MainWindow : Window
         MenuSaveFile.InputGesture = new KeyGesture(Key.S, Hotkeys.Command);
         MenuSaveFileAs.InputGesture = new KeyGesture(Key.S, Hotkeys.Command | KeyModifiers.Shift);
         MenuCloseTab.InputGesture = new KeyGesture(Key.W, Hotkeys.Command);
+        MenuPreferences.InputGesture = new KeyGesture(Key.OemComma, Hotkeys.Command);
 
         // And the search pill's caption (the palette itself opens from
         // OnKeyDown, which reads Hotkeys.Command live).

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -356,6 +356,10 @@ public partial class MainWindow : Window
         MenuSaveFileAs.InputGesture = new KeyGesture(Key.S, Hotkeys.Command | KeyModifiers.Shift);
         MenuCloseTab.InputGesture = new KeyGesture(Key.W, Hotkeys.Command);
 
+        // And the search pill's caption (the palette itself opens from
+        // OnKeyDown, which reads Hotkeys.Command live).
+        PaletteSearchShortcut.Text = Hotkeys.Label("K");
+
         void Add(KeyGesture gesture, Func<System.Windows.Input.ICommand?> resolve) =>
             KeyBindings.Add(new KeyBinding { Gesture = gesture, Command = new DelegatedCommand(resolve) });
     }
@@ -2623,6 +2627,9 @@ public partial class MainWindow : Window
     }
 
     // A press on the scrim (but not the card) dismisses the palette.
+    /// <summary>The command bar's centered search pill — same target as Ctrl+K / Ctrl+P.</summary>
+    private void OnPaletteSearchButtonClick(object? sender, RoutedEventArgs e) => OpenCommandPalette();
+
     private void OnPaletteScrimPressed(object? sender, PointerPressedEventArgs e) =>
         _viewModel?.CommandPalette.CloseCommand.Execute(null);
 


### PR DESCRIPTION
## What

Command-bar/tab-strip UX additions (all explicitly requested):

### 1. Drag-and-drop tab reorder
Tabs on the query strip now reorder by dragging — live, browser-style: the dragged tab lands after every tab whose center the pointer passes, with edge auto-scroll when the strip overflows. A plain click still just switches tabs (the drag only arms past the existing 4px threshold), and the ✕ chip stays a close click. The new order persists via the workspace snapshot, which already serializes `Tabs` in collection order.

### 2. ☰ app menu (top-left)
The discoverable home for file/tab commands — open/save/recent previously lived only in the command palette, invisible to anyone who does not know Ctrl+K:

- New query tab, Open .sql file…, **Open recent** (submenu rebuilt from the live recent-files list on every open; full path in the tooltip)
- Save, Save as…
- Close tab
- Switch connection…, Open connection in new window…
- Preferences… (Ctrl/Cmd+,)

Shortcut captions are set in `BuildKeyBindings`, so they track the live Ctrl/Cmd scheme per the no-hardcoded-gestures rule.

### 3. Centered search pill (VS Code-style)
The command bar's DockPanel becomes an `Auto|*|Auto` grid with a quiet card-toned capsule centered between the clusters — magnify icon + "Search tables, queries, actions…" (ellipsized on narrow windows, so it can't be mistaken for editor text search) + live Ctrl+K caption. Clicking it opens the command palette (same path as Ctrl+K/P), giving the palette its first visible entry point. On narrow windows the pill shrinks instead of overlapping.

CLAUDE.md's UI-rules section documents all of the above (and that they deliberately duplicate palette entries without loosening the minimalism default).

## Verified

Live on Windows (Debug build + computer-use): menu opens with correct items/captions, Open recent shows the real list, drag right and left both reorder correctly, plain tab clicks still switch, search pill renders centered and opens the palette with the search box focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)