### PR TITLE
Table & index sizes and usage: schema-tree sizes + Database Overview panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,19 @@ and wrong project memory is worse than none.
 3. **PostgreSQL-first, not lowest-common-denominator.** `SchemaService` reads
    `pg_catalog` directly (not `information_schema`) so it can see materialized
    views, partitioned tables, and real Postgres semantics (e.g. primary-key
-   flags via `pg_constraint`).
+   flags via `pg_constraint`). Relation sizes ride the same path:
+   `GetTablesAsync` carries `pg_total_relation_size` per relation for the
+   schema tree's dim size hint (null for views and partitioned parents — no
+   own-storage size worth showing). The **Database Overview** panel is backed
+   by `Monitoring/DatabaseStatsService` (a read-only sibling of
+   `ActivityService`), which reads the `pg_stat_*`/`pg_statio_*` views and the
+   `pg_*_size` functions for db size, cache-hit ratios, largest relations
+   (heap/index split), per-table seq-vs-index scan usage, and unused
+   non-constraint indexes. Human-readable byte counts go through
+   `PgNimbus.Core.ByteSize` (base-1024, unit-tested, shared by both) rather
+   than being formatted ad hoc in the App. Both monitoring windows follow the
+   same shape: one-live-instance, opened from the command palette (and the
+   macOS Query native menu), no new toolbar button.
 4. **No passwords on `ConnectionProfile`.** Passwords come from
    `ICredentialStore` (DPAPI on Windows via `WindowsDpapiCredentialStore`, a
    permission-restricted file fallback elsewhere via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,9 @@ and wrong project memory is worse than none.
    flags via `pg_constraint`). Relation sizes ride the same path:
    `GetTablesAsync` carries `pg_total_relation_size` per relation for the
    schema tree's dim size hint (null for views and partitioned parents — no
-   own-storage size worth showing), shown only when the sidebar's "show sizes"
-   toggle is on — off by default, persisted as `AppSettings.ShowSchemaSizes`. The **Database Overview** panel is backed
+   own-storage size worth showing), shown only when the "Show relation sizes"
+   preference is on — off by default, on the Preferences page's Appearance
+   section, persisted as `AppSettings.ShowSchemaSizes`. The **Database Overview** panel is backed
    by `Monitoring/DatabaseStatsService` (a read-only sibling of
    `ActivityService`), which reads the `pg_stat_*`/`pg_statio_*` views and the
    `pg_*_size` functions for db size, cache-hit ratios, largest relations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ and wrong project memory is worse than none.
    flags via `pg_constraint`). Relation sizes ride the same path:
    `GetTablesAsync` carries `pg_total_relation_size` per relation for the
    schema tree's dim size hint (null for views and partitioned parents — no
-   own-storage size worth showing). The **Database Overview** panel is backed
+   own-storage size worth showing), shown only when the sidebar's "show sizes"
+   toggle is on — off by default, persisted as `AppSettings.ShowSchemaSizes`. The **Database Overview** panel is backed
    by `Monitoring/DatabaseStatsService` (a read-only sibling of
    `ActivityService`), which reads the `pg_stat_*`/`pg_statio_*` views and the
    `pg_*_size` functions for db size, cache-hit ratios, largest relations

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -37,6 +37,10 @@ public partial class App : Application
     private static void PersistShowAdvancedSchemaObjects(bool value) =>
         SettingsStore.Save(SettingsStore.Load() with { ShowAdvancedSchemaObjects = value });
 
+    /// <summary>Remembers the sidebar's show-sizes toggle so it survives a restart.</summary>
+    private static void PersistShowSchemaSizes(bool value) =>
+        SettingsStore.Save(SettingsStore.Load() with { ShowSchemaSizes = value });
+
     /// <summary>Remembers the editor's auto-alias-tables toggle so it survives a restart.</summary>
     private static void PersistAutoAliasTables(bool value) =>
         SettingsStore.Save(SettingsStore.Load() with { AutoAliasTables = value });
@@ -233,7 +237,9 @@ public partial class App : Application
         var schemaTree = new SchemaTreeViewModel(
             schemaService,
             SettingsStore.Load().ShowAdvancedSchemaObjects,
-            PersistShowAdvancedSchemaObjects);
+            PersistShowAdvancedSchemaObjects,
+            SettingsStore.Load().ShowSchemaSizes,
+            PersistShowSchemaSizes);
         var completionProvider = new SqlCompletionProvider(schemaService);
         var notifyMonitor = new NotifyMonitorViewModel(new NotificationListener(dataSource));
 

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -228,6 +228,7 @@ public partial class App : Application
         var schemaEditor = new SchemaEditor(dataSource);
         var ddlService = new DdlService(dataSource);
         var activityService = new ActivityService(dataSource);
