### PR TITLE
Add scripts/demo: type-rich PostgreSQL demo dataset

### DIFF
--- a/scripts/demo/01_public.sql
+++ b/scripts/demo/01_public.sql
@@ -1,0 +1,115 @@
+-- pgNimbus demo data — 01: the simple `public` shop.
+--
+-- Creates and populates a small, approachable e-commerce schema plus the
+-- PostgreSQL extensions the richer schemas (02-05) rely on. Safe to re-run:
+-- the public.* demo tables are dropped and recreated.
+--
+-- Randomness note: every random() call lives in a subquery target list over
+-- generate_series (evaluated per row), and related rows are chosen by indexing
+-- into an array of candidate ids. Do NOT "pick a random row" with an
+-- uncorrelated `CROSS JOIN LATERAL (SELECT ... ORDER BY random() LIMIT 1)` —
+-- PostgreSQL evaluates that once and every row gets the SAME pick.
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS citext;
+CREATE EXTENSION IF NOT EXISTS hstore;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS ltree;
+CREATE EXTENSION IF NOT EXISTS vector;
+
+DROP TABLE IF EXISTS public.order_items CASCADE;
+DROP TABLE IF EXISTS public.orders      CASCADE;
+DROP TABLE IF EXISTS public.products    CASCADE;
+DROP TABLE IF EXISTS public.customers   CASCADE;
+
+CREATE TABLE public.customers (
+    id         integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    first_name varchar(50)  NOT NULL,
+    last_name  varchar(50)  NOT NULL,
+    email      varchar(255) UNIQUE NOT NULL,
+    created_at timestamptz  NOT NULL DEFAULT now(),
+    is_active  boolean      NOT NULL DEFAULT true
+);
+CREATE TABLE public.products (
+    id             integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    title          varchar(200) NOT NULL,
+    description    text,
+    price          numeric(10,2) NOT NULL CHECK (price > 0),
+    stock_quantity integer NOT NULL DEFAULT 0,
+    sku            varchar(32) UNIQUE NOT NULL,
+    updated_at     timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE public.orders (
+    id           integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    customer_id  integer NOT NULL REFERENCES public.customers(id) ON DELETE CASCADE,
+    order_date   timestamptz NOT NULL DEFAULT now(),
+    status       varchar(20) NOT NULL DEFAULT 'pending',
+    total_amount numeric(10,2) NOT NULL DEFAULT 0
+);
+CREATE TABLE public.order_items (
+    id         integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    order_id   integer NOT NULL REFERENCES public.orders(id) ON DELETE CASCADE,
+    product_id integer NOT NULL REFERENCES public.products(id),
+    quantity   integer NOT NULL CHECK (quantity > 0),
+    unit_price numeric(10,2) NOT NULL
+);
+
+COMMENT ON TABLE public.customers IS 'Retail customers (simple starter schema).';
+COMMENT ON TABLE public.orders    IS 'Customer orders; see commerce.orders for the richly-typed variant.';
+
+-- ~500 customers
+INSERT INTO public.customers (first_name, last_name, email, created_at, is_active)
+SELECT
+    (ARRAY['Emma','Liam','Olivia','Noah','Ava','Ethan','Sophia','Mason','Isabella','Lucas',
+           'Mia','Oliver','Amelia','Elijah','Harper','James','Evelyn','Benjamin','Abigail','Henry'])[1+floor(random()*20)::int],
+    (ARRAY['Smith','Johnson','Williams','Brown','Jones','Garcia','Miller','Davis','Rodriguez','Martinez',
+           'Hernandez','Lopez','Gonzalez','Wilson','Anderson','Thomas','Taylor','Moore','Jackson','Martin'])[1+floor(random()*20)::int],
+    'user' || g || '_' || floor(random()*100000)::int || '@example.com',
+    now() - (random()*730 || ' days')::interval,
+    random() > 0.15
+FROM generate_series(1, 500) g;
+
+-- ~200 products
+INSERT INTO public.products (title, description, price, stock_quantity, sku, updated_at)
+SELECT
+    (ARRAY['Wireless','Ergonomic','Premium','Compact','Portable','Smart','Vintage','Rugged','Ultra','Eco'])[1+floor(random()*10)::int]
+      || ' ' ||
+    (ARRAY['Mouse','Keyboard','Headphones','Monitor','Webcam','Charger','Speaker','Hub','Stand','Cable',
+           'Backpack','Bottle','Notebook','Lamp','Mug'])[1+floor(random()*15)::int]
+      || ' ' || g,
+    'Auto-generated demo product #' || g || '. Great for showcasing PgNimbus result rendering.',
+    round((random()*900 + 5)::numeric, 2),
+    floor(random()*500)::int,
+    'SKU-' || lpad(g::text, 6, '0'),
+    now() - (random()*200 || ' days')::interval
+FROM generate_series(1, 200) g;
+
+-- ~2000 orders, each tied to a random customer
+INSERT INTO public.orders (customer_id, order_date, status, total_amount)
+SELECT cust.a[s.ci], s.od, s.st, s.amt
+FROM (SELECT array_agg(id) a FROM public.customers) cust
+CROSS JOIN (
+    SELECT
+        1 + floor(random() * (SELECT count(*) FROM public.customers))::int AS ci,
+        now() - (random()*365 || ' days')::interval AS od,
+        (ARRAY['pending','paid','shipped','delivered','cancelled','refunded'])[1+floor(random()*6)::int] AS st,
+        round((random()*800 + 10)::numeric, 2) AS amt
+    FROM generate_series(1, 2000) g
+) s;
+
+-- 1-4 line items per order (item count correlated on order id so it varies)
+INSERT INTO public.order_items (order_id, product_id, quantity, unit_price)
+SELECT s.oid, prod.a[s.pi], s.qty, prod.p[s.pi]
+FROM (SELECT array_agg(id) a, array_agg(price) p FROM public.products) prod
+CROSS JOIN (
+    SELECT
+        o.id AS oid,
+        1 + floor(random() * (SELECT count(*) FROM public.products))::int AS pi,
+        1 + floor(random()*4)::int AS qty
+    FROM public.orders o
+    CROSS JOIN LATERAL generate_series(1, 1 + (o.id % 4)) li
+) s;
+
+COMMIT;

--- a/scripts/demo/02_commerce.sql
+++ b/scripts/demo/02_commerce.sql
@@ -1,0 +1,266 @@
+-- pgNimbus demo data — 02: the richly-typed `commerce` schema.
+--
+-- The showcase schema. Exercises custom enums, a composite type, a domain,
+-- and columns spanning uuid, arrays, jsonb, hstore, inet/cidr, geometric
+-- point/box, ranges, money, interval, bytea, pgvector, and generated +
+-- tsvector columns. Safe to re-run (schema is dropped and recreated).
+
+BEGIN;
+
+DROP SCHEMA IF EXISTS commerce CASCADE;
+CREATE SCHEMA commerce;
+
+-- --- Custom types ----------------------------------------------------------
+CREATE TYPE commerce.order_status     AS ENUM ('cart','pending','paid','packed','shipped','delivered','cancelled','refunded');
+CREATE TYPE commerce.payment_method   AS ENUM ('card','paypal','apple_pay','google_pay','bank_transfer','crypto','gift_card');
+CREATE TYPE commerce.product_category AS ENUM ('electronics','home','apparel','books','toys','grocery','sports','beauty','automotive');
+CREATE TYPE commerce.review_sentiment AS ENUM ('negative','neutral','positive');
+
+-- Composite type (shows up as a real type in the schema tree)
+CREATE TYPE commerce.address AS (
+    street  text,
+    city    text,
+    region  text,
+    postal  text,
+    country char(2)
+);
+
+-- Domain over citext with validation
+CREATE DOMAIN commerce.email_addr AS citext
+    CHECK (VALUE ~ '^[^@\s]+@[^@\s]+\.[^@\s]+$');
+
+-- --- Customers -------------------------------------------------------------
+CREATE TABLE commerce.customers (
+    id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    email          commerce.email_addr UNIQUE NOT NULL,
+    first_name     text NOT NULL,
+    last_name      text NOT NULL,
+    full_name      text GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED,
+    tags           text[] NOT NULL DEFAULT '{}',
+    interests      jsonb  NOT NULL DEFAULT '{}'::jsonb,
+    attrs          hstore,
+    loyalty_tier   smallint NOT NULL DEFAULT 0 CHECK (loyalty_tier BETWEEN 0 AND 5),
+    loyalty_points integer  NOT NULL DEFAULT 0,
+    signup_at      timestamptz NOT NULL DEFAULT now(),
+    last_login_ip  inet,
+    home_network   cidr,
+    home_location  point,
+    membership     daterange,
+    avatar_thumb   bytea,
+    search         tsvector GENERATED ALWAYS AS
+                     (to_tsvector('simple', first_name || ' ' || last_name || ' ' || email)) STORED
+);
+COMMENT ON TABLE  commerce.customers               IS 'Richly-typed customer records: arrays, jsonb, hstore, inet/cidr, geometric point, ranges, bytea, generated + tsvector columns.';
+COMMENT ON COLUMN commerce.customers.home_location IS 'Approximate (lon,lat) as a native point.';
+COMMENT ON COLUMN commerce.customers.search        IS 'Generated full-text search vector.';
+
+INSERT INTO commerce.customers
+    (email, first_name, last_name, tags, interests, attrs, loyalty_tier, loyalty_points,
+     signup_at, last_login_ip, home_network, home_location, membership, avatar_thumb)
+SELECT
+    'c' || g || '.' || floor(random()*100000)::int || '@shop.example',
+    (ARRAY['Emma','Liam','Olivia','Noah','Ava','Ethan','Sophia','Mason','Isabella','Lucas',
+           'Mia','Oliver','Amelia','Elijah','Harper','Aria','Leo','Nora','Kai','Zoe'])[1+floor(random()*20)::int],
+    (ARRAY['Smith','Nguyen','Kowalski','García','Müller','Rossi','Andersson','Yamamoto','Okafor','Silva',
+           'Petrov','Haddad','O''Brien','Novak','Dubois','Costa','Ivanov','Khan','Weber','Santos'])[1+floor(random()*20)::int],
+    (ARRAY['vip','newsletter','wholesale','beta','mobile','loyal','gift','early-access'])[1:1+floor(random()*4)::int],
+    jsonb_build_object(
+        'theme', (ARRAY['light','dark','system'])[1+floor(random()*3)::int],
+        'currency', (ARRAY['USD','EUR','GBP','JPY'])[1+floor(random()*4)::int],
+        'notifications', jsonb_build_object('email', random()>0.3, 'sms', random()>0.7),
+        'categories', to_jsonb((ARRAY['electronics','home','books','sports'])[1:1+floor(random()*3)::int])
+    ),
+    hstore(ARRAY['referrer', (ARRAY['google','friend','ad','organic'])[1+floor(random()*4)::int],
+                 'lang', (ARRAY['en','de','fr','ja','pt'])[1+floor(random()*5)::int]]),
+    floor(random()*6)::int,
+    floor(random()*50000)::int,
+    now() - (random()*900 || ' days')::interval,
+    ('192.168.' || floor(random()*255)::int || '.' || floor(random()*255)::int)::inet,
+    ('10.' || floor(random()*255)::int || '.0.0/16')::cidr,
+    point(round((random()*360-180)::numeric,4), round((random()*180-90)::numeric,4)),
+    daterange((now() - (random()*900||' days')::interval)::date,
+              (now() + (random()*400||' days')::interval)::date),
+    decode(md5(g::text), 'hex')  -- 16-byte pseudo "thumbnail" blob
+FROM generate_series(1, 800) g;
+
+-- --- Products --------------------------------------------------------------
+CREATE TABLE commerce.products (
+    id              bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    sku             citext UNIQUE NOT NULL,
+    name            text   NOT NULL,
+    category        commerce.product_category NOT NULL,
+    price           numeric(12,2) NOT NULL CHECK (price > 0),
+    cost            money         NOT NULL,
+    attributes      jsonb         NOT NULL DEFAULT '{}'::jsonb,
+    dimensions_cm   box,
+    tags            text[]        NOT NULL DEFAULT '{}',
+    rating          numeric(2,1)  CHECK (rating BETWEEN 0 AND 5),
+    embedding       vector(3),
+    weight_grams    integer,
+    in_stock        boolean       NOT NULL DEFAULT true,
+    lead_time       interval,
+    price_band      numrange,
+    added_at        timestamptz   NOT NULL DEFAULT now(),
+    discontinued_at timestamptz,
+    search          tsvector GENERATED ALWAYS AS (to_tsvector('english', name)) STORED
+);
+COMMENT ON TABLE commerce.products IS 'Product catalog exercising enum, money, box, vector (pgvector), interval, numrange, jsonb and a generated tsvector.';
+
+INSERT INTO commerce.products
+    (sku, name, category, price, cost, attributes, dimensions_cm, tags, rating,
+     embedding, weight_grams, in_stock, lead_time, price_band, added_at, discontinued_at)
+SELECT
+    'PRD-' || lpad(g::text, 6, '0'),
+    (ARRAY['Wireless','Ergonomic','Premium','Compact','Portable','Smart','Vintage','Rugged','Ultra','Eco',
+           'Deluxe','Classic','Pro','Mini','Max'])[1+floor(random()*15)::int]
+      || ' ' ||
+    (ARRAY['Mouse','Keyboard','Headphones','Monitor','Webcam','Charger','Speaker','Hub','Stand','Cable',
+           'Backpack','Bottle','Notebook','Lamp','Mug','Jacket','Sneakers','Novel','Drone','Blender'])[1+floor(random()*20)::int],
+    (enum_range(NULL::commerce.product_category))[1+floor(random()*9)::int],
+    round((random()*900 + 5)::numeric, 2),
+    (round((random()*400 + 2)::numeric, 2))::money,
+    jsonb_build_object(
+        'color', (ARRAY['black','white','silver','blue','red','green'])[1+floor(random()*6)::int],
+        'warranty_months', (ARRAY[6,12,24,36])[1+floor(random()*4)::int],
+        'specs', jsonb_build_object('bt', random()>0.5, 'usb_c', random()>0.4, 'wattage', floor(random()*120))
+    ),
+    box(point(0,0), point(round((random()*40+1)::numeric,1), round((random()*30+1)::numeric,1))),
+    (ARRAY['sale','new','bestseller','limited','clearance','featured'])[1:1+floor(random()*3)::int],
+    round((random()*4 + 1)::numeric, 1),
+    ARRAY[round(random()::numeric,4), round(random()::numeric,4), round(random()::numeric,4)]::vector,
+    floor(random()*3000 + 50)::int,
+    random() > 0.1,
+    (floor(random()*14)+1 || ' days')::interval,
+    numrange(round((random()*100)::numeric,2), round((random()*100+100)::numeric,2)),
+    now() - (random()*400 || ' days')::interval,
+    CASE WHEN random() < 0.08 THEN now() - (random()*30||' days')::interval END
+FROM generate_series(1, 300) g;
+
+-- --- Orders ----------------------------------------------------------------
+CREATE TABLE commerce.orders (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    order_no        bigint GENERATED ALWAYS AS IDENTITY,
+    customer_id     uuid NOT NULL REFERENCES commerce.customers(id) ON DELETE CASCADE,
+    status          commerce.order_status   NOT NULL DEFAULT 'pending',
+    payment         commerce.payment_method,
+    ship_to         commerce.address,
+    subtotal        numeric(12,2) NOT NULL,
+    tax             numeric(12,2) NOT NULL DEFAULT 0,
+    total           money         NOT NULL,
+    currency        char(3)       NOT NULL DEFAULT 'USD',
+    placed_at       timestamptz   NOT NULL DEFAULT now(),
+    delivery_window tstzrange,
+    notes           text
+);
+COMMENT ON TABLE commerce.orders IS 'Orders with a composite address type, tstzrange delivery window, money total and enum status/payment.';
+
+INSERT INTO commerce.orders
+    (customer_id, status, payment, ship_to, subtotal, tax, total, currency, placed_at, delivery_window, notes)
+SELECT
+    cust.a[s.ci],
+    (enum_range(NULL::commerce.order_status))[s.si],
+    (enum_range(NULL::commerce.payment_method))[s.pi],
+    ROW(s.house || ' ' || (ARRAY['Main','Oak','Maple','Elm','Cedar','Pine'])[s.streeti] || ' St',
+        (ARRAY['Berlin','Paris','Tokyo','Lisbon','Madrid','Oslo','Prague','Milan'])[s.cityi],
+        (ARRAY['BE','IDF','TK','LX','MD','OS','PR','MI'])[s.cityi],
+        lpad(s.postal::text, 5, '0'),
+        (ARRAY['DE','FR','JP','PT','ES','NO','CZ','IT'])[s.cityi]
+    )::commerce.address,
+    s.subtotal,
+    round(s.subtotal * 0.19, 2),
+    (round(s.subtotal * 1.19, 2))::money,
+    (ARRAY['USD','EUR','GBP','JPY'])[s.curi],
+    s.placed,
+    tstzrange(s.placed + interval '2 days', s.placed + interval '5 days'),
+    CASE WHEN s.notei <= 5 THEN (ARRAY['Leave at door','Gift wrap please','Call on arrival','Fragile','No contact delivery'])[s.notei] END
+FROM (SELECT array_agg(id) a FROM commerce.customers) cust
+CROSS JOIN (
+    SELECT
+        1 + floor(random() * (SELECT count(*) FROM commerce.customers))::int AS ci,
+        1 + floor(random()*8)::int  AS si,
+        1 + floor(random()*7)::int  AS pi,
+        1 + floor(random()*6)::int  AS streeti,
+        1 + floor(random()*8)::int  AS cityi,
+        1 + floor(random()*4)::int  AS curi,
+        1 + floor(random()*20)::int AS notei,   -- 1..5 => note, else null
+        floor(random()*9999)::int   AS house,
+        floor(random()*99999)::int  AS postal,
+        round((random()*800 + 10)::numeric, 2) AS subtotal,
+        now() - (random()*365 || ' days')::interval AS placed
+    FROM generate_series(1, 3000) g
+) s;
+
+-- --- Order items (two-column composite PK) ---------------------------------
+CREATE TABLE commerce.order_items (
+    order_id   uuid   NOT NULL REFERENCES commerce.orders(id) ON DELETE CASCADE,
+    product_id bigint NOT NULL REFERENCES commerce.products(id),
+    quantity   integer NOT NULL CHECK (quantity > 0),
+    unit_price numeric(12,2) NOT NULL,
+    discount   numeric(4,3)  NOT NULL DEFAULT 0 CHECK (discount >= 0 AND discount < 1),
+    PRIMARY KEY (order_id, product_id)
+);
+COMMENT ON TABLE commerce.order_items IS 'Order line items with a two-column composite primary key.';
+
+INSERT INTO commerce.order_items (order_id, product_id, quantity, unit_price, discount)
+SELECT DISTINCT ON (s.oid, prod.a[s.pi])
+    s.oid, prod.a[s.pi], s.qty, prod.pr[s.pi], s.disc
+FROM (SELECT array_agg(id ORDER BY id) a, array_agg(price ORDER BY id) pr FROM commerce.products) prod
+CROSS JOIN (
+    SELECT
+        o.id AS oid,
+        1 + floor(random() * (SELECT count(*) FROM commerce.products))::int AS pi,
+        1 + floor(random()*5)::int AS qty,
+        round((random()*0.3)::numeric, 3) AS disc
+    FROM commerce.orders o
+    CROSS JOIN LATERAL generate_series(1, 1 + (o.order_no % 4)) li
+) s;
+
+-- --- Reviews ---------------------------------------------------------------
+CREATE TABLE commerce.reviews (
+    id          bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    product_id  bigint NOT NULL REFERENCES commerce.products(id) ON DELETE CASCADE,
+    customer_id uuid   REFERENCES commerce.customers(id) ON DELETE SET NULL,
+    rating      smallint NOT NULL CHECK (rating BETWEEN 1 AND 5),
+    title       text,
+    body        text,
+    sentiment   commerce.review_sentiment,
+    aspects     text[],
+    helpful     integer NOT NULL DEFAULT 0,
+    metadata    jsonb,
+    posted_at   timestamptz NOT NULL DEFAULT now(),
+    search      tsvector GENERATED ALWAYS AS
+                  (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(body,''))) STORED
+);
+COMMENT ON TABLE commerce.reviews IS 'Product reviews with enum sentiment, text[] aspects and a generated tsvector over title+body.';
+
+INSERT INTO commerce.reviews (product_id, customer_id, rating, title, body, sentiment, aspects, helpful, metadata, posted_at)
+SELECT
+    prod.a[s.pi],
+    cust.a[s.ci],
+    s.rating,
+    (ARRAY['Love it','Not bad','Disappointed','Exceeded expectations','Would buy again','Meh','Fantastic','Broke quickly'])[s.titlei],
+    'This product is ' || (ARRAY['amazing and well built','decent for the price','not what I expected','the best I have owned','a bit flimsy'])[s.bodyi]
+      || '. Shipping was ' || (ARRAY['fast','slow','on time'])[s.shipi] || '.',
+    (CASE WHEN s.rating >= 4 THEN 'positive' WHEN s.rating = 3 THEN 'neutral' ELSE 'negative' END)::commerce.review_sentiment,
+    (ARRAY['quality','price','shipping','design','durability','support'])[1:1+floor(random()*3)::int],
+    s.helpful,
+    jsonb_build_object('verified_purchase', s.vp, 'edited', s.edited),
+    s.posted
+FROM (SELECT array_agg(id) a FROM commerce.products)  prod
+CROSS JOIN (SELECT array_agg(id) a FROM commerce.customers) cust
+CROSS JOIN (
+    SELECT
+        1 + floor(random() * (SELECT count(*) FROM commerce.products))::int  AS pi,
+        1 + floor(random() * (SELECT count(*) FROM commerce.customers))::int AS ci,
+        1 + floor(random()*5)::int AS rating,
+        1 + floor(random()*8)::int AS titlei,
+        1 + floor(random()*5)::int AS bodyi,
+        1 + floor(random()*3)::int AS shipi,
+        floor(random()*200)::int   AS helpful,
+        random() > 0.2  AS vp,
+        random() > 0.85 AS edited,
+        now() - (random()*300 || ' days')::interval AS posted
+    FROM generate_series(1, 2000) g
+) s;
+
+COMMIT;

