### PR TITLE
Release pipeline: fold winget job into build-windows, reuse linux-x64 publish for benchmarks, drop prepare job

### DIFF
--- a/.github/actions/version/action.yml
+++ b/.github/actions/version/action.yml
@@ -1,0 +1,35 @@
+name: Determine version
+description: >-
+  Resolves the build version: the tag name (minus the leading v) on a tag
+  push, the explicit workflow_dispatch input when given, else a dev version
+  from the run number. Exports it as $VERSION via GITHUB_ENV and as a step
+  output. Runs inline in each build job so no dedicated "prepare" runner has
+  to boot ahead of them.
+
+inputs:
+  version:
+    description: "Explicit version (no leading v) from workflow_dispatch; empty on tag pushes."
+    required: false
+    default: ""
+
+outputs:
+  version:
+    description: "The resolved version"
+    value: ${{ steps.version.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - id: version
+      shell: bash
+      run: |
+        if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          VERSION="${GITHUB_REF_NAME#v}"
+        elif [[ -n "${{ inputs.version }}" ]]; then
+          VERSION="${{ inputs.version }}"
+        else
+          VERSION="0.0.0-ci.$GITHUB_RUN_NUMBER"
+        fi
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        echo "Building version $VERSION"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,6 +19,14 @@ on:
         description: "Push results to the gh-pages benchmark history"
         type: boolean
         default: false
+      publish_artifact:
+        description: >-
+          Name of an artifact (from the calling workflow run) holding a
+          prebuilt linux-x64 NativeAOT publish as a .tar.gz; when set, the
+          benchmark script measures it instead of running its own slow AOT
+          publish. release.yml passes build-linux's publish here.
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       record_history:
@@ -65,6 +73,22 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq xvfb clang zlib1g-dev
+
+      # Reuse the caller's already-built AOT publish instead of publishing
+      # again (the single slowest step of this job). Tarred by the producer
+      # because artifact zips drop the executable bit.
+      - name: Download prebuilt AOT publish
+        if: inputs.publish_artifact != ''
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.publish_artifact }}
+
+      - name: Unpack prebuilt AOT publish
+        if: inputs.publish_artifact != ''
+        run: |
+          mkdir -p prebuilt-publish
+          tar -xzf publish-linux-x64.tar.gz -C prebuilt-publish
+          echo "PGNIMBUS_BENCH_PUBLISH_DIR=$PWD/prebuilt-publish/linux-x64" >> "$GITHUB_ENV"
 
       - name: Run benchmarks
         run: scripts/benchmarks/run-benchmarks.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: Release
 
 # Tag pushes (v1.2.3) cut a real GitHub Release; workflow_dispatch runs the
 # whole pipeline without publishing anything, for testing.
+#
+# Each build job resolves the version itself via .github/actions/version
+# (a composite action) — no dedicated "prepare" job, so no extra runner
+# boot at the head of the critical path.
 on:
   push:
     tags:
@@ -22,26 +26,11 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
 
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - name: Determine version
-        id: version
-        run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-          elif [[ -n "${{ inputs.version }}" ]]; then
-            VERSION="${{ inputs.version }}"
-          else
-            VERSION="0.0.0-ci.${{ github.run_number }}"
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Building version $VERSION"
-
+  # Chained after build-linux so it reuses that job's linux-x64 NativeAOT
+  # publish instead of doing the same slow publish a second time. This does
+  # not delay the release: the "release" job doesn't depend on benchmark.
   benchmark:
-    needs: prepare
+    needs: build-linux
     uses: ./.github/workflows/benchmark.yml
     permissions:
       contents: write
@@ -49,14 +38,17 @@ jobs:
       # Only append to the gh-pages trend history on a real tag-triggered
       # release, not a workflow_dispatch test run.
       record_history: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      publish_artifact: publish-linux-x64
 
   build-windows:
-    needs: prepare
     runs-on: windows-latest
-    env:
-      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - uses: actions/checkout@v7
+
+      - name: Determine version
+        uses: ./.github/actions/version
+        with:
+          version: ${{ inputs.version }}
 
       - uses: actions/setup-dotnet@v6
         with:
