### PR TITLE
Supply-chain proofs: SLSA attestations, CycloneDX SBOM, NuGet vulnerability gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,19 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
 
 jobs:
+  # Blocks PRs that add a package with a known vulnerability (GitHub Advisory
+  # Database via the repo dependency graph). Complements NuGetAudit in
+  # Directory.Build.props, which fails the build on advisories in packages
+  # already referenced.
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: moderate
+
   build-test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,26 @@ jobs:
           chmod +x scripts/linux/build-packages.sh
           ./scripts/linux/build-packages.sh publish/${{ matrix.rid }} "$VERSION" ${{ matrix.rid }} dist
 
+      # Software bill of materials: every NuGet package (direct + transitive)
+      # baked into the shipped app, as CycloneDX JSON. Generated once on the
+      # x64 leg — the NuGet dependency graph is RID-independent. -c Release
+      # matters: it keeps the Debug-only AvaloniaUI.DiagnosticsSupport
+      # reference (conditional PackageReference) out of the SBOM, matching
+      # what release binaries actually contain.
+      - name: Generate SBOM (CycloneDX)
+        if: matrix.rid == 'linux-x64'
+        run: |
+          dotnet tool install --global CycloneDX
+          dotnet-CycloneDX PgNimbus.App/PgNimbus.App.csproj -c Release -F Json \
+            -o sbom -fn "pgNimbus-${VERSION}-sbom.cdx.json" \
+            -sn pgNimbus -sv "$VERSION" -ed
+
+      - uses: actions/upload-artifact@v7
+        if: matrix.rid == 'linux-x64'
+        with:
+          name: sbom
+          path: sbom/*.cdx.json
+
       - uses: actions/upload-artifact@v7
         with:
           name: linux-packages-${{ matrix.rid }}
@@ -268,6 +288,11 @@ jobs:
     needs: [build-windows, build-macos, build-linux]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # For actions/attest-build-provenance (Sigstore signing via OIDC).
+      id-token: write
+      attestations: write
     steps:
       # Only the artifacts that ship in the Release. Notably excluded:
       # windows-msix (Store-submission-only, see build-windows),
@@ -277,13 +302,22 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
-          pattern: "{windows-msi,macos-dmg-arm64,linux-packages-*,winget-manifests}"
+          pattern: "{windows-msi,macos-dmg-arm64,linux-packages-*,winget-manifests,sbom}"
 
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum *.msi *.dmg *.zip *.AppImage *.tar.gz *.deb > SHA256SUMS.txt
+          sha256sum *.msi *.dmg *.zip *.AppImage *.tar.gz *.deb *.cdx.json > SHA256SUMS.txt
           cat SHA256SUMS.txt
+
+      # Signed SLSA build provenance (Sigstore) for every shipped file — the
+      # $0 substitute for code signing on the direct-download channel: proves
+      # a download was built by this workflow from this commit. Verify with:
+      #   gh attestation verify <file> --repo ${{ github.repository }}
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: artifacts/*
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
@@ -295,6 +329,7 @@ jobs:
             artifacts/*.AppImage
             artifacts/*.tar.gz
             artifacts/*.deb
+            artifacts/*.cdx.json
             artifacts/SHA256SUMS.txt
           generate_release_notes: true
           # Every build is unsigned until a code-signing cert / Apple

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,6 +438,32 @@ automatically discoverable via winget's built-in `msstore` source with no
 separate winget submission. It's an *additional* channel, not a replacement
 for the direct MSI + `winget-pkgs` path above — the two coexist.
 
+### Supply-chain proofs (2026-07)
+
+Unsigned binaries still get verifiable provenance, three layers:
+
+- **SLSA attestations** — the release job runs
+  `actions/attest-build-provenance` over every published asset (needs the
+  job's `id-token: write` + `attestations: write` permissions). Users
+  verify a download with
+  `gh attestation verify <file> --repo Shman4ik/pgNimbus` — proves it was
+  built by this workflow from a specific commit. This is the $0 substitute
+  for Authenticode on the direct-download channel; it does nothing for
+  SmartScreen (the Store channel covers that).
+- **SBOM** — the build-linux x64 leg generates a CycloneDX JSON SBOM of the
+  App's full NuGet graph (`dotnet-CycloneDX` on `PgNimbus.App.csproj`,
+  `-c Release` so the Debug-only conditional AvaloniaUI.DiagnosticsSupport
+  reference stays out — it's not in shipped binaries and must not appear in
+  the SBOM). Ships as the `pgNimbus-<ver>-sbom.cdx.json` release asset,
+  checksummed and attested like the binaries. Generated once (x64 only) —
+  the NuGet graph is RID-independent.
+- **Vulnerability gates** — the repo-root `Directory.Build.props` sets
+  `NuGetAuditMode=all` (transitive packages too) and promotes
+  moderate/high/critical audit warnings (NU1902–NU1904) to errors, so any
+  `dotnet build`/`restore` — local or CI — fails on a known advisory; ci.yml
+  additionally runs `dependency-review-action` on PRs to block newly-added
+  vulnerable packages at review time.
+
 ### Microsoft Store (MSIX)
 
 `build-windows` also packs `publish/win-x64` into a self-signed `.msix` via

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+
+  <!-- NuGet vulnerability audit on every restore: check direct + transitive
+       packages against known advisories and fail the build (not just warn) on
+       moderate/high/critical ones (NU1902-NU1904). Low (NU1901) stays a
+       warning. Complemented by dependency-review-action in ci.yml, which
+       blocks PRs that *add* a vulnerable package. -->
+  <PropertyGroup>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <WarningsAsErrors>$(WarningsAsErrors);NU1902;NU1903;NU1904</WarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ winget install pgNimbus --source msstore
 Grab `pgNimbus-<version>-win-x64.msi` from [Releases](https://github.com/Shman4ik/pgNimbus/releases) — a per-user installer, no admin rights needed.
 
 > [!NOTE]
-> The direct MSI is unsigned, so SmartScreen will warn on first run — click **More info → Run anyway**, or prefer the Store/WinGet path above.
+> The direct MSI is unsigned, so SmartScreen will warn on first run — click **More info → Run anyway**, or prefer the Store/WinGet path above. You can still [verify where the file came from](#verifying-a-download).
 
 ### macOS (early beta)
 
@@ -104,6 +104,16 @@ x64 and arm64 builds from [Releases](https://github.com/Shman4ik/pgNimbus/releas
 - **tar.gz** — unpack anywhere and run `./PgNimbus.App`.
 
 Every `vX.Y.Z` tag builds all of the above via [`release.yml`](.github/workflows/release.yml).
+
+### Verifying a download
+
+The direct-download builds are unsigned, but every release asset carries [signed build provenance](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations) — one command proves a file was built by this repo's release workflow from the tagged commit, not tampered with or rehosted:
+
+```bash
+gh attestation verify pgNimbus-<version>-win-x64.msi --repo Shman4ik/pgNimbus
+```
+
+Each release also ships `SHA256SUMS.txt` and a CycloneDX SBOM (`pgNimbus-<version>-sbom.cdx.json`) listing every bundled dependency.
 
 ## 🚀 Quick Start
 


### PR DESCRIPTION
Adds verifiable-security layers to the pipeline (items 1–3 from today's discussion), all $0:

## SLSA build provenance (release.yml)
The `release` job now runs `actions/attest-build-provenance@v4` over every published asset (MSI, dmg, AppImage, tar.gz, deb, winget zip, SBOM, SHA256SUMS.txt). Anyone can verify a download came from this repo's release workflow at a specific commit:

```
gh attestation verify pgNimbus-X.Y.Z-win-x64.msi --repo Shman4ik/pgNimbus
```

This is the free substitute for Authenticode on the direct-download channel (SmartScreen is still covered by the Store channel only). Needs `id-token: write` + `attestations: write` on the release job — added there, not top-level. Only runs on real tag releases (the job's existing `if:` gate), so `workflow_dispatch` test runs attest nothing.

## CycloneDX SBOM (release.yml)
The build-linux x64 leg generates `pgNimbus-<ver>-sbom.cdx.json` — the App's full direct+transitive NuGet graph — via the `CycloneDX` dotnet tool, and it ships as a release asset, checksummed and attested like the binaries. `-c Release` is deliberate: it evaluates the conditional PackageReference so the Debug-only `AvaloniaUI.DiagnosticsSupport` (commercial, never shipped) stays out of the SBOM. Verified locally: 36 packages, no DiagnosticsSupport in the output. Generated once (x64 only) since the NuGet graph is RID-independent.

## Vulnerability gates (Directory.Build.props + ci.yml)
- New repo-root `Directory.Build.props`: `NuGetAuditMode=all` (audits transitive packages too) and NU1902–NU1904 (moderate/high/critical advisories) promoted to errors — any `dotnet build`/`restore`, local or CI, now fails on a known CVE. NU1901 (low) stays a warning. Current state is clean: `dotnet list package --vulnerable --include-transitive` reports nothing, and a forced restore emits no NU19xx.
- `ci.yml` gets a `dependency-review` job (`actions/dependency-review-action@v5`, `fail-on-severity: moderate`) that blocks PRs which *add* a vulnerable package, before it ever lands.

CLAUDE.md's release-pipeline section documents all three (same-PR rule).

Note: the attestation + SBOM release-asset paths only fully exercise on the next `v*` tag; the SBOM step itself and dependency-review will run in CI before that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)