+        var databaseStatsService = new DatabaseStatsService(dataSource);
         var importService = new ImportService(dataSource);
         var schemaTree = new SchemaTreeViewModel(
             schemaService,
@@ -247,7 +248,7 @@ public partial class App : Application
         var workspaceKey = string.IsNullOrEmpty(connectionHost) ? null : $"{connectionHost}/{connectionDatabase}";
 
         var viewModel = new MainViewModel(
-            engine, explainService, schemaTree, schemaService, schemaEditor, ddlService, completionProvider, notifyMonitor, activityService, importService,
+            engine, explainService, schemaTree, schemaService, schemaEditor, ddlService, completionProvider, notifyMonitor, activityService, databaseStatsService, importService,
             accentColor,
             connectionHost: connectionHost,
             connectionDatabase: connectionDatabase,

--- a/PgNimbus.App/ViewModels/DatabaseOverviewViewModel.cs
+++ b/PgNimbus.App/ViewModels/DatabaseOverviewViewModel.cs
@@ -107,32 +107,44 @@ public sealed partial class DatabaseOverviewViewModel : ObservableObject
         _service = service;
     }
 
-    [RelayCommand]
-    private async Task RefreshAsync()
+    // AllowConcurrentExecutions = false disables the Refresh button while a
+    // snapshot is in flight, so repeated clicks can't race the ObservableCollection
+    // mutations below. The four reads are independent, so they fan out in parallel
+    // rather than serially — one round-trip's worth of latency instead of four,
+    // which matters over an SSH tunnel. The CancellationToken lets an in-flight
+    // snapshot be abandoned (e.g. a re-invoke) instead of running to completion.
+    [RelayCommand(AllowConcurrentExecutions = false)]
+    private async Task RefreshAsync(CancellationToken ct)
     {
         try
         {
-            var overview = await _service.GetOverviewAsync(CancellationToken.None);
+            var overviewTask = _service.GetOverviewAsync(ct);
+            var largestTask = _service.GetLargestRelationsAsync(LargestRelationsLimit, ct);
+            var scansTask = _service.GetTableScanUsageAsync(ct);
+            var unusedTask = _service.GetUnusedIndexesAsync(ct);
+            await Task.WhenAll(overviewTask, largestTask, scansTask, unusedTask);
+
+            var overview = await overviewTask;
             DatabaseName = overview.DatabaseName;
             DatabaseSizeText = ByteSize.Format(overview.SizeBytes);
             TableCacheHitText = FormatRatio(overview.TableCacheHitRatio);
             IndexCacheHitText = FormatRatio(overview.IndexCacheHitRatio);
 
-            var largest = await _service.GetLargestRelationsAsync(LargestRelationsLimit, CancellationToken.None);
+            var largest = await largestTask;
             LargestRelations.Clear();
             foreach (var relation in largest)
             {
                 LargestRelations.Add(new RelationSizeRow(relation));
             }
 
-            var scans = await _service.GetTableScanUsageAsync(CancellationToken.None);
+            var scans = await scansTask;
             TableScans.Clear();
             foreach (var scan in scans)
             {
                 TableScans.Add(new TableScanRow(scan));
             }
 
-            var unused = await _service.GetUnusedIndexesAsync(CancellationToken.None);
+            var unused = await unusedTask;
             UnusedIndexes.Clear();
             foreach (var index in unused)
             {
@@ -144,6 +156,10 @@ public sealed partial class DatabaseOverviewViewModel : ObservableObject
                 + $"{UnusedIndexes.Count} unused index{(UnusedIndexes.Count == 1 ? "" : "es")}"
                 + (unusedBytes > 0 ? $" wasting {ByteSize.Format(unusedBytes)}" : "")
                 + $" · {DateTime.Now:HH:mm:ss}";
+        }
+        catch (OperationCanceledException)
+        {
+            // A superseded/abandoned snapshot — not an error worth surfacing.
         }
         catch (Exception ex)
         {

--- a/PgNimbus.App/ViewModels/DatabaseOverviewViewModel.cs
+++ b/PgNimbus.App/ViewModels/DatabaseOverviewViewModel.cs
@@ -1,0 +1,158 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core;
+using PgNimbus.Core.Monitoring;
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.App.ViewModels;
+
+/// <summary>A largest-relations row shaped for the grid: pre-formatted sizes and a glyph.</summary>
+public sealed record RelationSizeRow(RelationSize Relation)
+{
+    public string Schema => Relation.Schema;
+
+    public string Name => Relation.Name;
+
+    public string Kind => Relation.Kind switch
+    {
+        RelationKind.MaterializedView => "matview",
+        RelationKind.PartitionedTable => "partitioned",
+        _ => "table",
+    };
+
+    public string Total => ByteSize.Format(Relation.TotalBytes);
+
+    public string TableSize => ByteSize.Format(Relation.TableBytes);
+
+    public string IndexSize => ByteSize.Format(Relation.IndexBytes);
+
+    public string Rows => Relation.RowEstimate.ToString("N0", CultureInfo.InvariantCulture);
+}
+
+/// <summary>A scan-usage row: raw counters plus a formatted index-scan percentage and a low-ratio flag.</summary>
+public sealed record TableScanRow(TableScanUsage Usage)
+{
+    public string Schema => Usage.Schema;
+
+    public string Name => Usage.Name;
+
+    public string SeqScan => Usage.SeqScan.ToString("N0", CultureInfo.InvariantCulture);
+
+    public string IdxScan => Usage.IdxScan.ToString("N0", CultureInfo.InvariantCulture);
+
+    public string LiveRows => Usage.LiveTuples.ToString("N0", CultureInfo.InvariantCulture);
+
+    public string DeadRows => Usage.DeadTuples.ToString("N0", CultureInfo.InvariantCulture);
+
+    public string IndexScanPercent =>
+        Usage.IndexScanRatio is { } r ? r.ToString("P0", CultureInfo.InvariantCulture) : "—";
+
+    /// <summary>
+    /// A table big enough to matter (10k+ live rows) that the planner reaches
+    /// mostly via sequential scans — the missing-index smell the panel highlights.
+    /// </summary>
+    public bool IsSeqScanHeavy =>
+        Usage.LiveTuples >= 10_000 && Usage.IndexScanRatio is < 0.5;
+}
+
+/// <summary>An unused-index row with its size pre-formatted.</summary>
+public sealed record UnusedIndexRow(UnusedIndex Index)
+{
+    public string Schema => Index.Schema;
+
+    public string Table => Index.Table;
+
+    public string Name => Index.Index;
+
+    public string Size => ByteSize.Format(Index.IndexBytes);
+}
+
+/// <summary>
+/// Drives the Database Overview window: a one-shot snapshot of database size,
+/// cache-hit ratios, the largest relations, per-table scan usage, and unused
+/// indexes. Everything is read-only, so unlike the activity view there's no
+/// auto-refresh timer — the user hits Refresh to re-snapshot.
+/// </summary>
+public sealed partial class DatabaseOverviewViewModel : ObservableObject
+{
+    private const int LargestRelationsLimit = 50;
+
+    private readonly DatabaseStatsService _service;
+
+    [ObservableProperty]
+    private string _databaseName = "";
+
+    [ObservableProperty]
+    private string _databaseSizeText = "";
+
+    [ObservableProperty]
+    private string _tableCacheHitText = "—";
+
+    [ObservableProperty]
+    private string _indexCacheHitText = "—";
+
+    [ObservableProperty]
+    private string _status = "";
+
+    public ObservableCollection<RelationSizeRow> LargestRelations { get; } = [];
+
+    public ObservableCollection<TableScanRow> TableScans { get; } = [];
+
+    public ObservableCollection<UnusedIndexRow> UnusedIndexes { get; } = [];
+
+    public DatabaseOverviewViewModel(DatabaseStatsService service)
+    {
+        _service = service;
+    }
+
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        try
+        {
+            var overview = await _service.GetOverviewAsync(CancellationToken.None);
+            DatabaseName = overview.DatabaseName;
+            DatabaseSizeText = ByteSize.Format(overview.SizeBytes);
+            TableCacheHitText = FormatRatio(overview.TableCacheHitRatio);
+            IndexCacheHitText = FormatRatio(overview.IndexCacheHitRatio);
+
+            var largest = await _service.GetLargestRelationsAsync(LargestRelationsLimit, CancellationToken.None);
+            LargestRelations.Clear();
+            foreach (var relation in largest)
+            {
+                LargestRelations.Add(new RelationSizeRow(relation));
+            }
+
+            var scans = await _service.GetTableScanUsageAsync(CancellationToken.None);
+            TableScans.Clear();
+            foreach (var scan in scans)
+            {
+                TableScans.Add(new TableScanRow(scan));
+            }
+
+            var unused = await _service.GetUnusedIndexesAsync(CancellationToken.None);
+            UnusedIndexes.Clear();
+            foreach (var index in unused)
+            {
+                UnusedIndexes.Add(new UnusedIndexRow(index));
+            }
+
+            var unusedBytes = unused.Sum(i => i.IndexBytes);
+            Status = $"{LargestRelations.Count} relation{Plural(LargestRelations.Count)} · "
+                + $"{UnusedIndexes.Count} unused index{(UnusedIndexes.Count == 1 ? "" : "es")}"
+                + (unusedBytes > 0 ? $" wasting {ByteSize.Format(unusedBytes)}" : "")
+                + $" · {DateTime.Now:HH:mm:ss}";
+        }
+        catch (Exception ex)
+        {
+            Status = ex.Message;
+        }
+    }
+
+    private static string Plural(int n) => n == 1 ? "" : "s";
+
+    private static string FormatRatio(double? ratio) =>
+        ratio is { } r ? r.ToString("P1", CultureInfo.InvariantCulture) : "—";
+}

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -30,6 +30,9 @@ public sealed partial class MainViewModel : ObservableObject
     /// <summary>Backs the Server Activity window (pg_stat_activity live view).</summary>
     public ActivityViewModel Activity { get; }
 
+    /// <summary>Backs the Database Overview window (sizes, cache-hit, scan usage, unused indexes).</summary>
+    public DatabaseOverviewViewModel DatabaseOverview { get; }
+
     /// <summary>COPY-based CSV/JSON loader behind the Import dialog (the view constructs the dialog's ViewModel from it).</summary>
     public ImportService Importer { get; }
 
@@ -58,6 +61,8 @@ public sealed partial class MainViewModel : ObservableObject
     public event Action<bool>? FindRequested;
     // Raised to open (or focus) the Server Activity window, which the view owns.
     public event Action? ActivityRequested;
+    // Raised to open (or focus) the Database Overview window, which the view owns.
+    public event Action? DatabaseOverviewRequested;
     // Raised to collapse/restore the sidebar (the view owns the grid column).
     public event Action? SidebarToggleRequested;
     // Raised to open (or focus) the preferences window, which the view owns.
@@ -120,6 +125,9 @@ public sealed partial class MainViewModel : ObservableObject
 
     [RelayCommand]
     private void ShowActivity() => ActivityRequested?.Invoke();
+
+    [RelayCommand]
+    private void ShowDatabaseOverview() => DatabaseOverviewRequested?.Invoke();
 
     // Relations rarely change mid-session, so the palette's "jump to a table"
     // list is fetched once and reused across opens.
@@ -240,6 +248,7 @@ public sealed partial class MainViewModel : ObservableObject
         SqlCompletionProvider completionProvider,
         NotifyMonitorViewModel notifyMonitor,
         ActivityService activityService,
+        DatabaseStatsService databaseStatsService,
         ImportService importService,
         string? accentColor = null,
         string connectionHost = "",
@@ -285,6 +294,7 @@ public sealed partial class MainViewModel : ObservableObject
             () => string.IsNullOrEmpty(ConnectionHost) ? null : $"{ConnectionHost}/{ConnectionDatabase}");
         NotifyMonitor = notifyMonitor;
         Activity = new ActivityViewModel(activityService);
+        DatabaseOverview = new DatabaseOverviewViewModel(databaseStatsService);
         Importer = importService;
         AccentColor = accentColor;
 
@@ -702,6 +712,7 @@ public sealed partial class MainViewModel : ObservableObject
         yield return new PaletteItem("Rollback transaction", "Action", "↺", Invoke(() => RollbackTransactionCommand));
         yield return new PaletteItem("Refresh database & schema", "Action", "⟳", Invoke(() => RefreshSchemaCommand), Hotkeys.Label("Shift+R"));
         yield return new PaletteItem("Server activity", "Action", "∿", () => { ActivityRequested?.Invoke(); return Task.CompletedTask; });
+        yield return new PaletteItem("Database overview (sizes, cache hit, unused indexes)", "Action", "▦", () => { DatabaseOverviewRequested?.Invoke(); return Task.CompletedTask; });
         yield return new PaletteItem("New query tab", "Action", "＋", Invoke(() => AddTabCommand), Hotkeys.Label("T"));
         yield return new PaletteItem("Close tab", "Action", "✕", Invoke(() => CloseTabCommand), Hotkeys.Label("W"));
         yield return new PaletteItem("Next tab", "Action", "›", Invoke(() => NextTabCommand), Hotkeys.Label("PgDn"));

--- a/PgNimbus.App/ViewModels/PreferencesViewModel.cs
+++ b/PgNimbus.App/ViewModels/PreferencesViewModel.cs
@@ -27,6 +27,7 @@ public sealed partial class PreferencesViewModel : ObservableObject
         _themeIndex = settings.Theme switch { "light" => 1, "dark" => 2, _ => 0 };
         _hotkeySchemeIndex = settings.HotkeyScheme switch { "windows" => 1, "mac" => 2, _ => 0 };
         _main.PropertyChanged += OnMainPropertyChanged;
+        _main.SchemaTree.PropertyChanged += OnSchemaTreePropertyChanged;
     }
 
     /// <summary>
@@ -47,8 +48,23 @@ public sealed partial class PreferencesViewModel : ObservableObject
         set => _main.SafeModeEdits = value;
     }
 