@@ -117,8 +109,28 @@ jobs:
           name: windows-msix
           path: pgNimbus-${{ env.VERSION }}-win-x64.msix
 
-    outputs:
-      msi_sha256: ${{ steps.sha.outputs.sha256 }}
+      # winget manifests are rendered right here rather than in a separate
+      # job: the MSI and its SHA256 are already at hand, so this saves a
+      # whole extra Windows runner (and the artifact round-trip) that used
+      # to sit on the critical path before "release".
+      - name: Render winget manifests
+        shell: bash
+        run: |
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/pgNimbus-${VERSION}-win-x64.msi"
+          bash scripts/winget/render-manifest.sh "$VERSION" "${{ steps.sha.outputs.sha256 }}" "$RELEASE_URL" manifests
+
+      - name: Validate winget manifests
+        shell: pwsh
+        run: winget validate --manifest manifests
+
+      - name: Zip winget manifests
+        shell: pwsh
+        run: Compress-Archive -Path manifests\* -DestinationPath winget-manifests.zip
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: winget-manifests
+          path: winget-manifests.zip
 
   build-macos:
     # Apple Silicon only: GitHub retired the last Intel macOS runner image
@@ -126,12 +138,14 @@ jobs:
     # entirely after the macos-15 image retires (Fall 2027). There's no
     # GitHub-hosted way to build osx-x64 anymore, and virtually all Macs
     # sold since 2020 are Apple Silicon anyway.
-    needs: prepare
     runs-on: macos-14
-    env:
-      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - uses: actions/checkout@v7
+
+      - name: Determine version
+        uses: ./.github/actions/version
+        with:
+          version: ${{ inputs.version }}
 
       - uses: actions/setup-dotnet@v6
         with:
@@ -189,7 +203,6 @@ jobs:
           path: dist/*.dmg
 
   build-linux:
-    needs: prepare
     strategy:
       matrix:
         include:
@@ -200,12 +213,15 @@ jobs:
           - runner: ubuntu-24.04-arm
             rid: linux-arm64
     runs-on: ${{ matrix.runner }}
-    env:
-      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-dotnet@v5
+      - name: Determine version
+        uses: ./.github/actions/version
+        with:
+          version: ${{ inputs.version }}
+
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -234,50 +250,34 @@ jobs:
           name: linux-packages-${{ matrix.rid }}
           path: dist/*
 
-  winget-manifest:
-    needs: [prepare, build-windows]
-    runs-on: windows-latest
-    env:
-      VERSION: ${{ needs.prepare.outputs.version }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: windows-msi
-          path: artifacts
-
-      - name: Render winget manifests
-        shell: bash
-        run: |
-          RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/v${VERSION}/pgNimbus-${VERSION}-win-x64.msi"
-          chmod +x scripts/winget/render-manifest.sh
-          ./scripts/winget/render-manifest.sh "$VERSION" "${{ needs.build-windows.outputs.msi_sha256 }}" "$RELEASE_URL" manifests
-
-      - name: Validate manifests
-        shell: pwsh
-        run: winget validate --manifest manifests
-
-      - name: Zip manifests
-        shell: pwsh
-        run: Compress-Archive -Path manifests\* -DestinationPath winget-manifests.zip
+      # The raw x64 publish output feeds the benchmark job so it doesn't
+      # repeat the slow NativeAOT publish. Tarred because upload-artifact
+      # zips files without their unix permissions — a bare upload would
+      # deliver a non-executable binary to the startup probe.
+      - name: Tar raw publish output (for benchmarks)
+        if: matrix.rid == 'linux-x64'
+        run: tar -C publish -czf publish-linux-x64.tar.gz linux-x64
 
       - uses: actions/upload-artifact@v7
+        if: matrix.rid == 'linux-x64'
         with:
-          name: winget-manifests
-          path: winget-manifests.zip
+          name: publish-linux-x64
+          path: publish-linux-x64.tar.gz
 
   release:
-    needs: [prepare, build-windows, build-macos, build-linux, winget-manifest]
+    needs: [build-windows, build-macos, build-linux]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    env:
-      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
+      # Only the artifacts that ship in the Release. Notably excluded:
+      # windows-msix (Store-submission-only, see build-windows),
+      # publish-linux-x64 (benchmark input — its .tar.gz would otherwise
+      # leak into the checksum globs below), bench-results.
       - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
+          pattern: "{windows-msi,macos-dmg-arm64,linux-packages-*,winget-manifests}"
 
       - name: Generate checksums
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,12 @@ the release pipeline don't pollute the trend history. Three moving parts:
    throughput of a 100k-row mixed-type SELECT, through `QueryEngine`'s
    streaming path (the same API the UI uses). Prints `PGNIMBUS_BENCH
    name=value` lines; config via `PGNIMBUS_BENCH_CONN/ROWS/ITERS`.
-3. **The script** — builds JIT Release, publishes linux-x64 NativeAOT, runs
+3. **The script** — builds JIT Release, publishes linux-x64 NativeAOT (or
+   measures an existing publish dir given via `PGNIMBUS_BENCH_PUBLISH_DIR` —
+   the release pipeline passes build-linux's x64 output through the
+   `publish_artifact` workflow input this way, as a `.tar.gz` because
+   artifact zips drop the exec bit, so the slow AOT publish isn't done
+   twice), runs
    the startup probe N times per mode under Xvfb (one discarded warm-up run,
    then medians), runs the query benchmarks, and writes
    `bench-results/benchmarks.json` (github-action-benchmark
@@ -411,10 +416,12 @@ job so it never publishes). It produces, per tag:
   `pgnimbus`), icons from the `design/masters/icon/` tiles. The NativeAOT
   `*.dbg` symbols side-file is excluded from all three packages. Unsigned,
   like the other direct-download channels.
-- **winget** — the workflow renders (via
+- **winget** — the `build-windows` job renders (via
   [`scripts/winget/render-manifest.sh`](scripts/winget/render-manifest.sh)
   and the templates in `packaging/winget/`) the three manifest files
-  winget requires and validates them with `winget validate`, but does
+  winget requires and validates them with `winget validate` right after
+  building the MSI (same job — the MSI and its SHA256 are already at
+  hand, no separate runner), but does
   **not** submit them anywhere. `winget-pkgs` needs a manual first PR
   (registers the `pgNimbus.pgNimbus` identifier) before any automated
   submission could work — the generated `winget-manifests.zip` release

--- a/scripts/benchmarks/run-benchmarks.sh
+++ b/scripts/benchmarks/run-benchmarks.sh
@@ -28,6 +28,10 @@
 #   PGNIMBUS_BENCH_CONN   connection string (default: localhost/postgres/postgres)
 #   PGNIMBUS_BENCH_RUNS   startup samples per mode, median reported (default 7)
 #   PGNIMBUS_BENCH_ROWS   row count for the streaming benchmarks (default 100000)
+#   PGNIMBUS_BENCH_PUBLISH_DIR  an existing linux-x64 NativeAOT publish dir to
+#                     measure instead of publishing one here (the release
+#                     pipeline reuses build-linux's output this way; must
+#                     contain PgNimbus.App and its side-car native libs)
 #   PGNIMBUS_BENCH_SKIP_AOT=1   skip the AOT publish + AOT metrics (quick local runs)
 
 set -euo pipefail
@@ -81,7 +85,15 @@ echo "== Building (JIT Release)"
 dotnet build -c Release >/dev/null
 JIT_BINARY=PgNimbus.App/bin/Release/net10.0/PgNimbus.App
 
-if [[ -z "${PGNIMBUS_BENCH_SKIP_AOT:-}" ]]; then
+if [[ -n "${PGNIMBUS_BENCH_PUBLISH_DIR:-}" ]]; then
+    echo "== Using prebuilt NativeAOT publish at $PGNIMBUS_BENCH_PUBLISH_DIR"
+    PUBLISH_DIR="$PGNIMBUS_BENCH_PUBLISH_DIR"
+    AOT_BINARY="$PUBLISH_DIR/PgNimbus.App"
+    [[ -f "$AOT_BINARY" ]] || { echo "error: no PgNimbus.App in $PUBLISH_DIR" >&2; exit 1; }
+    # CI hands the publish over as an artifact; artifact zips drop the exec
+    # bit (the producer tars to preserve it), so restore it defensively.
+    [[ -x "$AOT_BINARY" ]] || chmod +x "$AOT_BINARY"
+elif [[ -z "${PGNIMBUS_BENCH_SKIP_AOT:-}" ]]; then
     echo "== Publishing (NativeAOT linux-x64) — this is the slow part"
     AOT_BINARY=PgNimbus.App/bin/Release/net10.0/linux-x64/publish/PgNimbus.App
     PUBLISH_DIR=$(dirname "$AOT_BINARY")
@@ -89,6 +101,9 @@ if [[ -z "${PGNIMBUS_BENCH_SKIP_AOT:-}" ]]; then
     # would keep (and count) files a previous build no longer produces.
     rm -rf "$PUBLISH_DIR"
     dotnet publish PgNimbus.App -c Release -r linux-x64 -p:PublishAot=true >/dev/null
+fi
+
+if [[ -n "${AOT_BINARY:-}" ]]; then
     BINARY_SIZE_MB=$(awk "BEGIN { printf \"%.1f\", $(stat -c%s "$AOT_BINARY") / 1024 / 1024 }")
     # Measure what ships, not what publish leaves on disk: the MSI and MSIX
     # both exclude debug symbols (*.pdb — see installer/windows/Product.wxs


### PR DESCRIPTION
Consolidates the release pipeline — same artifacts, fewer runners, shorter critical path. Nothing a release ships changes.

## 1. winget manifests move into `build-windows`

The dedicated `winget-manifest` job was a whole Windows runner (the slowest to boot) chained *after* `build-windows` on the critical path before `release`, doing only `sed` over three templates + `winget validate`. It also had a dead step: it downloaded the `windows-msi` artifact, but `render-manifest.sh` takes the SHA256 as an argument and never reads the MSI file.

Now the render/validate/zip steps run at the end of `build-windows`, where the MSI and its hash already exist. The `msi_sha256` job-output plumbing goes away too.

## 2. Benchmarks reuse the linux-x64 AOT publish

`build-linux` (x64) and the benchmark script both published the same linux-x64 NativeAOT build — the slowest step of each job. Now:

- `build-linux` (x64 leg only) uploads its raw publish dir as `publish-linux-x64.tar.gz` — **tar, not a bare upload**, because artifact zips drop the unix exec bit and the startup probe needs a runnable binary;
- `benchmark.yml` gains a `publish_artifact` workflow_call input that downloads/unpacks it;
- `run-benchmarks.sh` gains `PGNIMBUS_BENCH_PUBLISH_DIR` to measure a prebuilt dir instead of publishing (with a defensive `chmod +x`). Standalone `workflow_dispatch` of benchmark.yml still self-publishes as before.

This chains `benchmark` after `build-linux`, which delays nothing: `release` never depended on `benchmark`.

## 3. `prepare` job → composite action

A runner booted solely to compute the version string, gating every build job on its boot time. Replaced by `.github/actions/version`, run inline after checkout in each build job (exports `$VERSION` via `GITHUB_ENV`, so all `${{ env.VERSION }}` references work unchanged). Tag detection now checks the ref directly instead of `event_name == push`.

## Minor

- `release` downloads only shipping artifacts via a `pattern` filter — previously it pulled everything, including the ~50 MB Store-only MSIX; and the new `publish-linux-x64.tar.gz` would otherwise have leaked into the `*.tar.gz` checksum glob and the Release assets.
- `build-linux`'s `setup-dotnet` aligned to `@v6` like the other jobs.
- CLAUDE.md's benchmark/winget pipeline descriptions updated in the same PR.

## Verification

YAML parses (all three files), `bash -n` on the modified script, and a manual trace of both trigger paths (tag push and `workflow_dispatch`). Suggest a `workflow_dispatch` test run of Release after merge to see the publish-reuse path execute for real before the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)