### PR TITLE
UX: type-aware display for PostgreSQL types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ Thumbs.db
 
 # Benchmark output (scripts/benchmarks/run-benchmarks.sh)
 bench-results/
+
+# Marketing drafts — kept local until published (avoid pre-publication indexing)
+docs/marketing/

--- a/PgNimbus.App/Converters/PgTypeVisuals.cs
+++ b/PgNimbus.App/Converters/PgTypeVisuals.cs
@@ -34,6 +34,10 @@ public static class PgTypeVisuals
         [PgTypeCategory.Vector] = "M5,17.59L15.59,7H9V5H19V15H17V8.41L6.41,19L5,17.59Z",
         [PgTypeCategory.FullText] = "M19.31,18.9L22.39,22L21,23.39L17.88,20.32C17.19,20.75 16.37,21 15.5,21C13,21 11,19 11,16.5C11,14 13,12 15.5,12C18,12 20,14 20,16.5C20,17.38 19.75,18.21 19.31,18.9M15.5,14A2.5,2.5 0 0,0 13,16.5A2.5,2.5 0 0,0 15.5,19A2.5,2.5 0 0,0 18,16.5A2.5,2.5 0 0,0 15.5,14M3,5H21V7H3V5M3,9H9V11H3V9M3,13H9V15H3V13M3,17H9V19H3V17Z",
         [PgTypeCategory.Array] = "M15,4V6H18V18H15V20H20V4M4,4V20H9V18H6V6H9V4H4Z",
+        // Enum — a bulleted list (one of a fixed set of labels).
+        [PgTypeCategory.Enum] = "M7,5H21V7H7V5M7,13V11H21V13H7M4,4.5A1.5,1.5 0 0,1 5.5,6A1.5,1.5 0 0,1 4,7.5A1.5,1.5 0 0,1 2.5,6A1.5,1.5 0 0,1 4,4.5M4,10.5A1.5,1.5 0 0,1 5.5,12A1.5,1.5 0 0,1 4,13.5A1.5,1.5 0 0,1 2.5,12A1.5,1.5 0 0,1 4,10.5M7,19V17H21V19H7M4,16.5A1.5,1.5 0 0,1 5.5,18A1.5,1.5 0 0,1 4,19.5A1.5,1.5 0 0,1 2.5,18A1.5,1.5 0 0,1 4,16.5Z",
+        // Composite — a record of named columns/fields.
+        [PgTypeCategory.Composite] = "M10,10.02H15V21H10V10.02M17,21H20C21.1,21 22,20.1 22,19V10H17V21M20,3H5C3.9,3 3,3.9 3,5V8H22V5C22,3.9 21.1,3 20,3M3,19C3,20.1 3.9,21 5,21H8V10H3V19Z",
     };
 
     private static readonly Dictionary<PgTypeCategory, string> Labels = new()
@@ -52,15 +56,11 @@ public static class PgTypeVisuals
         [PgTypeCategory.Vector] = "Vector",
         [PgTypeCategory.FullText] = "Full-text search",
         [PgTypeCategory.Array] = "Array",
+        [PgTypeCategory.Enum] = "Enum",
+        [PgTypeCategory.Composite] = "Composite",
     };
 
     private static readonly Dictionary<PgTypeCategory, Geometry?> GeometryCache = new();
-
-    /// <summary>The icon for a type name's category, or null when the family has no glyph (Other) or the path failed to parse.</summary>
-    public static Geometry? Icon(string? typeName) => IconFor(PgTypeCategorizer.Categorize(typeName));
-
-    /// <summary>The friendly family label for a type name's category, or empty for Other.</summary>
-    public static string Label(string? typeName) => LabelFor(PgTypeCategorizer.Categorize(typeName));
 
     /// <summary>The friendly family label for an already-resolved category, or empty for Other.</summary>
     public static string LabelFor(PgTypeCategory category) =>
@@ -92,25 +92,25 @@ public static class PgTypeVisuals
     }
 }
 