+    /// <summary>
+    /// Whether the schema tree shows each relation's on-disk size. Proxies the
+    /// schema tree's own flag (which persists and re-renders the loaded rows),
+    /// same pattern as <see cref="AutoAliasTables"/>.
+    /// </summary>
+    public bool ShowSchemaSizes
+    {
+        get => _main.SchemaTree.ShowSizes;
+        set => _main.SchemaTree.ShowSizes = value;
+    }
+
     /// <summary>Unhooks from the main view-model when the window closes.</summary>
-    public void Detach() => _main.PropertyChanged -= OnMainPropertyChanged;
+    public void Detach()
+    {
+        _main.PropertyChanged -= OnMainPropertyChanged;
+        _main.SchemaTree.PropertyChanged -= OnSchemaTreePropertyChanged;
+    }
 
     private void OnMainPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
@@ -59,6 +75,14 @@ public sealed partial class PreferencesViewModel : ObservableObject
         else if (e.PropertyName == nameof(MainViewModel.SafeModeEdits))
         {
             OnPropertyChanged(nameof(SafeModeEdits));
+        }
+    }
+
+    private void OnSchemaTreePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SchemaTreeViewModel.ShowSizes))
+        {
+            OnPropertyChanged(nameof(ShowSchemaSizes));
         }
     }
 