--- a/scripts/demo/03_iot.sql
+++ b/scripts/demo/03_iot.sql
@@ -1,0 +1,111 @@
+-- pgNimbus demo data — 03: the `iot` schema (partitioning + more types).
+--
+-- Devices exercise macaddr, inet/cidr, bit/varbit, geometric point/polygon and
+-- interval. `readings` is the demo's largest relation: a RANGE-partitioned-by-
+-- month time-series table (~200k rows) with a DEFAULT partition catching any
+-- out-of-range timestamps. Safe to re-run (schema is dropped and recreated).
+
+BEGIN;
+
+DROP SCHEMA IF EXISTS iot CASCADE;
+CREATE SCHEMA iot;
+
+CREATE TYPE iot.device_status AS ENUM ('online','offline','maintenance','error','provisioning');
+
+-- --- Devices ---------------------------------------------------------------
+CREATE TABLE iot.devices (
+    id           integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    serial       uuid NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+    name         text NOT NULL,
+    mac          macaddr UNIQUE NOT NULL,
+    ip           inet,
+    subnet       cidr,
+    firmware     bit(16),
+    flags        bit(8),
+    location     point,
+    coverage     polygon,
+    config       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    status       iot.device_status NOT NULL DEFAULT 'provisioning',
+    battery_pct  numeric(5,2) CHECK (battery_pct BETWEEN 0 AND 100),
+    uptime       interval,
+    installed_at timestamptz NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE iot.devices IS 'IoT fleet: macaddr, inet/cidr, bit/varbit firmware+flags, geometric point/polygon, interval uptime.';
+
+INSERT INTO iot.devices (name, mac, ip, subnet, firmware, flags, location, coverage, config, status, battery_pct, uptime, installed_at)
+SELECT
+    (ARRAY['Sensor','Gateway','Camera','Thermostat','Meter','Valve','Beacon','Hub'])[1+floor(random()*8)::int] || '-' || lpad(g::text,4,'0'),
+    ('08:00:2b:'
+        || lpad(to_hex(floor(random()*256)::int),2,'0') || ':'
+        || lpad(to_hex(floor(random()*256)::int),2,'0') || ':'
+        || lpad(to_hex(floor(random()*256)::int),2,'0'))::macaddr,
+    ('172.16.' || floor(random()*255)::int || '.' || floor(random()*254+1)::int)::inet,
+    ('172.16.' || floor(random()*255)::int || '.0/24')::cidr,
+    (floor(random()*65536)::int)::bit(16),
+    (floor(random()*256)::int)::bit(8),
+    point(round((random()*360-180)::numeric,4), round((random()*180-90)::numeric,4)),
+    polygon(box(point(round((random()*10)::numeric,2), round((random()*10)::numeric,2)),
+                point(round((random()*10+10)::numeric,2), round((random()*10+10)::numeric,2)))),
+    jsonb_build_object(
+        'model', (ARRAY['ESP32','RPi4','nRF52','STM32'])[1+floor(random()*4)::int],
+        'sample_rate_hz', (ARRAY[1,5,10,60])[1+floor(random()*4)::int],
+        'thresholds', jsonb_build_object('high', floor(random()*100), 'low', floor(random()*10))
+    ),
+    (enum_range(NULL::iot.device_status))[1+floor(random()*5)::int],
+    round((random()*100)::numeric, 2),
+    (floor(random()*4000) || ' hours')::interval,
+    now() - (random()*500 || ' days')::interval
+FROM generate_series(1, 120) g;
+
+-- --- Readings: RANGE-partitioned by month ----------------------------------
+CREATE TABLE iot.readings (
+    id          bigint GENERATED ALWAYS AS IDENTITY,
+    device_id   integer NOT NULL REFERENCES iot.devices(id) ON DELETE CASCADE,
+    recorded_at timestamptz NOT NULL,
+    metric      text NOT NULL,
+    value       double precision NOT NULL,
+    unit        text,
+    quality     smallint CHECK (quality BETWEEN 0 AND 100),
+    flags       bit(8),
+    payload     jsonb,
+    PRIMARY KEY (id, recorded_at)
+) PARTITION BY RANGE (recorded_at);
+COMMENT ON TABLE iot.readings IS 'Time-series sensor readings, RANGE-partitioned by month (see child partitions in the tree). The largest relation in the demo.';
+
+CREATE TABLE iot.readings_2026_01 PARTITION OF iot.readings FOR VALUES FROM ('2026-01-01') TO ('2026-02-01');
+CREATE TABLE iot.readings_2026_02 PARTITION OF iot.readings FOR VALUES FROM ('2026-02-01') TO ('2026-03-01');
+CREATE TABLE iot.readings_2026_03 PARTITION OF iot.readings FOR VALUES FROM ('2026-03-01') TO ('2026-04-01');
+CREATE TABLE iot.readings_2026_04 PARTITION OF iot.readings FOR VALUES FROM ('2026-04-01') TO ('2026-05-01');
+CREATE TABLE iot.readings_2026_05 PARTITION OF iot.readings FOR VALUES FROM ('2026-05-01') TO ('2026-06-01');
+CREATE TABLE iot.readings_2026_06 PARTITION OF iot.readings FOR VALUES FROM ('2026-06-01') TO ('2026-07-01');
+CREATE TABLE iot.readings_2026_07 PARTITION OF iot.readings FOR VALUES FROM ('2026-07-01') TO ('2026-08-01');
+CREATE TABLE iot.readings_default PARTITION OF iot.readings DEFAULT;
+
+INSERT INTO iot.readings (device_id, recorded_at, metric, value, unit, quality, flags, payload)
+SELECT
+    s.device_id,
+    s.recorded_at,
+    (ARRAY['temperature','humidity','pressure','co2','lux','voltage'])[s.mi],
+    round((random() * (ARRAY[50.0,100.0,1100.0,2000.0,10000.0,24.0])[s.mi])::numeric, 3)::double precision,
+    (ARRAY['°C','%','hPa','ppm','lx','V'])[s.mi],
+    s.quality,
+    s.flags,
+    CASE WHEN s.has_payload THEN jsonb_build_object('raw', floor(random()*1024), 'calibrated', random()>0.5) END
+FROM (
+    SELECT
+        1 + floor(random()*120)::int AS device_id,
+        timestamptz '2026-01-01' + (random() * (now() - timestamptz '2026-01-01')) AS recorded_at,
+        1 + floor(random()*6)::int   AS mi,
+        floor(random()*101)::int     AS quality,
+        (floor(random()*256)::int)::bit(8) AS flags,
+        random() < 0.15              AS has_payload
+    FROM generate_series(1, 200000) g
+) s;
+
+CREATE INDEX ix_readings_device_time ON iot.readings (device_id, recorded_at DESC);
+CREATE INDEX ix_readings_metric      ON iot.readings (metric);
+-- Deliberately narrow partial index that typical queries won't hit, so it
+-- surfaces in the "unused indexes" panel of the Database Overview.
+CREATE INDEX ix_readings_quality_unused ON iot.readings (quality) WHERE quality < 10;
+
+COMMIT;

--- a/scripts/demo/04_org.sql
+++ b/scripts/demo/04_org.sql
@@ -1,0 +1,108 @@
+-- pgNimbus demo data — 04: the `org` schema (ltree hierarchy).
+--
+-- An org chart stored as an ltree materialized path (GiST-indexed), plus
+-- employees with int4range salary bands, text[] skills, jsonb profiles and a
+-- self-referencing manager_id. Safe to re-run (schema is dropped/recreated).
+
+BEGIN;
+
+DROP SCHEMA IF EXISTS org CASCADE;
+CREATE SCHEMA org;
+
+-- --- Units: hierarchy via ltree --------------------------------------------
+CREATE TABLE org.units (
+    id          integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    path        ltree UNIQUE NOT NULL,
+    name        text NOT NULL,
+    headcount   integer NOT NULL DEFAULT 0,
+    budget      money,
+    cost_center text
+);
+COMMENT ON TABLE org.units IS 'Org hierarchy stored as an ltree materialized path (GiST-indexable tree).';
+
+INSERT INTO org.units (path, name, headcount, budget, cost_center) VALUES
+    ('company',                      'Acme Corp',         0, 25000000::money, 'CC-000'),
+    ('company.engineering',          'Engineering',       0,  9000000::money, 'CC-100'),
+    ('company.engineering.platform', 'Platform',         18,  3200000::money, 'CC-110'),
+    ('company.engineering.apps',     'Applications',     24,  3800000::money, 'CC-120'),
+    ('company.engineering.data',     'Data & ML',        12,  2000000::money, 'CC-130'),
+    ('company.sales',                'Sales',             0,  6000000::money, 'CC-200'),
+    ('company.sales.emea',           'Sales EMEA',       16,  2500000::money, 'CC-210'),
+    ('company.sales.amer',           'Sales Americas',   20,  2800000::money, 'CC-220'),
+    ('company.sales.apac',           'Sales APAC',       10,  1700000::money, 'CC-230'),
+    ('company.marketing',            'Marketing',        14,  3000000::money, 'CC-300'),
+    ('company.operations',           'Operations',        0,  4000000::money, 'CC-400'),
+    ('company.operations.support',   'Customer Support', 22,  1500000::money, 'CC-410'),
+    ('company.operations.finance',   'Finance',           9,  1200000::money, 'CC-420'),
+    ('company.operations.people',    'People & Culture',  7,   900000::money, 'CC-430');
+
+CREATE INDEX ix_units_path_gist ON org.units USING gist (path);
+
+-- --- Employees: int4range salary band, self-referencing manager -------------
+CREATE TABLE org.employees (
+    id          integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    unit_id     integer NOT NULL REFERENCES org.units(id),
+    manager_id  integer REFERENCES org.employees(id) ON DELETE SET NULL,
+    name        text NOT NULL,
+    title       text NOT NULL,
+    email       citext UNIQUE NOT NULL,
+    salary_band int4range NOT NULL,
+    salary      money NOT NULL,
+    skills      text[] NOT NULL DEFAULT '{}',
+    hired_on    date NOT NULL,
+    profile     jsonb NOT NULL DEFAULT '{}'::jsonb,
+    is_manager  boolean NOT NULL DEFAULT false
+);
+COMMENT ON TABLE org.employees IS 'Employees with int4range salary bands, text[] skills, jsonb profile and a self-referencing manager_id.';
+
+-- One manager per leaf unit (nlevel >= 3) first...
+INSERT INTO org.employees (unit_id, name, title, email, salary_band, salary, skills, hired_on, profile, is_manager)
+SELECT
+    u.id,
+    (ARRAY['Alex','Sam','Jordan','Taylor','Morgan','Casey','Riley','Jamie'])[1+floor(random()*8)::int] || ' ' ||
+    (ARRAY['Lee','Park','Cohen','Diaz','Fischer','Rossi','Novak','Bauer'])[1+floor(random()*8)::int],
+    u.name || ' Lead',
+    'lead.' || u.id || '@acme.example',
+    int4range(120000, 180000),
+    (round((random()*60000 + 120000)::numeric, 0))::money,
+    ARRAY['leadership','strategy','postgres'],
+    (date '2018-01-01' + (random()*2000)::int),
+    jsonb_build_object('level','M', 'remote', random()>0.5),
+    true
+FROM org.units u
+WHERE nlevel(u.path) >= 3;
+
+-- ...then rank-and-file employees, each reporting to a random manager.
+INSERT INTO org.employees (unit_id, manager_id, name, title, email, salary_band, salary, skills, hired_on, profile, is_manager)
+SELECT
+    mgr.units[s.mi],
+    mgr.ids[s.mi],
+    (ARRAY['Emma','Liam','Olivia','Noah','Ava','Ethan','Sophia','Mason','Isabella','Lucas','Mia','Leo'])[s.fni] || ' ' ||
+    (ARRAY['Smith','Nguyen','Garcia','Muller','Rossi','Andersson','Okafor','Silva','Petrov','Khan'])[s.lni],
+    (ARRAY['Engineer','Senior Engineer','Analyst','Specialist','Coordinator','Associate','Manager','Architect'])[s.ti],
+    'emp' || s.g || '.' || s.rnd || '@acme.example',
+    (ARRAY[int4range(60000,90000), int4range(90000,130000), int4range(130000,200000)])[s.bi],
+    (round((random()*140000 + 60000)::numeric, 0))::money,
+    (ARRAY['sql','python','react','go','rust','figma','excel','kubernetes','ml','sales'])[1:1+floor(random()*4)::int],
+    (date '2019-01-01' + (random()*2500)::int),
+    jsonb_build_object(
+        'level', (ARRAY['IC1','IC2','IC3','IC4','IC5'])[s.li],
+        'remote', random()>0.4,
+        'languages', to_jsonb((ARRAY['en','de','fr','es','ja'])[1:1+floor(random()*2)::int])
+    ),
+    false
+FROM (SELECT array_agg(id) ids, array_agg(unit_id) units FROM org.employees WHERE is_manager) mgr
+CROSS JOIN (
+    SELECT
+        g,
+        1 + floor(random() * (SELECT count(*) FROM org.employees WHERE is_manager))::int AS mi,
+        1 + floor(random()*12)::int AS fni,
+        1 + floor(random()*10)::int AS lni,
+        1 + floor(random()*8)::int  AS ti,
+        1 + floor(random()*3)::int  AS bi,
+        1 + floor(random()*5)::int  AS li,
+        floor(random()*100000)::int AS rnd
+    FROM generate_series(1, 300) g
+) s;
+
+COMMIT;

--- a/scripts/demo/05_analytics.sql
+++ b/scripts/demo/05_analytics.sql
@@ -1,0 +1,128 @@
+-- pgNimbus demo data — 05: the `analytics` schema (views, matviews, functions).
+--
+-- Depends on 01-04. Adds plain views, materialized views (with unique indexes
+-- so REFRESH CONCURRENTLY is possible), sql/plpgsql functions and a trigger,
+-- then refreshes the matviews and runs ANALYZE so the Database Overview panel
+-- has real planner stats. Safe to re-run (analytics schema is dropped/recreated).
+
+BEGIN;
+
+DROP SCHEMA IF EXISTS analytics CASCADE;
+CREATE SCHEMA analytics;
+
+-- --- Plain views -----------------------------------------------------------
+CREATE VIEW analytics.v_order_totals AS
+SELECT
+    o.id         AS order_id,
+    o.order_no,
+    o.customer_id,
+    o.status,
+    o.placed_at,
+    count(oi.product_id)          AS line_count,
+    coalesce(sum(oi.quantity), 0) AS units,
+    coalesce(sum(oi.quantity * oi.unit_price * (1 - oi.discount)), 0)::numeric(14,2) AS computed_total
+FROM commerce.orders o
+LEFT JOIN commerce.order_items oi ON oi.order_id = o.id
+GROUP BY o.id, o.order_no, o.customer_id, o.status, o.placed_at;
+COMMENT ON VIEW analytics.v_order_totals IS 'Per-order totals computed from line items (plain view).';
+
+CREATE VIEW analytics.v_customer_spend AS
+SELECT
+    c.id,
+    c.full_name,
+    c.email,
+    count(o.id)                        AS order_count,
+    coalesce(sum(t.computed_total), 0) AS lifetime_value,
+    max(o.placed_at)                   AS last_order_at
+FROM commerce.customers c
+LEFT JOIN commerce.orders o          ON o.customer_id = c.id
+LEFT JOIN analytics.v_order_totals t ON t.order_id = o.id
+GROUP BY c.id, c.full_name, c.email;
+COMMENT ON VIEW analytics.v_customer_spend IS 'Customer lifetime value, built on top of another view.';
+
+-- --- Materialized views (with refresh-friendly unique indexes) --------------
+CREATE MATERIALIZED VIEW analytics.mv_daily_sales AS
+SELECT
+    date_trunc('day', o.placed_at)::date AS sales_day,
+    count(*)                             AS orders,
+    sum(t.units)                         AS units,
+    sum(t.computed_total)::numeric(14,2) AS revenue
+FROM commerce.orders o
+JOIN analytics.v_order_totals t ON t.order_id = o.id
+GROUP BY 1
+WITH DATA;
+CREATE UNIQUE INDEX ux_mv_daily_sales_day ON analytics.mv_daily_sales (sales_day);
+COMMENT ON MATERIALIZED VIEW analytics.mv_daily_sales IS 'Daily order/revenue rollup (materialized; REFRESH CONCURRENTLY-ready via unique index).';
+
+CREATE MATERIALIZED VIEW analytics.mv_top_products AS
+SELECT
+    p.id       AS product_id,
+    p.name,
+    p.category,
+    count(DISTINCT oi.order_id)                     AS orders,
+    sum(oi.quantity)                                AS units_sold,
+    sum(oi.quantity * oi.unit_price)::numeric(14,2) AS gross_revenue,
+    round(avg(r.rating), 2)                         AS avg_rating
+FROM commerce.products p
+LEFT JOIN commerce.order_items oi ON oi.product_id = p.id
+LEFT JOIN commerce.reviews r      ON r.product_id = p.id
+GROUP BY p.id, p.name, p.category
+WITH DATA;
+CREATE UNIQUE INDEX ux_mv_top_products_id ON analytics.mv_top_products (product_id);
+COMMENT ON MATERIALIZED VIEW analytics.mv_top_products IS 'Best-selling products by revenue, joined with average review rating.';
+
+-- --- Functions -------------------------------------------------------------
+CREATE OR REPLACE FUNCTION commerce.apply_discount(price numeric, pct numeric)
+RETURNS numeric
+LANGUAGE sql IMMUTABLE STRICT AS $$
+    SELECT round(price * (1 - pct), 2);
+$$;
+COMMENT ON FUNCTION commerce.apply_discount IS 'Immutable helper: price after a fractional discount.';
+
+CREATE OR REPLACE FUNCTION analytics.customer_ltv(p_customer uuid)
+RETURNS numeric
+LANGUAGE plpgsql STABLE AS $$
+DECLARE
+    v_total numeric;
+BEGIN
+    SELECT coalesce(sum(oi.quantity * oi.unit_price * (1 - oi.discount)), 0)
+      INTO v_total
+      FROM commerce.orders o
+      JOIN commerce.order_items oi ON oi.order_id = o.id
+     WHERE o.customer_id = p_customer;
+    RETURN round(v_total, 2);
+END;
+$$;
+COMMENT ON FUNCTION analytics.customer_ltv IS 'Lifetime value for one customer (plpgsql).';
+
+-- Set-returning function using ltree descendant match
+CREATE OR REPLACE FUNCTION org.reports_under(p_path ltree)
+RETURNS TABLE (employee_id int, employee_name text, unit_name text, salary money)
+LANGUAGE sql STABLE AS $$
+    SELECT e.id, e.name, u.name, e.salary
+    FROM org.employees e
+    JOIN org.units u ON u.id = e.unit_id
+    WHERE u.path <@ p_path
+    ORDER BY e.salary DESC;
+$$;
+COMMENT ON FUNCTION org.reports_under IS 'All employees within an org subtree (ltree descendant match).';
+
+-- Trigger function + trigger (keeps public.products.updated_at fresh)
+CREATE OR REPLACE FUNCTION public.touch_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at := now();
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER trg_products_touch
+    BEFORE UPDATE ON public.products
+    FOR EACH ROW EXECUTE FUNCTION public.touch_updated_at();
+
+COMMIT;
+
+-- Populate the matviews and freshen planner stats (outside the transaction).
+REFRESH MATERIALIZED VIEW analytics.mv_daily_sales;
+REFRESH MATERIALIZED VIEW analytics.mv_top_products;
+ANALYZE;

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -1,0 +1,60 @@
+# pgNimbus demo data
+
+A type-rich, multi-schema PostgreSQL dataset (~46 MB) for exploring and
+demoing pgNimbus. It's built to exercise the PostgreSQL-first parts of the
+UI — the schema tree, relation sizes, the Database Overview panel, and the
+result-grid / cell-inspector rendering of exotic types.
+
+## What it creates
+
+Five schemas, loaded in order:
+
+| # | Schema | Highlights | Types on display |
+|---|--------|-----------|------------------|
+| 01 | `public` | The simple starter shop (~500 customers, 200 products, 2 000 orders) + an `updated_at` trigger. Also enables the extensions the other files need. | the everyday types |
+| 02 | `commerce` | The showcase — 800 customers, 300 products, 3 000 orders, ~7 500 line items, 2 000 reviews. | **enum**, **composite type** (`address`), **domain** (email over citext), uuid, `text[]`, **jsonb**, **hstore**, inet/cidr, `point`/`box`, **daterange/numrange/tstzrange**, **money**, interval, bytea, **`vector(3)`** (pgvector), generated + **tsvector** columns |
+| 03 | `iot` | 120 devices + **200 000 readings** in a monthly **RANGE-partitioned** table (8 partitions, ~33 MB — the largest relation). | macaddr, `bit`/`varbit`, polygon, partition tree |
+| 04 | `org` | An **`ltree`** org hierarchy (14 units) + 309 employees. | `int4range` salary bands, self-referencing `manager_id` |
+| 05 | `analytics` | 2 views, 2 materialized views, sql/plpgsql **functions**, then `REFRESH` + `ANALYZE`. | — |
+
+Required extensions (created by `01_public.sql`): `citext`, `hstore`,
+`pgcrypto`, `pg_trgm`, `ltree`, `vector` (pgvector). The connecting role must
+be allowed to `CREATE EXTENSION`.
+
+## Running it
+
+Point it at any PostgreSQL 14+ database (a throwaway local DB, a Docker
+`postgres`, or a hosted one like Neon). **It drops and recreates the demo
+schemas and the `public.*` demo tables**, so use a database you don't mind
+overwriting.
+
+```bash
+# macOS / Linux
+./seed.sh "postgres://user:pass@host:5432/dbname?sslmode=require"
+
+# Windows / PowerShell
+./seed.ps1 "postgres://user:pass@host:5432/dbname?sslmode=require"
+```
+
+Omit the argument to fall back to libpq's `PG*` environment variables
+(`PGHOST`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`, ...). You can also run the
+files by hand, in order:
+
+```bash
+for f in 01_public 02_commerce 03_iot 04_org 05_analytics; do
+    psql "$CONN" -v ON_ERROR_STOP=1 -f "$f.sql"
+done
+```
+
+The scripts are idempotent — re-running always lands in the same state.
+
+## A note on the randomness pattern
+
+The data is generated with `random()`, but **not** by picking a random
+related row with an uncorrelated `CROSS JOIN LATERAL (SELECT ... ORDER BY
+random() LIMIT 1)`. PostgreSQL is free to evaluate that subquery once and
+reuse a single result for every row, which silently collapses all the
+variety (every order to one customer, every reading to one metric). Instead,
+every `random()` call lives in a subquery target list over `generate_series`
+(evaluated per row), and related rows are chosen by indexing into an
+`array_agg` of candidate ids. Keep that pattern if you extend these scripts.

--- a/scripts/demo/seed.ps1
+++ b/scripts/demo/seed.ps1
@@ -1,0 +1,28 @@
+#!/usr/bin/env pwsh
+# Loads the pgNimbus type-rich demo dataset into a PostgreSQL database by
+# running 01..05 in order with psql. Idempotent: each run drops and recreates
+# the demo schemas, so it always ends in the same canonical state.
+#
+# Usage:
+#   ./seed.ps1 "postgres://user:pass@host:5432/dbname?sslmode=require"
+#   ./seed.ps1                     # use libpq PG* env vars (PGHOST, PGDATABASE, ...)
+#
+# Requires: psql on PATH, and a PostgreSQL 14+ server where the connecting
+# role may CREATE EXTENSION (citext, hstore, pgcrypto, pg_trgm, ltree, vector).
+param([string]$ConnectionString)
+
+$ErrorActionPreference = 'Stop'
+$dir = $PSScriptRoot
+
+foreach ($f in '01_public','02_commerce','03_iot','04_org','05_analytics') {
+    Write-Host ">>> $f.sql"
+    $file = Join-Path $dir "$f.sql"
+    if ($ConnectionString) {
+        psql $ConnectionString -v ON_ERROR_STOP=1 -q -f $file
+    } else {
+        psql -v ON_ERROR_STOP=1 -q -f $file
+    }
+    if ($LASTEXITCODE -ne 0) { throw "psql failed on $f.sql (exit $LASTEXITCODE)" }
+}
+
+Write-Host "Done. pgNimbus demo data loaded."

--- a/scripts/demo/seed.sh
+++ b/scripts/demo/seed.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Loads the pgNimbus type-rich demo dataset into a PostgreSQL database by
+# running 01..05 in order with psql. Idempotent: each run drops and recreates
+# the demo schemas, so it always ends in the same canonical state.
+#
+# Usage:
+#   ./seed.sh "postgres://user:pass@host:5432/dbname?sslmode=require"
+#   ./seed.sh                      # use libpq PG* env vars (PGHOST, PGDATABASE, ...)
+#
+# Requires: psql on PATH, and a PostgreSQL 14+ server where the connecting
+# role may CREATE EXTENSION (citext, hstore, pgcrypto, pg_trgm, ltree, vector).
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONN="${1:-}"
+
+run() {
+    if [[ -n "$CONN" ]]; then
+        psql "$CONN" -v ON_ERROR_STOP=1 -q -f "$1"
+    else
+        psql -v ON_ERROR_STOP=1 -q -f "$1"
+    fi
+}
+
+for f in 01_public 02_commerce 03_iot 04_org 05_analytics; do
+    echo ">>> ${f}.sql"
+    run "$DIR/${f}.sql"
+done
+
+echo "Done. pgNimbus demo data loaded."


### PR DESCRIPTION
## What

Adds `scripts/demo/` — a self-contained, idempotent PostgreSQL seed (~46 MB) for exploring and demoing pgNimbus. It's built to exercise the PostgreSQL-first parts of the UI: the schema tree, relation sizes, the Database Overview panel, and the result-grid / cell-inspector rendering of exotic types.

## Layout

Five ordered scripts, runnable via `seed.sh` / `seed.ps1` (thin `psql` wrappers) or by hand:

| # | Schema | Highlights | Types on display |
|---|--------|-----------|------------------|
| 01 | `public` | Simple starter shop (~500 customers, 200 products, 2 000 orders) + `updated_at` trigger; enables the extensions the rest need | everyday types |
| 02 | `commerce` | 800 customers, 300 products, 3 000 orders, ~7 500 items, 2 000 reviews | **enum**, **composite** (`address`), **domain** (email/citext), uuid, `text[]`, jsonb, hstore, inet/cidr, `point`/`box`, ranges, money, interval, bytea, **`vector(3)`** (pgvector), generated + **tsvector** |
| 03 | `iot` | 120 devices + **200 000 readings** in a monthly **RANGE-partitioned** table (8 partitions, ~33 MB — largest relation) | macaddr, `bit`/`varbit`, polygon, partition tree |
| 04 | `org` | **`ltree`** hierarchy (14 units) + 309 employees | `int4range` salary bands, self-ref `manager_id` |
| 05 | `analytics` | 2 views, 2 materialized views, sql/plpgsql functions, then `REFRESH` + `ANALYZE` | — |

Extensions used (created by `01`): `citext`, `hstore`, `pgcrypto`, `pg_trgm`, `ltree`, `vector`.

## Notes

- **Idempotent**: each run drops/recreates the demo schemas and `public.*` demo tables, always landing in the same canonical state. Run it against a database you don't mind overwriting.
- **Randomness pattern**: all `random()` calls live in a `generate_series` subquery target list (per-row), and related rows are chosen by indexing into an `array_agg` of candidate ids — *not* an uncorrelated `CROSS JOIN LATERAL (SELECT … ORDER BY random() LIMIT 1)`, which Postgres may evaluate once and reuse, collapsing all the variety. Documented in the README for anyone extending the scripts.

## Testing

Ran the full set end-to-end against PostgreSQL 18 (twice, to confirm idempotency). Verified diversity: 6 evenly-spread reading metrics, 782 distinct order customers across 366 days and 8 countries, reviews/items spanning all 300 products, 111 employees resolved under `org.reports_under('company.engineering')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)