-/// <summary>Binds a Postgres type-name string to its category icon (a <see cref="Geometry"/>).</summary>
+/// <summary>Binds a <see cref="PgTypeCategory"/> to its family icon (a <see cref="Geometry"/>).</summary>
 public sealed class PgTypeIconConverter : IValueConverter
 {
     public static readonly PgTypeIconConverter Instance = new();
 
     public object? Convert(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
-        PgTypeVisuals.Icon(value as string);
+        value is PgTypeCategory category ? PgTypeVisuals.IconFor(category) : null;
 
     public object? ConvertBack(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
         throw new System.NotSupportedException();
 }
 
-/// <summary>Binds a Postgres type-name string to its friendly family label (for a tooltip).</summary>
+/// <summary>Binds a <see cref="PgTypeCategory"/> to its friendly family label (for a tooltip).</summary>
 public sealed class PgTypeLabelConverter : IValueConverter
 {
     public static readonly PgTypeLabelConverter Instance = new();
 
     public object? Convert(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
-        PgTypeVisuals.Label(value as string);
+        value is PgTypeCategory category ? PgTypeVisuals.LabelFor(category) : string.Empty;
 
     public object? ConvertBack(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
         throw new System.NotSupportedException();

--- a/PgNimbus.App/Converters/PgTypeVisuals.cs
+++ b/PgNimbus.App/Converters/PgTypeVisuals.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.App.Converters;
+
+/// <summary>
+/// Maps a <see cref="PgTypeCategory"/> to the small monochrome icon and friendly
+/// label the schema tree and results grid show next to a column's type. One icon
+/// per family (not per exact type) keeps a single visual language across the
+/// dozens of concrete Postgres type names. Geometries are parsed once and cached;
+/// a bad path falls back to no icon rather than throwing, so a mis-typed glyph can
+/// never crash column virtualization.
+/// </summary>
+public static class PgTypeVisuals
+{
+    // 24×24 Material Design Icon paths — same family/style as the icons already in
+    // Theme.axaml. Categories with no natural glyph (Other) intentionally have none.
+    private static readonly Dictionary<PgTypeCategory, string> Paths = new()
+    {
+        [PgTypeCategory.Numeric] = "M4,17V9H2V7H6V17H4M22,15C22,16.11 21.1,17 20,17H16V15H20V13H18V11H20V9H16V7H20A2,2 0 0,1 22,9V10.5A1.5,1.5 0 0,1 20.5,12A1.5,1.5 0 0,1 22,13.5V15M14,15V17H8V13C8,11.89 8.9,11 10,11H12V9H8V7H12A2,2 0 0,1 14,9V11C14,12.11 13.1,13 12,13H10V15H14Z",
+        [PgTypeCategory.Text] = "M5,4V7H10.5V19H13.5V7H19V4H5Z",
+        [PgTypeCategory.Boolean] = "M17,7H7A5,5 0 0,0 2,12A5,5 0 0,0 7,17H17A5,5 0 0,0 22,12A5,5 0 0,0 17,7M17,15A3,3 0 0,1 14,12A3,3 0 0,1 17,9A3,3 0 0,1 20,12A3,3 0 0,1 17,15Z",
+        [PgTypeCategory.DateTime] = "M19,19H5V8H19M16,1V3H8V1H6V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3H18V1M17,12H12V17H17V12Z",
+        [PgTypeCategory.Uuid] = "M2,6H4V18H2V6M5,6H6V18H5V6M7,6H10V18H7V6M11,6H12V18H11V6M14,6H16V18H14V6M17,6H20V18H17V6M21,6H22V18H21V6Z",
+        [PgTypeCategory.Json] = "M5,3H7V5H5V10A2,2 0 0,1 3,12A2,2 0 0,1 5,14V19H7V21H5C3.93,20.73 3,20.1 3,19V15.5C3,14.4 2.1,13.5 1,13.5V11.5C2.1,11.5 3,10.6 3,9.5V6C3,4.9 3.9,4 5,4V3M19,3C20.07,3.27 21,3.9 21,5V8.5C21,9.6 21.9,10.5 23,10.5V12.5C21.9,12.5 21,13.4 21,14.5V18C21,19.1 20.1,20 19,20V21H17V19H19V14A2,2 0 0,1 21,12A2,2 0 0,1 19,10V5H17V3H19M12,15A1,1 0 0,1 13,16A1,1 0 0,1 12,17A1,1 0 0,1 11,16A1,1 0 0,1 12,15M8,15A1,1 0 0,1 9,16A1,1 0 0,1 8,17A1,1 0 0,1 7,16A1,1 0 0,1 8,15M16,15A1,1 0 0,1 17,16A1,1 0 0,1 16,17A1,1 0 0,1 15,16A1,1 0 0,1 16,15Z",
+        [PgTypeCategory.Network] = "M16.36,14C16.44,13.34 16.5,12.68 16.5,12C16.5,11.32 16.44,10.66 16.36,10H19.74C19.9,10.64 20,11.31 20,12C20,12.69 19.9,13.36 19.74,14M14.59,19.56C15.19,18.45 15.65,17.25 15.97,16H18.92C17.96,17.65 16.43,18.93 14.59,19.56M14.34,14H9.66C9.56,13.34 9.5,12.68 9.5,12C9.5,11.32 9.56,10.65 9.66,10H14.34C14.43,10.65 14.5,11.32 14.5,12C14.5,12.68 14.43,13.34 14.34,14M12,19.96C11.17,18.76 10.5,17.43 10.09,16H13.91C13.5,17.43 12.83,18.76 12,19.96M8,8H5.08C6.03,6.34 7.57,5.06 9.4,4.44C8.8,5.55 8.35,6.75 8,8M5.08,16H8C8.35,17.25 8.8,18.45 9.4,19.56C7.57,18.93 6.03,17.65 5.08,16M4.26,14C4.1,13.36 4,12.69 4,12C4,11.31 4.1,10.64 4.26,10H7.64C7.56,10.66 7.5,11.32 7.5,12C7.5,12.68 7.56,13.34 7.64,14M12,4.03C12.83,5.23 13.5,6.57 13.91,8H10.09C10.5,6.57 11.17,5.23 12,4.03M18.92,8H15.97C15.65,6.75 15.19,5.55 14.59,4.44C16.43,5.07 17.96,6.34 18.92,8M12,2C6.47,2 2,6.5 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z",
+        [PgTypeCategory.Geometric] = "M2,2H8V4H16V2H22V8H20V16H22V22H16V20H8V22H2V16H4V8H2V2M16,18V16H18V8H16V6H8V8H6V16H8V18H16M4,4V6H6V4H4M18,4V6H20V4H18M4,18V20H6V18H4M18,18V20H20V18H18Z",
+        [PgTypeCategory.Range] = "M9,11H15V8L19,12L15,16V13H9V16L5,12L9,8V11M2,20V4H4V20H2M20,20V4H22V20H20Z",
+        [PgTypeCategory.Binary] = "M17,17H7V7H17M21,11V9H19V7C19,5.89 18.1,5 17,5H15V3H13V5H11V3H9V5H7C5.89,5 5,5.89 5,7V9H3V11H5V13H3V15H5V17A2,2 0 0,0 7,19H9V21H11V19H13V21H15V19H17A2,2 0 0,0 19,17V15H21V13H19V11M13,13H11V11H13M15,9H9V15H15V9Z",
+        [PgTypeCategory.BitString] = "M2,10H6V14H2V10M8,10H12V14H8V10M14,10H18V14H14V10M20,10H22V14H20V10Z",
+        [PgTypeCategory.Vector] = "M5,17.59L15.59,7H9V5H19V15H17V8.41L6.41,19L5,17.59Z",
+        [PgTypeCategory.FullText] = "M19.31,18.9L22.39,22L21,23.39L17.88,20.32C17.19,20.75 16.37,21 15.5,21C13,21 11,19 11,16.5C11,14 13,12 15.5,12C18,12 20,14 20,16.5C20,17.38 19.75,18.21 19.31,18.9M15.5,14A2.5,2.5 0 0,0 13,16.5A2.5,2.5 0 0,0 15.5,19A2.5,2.5 0 0,0 18,16.5A2.5,2.5 0 0,0 15.5,14M3,5H21V7H3V5M3,9H9V11H3V9M3,13H9V15H3V13M3,17H9V19H3V17Z",
+        [PgTypeCategory.Array] = "M15,4V6H18V18H15V20H20V4M4,4V20H9V18H6V6H9V4H4Z",
+    };
+
+    private static readonly Dictionary<PgTypeCategory, string> Labels = new()
+    {
+        [PgTypeCategory.Numeric] = "Numeric",
+        [PgTypeCategory.Text] = "Text",
+        [PgTypeCategory.Boolean] = "Boolean",
+        [PgTypeCategory.DateTime] = "Date / time",
+        [PgTypeCategory.Uuid] = "UUID",
+        [PgTypeCategory.Json] = "JSON",
+        [PgTypeCategory.Network] = "Network address",
+        [PgTypeCategory.Geometric] = "Geometric",
+        [PgTypeCategory.Range] = "Range",
+        [PgTypeCategory.Binary] = "Binary",
+        [PgTypeCategory.BitString] = "Bit string",
+        [PgTypeCategory.Vector] = "Vector",
+        [PgTypeCategory.FullText] = "Full-text search",
+        [PgTypeCategory.Array] = "Array",
+    };
+
+    private static readonly Dictionary<PgTypeCategory, Geometry?> GeometryCache = new();
+
+    /// <summary>The icon for a type name's category, or null when the family has no glyph (Other) or the path failed to parse.</summary>
+    public static Geometry? Icon(string? typeName) => IconFor(PgTypeCategorizer.Categorize(typeName));
+
+    /// <summary>The friendly family label for a type name's category, or empty for Other.</summary>
+    public static string Label(string? typeName) =>
+        Labels.TryGetValue(PgTypeCategorizer.Categorize(typeName), out var label) ? label : string.Empty;
+
+    private static Geometry? IconFor(PgTypeCategory category)
+    {
+        if (GeometryCache.TryGetValue(category, out var cached))
+        {
+            return cached;
+        }
+
+        Geometry? geometry = null;
+        if (Paths.TryGetValue(category, out var path))
+        {
+            try
+            {
+                geometry = Geometry.Parse(path);
+            }
+            catch
+            {
+                geometry = null;
+            }
+        }
+
+        GeometryCache[category] = geometry;
+        return geometry;
+    }
+}
+
+/// <summary>Binds a Postgres type-name string to its category icon (a <see cref="Geometry"/>).</summary>
+public sealed class PgTypeIconConverter : IValueConverter
+{
+    public static readonly PgTypeIconConverter Instance = new();
+
+    public object? Convert(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
+        PgTypeVisuals.Icon(value as string);
+
+    public object? ConvertBack(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
+        throw new System.NotSupportedException();
+}
+
+/// <summary>Binds a Postgres type-name string to its friendly family label (for a tooltip).</summary>
+public sealed class PgTypeLabelConverter : IValueConverter
+{
+    public static readonly PgTypeLabelConverter Instance = new();
+
+    public object? Convert(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
+        PgTypeVisuals.Label(value as string);
+
+    public object? ConvertBack(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
+        throw new System.NotSupportedException();
+}

--- a/PgNimbus.App/Converters/PgTypeVisuals.cs
+++ b/PgNimbus.App/Converters/PgTypeVisuals.cs
@@ -60,10 +60,14 @@ public static class PgTypeVisuals
     public static Geometry? Icon(string? typeName) => IconFor(PgTypeCategorizer.Categorize(typeName));
 
     /// <summary>The friendly family label for a type name's category, or empty for Other.</summary>
-    public static string Label(string? typeName) =>
-        Labels.TryGetValue(PgTypeCategorizer.Categorize(typeName), out var label) ? label : string.Empty;
+    public static string Label(string? typeName) => LabelFor(PgTypeCategorizer.Categorize(typeName));
 
-    private static Geometry? IconFor(PgTypeCategory category)
+    /// <summary>The friendly family label for an already-resolved category, or empty for Other.</summary>
+    public static string LabelFor(PgTypeCategory category) =>
+        Labels.TryGetValue(category, out var label) ? label : string.Empty;
+
+    /// <summary>The icon for an already-resolved category, or null when the family has no glyph (Other) or the path failed to parse.</summary>
+    public static Geometry? IconFor(PgTypeCategory category)
     {
         if (GeometryCache.TryGetValue(category, out var cached))
         {

--- a/PgNimbus.App/Converters/RowIndexConverter.cs
+++ b/PgNimbus.App/Converters/RowIndexConverter.cs
@@ -28,16 +28,27 @@ public sealed class RowIndexConverter : IValueConverter
             ? row[_index] switch
             {
                 null => NullPlaceholder,
+                // bytea arrives as byte[]; its default ToString is the useless
+                // "System.Byte[]". Show a capped \x-hex preview (the same shape
+                // the cell inspector uses, which carries the full value) rather
+                // than materializing megabytes of hex for a large blob inline.
+                byte[] bytes => FormatByteaPreview(bytes),
                 // Array columns render in Postgres's literal syntax ("{a,b}")
                 // instead of the CLR default ("System.String[]") — readable,
                 // and editable in place since the cell editor pre-fills from
                 // this text and the edit pipeline casts it back server-side.
-                // bytea (byte[]) is deliberately left alone.
-                byte[] bytes => bytes,
                 Array array => PgValueSyntax.FormatArray(array),
                 var cell => cell,
             }
             : null;
+
+    /// <summary>Bytes shown before a bytea preview is truncated — enough to read a magic number, not a whole blob.</summary>
+    private const int ByteaPreviewBytes = 24;
+
+    private static string FormatByteaPreview(byte[] bytes) =>
+        bytes.Length <= ByteaPreviewBytes
+            ? "\\x" + System.Convert.ToHexString(bytes)
+            : "\\x" + System.Convert.ToHexString(bytes.AsSpan(0, ByteaPreviewBytes)) + "…";
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/PgNimbus.App/Converters/RowIndexConverter.cs
+++ b/PgNimbus.App/Converters/RowIndexConverter.cs
@@ -43,6 +43,36 @@ public sealed class RowIndexConverter : IValueConverter
         throw new NotSupportedException();
 }
 
+/// <summary>
+/// Renders a boolean cell as a ✓/✗ glyph instead of the literal "true"/"false"
+/// text, so a boolean column reads at a glance. SQL NULL keeps the same "NULL"
+/// placeholder every other column uses (dimmed via <see cref="NullCellOpacityConverter"/>).
+/// </summary>
+public sealed class BoolCellGlyphConverter : IValueConverter
+{
+    public const string True = "✓";  // ✓
+    public const string False = "✗";  // ✗
+
+    private readonly int _index;
+
+    public BoolCellGlyphConverter(int index) => _index = index;
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is object?[] row && _index < row.Length
+            ? row[_index] switch
+            {
+                null => RowIndexConverter.NullPlaceholder,
+                bool b => b ? True : False,
+                // A boolean column should only ever hold bool/null, but never
+                // throw on a surprise value — show its text form.
+                var other => other.ToString(),
+            }
+            : null;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
 /// <summary>Dims cells whose underlying value is SQL NULL, so the "NULL" placeholder reads as a marker, not data.</summary>
 public sealed class NullCellOpacityConverter : IValueConverter
 {

--- a/PgNimbus.App/ResultTextColumn.cs
+++ b/PgNimbus.App/ResultTextColumn.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.Media;
 using PgNimbus.App.Converters;
 using PgNimbus.Core.Schema;
 
@@ -15,6 +16,10 @@ namespace PgNimbus.App;
 /// reads as a marker rather than data. The display element's DataContext is
 /// the row array, so a plain style can't see the cell value - the opacity
 /// binding has to be attached per generated element.
+/// The column also renders type-aware: given its resolved
+/// <see cref="PgTypeCategory"/> it right-aligns and mono-fonts numeric cells
+/// (so digits line up) and shows a ✓/✗ glyph for booleans instead of the
+/// literal "true"/"false" — for every result set, not just editable ones.
 /// When the result maps to an editable table, the column also knows its
 /// Postgres type (via <paramref name="editorMeta"/>) and generates a
 /// type-appropriate cell editor: a dropdown of pg_enum labels for enum
@@ -25,13 +30,19 @@ namespace PgNimbus.App;
 /// </summary>
 public sealed class ResultTextColumn : DataGridTextColumn
 {
+    // Shared numeric font — the same mono stack the SQL editor/inspector use, so
+    // digits line up column-to-column under the right-aligned numeric cells.
+    private static readonly FontFamily MonoFont = new("Cascadia Code,Consolas,Menlo,monospace");
+
     private readonly int _index;
     private readonly ColumnDetail? _editorMeta;
+    private readonly PgTypeCategory _category;
 
-    public ResultTextColumn(int index, ColumnDetail? editorMeta = null)
+    public ResultTextColumn(int index, ColumnDetail? editorMeta = null, PgTypeCategory category = PgTypeCategory.Other)
     {
         _index = index;
         _editorMeta = editorMeta;
+        _category = category;
 
         if (editorMeta?.Editor is ColumnValueEditor.Boolean or ColumnValueEditor.Enum
             or ColumnValueEditor.Date or ColumnValueEditor.Timestamp)
@@ -54,11 +65,33 @@ public sealed class ResultTextColumn : DataGridTextColumn
         Justification = "Pathless binding uses a converter only; no dynamic code.")]
     protected override Control GenerateElement(DataGridCell cell, object dataItem)
     {
+        // Boolean cells read as a ✓/✗ glyph rather than "true"/"false" — its own
+        // TextBlock (bound through the glyph converter), centered.
+        if (_category == PgTypeCategory.Boolean)
+        {
+            var glyph = new TextBlock
+            {
+                TextAlignment = TextAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+            };
+            glyph.Bind(TextBlock.TextProperty, new Binding { Converter = new BoolCellGlyphConverter(_index) });
+            glyph.Bind(Visual.OpacityProperty, new Binding { Converter = new NullCellOpacityConverter(_index) });
+            return glyph;
+        }
+
         var element = base.GenerateElement(cell, dataItem);
         element.Bind(Visual.OpacityProperty, new Binding
         {
             Converter = new NullCellOpacityConverter(_index),
         });
+
+        // Numeric cells right-align and use the mono font so digits line up and
+        // magnitudes are comparable down the column.
+        if (_category == PgTypeCategory.Numeric && element is TextBlock text)
+        {
+            text.TextAlignment = TextAlignment.Right;
+            text.FontFamily = MonoFont;
+        }
 
         return element;
     }

--- a/PgNimbus.App/ViewModels/ColumnNode.cs
+++ b/PgNimbus.App/ViewModels/ColumnNode.cs
@@ -11,6 +11,9 @@ public sealed class ColumnNode : SchemaTreeNode
         DomainBaseType = detail.DomainBaseType;
         NotNull = detail.NotNull;
         IsPrimaryKey = detail.IsPrimaryKey;
+        // Resolve the icon family once: enum/composite come from the catalog kind
+        // (via Editor), domains from their base type, everything else by name.
+        Category = PgTypeCategorizer.CategorizeColumn(detail.DataType, detail.DomainBaseType, detail.Editor);
     }
 
     public string DataType { get; }
@@ -21,12 +24,8 @@ public sealed class ColumnNode : SchemaTreeNode
     /// <summary>The compact form shown in the tree (see <see cref="PgTypeAbbreviations"/>).</summary>
     public string DataTypeShort => PgTypeAbbreviations.Abbreviate(DataType);
 
-    /// <summary>
-    /// The type name the category icon is derived from — the declared type, or,
-    /// when that's a domain with no icon of its own, the base type it resolves to
-    /// (so a domain over citext still shows the text glyph).
-    /// </summary>
-    public string? TypeClassifier => PgTypeCategorizer.ClassifierType(DataType, DomainBaseType);
+    /// <summary>The type family driving the category icon shown next to the type text.</summary>
+    public PgTypeCategory Category { get; }
 
     /// <summary>
     /// The full type name for a hover tooltip — but only when it differs from the

--- a/PgNimbus.App/ViewModels/ColumnNode.cs
+++ b/PgNimbus.App/ViewModels/ColumnNode.cs
@@ -8,14 +8,25 @@ public sealed class ColumnNode : SchemaTreeNode
     {
         Name = detail.Name;
         DataType = detail.DataType;
+        DomainBaseType = detail.DomainBaseType;
         NotNull = detail.NotNull;
         IsPrimaryKey = detail.IsPrimaryKey;
     }
 
     public string DataType { get; }
 
+    /// <summary>The base type a domain column resolves to (e.g. "citext" for a domain over citext); null when the declared type isn't a domain.</summary>
+    public string? DomainBaseType { get; }
+
     /// <summary>The compact form shown in the tree (see <see cref="PgTypeAbbreviations"/>).</summary>
     public string DataTypeShort => PgTypeAbbreviations.Abbreviate(DataType);
+
+    /// <summary>
+    /// The type name the category icon is derived from — the declared type, or,
+    /// when that's a domain with no icon of its own, the base type it resolves to
+    /// (so a domain over citext still shows the text glyph).
+    /// </summary>
+    public string? TypeClassifier => PgTypeCategorizer.ClassifierType(DataType, DomainBaseType);
 
     /// <summary>
     /// The full type name for a hover tooltip — but only when it differs from the

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -206,6 +206,15 @@ public sealed partial class QueryViewModel : ObservableObject
     public ObservableCollection<string> ColumnNames { get; } = [];
 
     /// <summary>
+    /// The Postgres type name of result column <paramref name="index"/> (as the
+    /// wire protocol reports it — "jsonb", "integer[]", "timestamp with time
+    /// zone", …), or null when out of range. Available for every result set, not
+    /// just editable ones, so the grid can show a type-family icon per column.
+    /// </summary>
+    public string? ColumnTypeName(int index) =>
+        index >= 0 && index < _columns.Count ? _columns[index].DataTypeName : null;
+
+    /// <summary>
     /// The grid's rows. Replaced wholesale (a fresh list instance) rather than
     /// mutated in bulk: the DataGrid's CollectionChanged handling costs
     /// ~200 µs per row whether the change arrives as per-item Adds, a range

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -48,11 +48,12 @@
                     <PathIcon Data="{StaticResource KeyIconGeometry}" Width="12" Height="12" IsVisible="{Binding IsPrimaryKey}" />
                 </Panel>
                 <TextBlock Text="{Binding Name}" />
-                <!-- Category icon (numeric/text/date/json…) — one glyph per type family;
-                     domains resolve to their base type's icon via TypeClassifier -->
-                <PathIcon Data="{Binding TypeClassifier, Converter={x:Static conv2:PgTypeIconConverter.Instance}}"
+                <!-- Category icon (numeric/text/date/json/enum…) — one glyph per type
+                     family; enum/composite resolved from the catalog kind, domains
+                     from their base type (see ColumnNode.Category) -->
+                <PathIcon Data="{Binding Category, Converter={x:Static conv2:PgTypeIconConverter.Instance}}"
                           Width="11" Height="11" Opacity="0.5" VerticalAlignment="Center"
-                          ToolTip.Tip="{Binding TypeClassifier, Converter={x:Static conv2:PgTypeLabelConverter.Instance}}"
+                          ToolTip.Tip="{Binding Category, Converter={x:Static conv2:PgTypeLabelConverter.Instance}}"
                           ToolTip.ShowDelay="300" />
                 <!-- Abbreviated type (timestamptz, varchar…) with the full name on a brief hover -->
                 <TextBlock Text="{Binding DataTypeShort}" Opacity="0.6" FontSize="11" VerticalAlignment="Center"

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -48,6 +48,11 @@
                     <PathIcon Data="{StaticResource KeyIconGeometry}" Width="12" Height="12" IsVisible="{Binding IsPrimaryKey}" />
                 </Panel>
                 <TextBlock Text="{Binding Name}" />
+                <!-- Category icon (numeric/text/date/json…) — one glyph per type family -->
+                <PathIcon Data="{Binding DataType, Converter={x:Static conv2:PgTypeIconConverter.Instance}}"
+                          Width="11" Height="11" Opacity="0.5" VerticalAlignment="Center"
+                          ToolTip.Tip="{Binding DataType, Converter={x:Static conv2:PgTypeLabelConverter.Instance}}"
+                          ToolTip.ShowDelay="300" />
                 <!-- Abbreviated type (timestamptz, varchar…) with the full name on a brief hover -->
                 <TextBlock Text="{Binding DataTypeShort}" Opacity="0.6" FontSize="11" VerticalAlignment="Center"
                            ToolTip.Tip="{Binding FullTypeTip}" ToolTip.ShowDelay="150" />

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -48,10 +48,11 @@
                     <PathIcon Data="{StaticResource KeyIconGeometry}" Width="12" Height="12" IsVisible="{Binding IsPrimaryKey}" />
                 </Panel>
                 <TextBlock Text="{Binding Name}" />
-                <!-- Category icon (numeric/text/date/json…) — one glyph per type family -->
-                <PathIcon Data="{Binding DataType, Converter={x:Static conv2:PgTypeIconConverter.Instance}}"
+                <!-- Category icon (numeric/text/date/json…) — one glyph per type family;
+                     domains resolve to their base type's icon via TypeClassifier -->
+                <PathIcon Data="{Binding TypeClassifier, Converter={x:Static conv2:PgTypeIconConverter.Instance}}"
                           Width="11" Height="11" Opacity="0.5" VerticalAlignment="Center"
-                          ToolTip.Tip="{Binding DataType, Converter={x:Static conv2:PgTypeLabelConverter.Instance}}"
+                          ToolTip.Tip="{Binding TypeClassifier, Converter={x:Static conv2:PgTypeLabelConverter.Instance}}"
                           ToolTip.ShowDelay="300" />
                 <!-- Abbreviated type (timestamptz, varchar…) with the full name on a brief hover -->
                 <TextBlock Text="{Binding DataTypeShort}" Opacity="0.6" FontSize="11" VerticalAlignment="Center"

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -2831,8 +2831,12 @@ public partial class MainWindow : Window
             // known; fall back to the wire name for arbitrary queries. Domains
             // resolve to their base type's family (see ClassifierType).
             var declaredType = editorMeta?.DataType ?? query.ColumnTypeName(i);
-            var category = PgTypeCategorizer.Categorize(
-                PgTypeCategorizer.ClassifierType(declaredType, editorMeta?.DomainBaseType));
+            // In browse mode the catalog kind is known, so enum/composite columns
+            // get their own icon; an arbitrary query only has the wire type name,
+            // where an enum is indistinguishable from Other.
+            var category = editorMeta is { } meta
+                ? PgTypeCategorizer.CategorizeColumn(declaredType, meta.DomainBaseType, meta.Editor)
+                : PgTypeCategorizer.Categorize(PgTypeCategorizer.ClassifierType(declaredType, null));
 
             ResultsGrid.Columns.Add(new ResultTextColumn(i, editorMeta, category)
             {

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -2868,6 +2868,10 @@ public partial class MainWindow : Window
         // Prefer the browse-mode format_type spelling ("numeric(12,2)") when known;
         // fall back to the wire name ("numeric") for arbitrary queries.
         var richType = meta?.DataType ?? typeName;
+        // A domain column carries no icon of its own — classify by its base type so
+        // e.g. a domain over citext still shows the text glyph. The tooltip keeps
+        // the declared (domain) type name.
+        var iconType = PgTypeCategorizer.ClassifierType(richType, meta?.DomainBaseType);
 
         var panel = new StackPanel
         {
@@ -2876,7 +2880,7 @@ public partial class MainWindow : Window
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
         };
 
-        if (Converters.PgTypeVisuals.Icon(richType) is { } icon)
+        if (Converters.PgTypeVisuals.Icon(iconType) is { } icon)
         {
             panel.Children.Add(new PathIcon
             {
@@ -2894,7 +2898,7 @@ public partial class MainWindow : Window
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
         });
 
-        if (BuildHeaderTooltip(richType, meta) is { } tip)
+        if (BuildHeaderTooltip(richType, iconType, meta) is { } tip)
         {
             ToolTip.SetTip(panel, tip);
             ToolTip.SetShowDelay(panel, 300);
@@ -2903,15 +2907,18 @@ public partial class MainWindow : Window
         return panel;
     }
 
-    private static string? BuildHeaderTooltip(string? typeName, ColumnDetail? meta)
+    // displayType is the declared type shown to the user (a domain keeps its own
+    // name); classifyType is what the family label is derived from (the domain's
+    // base type), so a domain over citext still reads "· Text".
+    private static string? BuildHeaderTooltip(string? displayType, string? classifyType, ColumnDetail? meta)
     {
-        if (string.IsNullOrEmpty(typeName))
+        if (string.IsNullOrEmpty(displayType))
         {
             return null;
         }
 
-        var family = Converters.PgTypeVisuals.Label(typeName);
-        var text = string.IsNullOrEmpty(family) ? typeName : $"{typeName}  ·  {family}";
+        var family = Converters.PgTypeVisuals.Label(classifyType);
+        var text = string.IsNullOrEmpty(family) ? displayType : $"{displayType}  ·  {family}";
 
         if (meta is not null)
         {

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -2829,7 +2829,7 @@ public partial class MainWindow : Window
 
             ResultsGrid.Columns.Add(new ResultTextColumn(i, editorMeta)
             {
-                Header = query.ColumnNames[i],
+                Header = CreateColumnHeader(query.ColumnNames[i], query.ColumnTypeName(i), editorMeta),
                 // Avalonia 12's DataGrid infers "read-only" from a column's
                 // binding path — and a pathless converter binding (the
                 // AOT-safe pattern used here) has none, which silently made
@@ -2856,5 +2856,82 @@ public partial class MainWindow : Window
                 MaxWidth = 560,
             });
         }
+    }
+
+    // A results-grid column header: the type-family icon (when the type has one)
+    // plus the column name, with a tooltip carrying the full type, its family,
+    // and — in browse mode, where the table's real columns are known — its
+    // primary-key / not-null flags. The type name comes from the wire protocol so
+    // every result set gets the icon, not just editable ones.
+    private static Control CreateColumnHeader(string name, string? typeName, ColumnDetail? meta)
+    {
+        // Prefer the browse-mode format_type spelling ("numeric(12,2)") when known;
+        // fall back to the wire name ("numeric") for arbitrary queries.
+        var richType = meta?.DataType ?? typeName;
+
+        var panel = new StackPanel
+        {
+            Orientation = Avalonia.Layout.Orientation.Horizontal,
+            Spacing = 5,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+        };
+
+        if (Converters.PgTypeVisuals.Icon(richType) is { } icon)
+        {
+            panel.Children.Add(new PathIcon
+            {
+                Data = icon,
+                Width = 11,
+                Height = 11,
+                Opacity = 0.5,
+                VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            });
+        }
+
+        panel.Children.Add(new TextBlock
+        {
+            Text = name,
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+        });
+
+        if (BuildHeaderTooltip(richType, meta) is { } tip)
+        {
+            ToolTip.SetTip(panel, tip);
+            ToolTip.SetShowDelay(panel, 300);
+        }
+
+        return panel;
+    }
+
+    private static string? BuildHeaderTooltip(string? typeName, ColumnDetail? meta)
+    {
+        if (string.IsNullOrEmpty(typeName))
+        {
+            return null;
+        }
+
+        var family = Converters.PgTypeVisuals.Label(typeName);
+        var text = string.IsNullOrEmpty(family) ? typeName : $"{typeName}  ·  {family}";
+
+        if (meta is not null)
+        {
+            var flags = new System.Collections.Generic.List<string>(2);
+            if (meta.IsPrimaryKey)
+            {
+                flags.Add("primary key");
+            }
+
+            if (meta.NotNull)
+            {
+                flags.Add("not null");
+            }
+
+            if (flags.Count > 0)
+            {
+                text += "\n" + string.Join("  ·  ", flags);
+            }
+        }
+
+        return text;
     }
 }

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -2825,11 +2825,18 @@ public partial class MainWindow : Window
             // In browse mode the edit context knows each column's Postgres
             // type — the column uses it to generate a type-aware cell editor
             // (enum dropdown, checkbox, date picker) instead of a TextBox.
-            var editorMeta = query.EditContext?.Column(query.ColumnNames[i]);
+            var name = query.ColumnNames[i];
+            var editorMeta = query.EditContext?.Column(name);
+            // Prefer the browse-mode format_type spelling ("numeric(12,2)") when
+            // known; fall back to the wire name for arbitrary queries. Domains
+            // resolve to their base type's family (see ClassifierType).
+            var declaredType = editorMeta?.DataType ?? query.ColumnTypeName(i);
+            var category = PgTypeCategorizer.Categorize(
+                PgTypeCategorizer.ClassifierType(declaredType, editorMeta?.DomainBaseType));
 
-            ResultsGrid.Columns.Add(new ResultTextColumn(i, editorMeta)
+            ResultsGrid.Columns.Add(new ResultTextColumn(i, editorMeta, category)
             {
-                Header = CreateColumnHeader(query.ColumnNames[i], query.ColumnTypeName(i), editorMeta),
+                Header = CreateColumnHeader(name, declaredType, category, editorMeta),
                 // Avalonia 12's DataGrid infers "read-only" from a column's
                 // binding path — and a pathless converter binding (the
                 // AOT-safe pattern used here) has none, which silently made
@@ -2863,24 +2870,21 @@ public partial class MainWindow : Window
     // and — in browse mode, where the table's real columns are known — its
     // primary-key / not-null flags. The type name comes from the wire protocol so
     // every result set gets the icon, not just editable ones.
-    private static Control CreateColumnHeader(string name, string? typeName, ColumnDetail? meta)
+    private static Control CreateColumnHeader(string name, string? displayType, PgTypeCategory category, ColumnDetail? meta)
     {
-        // Prefer the browse-mode format_type spelling ("numeric(12,2)") when known;
-        // fall back to the wire name ("numeric") for arbitrary queries.
-        var richType = meta?.DataType ?? typeName;
-        // A domain column carries no icon of its own — classify by its base type so
-        // e.g. a domain over citext still shows the text glyph. The tooltip keeps
-        // the declared (domain) type name.
-        var iconType = PgTypeCategorizer.ClassifierType(richType, meta?.DomainBaseType);
-
         var panel = new StackPanel
         {
             Orientation = Avalonia.Layout.Orientation.Horizontal,
             Spacing = 5,
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            // Numeric cells right-align — sit the header over them so name and
+            // digits share an edge.
+            HorizontalAlignment = category == PgTypeCategory.Numeric
+                ? Avalonia.Layout.HorizontalAlignment.Right
+                : Avalonia.Layout.HorizontalAlignment.Left,
         };
 
-        if (Converters.PgTypeVisuals.Icon(iconType) is { } icon)
+        if (Converters.PgTypeVisuals.IconFor(category) is { } icon)
         {
             panel.Children.Add(new PathIcon
             {
@@ -2898,7 +2902,7 @@ public partial class MainWindow : Window
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
         });
 
-        if (BuildHeaderTooltip(richType, iconType, meta) is { } tip)
+        if (BuildHeaderTooltip(displayType, category, meta) is { } tip)
         {
             ToolTip.SetTip(panel, tip);
             ToolTip.SetShowDelay(panel, 300);
@@ -2908,16 +2912,16 @@ public partial class MainWindow : Window
     }
 
     // displayType is the declared type shown to the user (a domain keeps its own
-    // name); classifyType is what the family label is derived from (the domain's
-    // base type), so a domain over citext still reads "· Text".
-    private static string? BuildHeaderTooltip(string? displayType, string? classifyType, ColumnDetail? meta)
+    // name); the family label comes from the resolved category, so a domain over
+    // citext still reads "· Text".
+    private static string? BuildHeaderTooltip(string? displayType, PgTypeCategory category, ColumnDetail? meta)
     {
         if (string.IsNullOrEmpty(displayType))
         {
             return null;
         }
 
-        var family = Converters.PgTypeVisuals.Label(classifyType);
+        var family = Converters.PgTypeVisuals.LabelFor(category);
         var text = string.IsNullOrEmpty(family) ? displayType : $"{displayType}  ·  {family}";
 
         if (meta is not null)

--- a/PgNimbus.Core.Tests/Schema/PgTypeCategorizerTests.cs
+++ b/PgNimbus.Core.Tests/Schema/PgTypeCategorizerTests.cs
@@ -98,6 +98,19 @@ public class PgTypeCategorizerTests
     }
 
     [Test]
+    // The editor identifies enum/composite, which a bare name can't.
+    [Arguments("device_status", ColumnValueEditor.Enum, PgTypeCategory.Enum)]
+    [Arguments("address", ColumnValueEditor.Composite, PgTypeCategory.Composite)]
+    // Other editors don't override the name-based family.
+    [Arguments("integer", ColumnValueEditor.Text, PgTypeCategory.Numeric)]
+    [Arguments("boolean", ColumnValueEditor.Boolean, PgTypeCategory.Boolean)]
+    [Arguments("jsonb", ColumnValueEditor.Text, PgTypeCategory.Json)]
+    public async Task CategorizeColumnUsesEditorForEnumAndComposite(string declared, ColumnValueEditor editor, PgTypeCategory expected)
+    {
+        await Assert.That(PgTypeCategorizer.CategorizeColumn(declared, null, editor)).IsEqualTo(expected);
+    }
+
+    [Test]
     // A domain (declared name classifies as Other) falls back to its base type.
     [Arguments("email_addr", "citext", PgTypeCategory.Text)]
     [Arguments("commerce.email_addr", "citext", PgTypeCategory.Text)]

--- a/PgNimbus.Core.Tests/Schema/PgTypeCategorizerTests.cs
+++ b/PgNimbus.Core.Tests/Schema/PgTypeCategorizerTests.cs
@@ -1,0 +1,99 @@
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.Core.Tests.Schema;
+
+public class PgTypeCategorizerTests
+{
+    [Test]
+    // Numeric family — every width/precision and the float/money/oid spellings.
+    [Arguments("smallint", PgTypeCategory.Numeric)]
+    [Arguments("integer", PgTypeCategory.Numeric)]
+    [Arguments("bigint", PgTypeCategory.Numeric)]
+    [Arguments("int4", PgTypeCategory.Numeric)]
+    [Arguments("numeric(10,2)", PgTypeCategory.Numeric)]
+    [Arguments("numeric", PgTypeCategory.Numeric)]
+    [Arguments("double precision", PgTypeCategory.Numeric)]
+    [Arguments("real", PgTypeCategory.Numeric)]
+    [Arguments("money", PgTypeCategory.Numeric)]
+    // Text family.
+    [Arguments("text", PgTypeCategory.Text)]
+    [Arguments("character varying(255)", PgTypeCategory.Text)]
+    [Arguments("character varying", PgTypeCategory.Text)]
+    [Arguments("character(10)", PgTypeCategory.Text)]
+    [Arguments("citext", PgTypeCategory.Text)]
+    [Arguments("name", PgTypeCategory.Text)]
+    // Boolean.
+    [Arguments("boolean", PgTypeCategory.Boolean)]
+    [Arguments("bool", PgTypeCategory.Boolean)]
+    // Date/time family.
+    [Arguments("date", PgTypeCategory.DateTime)]
+    [Arguments("timestamp without time zone", PgTypeCategory.DateTime)]
+    [Arguments("timestamp with time zone", PgTypeCategory.DateTime)]
+    [Arguments("timestamptz", PgTypeCategory.DateTime)]
+    [Arguments("time with time zone", PgTypeCategory.DateTime)]
+    [Arguments("interval", PgTypeCategory.DateTime)]
+    // Singletons.
+    [Arguments("uuid", PgTypeCategory.Uuid)]
+    [Arguments("json", PgTypeCategory.Json)]
+    [Arguments("jsonb", PgTypeCategory.Json)]
+    [Arguments("hstore", PgTypeCategory.Json)]
+    [Arguments("inet", PgTypeCategory.Network)]
+    [Arguments("cidr", PgTypeCategory.Network)]
+    [Arguments("macaddr", PgTypeCategory.Network)]
+    [Arguments("point", PgTypeCategory.Geometric)]
+    [Arguments("polygon", PgTypeCategory.Geometric)]
+    [Arguments("box", PgTypeCategory.Geometric)]
+    [Arguments("bytea", PgTypeCategory.Binary)]
+    [Arguments("bit(8)", PgTypeCategory.BitString)]
+    [Arguments("bit varying", PgTypeCategory.BitString)]
+    [Arguments("varbit", PgTypeCategory.BitString)]
+    [Arguments("vector(3)", PgTypeCategory.Vector)]
+    [Arguments("halfvec", PgTypeCategory.Vector)]
+    [Arguments("tsvector", PgTypeCategory.FullText)]
+    [Arguments("tsquery", PgTypeCategory.FullText)]
+    // Ranges + multiranges.
+    [Arguments("int4range", PgTypeCategory.Range)]
+    [Arguments("numrange", PgTypeCategory.Range)]
+    [Arguments("tstzrange", PgTypeCategory.Range)]
+    [Arguments("int4multirange", PgTypeCategory.Range)]
+    // Unknown / user types fall through.
+    [Arguments("mood", PgTypeCategory.Other)]
+    [Arguments("ltree", PgTypeCategory.Other)]
+    [Arguments("xml", PgTypeCategory.Text)]
+    public async Task Categorizes(string typeName, PgTypeCategory expected)
+    {
+        await Assert.That(PgTypeCategorizer.Categorize(typeName)).IsEqualTo(expected);
+    }
+
+    [Test]
+    // Arrays win over the element family, from either spelling format_type/wire
+    // uses ("integer[]") or the internal catalog spelling ("_int4").
+    [Arguments("integer[]")]
+    [Arguments("text[]")]
+    [Arguments("uuid[]")]
+    [Arguments("numeric(10,2)[]")]
+    [Arguments("_int4")]
+    [Arguments("mood[]")]
+    public async Task ArraysAreArrays(string typeName)
+    {
+        await Assert.That(PgTypeCategorizer.Categorize(typeName)).IsEqualTo(PgTypeCategory.Array);
+    }
+
+    [Test]
+    [Arguments("INTEGER", PgTypeCategory.Numeric)]
+    [Arguments("  jsonb  ", PgTypeCategory.Json)]
+    [Arguments("public.mood", PgTypeCategory.Other)]
+    public async Task NormalizesCaseWhitespaceAndSchema(string typeName, PgTypeCategory expected)
+    {
+        await Assert.That(PgTypeCategorizer.Categorize(typeName)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments(null)]
+    public async Task BlankIsOther(string? typeName)
+    {
+        await Assert.That(PgTypeCategorizer.Categorize(typeName)).IsEqualTo(PgTypeCategory.Other);
+    }
+}

--- a/PgNimbus.Core.Tests/Schema/PgTypeCategorizerTests.cs
+++ b/PgNimbus.Core.Tests/Schema/PgTypeCategorizerTests.cs
@@ -96,4 +96,21 @@ public class PgTypeCategorizerTests
     {
         await Assert.That(PgTypeCategorizer.Categorize(typeName)).IsEqualTo(PgTypeCategory.Other);
     }
+
+    [Test]
+    // A domain (declared name classifies as Other) falls back to its base type.
+    [Arguments("email_addr", "citext", PgTypeCategory.Text)]
+    [Arguments("commerce.email_addr", "citext", PgTypeCategory.Text)]
+    [Arguments("us_postal", "text", PgTypeCategory.Text)]
+    [Arguments("positive_int", "integer", PgTypeCategory.Numeric)]
+    // A declared type that already classifies keeps its own family, base ignored.
+    [Arguments("integer", "text", PgTypeCategory.Numeric)]
+    [Arguments("jsonb", null, PgTypeCategory.Json)]
+    // No base type to fall back to → stays Other.
+    [Arguments("mood", null, PgTypeCategory.Other)]
+    public async Task DomainColumnsClassifyByBaseType(string declared, string? baseType, PgTypeCategory expected)
+    {
+        await Assert.That(PgTypeCategorizer.Categorize(PgTypeCategorizer.ClassifierType(declared, baseType)))
+            .IsEqualTo(expected);
+    }
 }

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -854,10 +854,14 @@ public sealed class QueryEngine
     // that would have read fine arrives as its Postgres literal, which the grid
     // already renders.
     //
-    // bit / bit varying are also requested as text: Npgsql maps them to a
-    // BitArray whose default ToString is just the class name ("System.Collections.
-    // BitArray"), useless in a cell. Its text form is the bit literal ("10110000"),
-    // which is exactly what a user expects to see and edit.
+    // bit / bit varying and hstore are also requested as text: Npgsql maps them to
+    // a BitArray / Dictionary<string,string> whose default ToString is just the
+    // class name ("System.Collections.BitArray", "System.Collections.Generic.
+    // Dictionary`2[…]"), useless in a cell. Their text form is the value itself
+    // (the bit literal "10110000", the hstore literal "\"k\"=>\"v\"") — what a user
+    // expects to see and edit. Both are small, so the extra round trip is cheap.
+    private static readonly Type HstoreType = typeof(System.Collections.Generic.Dictionary<string, string>);
+
     private static bool NeedsTextFormat(NpgsqlDataReader reader, int column)
     {
         if (NeedsTextFormat(reader.GetPostgresType(column)))
@@ -868,7 +872,9 @@ public sealed class QueryEngine
         try
         {
             var clrType = reader.GetFieldType(column);
-            return clrType == typeof(object) || clrType == typeof(System.Collections.BitArray);
+            return clrType == typeof(object)
+                || clrType == typeof(System.Collections.BitArray)
+                || clrType == HstoreType;
         }
         catch
         {

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -853,6 +853,11 @@ public sealed class QueryEngine
     // current. Requesting the column as text is always safe: worst case a value
     // that would have read fine arrives as its Postgres literal, which the grid
     // already renders.
+    //
+    // bit / bit varying are also requested as text: Npgsql maps them to a
+    // BitArray whose default ToString is just the class name ("System.Collections.
+    // BitArray"), useless in a cell. Its text form is the bit literal ("10110000"),
+    // which is exactly what a user expects to see and edit.
     private static bool NeedsTextFormat(NpgsqlDataReader reader, int column)
     {
         if (NeedsTextFormat(reader.GetPostgresType(column)))
@@ -862,7 +867,8 @@ public sealed class QueryEngine
 
         try
         {
-            return reader.GetFieldType(column) == typeof(object);
+            var clrType = reader.GetFieldType(column);
+            return clrType == typeof(object) || clrType == typeof(System.Collections.BitArray);
         }
         catch
         {

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -844,6 +844,33 @@ public sealed class QueryEngine
         _ => false,
     };
 
+    // The same "unreadable as object" failure hits any base type Npgsql has no
+    // handler for — an extension type with no plugin loaded: pgvector's vector /
+    // halfvec / sparsevec, PostGIS geometry, and the like. Npgsql resolves such a
+    // column's CLR type to System.Object (or can't resolve it at all), and
+    // GetValue then throws the identical error. Detecting it by resolved CLR type
+    // rather than by name catches every such type without an allowlist to keep
+    // current. Requesting the column as text is always safe: worst case a value
+    // that would have read fine arrives as its Postgres literal, which the grid
+    // already renders.
+    private static bool NeedsTextFormat(NpgsqlDataReader reader, int column)
+    {
+        if (NeedsTextFormat(reader.GetPostgresType(column)))
+        {
+            return true;
+        }
+
+        try
+        {
+            return reader.GetFieldType(column) == typeof(object);
+        }
+        catch
+        {
+            // No resolvable CLR type at all — GetValue would throw too, so read it as text.
+            return true;
+        }
+    }
+
     /// <summary>
     /// A per-column "request as text" mask for <see cref="NpgsqlCommand.UnknownResultTypeList"/>,
     /// or null when every column materializes fine as-is (the common case — no
@@ -854,7 +881,7 @@ public sealed class QueryEngine
         bool[]? mask = null;
         for (var i = 0; i < reader.FieldCount; i++)
         {
-            if (NeedsTextFormat(reader.GetPostgresType(i)))
+            if (NeedsTextFormat(reader, i))
             {
                 (mask ??= new bool[reader.FieldCount])[i] = true;
             }

--- a/PgNimbus.Core/Schema/PgTypeCategory.cs
+++ b/PgNimbus.Core/Schema/PgTypeCategory.cs
@@ -126,6 +126,19 @@ public static class PgTypeCategorizer
         };
     }
 
+    /// <summary>
+    /// The type name a possibly-domain column should be classified by: the
+    /// domain's resolved base type when the declared type has no category of its
+    /// own (a user domain name is <see cref="PgTypeCategory.Other"/> by name), so
+    /// a domain over citext still reads as Text and a domain over inet as Network.
+    /// Returns <paramref name="declaredType"/> unchanged when it already classifies
+    /// or there's no base type to fall back to.
+    /// </summary>
+    public static string? ClassifierType(string? declaredType, string? domainBaseType) =>
+        !string.IsNullOrWhiteSpace(domainBaseType) && Categorize(declaredType) == PgTypeCategory.Other
+            ? domainBaseType
+            : declaredType;
+
     // The only ranges we treat as ranges by name — user ranges (typtype 'r' with
     // a bespoke name) can't be recognized from the string and stay Other.
     private static bool IsKnownRange(string name) => name is

--- a/PgNimbus.Core/Schema/PgTypeCategory.cs
+++ b/PgNimbus.Core/Schema/PgTypeCategory.cs
@@ -54,6 +54,12 @@ public enum PgTypeCategory
 
     /// <summary>Any array type (integer[], text[], …).</summary>
     Array,
+
+    /// <summary>An enum type — one of a fixed set of labels. Not detectable from a bare name; needs the pg_type kind.</summary>
+    Enum,
+
+    /// <summary>A composite (row) type — a record of named fields. Not detectable from a bare name.</summary>
+    Composite,
 }
 
 /// <summary>
@@ -125,6 +131,21 @@ public static class PgTypeCategorizer
             _ => PgTypeCategory.Other,
         };
     }
+
+    /// <summary>
+    /// Classifies a column using both its type name and the pg_type kind the
+    /// catalog already resolved into a <see cref="ColumnValueEditor"/>. Enum and
+    /// composite types have no category of their own by name (they'd be
+    /// <see cref="PgTypeCategory.Other"/>); the editor is the one signal that tells
+    /// them apart, so it wins. Everything else falls through to the name-based
+    /// <see cref="Categorize(string?)"/> with domains resolved to their base type.
+    /// </summary>
+    public static PgTypeCategory CategorizeColumn(string? declaredType, string? domainBaseType, ColumnValueEditor editor) => editor switch
+    {
+        ColumnValueEditor.Enum => PgTypeCategory.Enum,
+        ColumnValueEditor.Composite => PgTypeCategory.Composite,
+        _ => Categorize(ClassifierType(declaredType, domainBaseType)),
+    };
 
     /// <summary>
     /// The type name a possibly-domain column should be classified by: the

--- a/PgNimbus.Core/Schema/PgTypeCategory.cs
+++ b/PgNimbus.Core/Schema/PgTypeCategory.cs
@@ -1,0 +1,181 @@
+namespace PgNimbus.Core.Schema;
+
+/// <summary>
+/// A broad visual family a Postgres type belongs to, used to pick a single
+/// icon/accent for a column in the schema tree and results grid. This is a
+/// coarser bucket than the exact type — every integer/numeric/float shares the
+/// <see cref="Numeric"/> family, every char/text/varchar shares <see cref="Text"/>,
+/// and so on — so the UI speaks one consistent visual language regardless of the
+/// dozens of concrete type names Postgres reports.
+/// </summary>
+public enum PgTypeCategory
+{
+    /// <summary>Anything without a more specific family (xml, ltree, unknown user types, …).</summary>
+    Other,
+
+    /// <summary>smallint/integer/bigint, numeric/decimal, real/double, money, oid.</summary>
+    Numeric,
+
+    /// <summary>text, varchar, char, name, citext.</summary>
+    Text,
+
+    /// <summary>boolean.</summary>
+    Boolean,
+
+    /// <summary>date, time, timestamp (with/without tz), interval.</summary>
+    DateTime,
+
+    /// <summary>uuid.</summary>
+    Uuid,
+
+    /// <summary>json, jsonb, jsonpath, hstore.</summary>
+    Json,
+
+    /// <summary>inet, cidr, macaddr, macaddr8.</summary>
+    Network,
+
+    /// <summary>point, line, lseg, box, path, polygon, circle.</summary>
+    Geometric,
+
+    /// <summary>int4range/numrange/tstzrange/… and their multirange counterparts.</summary>
+    Range,
+
+    /// <summary>bytea.</summary>
+    Binary,
+
+    /// <summary>bit, bit varying (varbit).</summary>
+    BitString,
+
+    /// <summary>pgvector: vector, halfvec, sparsevec.</summary>
+    Vector,
+
+    /// <summary>tsvector, tsquery.</summary>
+    FullText,
+
+    /// <summary>Any array type (integer[], text[], …).</summary>
+    Array,
+}
+
+/// <summary>
+/// Classifies a Postgres type <em>name</em> into a coarse <see cref="PgTypeCategory"/>.
+/// Deliberately name-based so the same helper works for both the
+/// <c>format_type</c> strings <see cref="SchemaService"/> reads for the schema
+/// tree and the wire-protocol <c>GetDataTypeName</c> strings a result set carries
+/// per column — which are nearly identical spellings. Enum/composite/domain can't
+/// be told apart from a bare name, so those land in a base-type or
+/// <see cref="PgTypeCategory.Other"/> family; callers that already know the
+/// pg_type kind (e.g. the schema tree, via <see cref="ColumnValueEditor"/>) can
+/// refine from there.
+/// </summary>
+public static class PgTypeCategorizer
+{
+    public static PgTypeCategory Categorize(string? typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName))
+        {
+            return PgTypeCategory.Other;
+        }
+
+        var name = Normalize(typeName, out var isArray);
+        if (isArray)
+        {
+            return PgTypeCategory.Array;
+        }
+
+        // Ranges/multiranges: match by suffix so user-defined ranges over a
+        // base type (myrange) are missed (they fall through to Other), but every
+        // built-in *range/*multirange is caught without listing each one.
+        if (name.EndsWith("multirange", StringComparison.Ordinal) ||
+            name.EndsWith("range", StringComparison.Ordinal) && IsKnownRange(name))
+        {
+            return PgTypeCategory.Range;
+        }
+
+        return name switch
+        {
+            "smallint" or "integer" or "bigint" or "int" or "int2" or "int4" or "int8"
+                or "numeric" or "decimal" or "real" or "double precision" or "float4" or "float8"
+                or "money" or "oid" => PgTypeCategory.Numeric,
+
+            "text" or "character varying" or "varchar" or "character" or "char" or "bpchar"
+                or "name" or "citext" or "\"char\"" or "xml" => PgTypeCategory.Text,
+
+            "boolean" or "bool" => PgTypeCategory.Boolean,
+
+            "date" or "timestamp" or "timestamptz" or "timestamp without time zone"
+                or "timestamp with time zone" or "time" or "timetz" or "time without time zone"
+                or "time with time zone" or "interval" => PgTypeCategory.DateTime,
+
+            "uuid" => PgTypeCategory.Uuid,
+
+            "json" or "jsonb" or "jsonpath" or "hstore" => PgTypeCategory.Json,
+
+            "inet" or "cidr" or "macaddr" or "macaddr8" => PgTypeCategory.Network,
+
+            "point" or "line" or "lseg" or "box" or "path" or "polygon" or "circle" => PgTypeCategory.Geometric,
+
+            "bytea" => PgTypeCategory.Binary,
+
+            "bit" or "bit varying" or "varbit" => PgTypeCategory.BitString,
+
+            "vector" or "halfvec" or "sparsevec" => PgTypeCategory.Vector,
+
+            "tsvector" or "tsquery" => PgTypeCategory.FullText,
+
+            _ => PgTypeCategory.Other,
+        };
+    }
+
+    // The only ranges we treat as ranges by name — user ranges (typtype 'r' with
+    // a bespoke name) can't be recognized from the string and stay Other.
+    private static bool IsKnownRange(string name) => name is
+        "int4range" or "int8range" or "numrange" or "tsrange" or "tstzrange" or "daterange";
+
+    /// <summary>
+    /// Lower-cases, drops a length/precision modifier ("numeric(10,2)" → "numeric"),
+    /// strips schema qualification ("public.mood" → "mood"), and reports whether the
+    /// type is an array (trailing "[]" from format_type, or a leading "_" internal
+    /// array name) — with the array marker removed from the returned base name.
+    /// </summary>
+    private static string Normalize(string typeName, out bool isArray)
+    {
+        var span = typeName.AsSpan().Trim();
+
+        // Cut any "(modifier)" — always the tail of the base-type spelling.
+        var paren = span.IndexOf('(');
+        if (paren >= 0)
+        {
+            // Keep a possible "[]" that follows the modifier (e.g. "numeric(10,2)[]").
+            var afterParen = span[paren..];
+            var closer = afterParen.IndexOf(')');
+            var suffix = closer >= 0 ? afterParen[(closer + 1)..] : default;
+            span = string.Concat(span[..paren].ToString(), suffix.ToString()).AsSpan();
+        }
+
+        span = span.Trim();
+
+        isArray = false;
+        if (span.EndsWith("[]"))
+        {
+            isArray = true;
+            span = span[..^2].TrimEnd();
+        }
+
+        // Schema-qualified user types ("public.mood") — keep the local name.
+        var dot = span.LastIndexOf('.');
+        if (dot >= 0)
+        {
+            span = span[(dot + 1)..];
+        }
+
+        var name = span.ToString().ToLowerInvariant();
+
+        // Internal array spelling ("_int4") — only when not already handled above.
+        if (!isArray && name.Length > 1 && name[0] == '_')
+        {
+            isArray = true;
+        }
+
+        return name;
+    }
+}


### PR DESCRIPTION
Iterative UX polish for how pgNimbus surfaces PostgreSQL types — clearer icons per type family, tooltips, and type-aware cell rendering. Built and verified against the demo Neon DB in both light and dark themes each iteration.

## Landed so far
- **Core `PgTypeCategorizer`** — pure, name-based classifier mapping any Postgres type name (`format_type` or wire `GetDataTypeName`) to a coarse `PgTypeCategory` family. Unit-tested.
- **Schema tree icons** — one monochrome MDI glyph per type family next to each column's type (numeric / text / date-time / boolean / uuid / json / network / geometric / range / binary / bit-string / vector / full-text / array). Enum/composite/domain (unresolvable from a bare name) show no icon.

## Planned (tracked in-session)
- Type icons in results-grid column headers (for any query, via `ColumnInfo.DataTypeName`)
- Header + truncated-cell tooltips
- Type-aware cell rendering (numeric right-align/mono, boolean ✓/✗)
- Inspector polish (bytea hex, geometry/vector preview)

Owner review requested — nothing here should be merged without your sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)