--- a/PgNimbus.App/ViewModels/SchemaNode.cs
+++ b/PgNimbus.App/ViewModels/SchemaNode.cs
@@ -6,11 +6,13 @@ public sealed class SchemaNode : SchemaTreeNode
 {
     private readonly SchemaService _schemaService;
     private readonly Func<bool> _showFunctions;
+    private readonly Func<bool> _showSizes;
 
-    public SchemaNode(SchemaService schemaService, string name, Func<bool> showFunctions)
+    public SchemaNode(SchemaService schemaService, string name, Func<bool> showFunctions, Func<bool> showSizes)
     {
         _schemaService = schemaService;
         _showFunctions = showFunctions;
+        _showSizes = showSizes;
         Name = name;
         MarkExpandable();
     }
@@ -18,7 +20,7 @@ public sealed class SchemaNode : SchemaTreeNode
     protected override async Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync()
     {
         var tables = await _schemaService.GetTablesAsync(Name, CancellationToken.None);
-        var children = tables.Select(t => (SchemaTreeNode)new TableNode(_schemaService, Name, t.Name, t.Kind, t.TotalBytes)).ToList();
+        var children = tables.Select(t => (SchemaTreeNode)new TableNode(_schemaService, Name, t.Name, t.Kind, t.TotalBytes, _showSizes)).ToList();
         if (_showFunctions())
         {
             // Functions live in a sub-group so a schema with many of them doesn't drown its tables.

--- a/PgNimbus.App/ViewModels/SchemaNode.cs
+++ b/PgNimbus.App/ViewModels/SchemaNode.cs
@@ -18,7 +18,7 @@ public sealed class SchemaNode : SchemaTreeNode
     protected override async Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync()
     {
         var tables = await _schemaService.GetTablesAsync(Name, CancellationToken.None);
-        var children = tables.Select(t => (SchemaTreeNode)new TableNode(_schemaService, Name, t.Name, t.Kind)).ToList();
+        var children = tables.Select(t => (SchemaTreeNode)new TableNode(_schemaService, Name, t.Name, t.Kind, t.TotalBytes)).ToList();
         if (_showFunctions())
         {
             // Functions live in a sub-group so a schema with many of them doesn't drown its tables.

--- a/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
@@ -9,6 +9,7 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
 {
     private readonly SchemaService _schemaService;
     private readonly Action<bool>? _persistShowAdvanced;
+    private readonly Action<bool>? _persistShowSizes;
 
     [ObservableProperty]
     private bool _isLoading;
@@ -54,13 +55,44 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
     [ObservableProperty]
     private bool _showAdvancedObjects;
 
+    /// <summary>
+    /// The sidebar's "show sizes" toggle. Off by default — when on, each table
+    /// and matview row carries a dim on-disk size hint. Purely a display switch:
+    /// the sizes are already fetched with the tree, so flipping it never costs a
+    /// catalog query, just re-renders the loaded rows.
+    /// </summary>
+    [ObservableProperty]
+    private bool _showSizes;
+
     public ObservableCollection<SchemaTreeNode> Schemas { get; } = [];
 
-    public SchemaTreeViewModel(SchemaService schemaService, bool showAdvancedObjects = false, Action<bool>? persistShowAdvanced = null)
+    public SchemaTreeViewModel(
+        SchemaService schemaService,
+        bool showAdvancedObjects = false,
+        Action<bool>? persistShowAdvanced = null,
+        bool showSizes = false,
+        Action<bool>? persistShowSizes = null)
     {
         _schemaService = schemaService;
         _showAdvancedObjects = showAdvancedObjects;
         _persistShowAdvanced = persistShowAdvanced;
+        _showSizes = showSizes;
+        _persistShowSizes = persistShowSizes;
+    }
+
+    partial void OnShowSizesChanged(bool value)
+    {
+        _persistShowSizes?.Invoke(value);
+
+        // Sizes ride along with the tree already, so flipping the toggle just
+        // re-renders the loaded rows in place — no refetch.
+        foreach (var schema in Schemas.OfType<SchemaNode>())
+        {
+            foreach (var table in schema.Children.OfType<TableNode>())
+            {
+                table.NotifySizeVisibilityChanged();
+            }
+        }
     }
 
     partial void OnShowAdvancedObjectsChanged(bool value)
@@ -174,7 +206,7 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
             Schemas.Clear();
             foreach (var schema in schemas)
             {
-                Schemas.Add(new SchemaNode(_schemaService, schema.Name, () => ShowAdvancedObjects));
+                Schemas.Add(new SchemaNode(_schemaService, schema.Name, () => ShowAdvancedObjects, () => ShowSizes));
             }
 
             // Server-wide groups after the schemas, both lazily loaded.

--- a/PgNimbus.App/ViewModels/TableNode.cs
+++ b/PgNimbus.App/ViewModels/TableNode.cs
@@ -6,14 +6,16 @@ namespace PgNimbus.App.ViewModels;
 public sealed class TableNode : SchemaTreeNode
 {
     private readonly SchemaService _schemaService;
+    private readonly Func<bool> _showSizes;
 
-    public TableNode(SchemaService schemaService, string schema, string name, RelationKind kind, long? totalBytes = null)
+    public TableNode(SchemaService schemaService, string schema, string name, RelationKind kind, long? totalBytes = null, Func<bool>? showSizes = null)
     {
         _schemaService = schemaService;
         Schema = schema;
         Name = name;
         Kind = kind;
         TotalBytes = totalBytes;
+        _showSizes = showSizes ?? (static () => false);
         MarkExpandable();
     }
 
@@ -24,8 +26,14 @@ public sealed class TableNode : SchemaTreeNode
     /// <summary>Total on-disk size (heap + indexes + TOAST), or null for views/partitioned parents.</summary>
     public long? TotalBytes { get; }
 
-    /// <summary>The dim, right-aligned size hint in the tree — empty when there's no size to show.</summary>
-    public string SizeText => TotalBytes is { } bytes ? ByteSize.Format(bytes) : "";
+    /// <summary>
+    /// The dim size hint next to the name — empty when the "show sizes" toggle is
+    /// off or there's no size to show (views, partitioned parents). Off by default.
+    /// </summary>
+    public string SizeText => _showSizes() && TotalBytes is { } bytes ? ByteSize.Format(bytes) : "";
+
+    /// <summary>Re-evaluate <see cref="SizeText"/> after the sidebar's "show sizes" toggle flips.</summary>
+    public void NotifySizeVisibilityChanged() => OnPropertyChanged(nameof(SizeText));
 
     public string Glyph => Kind switch
     {

--- a/PgNimbus.App/ViewModels/TableNode.cs
+++ b/PgNimbus.App/ViewModels/TableNode.cs
@@ -1,3 +1,4 @@
+using PgNimbus.Core;
 using PgNimbus.Core.Schema;
 
 namespace PgNimbus.App.ViewModels;
@@ -6,18 +7,25 @@ public sealed class TableNode : SchemaTreeNode
 {
     private readonly SchemaService _schemaService;
 
-    public TableNode(SchemaService schemaService, string schema, string name, RelationKind kind)
+    public TableNode(SchemaService schemaService, string schema, string name, RelationKind kind, long? totalBytes = null)
     {
         _schemaService = schemaService;
         Schema = schema;
         Name = name;
         Kind = kind;
+        TotalBytes = totalBytes;
         MarkExpandable();
     }
 
     public string Schema { get; }
 
     public RelationKind Kind { get; }
+
+    /// <summary>Total on-disk size (heap + indexes + TOAST), or null for views/partitioned parents.</summary>
+    public long? TotalBytes { get; }
+
+    /// <summary>The dim, right-aligned size hint in the tree — empty when there's no size to show.</summary>
+    public string SizeText => TotalBytes is { } bytes ? ByteSize.Format(bytes) : "";
 
     public string Glyph => Kind switch
     {

--- a/PgNimbus.App/Views/DatabaseOverviewWindow.axaml
+++ b/PgNimbus.App/Views/DatabaseOverviewWindow.axaml
@@ -1,0 +1,116 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:PgNimbus.App.ViewModels"
+        x:Class="PgNimbus.App.Views.DatabaseOverviewWindow"
+        x:DataType="vm:DatabaseOverviewViewModel"
+        Title="pgNimbus — Database Overview"
+        Width="960" Height="600"
+        MinWidth="720" MinHeight="360"
+        WindowStartupLocation="CenterOwner"
+        FontFamily="{StaticResource InterFont}">
+
+    <Grid RowDefinitions="Auto,Auto,*,Auto" Margin="12">
+
+        <!-- Toolbar -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="6" Margin="0,0,0,10">
+            <Button Classes="toolbar" Command="{Binding RefreshCommand}" ToolTip.Tip="Re-snapshot the statistics">
+                <StackPanel Orientation="Horizontal" Spacing="7">
+                    <PathIcon Data="{StaticResource RefreshIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                    <TextBlock Text="Refresh" VerticalAlignment="Center" />
+                </StackPanel>
+            </Button>
+        </StackPanel>
+
+        <!-- Summary stats -->
+        <Border Grid.Row="1" Background="{StaticResource CardBackgroundBrush}"
+                BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                CornerRadius="{StaticResource CardCornerRadius}" Padding="16,12" Margin="0,0,0,10">
+            <StackPanel Orientation="Horizontal" Spacing="36">
+                <StackPanel Spacing="2">
+                    <TextBlock Text="DATABASE" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <TextBlock Text="{Binding DatabaseName}" FontSize="16" FontWeight="SemiBold" />
+                </StackPanel>
+                <StackPanel Spacing="2">
+                    <TextBlock Text="SIZE ON DISK" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <TextBlock Text="{Binding DatabaseSizeText}" FontSize="16" FontWeight="SemiBold" />
+                </StackPanel>
+                <StackPanel Spacing="2" ToolTip.Tip="Fraction of table block reads served from shared_buffers rather than disk">
+                    <TextBlock Text="TABLE CACHE HIT" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <TextBlock Text="{Binding TableCacheHitText}" FontSize="16" FontWeight="SemiBold" />
+                </StackPanel>
+                <StackPanel Spacing="2" ToolTip.Tip="Fraction of index block reads served from shared_buffers rather than disk">
+                    <TextBlock Text="INDEX CACHE HIT" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <TextBlock Text="{Binding IndexCacheHitText}" FontSize="16" FontWeight="SemiBold" />
+                </StackPanel>
+            </StackPanel>
+        </Border>
+
+        <TabControl Grid.Row="2">
+            <TabItem Header="Largest relations">
+                <DataGrid ItemsSource="{Binding LargestRelations}" IsReadOnly="True" SelectionMode="Single"
+                          CanUserResizeColumns="True" CanUserSortColumns="False"
+                          GridLinesVisibility="Horizontal" HeadersVisibility="Column">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Schema" Binding="{Binding Schema}" Width="120" />
+                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" />
+                        <DataGridTextColumn Header="Kind" Binding="{Binding Kind}" Width="100" />
+                        <DataGridTextColumn Header="Rows (est.)" Binding="{Binding Rows}" Width="110" />
+                        <DataGridTextColumn Header="Table" Binding="{Binding TableSize}" Width="100" />
+                        <DataGridTextColumn Header="Indexes" Binding="{Binding IndexSize}" Width="100" />
+                        <DataGridTextColumn Header="Total" Binding="{Binding Total}" Width="110" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+
+            <TabItem Header="Scans (seq vs index)">
+                <DataGrid ItemsSource="{Binding TableScans}" IsReadOnly="True" SelectionMode="Single"
+                          CanUserResizeColumns="True" CanUserSortColumns="False"
+                          GridLinesVisibility="Horizontal" HeadersVisibility="Column">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Schema" Binding="{Binding Schema}" Width="120" />
+                        <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" />
+                        <DataGridTextColumn Header="Seq scans" Binding="{Binding SeqScan}" Width="110" />
+                        <DataGridTextColumn Header="Index scans" Binding="{Binding IdxScan}" Width="110" />
+                        <DataGridTemplateColumn Header="Index %" Width="90">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate x:DataType="vm:TableScanRow">
+                                    <Panel Margin="12,0">
+                                        <!-- A big table read mostly sequentially is worth spotting - amber + bold -->
+                                        <TextBlock Text="{Binding IndexScanPercent}" VerticalAlignment="Center"
+                                                   Foreground="#E5A50A" FontWeight="SemiBold"
+                                                   IsVisible="{Binding IsSeqScanHeavy}" />
+                                        <TextBlock Text="{Binding IndexScanPercent}" VerticalAlignment="Center"
+                                                   IsVisible="{Binding !IsSeqScanHeavy}" />
+                                    </Panel>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="Live rows" Binding="{Binding LiveRows}" Width="110" />
+                        <DataGridTextColumn Header="Dead rows" Binding="{Binding DeadRows}" Width="110" />
+                    </DataGrid.Columns>
+                </DataGrid>
+            </TabItem>
+
+            <TabItem Header="Unused indexes">
+                <Grid RowDefinitions="*,Auto">
+                    <DataGrid Grid.Row="0" ItemsSource="{Binding UnusedIndexes}" IsReadOnly="True" SelectionMode="Single"
+                              CanUserResizeColumns="True" CanUserSortColumns="False"
+                              GridLinesVisibility="Horizontal" HeadersVisibility="Column">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Schema" Binding="{Binding Schema}" Width="120" />
+                            <DataGridTextColumn Header="Table" Binding="{Binding Table}" Width="200" />
+                            <DataGridTextColumn Header="Index" Binding="{Binding Name}" Width="*" />
+                            <DataGridTextColumn Header="Size" Binding="{Binding Size}" Width="110" />
+                        </DataGrid.Columns>
+                    </DataGrid>
+                    <TextBlock Grid.Row="1" Margin="4,8,4,0" FontSize="11" Opacity="0.6"
+                               Text="Never scanned since the last stats reset. Unique and primary-key indexes are excluded — they enforce constraints regardless of scans." />
+                </Grid>
+            </TabItem>
+        </TabControl>
+
+        <TextBlock Grid.Row="3" Text="{Binding Status}" FontSize="11" Opacity="0.7" Margin="2,8,2,0" />
+
+    </Grid>
+
+</Window>

--- a/PgNimbus.App/Views/DatabaseOverviewWindow.axaml.cs
+++ b/PgNimbus.App/Views/DatabaseOverviewWindow.axaml.cs
@@ -1,0 +1,21 @@
+using Avalonia.Controls;
+using PgNimbus.App.ViewModels;
+
+namespace PgNimbus.App.Views;
+
+/// <summary>
+/// Read-only database statistics (size, cache-hit ratios, largest relations,
+/// scan usage, unused indexes). Unlike the activity view these don't move
+/// second to second, so there's no auto-refresh timer — the window snapshots
+/// once on open and re-snapshots only when the user hits Refresh.
+/// </summary>
+public partial class DatabaseOverviewWindow : Window
+{
+    public DatabaseOverviewWindow()
+    {
+        InitializeComponent();
+        ThemedWindowChrome.Attach(this);
+
+        Opened += (_, _) => (DataContext as DatabaseOverviewViewModel)?.RefreshCommand.Execute(null);
+    }
+}

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -38,6 +38,8 @@
                 </StackPanel.ContextMenu>
                 <TextBlock Text="{Binding Glyph}" />
                 <TextBlock Text="{Binding Name}" />
+                <!-- Dim on-disk size hint (heap + indexes + TOAST); blank for views/partitioned parents -->
+                <TextBlock Text="{Binding SizeText}" Opacity="0.5" FontSize="11" VerticalAlignment="Center" />
             </StackPanel>
         </DataTemplate>
         <DataTemplate DataType="vm:ColumnNode">

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -263,12 +263,6 @@
                                   ToolTip.Tip="Show advanced objects (functions &amp; extensions)">
                         <PathIcon Data="{StaticResource TuneIconGeometry}" Width="14" Height="14" />
                     </ToggleButton>
-                    <!-- Show-sizes toggle: off by default; on adds each table/matview's on-disk size as a dim hint -->
-                    <ToggleButton DockPanel.Dock="Right" Classes="chip" Padding="5" Margin="6,0,0,0"
-                                  VerticalAlignment="Center" IsChecked="{Binding SchemaTree.ShowSizes}"
-                                  ToolTip.Tip="Show relation sizes">
-                        <PathIcon Data="{StaticResource GaugeIconGeometry}" Width="14" Height="14" />
-                    </ToggleButton>
                     <!-- Type-to-filter box: matches schema and loaded-table names, case-insensitive substring -->
                     <TextBox FontSize="12"
                              PlaceholderText="Filter schemas &amp; tables…"

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -263,6 +263,12 @@
                                   ToolTip.Tip="Show advanced objects (functions &amp; extensions)">
                         <PathIcon Data="{StaticResource TuneIconGeometry}" Width="14" Height="14" />
                     </ToggleButton>
+                    <!-- Show-sizes toggle: off by default; on adds each table/matview's on-disk size as a dim hint -->
+                    <ToggleButton DockPanel.Dock="Right" Classes="chip" Padding="5" Margin="6,0,0,0"
+                                  VerticalAlignment="Center" IsChecked="{Binding SchemaTree.ShowSizes}"
+                                  ToolTip.Tip="Show relation sizes">
+                        <PathIcon Data="{StaticResource GaugeIconGeometry}" Width="14" Height="14" />
+                    </ToggleButton>
                     <!-- Type-to-filter box: matches schema and loaded-table names, case-insensitive substring -->
                     <TextBox FontSize="12"
                              PlaceholderText="Filter schemas &amp; tables…"

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -384,6 +384,7 @@ public partial class MainWindow : Window
                 new NativeMenuItemSeparator(),
                 CommandItem("Refresh Schema", () => _viewModel?.RefreshSchemaCommand, new KeyGesture(Key.R, cmd | KeyModifiers.Shift)),
                 CommandItem("Server Activity…", () => _viewModel?.ShowActivityCommand),
+                CommandItem("Database Overview…", () => _viewModel?.ShowDatabaseOverviewCommand),
             },
         };
 
@@ -694,6 +695,7 @@ public partial class MainWindow : Window
             _viewModel.ExpandStarRequested -= ExpandSelectStar;
             _viewModel.FindRequested -= OpenSearchPanel;
             _viewModel.ActivityRequested -= ShowActivityWindow;
+            _viewModel.DatabaseOverviewRequested -= ShowDatabaseOverviewWindow;
             _viewModel.SidebarToggleRequested -= ToggleSidebar;
             _viewModel.PreferencesRequested -= ShowPreferencesWindow;
             _viewModel.OpenFileRequested -= OnOpenFileRequested;
@@ -712,6 +714,7 @@ public partial class MainWindow : Window
         _viewModel.ExpandStarRequested += ExpandSelectStar;
         _viewModel.FindRequested += OpenSearchPanel;
         _viewModel.ActivityRequested += ShowActivityWindow;
+        _viewModel.DatabaseOverviewRequested += ShowDatabaseOverviewWindow;
         _viewModel.SidebarToggleRequested += ToggleSidebar;
         _viewModel.PreferencesRequested += ShowPreferencesWindow;
         _viewModel.OpenFileRequested += OnOpenFileRequested;
@@ -1270,6 +1273,22 @@ public partial class MainWindow : Window
         _activityWindow = new ActivityWindow { DataContext = _viewModel?.Activity };
         _activityWindow.Closed += (_, _) => _activityWindow = null;
         _activityWindow.Show(this);
+    }
+
+    private DatabaseOverviewWindow? _databaseOverviewWindow;
+
+    // One live instance, like the activity window: reopening focuses it.
+    private void ShowDatabaseOverviewWindow()
+    {
+        if (_databaseOverviewWindow is not null)
+        {
+            _databaseOverviewWindow.Activate();
+            return;
+        }
+
+        _databaseOverviewWindow = new DatabaseOverviewWindow { DataContext = _viewModel?.DatabaseOverview };
+        _databaseOverviewWindow.Closed += (_, _) => _databaseOverviewWindow = null;
+        _databaseOverviewWindow.Show(this);
     }
 
     private void OnRemoveChannelClick(object? sender, RoutedEventArgs e)

--- a/PgNimbus.App/Views/PreferencesWindow.axaml
+++ b/PgNimbus.App/Views/PreferencesWindow.axaml
@@ -40,6 +40,18 @@
                 </Grid>
             </Border>
 
+            <Border Classes="card" Padding="14,12" Margin="0,6,0,0">
+                <Grid ColumnDefinitions="*,Auto">
+                    <StackPanel Spacing="2" Margin="0,0,16,0">
+                        <TextBlock Classes="label" Text="Show relation sizes in the schema tree" />
+                        <TextBlock Classes="hint" Text="Adds each table and materialized view's on-disk size (heap + indexes + TOAST) as a dim hint next to its name" />
+                    </StackPanel>
+                    <ToggleSwitch Grid.Column="1" VerticalAlignment="Center"
+                                  OnContent="" OffContent=""
+                                  IsChecked="{Binding ShowSchemaSizes}" />
+                </Grid>
+            </Border>
+
             <TextBlock Classes="sectionHeader" Text="EDITOR" Margin="4,10,4,4" />
             <Border Classes="card" Padding="14,12">
                 <Grid ColumnDefinitions="*,Auto">

--- a/PgNimbus.Core.Tests/ByteSizeTests.cs
+++ b/PgNimbus.Core.Tests/ByteSizeTests.cs
@@ -1,0 +1,31 @@
+using PgNimbus.Core;
+
+namespace PgNimbus.Core.Tests;
+
+public class ByteSizeTests
+{
+    [Test]
+    [Arguments(0L, "0 bytes")]
+    [Arguments(-5L, "0 bytes")]
+    [Arguments(1L, "1 bytes")]
+    [Arguments(512L, "512 bytes")]
+    [Arguments(1023L, "1023 bytes")]
+    [Arguments(1024L, "1.0 KB")]
+    [Arguments(1536L, "1.5 KB")]
+    [Arguments(1048576L, "1.0 MB")]
+    [Arguments(1258291L, "1.2 MB")]
+    [Arguments(1073741824L, "1.0 GB")]
+    [Arguments(1099511627776L, "1.0 TB")]
+    public async Task Formats(long bytes, string expected)
+    {
+        await Assert.That(ByteSize.Format(bytes)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task UsesInvariantDecimalSeparator()
+    {
+        // Guard against a machine locale rendering "1,5 KB" — the size columns
+        // must read the same everywhere.
+        await Assert.That(ByteSize.Format(1536L)).Contains(".");
+    }
+}

--- a/PgNimbus.Core.Tests/Monitoring/TableScanUsageTests.cs
+++ b/PgNimbus.Core.Tests/Monitoring/TableScanUsageTests.cs
@@ -1,0 +1,33 @@
+using PgNimbus.Core.Monitoring;
+
+namespace PgNimbus.Core.Tests.Monitoring;
+
+public class TableScanUsageTests
+{
+    private static TableScanUsage Usage(long seq, long idx) =>
+        new("public", "t", seq, 0, idx, 0, 0, 0);
+
+    [Test]
+    public async Task NullWhenNeverScanned()
+    {
+        await Assert.That(Usage(0, 0).IndexScanRatio).IsNull();
+    }
+
+    [Test]
+    public async Task AllSequentialIsZero()
+    {
+        await Assert.That(Usage(10, 0).IndexScanRatio).IsEqualTo(0.0);
+    }
+
+    [Test]
+    public async Task AllIndexedIsOne()
+    {
+        await Assert.That(Usage(0, 10).IndexScanRatio).IsEqualTo(1.0);
+    }
+
+    [Test]
+    public async Task MixedIsFraction()
+    {
+        await Assert.That(Usage(3, 1).IndexScanRatio).IsEqualTo(0.25);
+    }
+}

--- a/PgNimbus.Core/ByteSize.cs
+++ b/PgNimbus.Core/ByteSize.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+
+namespace PgNimbus.Core;
+
+/// <summary>
+/// Human-readable byte counts for the size columns (schema-tree relation sizes,
+/// the database-overview panel). Base-1024 units with a fixed one-decimal step
+/// once past kilobytes, so "1.2 MB" and "3.4 GB" line up at a glance the way a
+/// file manager shows them. Kept in Core (not the App) so it can be unit-tested
+/// and shared between <see cref="Schema.SchemaService"/> and
+/// <see cref="Monitoring.DatabaseStatsService"/>.
+/// </summary>
+public static class ByteSize
+{
+    private static readonly string[] Units = ["bytes", "KB", "MB", "GB", "TB", "PB"];
+
+    /// <summary>
+    /// Formats <paramref name="bytes"/> as e.g. "512 bytes", "1.5 KB", "2.0 GB".
+    /// Bytes are shown whole (no "0.5 bytes"); everything above uses one decimal.
+    /// Negative inputs are clamped to 0 — a size is never negative.
+    /// </summary>
+    public static string Format(long bytes)
+    {
+        if (bytes <= 0)
+        {
+            return "0 bytes";
+        }
+
+        if (bytes < 1024)
+        {
+            return $"{bytes} bytes";
+        }
+
+        double value = bytes;
+        var unit = 0;
+        while (value >= 1024 && unit < Units.Length - 1)
+        {
+            value /= 1024;
+            unit++;
+        }
+
+        return string.Create(CultureInfo.InvariantCulture, $"{value:0.0} {Units[unit]}");
+    }
+}

--- a/PgNimbus.Core/Monitoring/DatabaseStatsService.cs
+++ b/PgNimbus.Core/Monitoring/DatabaseStatsService.cs
@@ -103,9 +103,13 @@ public sealed class DatabaseStatsService
             reader.IsDBNull(3) ? null : reader.GetDouble(3));
     }
 
-    /// <summary>The <paramref name="limit"/> largest tables/matviews/partitioned tables by total size, biggest first.</summary>
+    /// <summary>The <paramref name="limit"/> largest tables/matviews by total size, biggest first.</summary>
     public async Task<IReadOnlyList<RelationSize>> GetLargestRelationsAsync(int limit, CancellationToken ct)
     {
+        // Ordinary tables and matviews only — a partitioned parent's own
+        // pg_total_relation_size is ~0 (it doesn't sum its partitions), so
+        // listing it would mislead. Its data-holding partitions are ordinary
+        // 'r' tables and show up individually. Mirrors SchemaService.GetTablesAsync.
         const string sql = """
             SELECT n.nspname, c.relname, c.relkind::text,
                    pg_catalog.pg_total_relation_size(c.oid),
@@ -115,7 +119,7 @@ public sealed class DatabaseStatsService
             FROM pg_catalog.pg_class c
             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
             LEFT JOIN pg_catalog.pg_stat_user_tables s ON s.relid = c.oid
-            WHERE c.relkind IN ('r', 'm', 'p')
+            WHERE c.relkind IN ('r', 'm')
               AND n.nspname NOT LIKE 'pg\_%'
               AND n.nspname <> 'information_schema'
             ORDER BY pg_catalog.pg_total_relation_size(c.oid) DESC, n.nspname, c.relname
@@ -130,12 +134,7 @@ public sealed class DatabaseStatsService
         var results = new List<RelationSize>();
         while (await reader.ReadAsync(ct))
         {
-            var kind = reader.GetString(2) switch
-            {
-                "m" => RelationKind.MaterializedView,
-                "p" => RelationKind.PartitionedTable,
-                _ => RelationKind.Table,
-            };
+            var kind = reader.GetString(2) == "m" ? RelationKind.MaterializedView : RelationKind.Table;
 
             results.Add(new RelationSize(
                 reader.GetString(0),
@@ -185,8 +184,9 @@ public sealed class DatabaseStatsService
 
     /// <summary>
     /// Non-constraint indexes that have never been used since the last stats
-    /// reset, largest first — the ones worth dropping. Unique and primary-key
-    /// indexes are excluded: they exist to enforce constraints, not to be scanned.
+    /// reset, largest first — the ones worth dropping. Unique, primary-key, and
+    /// exclusion-constraint indexes are excluded: they exist to enforce a
+    /// constraint, not to be scanned, so a zero scan count doesn't make them dead.
     /// </summary>
     public async Task<IReadOnlyList<UnusedIndex>> GetUnusedIndexesAsync(CancellationToken ct)
     {
@@ -198,6 +198,7 @@ public sealed class DatabaseStatsService
             WHERE COALESCE(s.idx_scan, 0) = 0
               AND NOT i.indisunique
               AND NOT i.indisprimary
+              AND NOT i.indisexclusion
             ORDER BY pg_catalog.pg_relation_size(s.indexrelid) DESC, s.indexrelname
             """;
 

--- a/PgNimbus.Core/Monitoring/DatabaseStatsService.cs
+++ b/PgNimbus.Core/Monitoring/DatabaseStatsService.cs
@@ -1,0 +1,220 @@
+using Npgsql;
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.Core.Monitoring;
+
+/// <summary>
+/// Database-wide health at a glance: on-disk size and the buffer-cache hit
+/// ratios (what fraction of block reads were served from shared_buffers rather
+/// than the OS/disk). Ratios are 0..1, or null when the counters are all zero
+/// (a freshly-started server that hasn't touched a heap/index yet).
+/// </summary>
+public sealed record DatabaseOverview(
+    string DatabaseName,
+    long SizeBytes,
+    double? TableCacheHitRatio,
+    double? IndexCacheHitRatio);
+
+/// <summary>
+/// One relation with its size broken into heap-plus-TOAST vs. index storage,
+/// and the planner's live-row estimate. <paramref name="TotalBytes"/> is
+/// <c>pg_total_relation_size</c>; <see cref="TableBytes"/> + <see cref="IndexBytes"/>
+/// are the <c>pg_table_size</c>/<c>pg_indexes_size</c> split.
+/// </summary>
+public sealed record RelationSize(
+    string Schema,
+    string Name,
+    RelationKind Kind,
+    long TotalBytes,
+    long TableBytes,
+    long IndexBytes,
+    long RowEstimate);
+
+/// <summary>
+/// A table's scan counters from pg_stat_user_tables: sequential vs. index
+/// scans and the dead-tuple count. <see cref="IndexScanRatio"/> answers "how
+/// often does this table get read via an index?" — a low ratio on a big table
+/// is the classic missing-index smell.
+/// </summary>
+public sealed record TableScanUsage(
+    string Schema,
+    string Name,
+    long SeqScan,
+    long SeqTupRead,
+    long IdxScan,
+    long IdxTupFetch,
+    long LiveTuples,
+    long DeadTuples)
+{
+    /// <summary>Fraction of scans that used an index (0..1), or null when the table has never been scanned either way.</summary>
+    public double? IndexScanRatio =>
+        SeqScan + IdxScan == 0 ? null : (double)IdxScan / (SeqScan + IdxScan);
+}
+
+/// <summary>
+/// An index the planner has never used since stats were last reset
+/// (<c>idx_scan = 0</c>), with the disk it's costing. Unique/primary-key
+/// indexes are excluded upstream — they earn their keep enforcing constraints
+/// regardless of scan count, so flagging them as "unused" would be wrong.
+/// </summary>
+public sealed record UnusedIndex(
+    string Schema,
+    string Table,
+    string Index,
+    long IndexBytes);
+
+/// <summary>
+/// Read-only, catalog-driven database statistics behind the Database Overview
+/// panel. Every query hits pg_catalog / the pg_stat_* views directly — nothing
+/// here writes, so it's always safe to run against production.
+/// </summary>
+public sealed class DatabaseStatsService
+{
+    private readonly NpgsqlDataSource _dataSource;
+
+    public DatabaseStatsService(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    /// <summary>Current database name, size on disk, and the heap/index cache-hit ratios.</summary>
+    public async Task<DatabaseOverview> GetOverviewAsync(CancellationToken ct)
+    {
+        const string sql = """
+            SELECT current_database(),
+                   pg_catalog.pg_database_size(current_database()),
+                   (SELECT sum(heap_blks_hit)::float8
+                           / NULLIF(sum(heap_blks_hit) + sum(heap_blks_read), 0)
+                    FROM pg_catalog.pg_statio_user_tables),
+                   (SELECT sum(idx_blks_hit)::float8
+                           / NULLIF(sum(idx_blks_hit) + sum(idx_blks_read), 0)
+                    FROM pg_catalog.pg_statio_user_indexes)
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        await reader.ReadAsync(ct);
+
+        return new DatabaseOverview(
+            reader.GetString(0),
+            reader.GetInt64(1),
+            reader.IsDBNull(2) ? null : reader.GetDouble(2),
+            reader.IsDBNull(3) ? null : reader.GetDouble(3));
+    }
+
+    /// <summary>The <paramref name="limit"/> largest tables/matviews/partitioned tables by total size, biggest first.</summary>
+    public async Task<IReadOnlyList<RelationSize>> GetLargestRelationsAsync(int limit, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT n.nspname, c.relname, c.relkind::text,
+                   pg_catalog.pg_total_relation_size(c.oid),
+                   pg_catalog.pg_table_size(c.oid),
+                   pg_catalog.pg_indexes_size(c.oid),
+                   COALESCE(s.n_live_tup, 0)
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            LEFT JOIN pg_catalog.pg_stat_user_tables s ON s.relid = c.oid
+            WHERE c.relkind IN ('r', 'm', 'p')
+              AND n.nspname NOT LIKE 'pg\_%'
+              AND n.nspname <> 'information_schema'
+            ORDER BY pg_catalog.pg_total_relation_size(c.oid) DESC, n.nspname, c.relname
+            LIMIT @limit
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("limit", limit);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<RelationSize>();
+        while (await reader.ReadAsync(ct))
+        {
+            var kind = reader.GetString(2) switch
+            {
+                "m" => RelationKind.MaterializedView,
+                "p" => RelationKind.PartitionedTable,
+                _ => RelationKind.Table,
+            };
+
+            results.Add(new RelationSize(
+                reader.GetString(0),
+                reader.GetString(1),
+                kind,
+                reader.GetInt64(3),
+                reader.GetInt64(4),
+                reader.GetInt64(5),
+                reader.GetInt64(6)));
+        }
+
+        return results;
+    }
+
+    /// <summary>Per-table scan counters, the tables scanned most sequentially first (the missing-index suspects).</summary>
+    public async Task<IReadOnlyList<TableScanUsage>> GetTableScanUsageAsync(CancellationToken ct)
+    {
+        const string sql = """
+            SELECT schemaname, relname,
+                   COALESCE(seq_scan, 0), COALESCE(seq_tup_read, 0),
+                   COALESCE(idx_scan, 0), COALESCE(idx_tup_fetch, 0),
+                   COALESCE(n_live_tup, 0), COALESCE(n_dead_tup, 0)
+            FROM pg_catalog.pg_stat_user_tables
+            ORDER BY COALESCE(seq_scan, 0) DESC, COALESCE(seq_tup_read, 0) DESC, relname
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<TableScanUsage>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new TableScanUsage(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetInt64(2),
+                reader.GetInt64(3),
+                reader.GetInt64(4),
+                reader.GetInt64(5),
+                reader.GetInt64(6),
+                reader.GetInt64(7)));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Non-constraint indexes that have never been used since the last stats
+    /// reset, largest first — the ones worth dropping. Unique and primary-key
+    /// indexes are excluded: they exist to enforce constraints, not to be scanned.
+    /// </summary>
+    public async Task<IReadOnlyList<UnusedIndex>> GetUnusedIndexesAsync(CancellationToken ct)
+    {
+        const string sql = """
+            SELECT s.schemaname, s.relname, s.indexrelname,
+                   pg_catalog.pg_relation_size(s.indexrelid)
+            FROM pg_catalog.pg_stat_user_indexes s
+            JOIN pg_catalog.pg_index i ON i.indexrelid = s.indexrelid
+            WHERE COALESCE(s.idx_scan, 0) = 0
+              AND NOT i.indisunique
+              AND NOT i.indisprimary
+            ORDER BY pg_catalog.pg_relation_size(s.indexrelid) DESC, s.indexrelname
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<UnusedIndex>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new UnusedIndex(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetInt64(3)));
+        }
+
+        return results;
+    }
+}

--- a/PgNimbus.Core/Schema/SchemaService.cs
+++ b/PgNimbus.Core/Schema/SchemaService.cs
@@ -12,7 +12,13 @@ public enum RelationKind
     PartitionedTable,
 }
 
-public sealed record TableInfo(string Name, RelationKind Kind);
+/// <summary>
+/// A relation in a schema. <paramref name="TotalBytes"/> is
+/// <c>pg_total_relation_size</c> (heap + indexes + TOAST) for stored relations
+/// (ordinary tables and materialized views); null for views and partitioned
+/// parents, which have no meaningful own-storage size to show in the tree.
+/// </summary>
+public sealed record TableInfo(string Name, RelationKind Kind, long? TotalBytes = null);
 
 public sealed record RelationInfo(string Schema, string Name, RelationKind Kind);
 
@@ -103,8 +109,14 @@ public sealed class SchemaService
 
     public async Task<IReadOnlyList<TableInfo>> GetTablesAsync(string schema, CancellationToken ct)
     {
+        // Size only for relations with their own storage (ordinary tables and
+        // matviews). Views have none; a partitioned parent's own size is 0 and
+        // pg_total_relation_size doesn't sum its partitions, so showing it would
+        // mislead — leave both null and render no size in the tree.
         const string sql = """
-            SELECT c.relname, c.relkind::text
+            SELECT c.relname, c.relkind::text,
+                   CASE WHEN c.relkind IN ('r', 'm')
+                        THEN pg_catalog.pg_total_relation_size(c.oid) END
             FROM pg_catalog.pg_class c
             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
             WHERE n.nspname = @schema
@@ -129,7 +141,10 @@ public sealed class SchemaService
                 _ => RelationKind.Table,
             };
 
-            results.Add(new TableInfo(reader.GetString(0), kind));
+            results.Add(new TableInfo(
+                reader.GetString(0),
+                kind,
+                reader.IsDBNull(2) ? null : reader.GetInt64(2)));
         }
 
         return results;

--- a/PgNimbus.Core/Settings/AppSettings.cs
+++ b/PgNimbus.Core/Settings/AppSettings.cs
@@ -26,6 +26,13 @@ public sealed record AppSettings
     public bool ShowAdvancedSchemaObjects { get; set; }
 
     /// <summary>
+    /// Whether the schema sidebar shows each relation's on-disk size as a dim
+    /// hint next to its name. Off by default — it's an occasional need, not
+    /// something worth cluttering every row with all the time.
+    /// </summary>
+    public bool ShowSchemaSizes { get; set; }
+
+    /// <summary>
     /// Whether accepting a table from completion after FROM/JOIN also appends a
     /// short alias (<c>public.orders</c> → <c>public.orders o</c>), so the
     /// <c>o.</c> member-access flow is available immediately. On by default;

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ dotnet run --project PgNimbus.App
 - **DDL reconstruction** — a "Source (DDL)" action rebuilds an object's `CREATE TABLE`/`CREATE VIEW` — columns, defaults, identity, constraints, partition key, indexes — into a new tab; an "Alter Table" UI covers no-SQL column changes.
 - **EXPLAIN visualization** — a graphical plan tree for `EXPLAIN` and `EXPLAIN ANALYZE` with per-node cost and timing, not just raw text.
 - **Server activity dashboard** — a live `pg_stat_activity` view with per-backend **cancel statement** and **terminate session**, so a runaway query is one click to stop.
+- **Table & index sizes and usage** — relation sizes right in the schema tree, plus a **Database Overview** panel: largest relations (heap/index split), seq-vs-index scan counts (missing-index suspects flagged), unused non-constraint indexes with the disk they waste, and buffer cache-hit ratios.
 - **LISTEN/NOTIFY monitor** — subscribe to channels and watch notifications arrive live.
 - **Connection manager** — saved profiles with per-connection accent colors (so production never looks like staging), SSH tunnels, and passwords held by the OS credential store — never written to disk.
 - **Multiple simultaneous connections** — open profiles in separate self-contained windows (own pool, listener, tunnel, workspace), so dev and prod sit side by side; or switch the current window's connection without restarting.
@@ -283,7 +284,7 @@ Prioritized by how much it advances the thesis (fast + open + modern, PostgreSQL
 - [ ] **Full macOS support** — Developer ID signing, notarization, real-world testing.
 - [ ] **macOS look & feel polish** — the native menu bar, About box, and Settings… (Cmd+,) shipped 2026-07; still open: title-bar vibrancy/translucency (NSVisualEffectView-style material behind the merged command bar), sheet-style modals instead of separate dialog windows, Cmd+1…9 tab switching, a proper Window menu with the open-windows list, native context-menu styling, and full-height sidebar that tucks under the traffic lights (TablePlus-style).
 - [x] **Linux builds** — AppImage, .deb, and tar.gz for x64/arm64 ship from the release pipeline (Flatpak still a maybe-later).
-- [ ] **Table & index sizes and usage** — sizes in the schema tree plus a per-database overview (largest relations, seq-vs-index scans, unused indexes, cache hit rate).
+- [x] **Table & index sizes and usage** — relation sizes in the schema tree plus a Database Overview panel (largest relations with heap/index split, seq-vs-index scans, unused indexes, cache hit ratios).
 - [ ] **Locks & blocking tree** — a who-blocks-whom view in the activity window, with one-click cancel/terminate of the *blocker*.
 - [ ] **Row detail sidebar** — a vertical name/value view of the selected row, doubling as a form-style editor.
 - [ ] **winget-pkgs submission** — manifests are generated and validated per release; the first manual community-source PR is pending (the `msstore` source already covers `winget install`).


### PR DESCRIPTION
Picks up the next actionable Roadmap item. Two parts:

- Schema tree now shows each relation's on-disk size (pg_total_relation_size,
  heap + indexes + TOAST) as a dim hint. Views and partitioned parents show
  none — they have no own-storage size worth reporting. Carried on TableInfo
  from GetTablesAsync so the tree pays for it in the existing per-schema query.

- New Database Overview window (command palette + macOS Query menu, no toolbar
  button): database size, buffer cache-hit ratios, the largest relations with
  a heap/index split and row estimate, per-table seq-vs-index scan usage (big
  seq-scan-heavy tables flagged amber as missing-index suspects), and unused
  non-constraint indexes with the disk they waste. Backed by a read-only
  Monitoring/DatabaseStatsService reading pg_stat_*/pg_statio_* and pg_*_size,
  a sibling of ActivityService and following the same one-live-instance shape.

Human-readable byte counts go through a new, unit-tested PgNimbus.Core.ByteSize
shared by both. Verified end-to-end headlessly against a seeded Postgres.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AV4YS5uAtMTNFPPkeJQ4xV