### PR TITLE
Schema tree: sequences, types, indexes & triggers + type-aware relation icons

### DIFF
--- a/PgNimbus.App/Converters/RelationKindVisuals.cs
+++ b/PgNimbus.App/Converters/RelationKindVisuals.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.App.Converters;
+
+/// <summary>
+/// Maps a <see cref="RelationKind"/> to the small monochrome icon and friendly
+/// label the schema tree shows for a relation — the same one-icon-plus-tooltip
+/// language the column type family uses (see <see cref="PgTypeVisuals"/>), so a
+/// table, view, materialized view, and partitioned table each read distinctly at
+/// a glance instead of relying on near-identical box glyphs. Geometries are parsed
+/// once and cached; a bad path falls back to no icon rather than throwing.
+/// </summary>
+public static class RelationKindVisuals
+{
+    // 24×24 Material Design Icon paths — same family/style as the icons in Theme.axaml.
+    private static readonly Dictionary<RelationKind, string> Paths = new()
+    {
+        // table
+        [RelationKind.Table] = "M5,4H19A2,2 0 0,1 21,6V17A2,2 0 0,1 19,19H5A2,2 0 0,1 3,17V6A2,2 0 0,1 5,4M5,8V12H11V8H5M13,8V12H19V8H13M5,14V17H11V14H5M13,14V17H19V14H13Z",
+        // eye — a view is a saved SELECT you look through
+        [RelationKind.View] = "M12,9A3,3 0 0,1 15,12A3,3 0 0,1 12,15A3,3 0 0,1 9,12A3,3 0 0,1 12,9M12,4.5C7,4.5 2.73,7.61 1,12C2.73,16.39 7,19.5 12,19.5C17,19.5 21.27,16.39 23,12C21.27,7.61 17,4.5 12,4.5M12,17A5,5 0 0,1 7,12A5,5 0 0,1 12,7A5,5 0 0,1 17,12A5,5 0 0,1 12,17Z",
+        // grid-large — a view with its own materialized storage
+        [RelationKind.MaterializedView] = "M3,3H21V21H3V3M5,5V11H11V5H5M13,5V11H19V5H13M5,13V19H11V13H5M13,13V19H19V13H13Z",
+        // sitemap — a partitioned parent branching into its partitions
+        [RelationKind.PartitionedTable] = "M9,2V8H11V11H5C3.89,11 3,11.89 3,13V16H1V22H7V16H5V13H11V16H9V22H15V16H13V13H19V16H17V22H23V16H21V13C21,11.89 20.1,11 19,11H13V8H15V2H9Z",
+    };
+
+    private static readonly Dictionary<RelationKind, string> Labels = new()
+    {
+        [RelationKind.Table] = "Table",
+        [RelationKind.View] = "View",
+        [RelationKind.MaterializedView] = "Materialized view",
+        [RelationKind.PartitionedTable] = "Partitioned table",
+    };
+
+    private static readonly Dictionary<RelationKind, Geometry?> GeometryCache = new();
+
+    public static string LabelFor(RelationKind kind) =>
+        Labels.TryGetValue(kind, out var label) ? label : "Relation";
+
+    public static Geometry? IconFor(RelationKind kind)
+    {
+        if (GeometryCache.TryGetValue(kind, out var cached))
+        {
+            return cached;
+        }
+
+        Geometry? geometry = null;
+        if (Paths.TryGetValue(kind, out var path))
+        {
+            try
+            {
+                geometry = Geometry.Parse(path);
+            }
+            catch
+            {
+                geometry = null;
+            }
+        }
+
+        GeometryCache[kind] = geometry;
+        return geometry;
+    }
+}
+
+/// <summary>Binds a <see cref="RelationKind"/> to its family icon (a <see cref="Geometry"/>).</summary>
+public sealed class RelationKindIconConverter : IValueConverter
+{
+    public static readonly RelationKindIconConverter Instance = new();
+
+    public object? Convert(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
+        value is RelationKind kind ? RelationKindVisuals.IconFor(kind) : null;
+
+    public object? ConvertBack(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
+        throw new System.NotSupportedException();
+}
+
+/// <summary>Binds a <see cref="RelationKind"/> to its friendly label (for a tooltip).</summary>
+public sealed class RelationKindLabelConverter : IValueConverter
+{
+    public static readonly RelationKindLabelConverter Instance = new();
+
+    public object? Convert(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
+        value is RelationKind kind ? RelationKindVisuals.LabelFor(kind) : string.Empty;
+
+    public object? ConvertBack(object? value, System.Type targetType, object? parameter, CultureInfo culture) =>
+        throw new System.NotSupportedException();
+}

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -180,6 +180,11 @@
         <StreamGeometry x:Key="FunctionIconGeometry">M15.6,5.29C14.5,5.19 13.53,6 13.43,7.11L13.18,10H16V12H13L12.56,17.07C12.37,19.27 10.43,20.9 8.23,20.7C6.92,20.59 5.82,19.86 5.17,18.83L6.67,17.33C6.91,18.11 7.57,18.63 8.43,18.71C9.5,18.81 10.5,18 10.57,16.89L11,12H8V10H11.17L11.44,6.93C11.63,4.73 13.57,3.1 15.77,3.3C17.08,3.41 18.18,4.14 18.83,5.17L17.33,6.67C17.09,5.89 16.43,5.37 15.6,5.29Z</StreamGeometry>
         <StreamGeometry x:Key="PuzzleIconGeometry">M20.5,11H19V7C19,5.89 18.1,5 17,5H13V3.5A2.5,2.5 0 0,0 10.5,1A2.5,2.5 0 0,0 8,3.5V5H4A2,2 0 0,0 2,7V10.8H3.5C5,10.8 6.2,12 6.2,13.5C6.2,15 5,16.2 3.5,16.2H2V20A2,2 0 0,0 4,22H7.8V20.5C7.8,19 9,17.8 10.5,17.8C12,17.8 13.2,19 13.2,20.5V22H17A2,2 0 0,0 19,20V16H20.5A2.5,2.5 0 0,0 23,13.5A2.5,2.5 0 0,0 20.5,11Z</StreamGeometry>
         <StreamGeometry x:Key="AccountMultipleIconGeometry">M16,13C15.71,13 15.38,13 15.03,13.05C16.19,13.89 17,15 17,16.5V19H23V16.5C23,14.17 18.33,13 16,13M8,13C5.67,13 1,14.17 1,16.5V19H15V16.5C15,14.17 10.33,13 8,13M8,11A3,3 0 0,0 11,8A3,3 0 0,0 8,5A3,3 0 0,0 5,8A3,3 0 0,0 8,11M16,11A3,3 0 0,0 19,8A3,3 0 0,0 16,5A3,3 0 0,0 13,8A3,3 0 0,0 16,11Z</StreamGeometry>
+        <!-- Advanced schema-tree groups: counter (sequences) / shape (types) / sort (indexes).
+             Triggers reuse FlashIconGeometry above; individual sequence/index rows reuse these. -->
+        <StreamGeometry x:Key="SequenceIconGeometry">M4,4H20A2,2 0 0,1 22,6V18A2,2 0 0,1 20,20H4A2,2 0 0,1 2,18V6A2,2 0 0,1 4,4M4,6V18H20V6H4M6,9H8V11H6V9M6,13H14V15H6V13M16,13H18V15H16V13M10,9H18V11H10V9Z</StreamGeometry>
+        <StreamGeometry x:Key="ShapeIconGeometry">M11,13.5V21.5H3V13.5H11M12,2L17.5,11H6.5L12,2M17.5,13C20,13 22,15 22,17.5C22,20 20,22 17.5,22C15,22 13,20 13,17.5C13,15 15,13 17.5,13Z</StreamGeometry>
+        <StreamGeometry x:Key="SortIconGeometry">M3,13H15V11H3M3,6V8H21V6M3,18H9V16H3V18Z</StreamGeometry>
         <StreamGeometry x:Key="TuneIconGeometry">M3,17V19H9V17H3M3,5V7H13V5H3M13,21V19H21V17H13V15H11V21H13M7,9V11H3V13H7V15H9V9H7M21,13V11H11V13H21M15,9H17V7H21V5H17V3H15V9Z</StreamGeometry>
         <StreamGeometry x:Key="SwapHorizontalIconGeometry">M21,9L17,5V8H10V10H17V13M7,11L3,15L7,19V16H14V14H7V11Z</StreamGeometry>
         <!-- Editor actions: auto-fix (magic wand) for Format SQL, text-wrap for the word-wrap toggle (MDI). -->

--- a/PgNimbus.App/ViewModels/SchemaNode.cs
+++ b/PgNimbus.App/ViewModels/SchemaNode.cs
@@ -5,13 +5,13 @@ namespace PgNimbus.App.ViewModels;
 public sealed class SchemaNode : SchemaTreeNode
 {
     private readonly SchemaService _schemaService;
-    private readonly Func<bool> _showFunctions;
+    private readonly Func<bool> _showAdvanced;
     private readonly Func<bool> _showSizes;
 
-    public SchemaNode(SchemaService schemaService, string name, Func<bool> showFunctions, Func<bool> showSizes)
+    public SchemaNode(SchemaService schemaService, string name, Func<bool> showAdvanced, Func<bool> showSizes)
     {
         _schemaService = schemaService;
-        _showFunctions = showFunctions;
+        _showAdvanced = showAdvanced;
         _showSizes = showSizes;
         Name = name;
         MarkExpandable();
@@ -20,36 +20,62 @@ public sealed class SchemaNode : SchemaTreeNode
     protected override async Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync()
     {
         var tables = await _schemaService.GetTablesAsync(Name, CancellationToken.None);
-        var children = tables.Select(t => (SchemaTreeNode)new TableNode(_schemaService, Name, t.Name, t.Kind, t.TotalBytes, _showSizes)).ToList();
-        if (_showFunctions())
+        var children = tables
+            .Select(t => (SchemaTreeNode)new TableNode(_schemaService, Name, t.Name, t.Kind, t.TotalBytes, _showSizes, _showAdvanced))
+            .ToList();
+        if (_showAdvanced())
         {
-            // Functions live in a sub-group so a schema with many of them doesn't drown its tables.
-            children.Add(new FunctionsGroupNode(_schemaService, Name));
+            // The advanced schema objects live in their own sub-groups so a schema
+            // with many of them doesn't drown its tables.
+            children.AddRange(AdvancedGroups());
         }
 
         return children;
     }
 
-    /// <summary>
-    /// Adds/removes the "Functions" sub-group in place when the advanced-objects
-    /// toggle flips. Only touches an already-loaded child list — an unloaded
-    /// schema picks the current toggle state up on first expand.
-    /// </summary>
-    public void SetFunctionsGroupVisible(bool visible)
+    private IEnumerable<SchemaTreeNode> AdvancedGroups()
     {
-        var existing = Children.OfType<FunctionsGroupNode>().FirstOrDefault();
-        if (visible == (existing is not null))
+        yield return new FunctionsGroupNode(_schemaService, Name);
+        yield return new SequencesGroupNode(_schemaService, Name);
+        yield return new TypesGroupNode(_schemaService, Name);
+    }
+
+    /// <summary>
+    /// Adds/removes the advanced sub-groups (Functions, Sequences, Types) in place
+    /// when the advanced-objects toggle flips, and cascades the same flip to each
+    /// loaded table's own Indexes/Triggers sub-groups. Only touches an already-loaded
+    /// child list — an unloaded schema picks the current toggle state up on first expand.
+    /// </summary>
+    public void SetAdvancedGroupsVisible(bool visible)
+    {
+        // A not-yet-loaded (placeholder) or errored schema has no real children to flip.
+        if (Children.Any(c => c is PlaceholderNode or ErrorNode))
         {
             return;
         }
 
-        if (!visible)
+        var hasGroups = Children.Any(c => c is FunctionsGroupNode);
+        if (visible && !hasGroups)
         {
-            Children.Remove(existing!);
+            foreach (var group in AdvancedGroups())
+            {
+                Children.Add(group);
+            }
         }
-        else if (!Children.Any(c => c is PlaceholderNode or ErrorNode))
+        else if (!visible && hasGroups)
         {
-            Children.Add(new FunctionsGroupNode(_schemaService, Name));
+            foreach (var group in Children.Where(IsAdvancedGroup).ToList())
+            {
+                Children.Remove(group);
+            }
+        }
+
+        foreach (var table in Children.OfType<TableNode>())
+        {
+            table.SetAdvancedSubGroupsVisible(visible);
         }
     }
+
+    private static bool IsAdvancedGroup(SchemaTreeNode node) =>
+        node is FunctionsGroupNode or SequencesGroupNode or TypesGroupNode;
 }

--- a/PgNimbus.App/ViewModels/SchemaObjectNodes.cs
+++ b/PgNimbus.App/ViewModels/SchemaObjectNodes.cs
@@ -1,0 +1,266 @@
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.App.ViewModels;
+
+/// <summary>"Sequences" group under a schema — lazily lists that schema's sequences.</summary>
+public sealed class SequencesGroupNode : SchemaTreeNode
+{
+    private readonly SchemaService _schemaService;
+
+    public SequencesGroupNode(SchemaService schemaService, string schema)
+    {
+        _schemaService = schemaService;
+        Schema = schema;
+        Name = "Sequences";
+        MarkExpandable();
+    }
+
+    public string Schema { get; }
+
+    protected override async Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync()
+    {
+        var sequences = await _schemaService.GetSequencesAsync(Schema, CancellationToken.None);
+        if (sequences.Count == 0)
+        {
+            return [new EmptyNode { Name = "No sequences" }];
+        }
+
+        return sequences.Select(s => (SchemaTreeNode)new SequenceNode(s)).ToList();
+    }
+}
+
+public sealed class SequenceNode : SchemaTreeNode
+{
+    public SequenceNode(SequenceInfo info)
+    {
+        Name = info.Name;
+        DataType = info.DataType;
+        IncrementBy = info.IncrementBy;
+        LastValue = info.LastValue;
+        StartValue = info.StartValue;
+        MinValue = info.MinValue;
+        MaxValue = info.MaxValue;
+        Cycle = info.Cycle;
+    }
+
+    public string DataType { get; }
+
+    public long IncrementBy { get; }
+
+    public long? LastValue { get; }
+
+    public long StartValue { get; }
+
+    public long MinValue { get; }
+
+    public long MaxValue { get; }
+
+    public bool Cycle { get; }
+
+    /// <summary>The dim detail after the name — the value type and, if the sequence has advanced, its current value.</summary>
+    public string Detail => LastValue is { } last ? $"{DataType}  ·  at {last}" : DataType;
+
+    public string Tooltip
+    {
+        get
+        {
+            var parts = new List<string>
+            {
+                $"{Name}  ({DataType})",
+                $"increment {IncrementBy}",
+                LastValue is { } last ? $"current {last}" : "not yet used",
+                $"range {MinValue} … {MaxValue}",
+            };
+            if (Cycle)
+            {
+                parts.Add("cycles");
+            }
+
+            return string.Join("\n", parts);
+        }
+    }
+}
+
+/// <summary>"Types" group under a schema — user-defined enums, composites, and domains.</summary>
+public sealed class TypesGroupNode : SchemaTreeNode
+{
+    private readonly SchemaService _schemaService;
+
+    public TypesGroupNode(SchemaService schemaService, string schema)
+    {
+        _schemaService = schemaService;
+        Schema = schema;
+        Name = "Types";
+        MarkExpandable();
+    }
+
+    public string Schema { get; }
+
+    protected override async Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync()
+    {
+        var types = await _schemaService.GetUserTypesAsync(Schema, CancellationToken.None);
+        if (types.Count == 0)
+        {
+            return [new EmptyNode { Name = "No user types" }];
+        }
+
+        return types.Select(t => (SchemaTreeNode)new UserTypeNode(t)).ToList();
+    }
+}
+
+public sealed class UserTypeNode : SchemaTreeNode
+{
+    public UserTypeNode(UserTypeInfo info)
+    {
+        Name = info.Name;
+        TypType = info.TypType;
+        EnumLabels = info.EnumLabels;
+        CompositeFields = info.CompositeFields;
+        DomainBaseType = info.DomainBaseType;
+        DomainNotNull = info.DomainNotNull;
+
+        // Reuse the column type-icon language: enums and composites have their own
+        // family icon; a domain reads as its underlying base type's family.
+        Category = TypType switch
+        {
+            'e' => PgTypeCategory.Enum,
+            'c' => PgTypeCategory.Composite,
+            'd' => PgTypeCategorizer.Categorize(DomainBaseType),
+            _ => PgTypeCategory.Other,
+        };
+    }
+
+    /// <summary>pg_type.typtype: e(num), c(omposite), d(omain).</summary>
+    public char TypType { get; }
+
+    public IReadOnlyList<string> EnumLabels { get; }
+
+    public IReadOnlyList<string> CompositeFields { get; }
+
+    public string? DomainBaseType { get; }
+
+    public bool DomainNotNull { get; }
+
+    /// <summary>The type family driving the icon shown next to the name (see <see cref="Category"/>).</summary>
+    public PgTypeCategory Category { get; }
+
+    /// <summary>The dim detail after the name — kind plus a compact summary of the type's shape.</summary>
+    public string Detail => TypType switch
+    {
+        'e' => $"enum  ·  {EnumLabels.Count} label{(EnumLabels.Count == 1 ? "" : "s")}",
+        'c' => $"composite  ·  {CompositeFields.Count} field{(CompositeFields.Count == 1 ? "" : "s")}",
+        'd' => DomainNotNull ? $"domain → {DomainBaseType}  ·  NOT NULL" : $"domain → {DomainBaseType}",
+        _ => string.Empty,
+    };
+
+    public string Tooltip => TypType switch
+    {
+        'e' => EnumLabels.Count == 0 ? Name : string.Join("  |  ", EnumLabels),
+        'c' => CompositeFields.Count == 0 ? Name : string.Join("\n", CompositeFields),
+        'd' => DomainNotNull ? $"domain over {DomainBaseType} (NOT NULL)" : $"domain over {DomainBaseType}",
+        _ => Name,
+    };
+}
+
+/// <summary>"Indexes" sub-group under a table/matview — lazily lists its indexes.</summary>
+public sealed class IndexesGroupNode : SchemaTreeNode
+{
+    private readonly SchemaService _schemaService;
+
+    public IndexesGroupNode(SchemaService schemaService, string schema, string table)
+    {
+        _schemaService = schemaService;
+        Schema = schema;
+        Table = table;
+        Name = "Indexes";
+        MarkExpandable();
+    }
+
+    public string Schema { get; }
+
+    public string Table { get; }
+
+    protected override async Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync()
+    {
+        var indexes = await _schemaService.GetIndexesAsync(Schema, Table, CancellationToken.None);
+        if (indexes.Count == 0)
+        {
+            return [new EmptyNode { Name = "No indexes" }];
+        }
+
+        return indexes.Select(i => (SchemaTreeNode)new IndexNode(i)).ToList();
+    }
+}
+
+public sealed class IndexNode : SchemaTreeNode
+{
+    public IndexNode(IndexInfo info)
+    {
+        Name = info.Name;
+        IsUnique = info.IsUnique;
+        IsPrimary = info.IsPrimary;
+        Definition = info.Definition;
+    }
+
+    public bool IsUnique { get; }
+
+    public bool IsPrimary { get; }
+
+    public string Definition { get; }
+
+    /// <summary>The dim tag after the name: primary key / unique / (nothing for a plain index).</summary>
+    public string Detail => IsPrimary ? "primary key" : IsUnique ? "unique" : string.Empty;
+
+    /// <summary>The full CREATE INDEX definition, shown on hover.</summary>
+    public string Tooltip => Definition;
+}
+
+/// <summary>"Triggers" sub-group under a table/view — lazily lists its user triggers.</summary>
+public sealed class TriggersGroupNode : SchemaTreeNode
+{
+    private readonly SchemaService _schemaService;
+
+    public TriggersGroupNode(SchemaService schemaService, string schema, string table)
+    {
+        _schemaService = schemaService;
+        Schema = schema;
+        Table = table;
+        Name = "Triggers";
+        MarkExpandable();
+    }
+
+    public string Schema { get; }
+
+    public string Table { get; }
+
+    protected override async Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync()
+    {
+        var triggers = await _schemaService.GetTriggersAsync(Schema, Table, CancellationToken.None);
+        if (triggers.Count == 0)
+        {
+            return [new EmptyNode { Name = "No triggers" }];
+        }
+
+        return triggers.Select(t => (SchemaTreeNode)new TriggerNode(t)).ToList();
+    }
+}
+
+public sealed class TriggerNode : SchemaTreeNode
+{
+    public TriggerNode(TriggerInfo info)
+    {
+        Name = info.Name;
+        Enabled = info.Enabled;
+        Definition = info.Definition;
+    }
+
+    public bool Enabled { get; }
+
+    public string Definition { get; }
+
+    /// <summary>A dim "disabled" tag for a trigger that won't fire; empty when enabled.</summary>
+    public string Detail => Enabled ? string.Empty : "disabled";
+
+    /// <summary>The full CREATE TRIGGER definition, shown on hover.</summary>
+    public string Tooltip => Definition;
+}

--- a/PgNimbus.App/ViewModels/SchemaTreeNode.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeNode.cs
@@ -73,3 +73,6 @@ public abstract partial class SchemaTreeNode : ObservableObject
 public sealed class PlaceholderNode : SchemaTreeNode;
 
 public sealed class ErrorNode : SchemaTreeNode;
+
+/// <summary>A dim "(nothing here)" leaf shown when a loaded group turns out to be empty.</summary>
+public sealed class EmptyNode : SchemaTreeNode;

--- a/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
@@ -47,10 +47,11 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
 
     /// <summary>
     /// The sidebar's "advanced objects" toggle. Off (the default), the tree
-    /// shows just schemas/tables and Roles; on, each schema also gets its
-    /// Functions group and the root gains the Extensions group. Purely a
-    /// declutter switch — the advanced groups are lazy either way, so the
-    /// toggle never costs a catalog query by itself.
+    /// shows just schemas/tables and Roles; on, each schema gains its Functions,
+    /// Sequences, and Types sub-groups, each table gains Indexes/Triggers
+    /// sub-groups, and the root gains the Extensions group. Purely a declutter
+    /// switch — the advanced groups are lazy either way, so the toggle never costs
+    /// a catalog query by itself.
     /// </summary>
     [ObservableProperty]
     private bool _showAdvancedObjects;
@@ -115,7 +116,7 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
 
         foreach (var schema in Schemas.OfType<SchemaNode>())
         {
-            schema.SetFunctionsGroupVisible(value);
+            schema.SetAdvancedGroupsVisible(value);
         }
 
         // Newly inserted nodes default to visible; a live filter has to vet them.

--- a/PgNimbus.App/ViewModels/TableNode.cs
+++ b/PgNimbus.App/ViewModels/TableNode.cs
@@ -7,8 +7,11 @@ public sealed class TableNode : SchemaTreeNode
 {
     private readonly SchemaService _schemaService;
     private readonly Func<bool> _showSizes;
+    private readonly Func<bool> _showAdvanced;
 
-    public TableNode(SchemaService schemaService, string schema, string name, RelationKind kind, long? totalBytes = null, Func<bool>? showSizes = null)
+    public TableNode(
+        SchemaService schemaService, string schema, string name, RelationKind kind,
+        long? totalBytes = null, Func<bool>? showSizes = null, Func<bool>? showAdvanced = null)
     {
         _schemaService = schemaService;
         Schema = schema;
@@ -16,6 +19,7 @@ public sealed class TableNode : SchemaTreeNode
         Kind = kind;
         TotalBytes = totalBytes;
         _showSizes = showSizes ?? (static () => false);
+        _showAdvanced = showAdvanced ?? (static () => false);
         MarkExpandable();
     }
 
@@ -35,18 +39,63 @@ public sealed class TableNode : SchemaTreeNode
     /// <summary>Re-evaluate <see cref="SizeText"/> after the sidebar's "show sizes" toggle flips.</summary>
     public void NotifySizeVisibilityChanged() => OnPropertyChanged(nameof(SizeText));
 
-    public string Glyph => Kind switch
-    {
-        RelationKind.Table => "▤",
-        RelationKind.View => "▥",
-        RelationKind.MaterializedView => "▦",
-        RelationKind.PartitionedTable => "▧",
-        _ => "▤",
-    };
+    /// <summary>Only relations with real storage carry indexes (tables, matviews, partitioned parents) — not plain views.</summary>
+    private bool CanHaveIndexes => Kind is RelationKind.Table or RelationKind.MaterializedView or RelationKind.PartitionedTable;
+
+    /// <summary>Triggers can sit on tables, (INSTEAD OF) views, and partitioned parents — but not on materialized views.</summary>
+    private bool CanHaveTriggers => Kind is RelationKind.Table or RelationKind.View or RelationKind.PartitionedTable;
 
     protected override async Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync()
     {
         var columns = await _schemaService.GetColumnsAsync(Schema, Name, CancellationToken.None);
-        return columns.Select(c => (SchemaTreeNode)new ColumnNode(c)).ToList();
+        var children = columns.Select(c => (SchemaTreeNode)new ColumnNode(c)).ToList();
+        if (_showAdvanced())
+        {
+            children.AddRange(AdvancedSubGroups());
+        }
+
+        return children;
+    }
+
+    private IEnumerable<SchemaTreeNode> AdvancedSubGroups()
+    {
+        if (CanHaveIndexes)
+        {
+            yield return new IndexesGroupNode(_schemaService, Schema, Name);
+        }
+
+        if (CanHaveTriggers)
+        {
+            yield return new TriggersGroupNode(_schemaService, Schema, Name);
+        }
+    }
+
+    /// <summary>
+    /// Adds/removes this table's Indexes/Triggers sub-groups in place when the
+    /// advanced-objects toggle flips. Only touches an already-loaded (column) child
+    /// list — an unexpanded table picks the current toggle state up on first expand.
+    /// </summary>
+    public void SetAdvancedSubGroupsVisible(bool visible)
+    {
+        if (Children.Any(c => c is PlaceholderNode or ErrorNode))
+        {
+            return;
+        }
+
+        var hasGroups = Children.Any(c => c is IndexesGroupNode or TriggersGroupNode);
+        if (visible && !hasGroups)
+        {
+            foreach (var group in AdvancedSubGroups())
+            {
+                Children.Add(group);
+            }
+        }
+        else if (!visible && hasGroups)
+        {
+            foreach (var group in Children.Where(c => c is IndexesGroupNode or TriggersGroupNode).ToList())
+            {
+                Children.Remove(group);
+            }
+        }
     }
 }

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -36,7 +36,13 @@
                         <MenuItem Header="Alter Table..." Tag="{Binding}" Click="OnAlterTableClick" />
                     </ContextMenu>
                 </StackPanel.ContextMenu>
-                <TextBlock Text="{Binding Glyph}" />
+                <!-- One family icon per relation kind (table/view/matview/partitioned)
+                     with the exact kind on hover — same one-glyph-plus-tooltip
+                     language the column type family uses -->
+                <PathIcon Data="{Binding Kind, Converter={x:Static conv2:RelationKindIconConverter.Instance}}"
+                          Width="12" Height="12" VerticalAlignment="Center" Opacity="0.75"
+                          ToolTip.Tip="{Binding Kind, Converter={x:Static conv2:RelationKindLabelConverter.Instance}}"
+                          ToolTip.ShowDelay="300" />
                 <TextBlock Text="{Binding Name}" />
                 <!-- Dim on-disk size hint (heap + indexes + TOAST); blank for views/partitioned parents -->
                 <TextBlock Text="{Binding SizeText}" Opacity="0.5" FontSize="11" VerticalAlignment="Center" />
@@ -114,6 +120,64 @@
                 <TextBlock Text="{Binding Name}" />
                 <TextBlock Text="{Binding AttributesLabel}" Opacity="0.6" FontSize="11" VerticalAlignment="Center" />
             </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:SequencesGroupNode">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <PathIcon Data="{StaticResource SequenceIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" Opacity="0.8" />
+                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Opacity="0.85" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:SequenceNode">
+            <StackPanel Orientation="Horizontal" Spacing="6" ToolTip.Tip="{Binding Tooltip}" ToolTip.ShowDelay="200">
+                <PathIcon Data="{StaticResource SequenceIconGeometry}" Width="11" Height="11" Opacity="0.5" VerticalAlignment="Center" />
+                <TextBlock Text="{Binding Name}" />
+                <TextBlock Text="{Binding Detail}" Opacity="0.6" FontSize="11" VerticalAlignment="Center" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:TypesGroupNode">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <PathIcon Data="{StaticResource ShapeIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" Opacity="0.8" />
+                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Opacity="0.85" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:UserTypeNode">
+            <StackPanel Orientation="Horizontal" Spacing="6" ToolTip.Tip="{Binding Tooltip}" ToolTip.ShowDelay="200">
+                <!-- Reuse the column type-family icon language: enum/composite have
+                     their own glyph; a domain shows its base type's family icon -->
+                <PathIcon Data="{Binding Category, Converter={x:Static conv2:PgTypeIconConverter.Instance}}"
+                          Width="11" Height="11" Opacity="0.55" VerticalAlignment="Center" />
+                <TextBlock Text="{Binding Name}" />
+                <TextBlock Text="{Binding Detail}" Opacity="0.6" FontSize="11" VerticalAlignment="Center" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:IndexesGroupNode">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <PathIcon Data="{StaticResource SortIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" Opacity="0.8" />
+                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Opacity="0.85" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:IndexNode">
+            <StackPanel Orientation="Horizontal" Spacing="6" ToolTip.Tip="{Binding Tooltip}" ToolTip.ShowDelay="200">
+                <PathIcon Data="{StaticResource SortIconGeometry}" Width="11" Height="11" Opacity="0.5" VerticalAlignment="Center" />
+                <TextBlock Text="{Binding Name}" />
+                <TextBlock Text="{Binding Detail}" Opacity="0.6" FontSize="11" VerticalAlignment="Center" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:TriggersGroupNode">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <PathIcon Data="{StaticResource FlashIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" Opacity="0.8" />
+                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Opacity="0.85" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:TriggerNode">
+            <StackPanel Orientation="Horizontal" Spacing="6" ToolTip.Tip="{Binding Tooltip}" ToolTip.ShowDelay="200">
+                <PathIcon Data="{StaticResource FlashIconGeometry}" Width="11" Height="11" Opacity="0.5" VerticalAlignment="Center" />
+                <TextBlock Text="{Binding Name}" />
+                <TextBlock Text="{Binding Detail}" Opacity="0.6" FontSize="11" VerticalAlignment="Center" />
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="vm:EmptyNode">
+            <TextBlock Text="{Binding Name}" Opacity="0.45" FontStyle="Italic" />
         </DataTemplate>
         <DataTemplate DataType="vm:PlaceholderNode">
             <TextBlock Text="Loading..." Opacity="0.5" FontStyle="Italic" />
@@ -264,10 +328,11 @@
                             ToolTip.Tip="Refresh database &amp; schema (Ctrl+Shift+R)">
                         <PathIcon Data="{StaticResource RefreshIconGeometry}" Width="14" Height="14" />
                     </Button>
-                    <!-- Advanced-objects toggle: off = schemas/tables + Roles only; on adds Functions groups and Extensions -->
+                    <!-- Advanced-objects toggle: off = schemas/tables + Roles only; on adds
+                         Functions/Sequences/Types groups, per-table Indexes/Triggers, and Extensions -->
                     <ToggleButton DockPanel.Dock="Right" Classes="chip" Padding="5" Margin="6,0,0,0"
                                   VerticalAlignment="Center" IsChecked="{Binding SchemaTree.ShowAdvancedObjects}"
-                                  ToolTip.Tip="Show advanced objects (functions &amp; extensions)">
+                                  ToolTip.Tip="Show advanced objects (functions, sequences, types, indexes, triggers, extensions)">
                         <PathIcon Data="{StaticResource TuneIconGeometry}" Width="14" Height="14" />
                     </ToggleButton>
                     <!-- Type-to-filter box: matches schema and loaded-table names, case-insensitive substring -->

--- a/PgNimbus.Core/Schema/SchemaService.cs
+++ b/PgNimbus.Core/Schema/SchemaService.cs
@@ -61,6 +61,32 @@ public sealed record ExtensionInfo(string Name, string? InstalledVersion, string
 public sealed record RoleInfo(string Name, bool CanLogin, bool IsSuperuser, bool CanCreateDb, bool CanCreateRole);
 
 /// <summary>
+/// A sequence (pg_sequences). <paramref name="LastValue"/> is null when the
+/// sequence has never been advanced (no <c>nextval</c> yet), which pg reports as
+/// a null last_value rather than the start value.
+/// </summary>
+public sealed record SequenceInfo(
+    string Name, string DataType, long IncrementBy, long? LastValue,
+    long StartValue, long MinValue, long MaxValue, bool Cycle);
+
+/// <summary>
+/// A user-defined type: enum (<c>e</c>), composite (<c>c</c>), or domain (<c>d</c>),
+/// per pg_type.typtype. Only the fields relevant to the kind are populated —
+/// <paramref name="EnumLabels"/> for enums, <paramref name="CompositeFields"/> for
+/// composites, <paramref name="DomainBaseType"/>/<paramref name="DomainNotNull"/>
+/// for domains — the rest are empty/default.
+/// </summary>
+public sealed record UserTypeInfo(
+    string Name, char TypType, string? DomainBaseType, bool DomainNotNull,
+    IReadOnlyList<string> EnumLabels, IReadOnlyList<string> CompositeFields);
+
+/// <summary>An index on a relation. <paramref name="Definition"/> is the full <c>pg_get_indexdef</c> for the tooltip.</summary>
+public sealed record IndexInfo(string Name, bool IsUnique, bool IsPrimary, string Definition);
+
+/// <summary>A user (non-internal) trigger. <paramref name="Definition"/> is the full <c>pg_get_triggerdef</c>; <paramref name="Enabled"/> is false only for a fully-disabled trigger.</summary>
+public sealed record TriggerInfo(string Name, string Definition, bool Enabled);
+
+/// <summary>
 /// A foreign key edge: <paramref name="FromColumns"/> on <paramref name="FromSchema"/>.<paramref name="FromTable"/>
 /// (the referencing/"child" side) reference <paramref name="ToColumns"/> on
 /// <paramref name="ToSchema"/>.<paramref name="ToTable"/> (the referenced/"parent" side), positionally paired.
@@ -509,6 +535,152 @@ public sealed class SchemaService
             results.Add(new ForeignKeyInfo(
                 reader.GetString(0), reader.GetString(1), reader.GetFieldValue<string[]>(2),
                 reader.GetString(3), reader.GetString(4), reader.GetFieldValue<string[]>(5)));
+        }
+
+        return results;
+    }
+
+    /// <summary>Sequences in a schema (pg_sequences), with the headline numbers worth a tooltip.</summary>
+    public async Task<IReadOnlyList<SequenceInfo>> GetSequencesAsync(string schema, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT s.sequencename, s.data_type::text, s.increment_by, s.last_value,
+                   s.start_value, s.min_value, s.max_value, s.cycle
+            FROM pg_catalog.pg_sequences s
+            WHERE s.schemaname = @schema
+            ORDER BY s.sequencename
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("schema", schema);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<SequenceInfo>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new SequenceInfo(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetInt64(2),
+                reader.IsDBNull(3) ? null : reader.GetInt64(3),
+                reader.GetInt64(4),
+                reader.GetInt64(5),
+                reader.GetInt64(6),
+                reader.GetBoolean(7)));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// User-defined types in a schema: enums, standalone composites, and domains.
+    /// Table row-types (the composite pg auto-creates per table) and array types
+    /// are excluded — only types a user actually declares. Each row carries just
+    /// the detail its kind needs (enum labels / composite fields / domain base).
+    /// </summary>
+    public async Task<IReadOnlyList<UserTypeInfo>> GetUserTypesAsync(string schema, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT t.typname,
+                   t.typtype::text,
+                   CASE WHEN t.typtype = 'd' THEN pg_catalog.format_type(t.typbasetype, t.typtypmod) END,
+                   CASE WHEN t.typtype = 'd' THEN t.typnotnull ELSE false END,
+                   CASE WHEN t.typtype = 'e' THEN
+                       (SELECT array_agg(e.enumlabel ORDER BY e.enumsortorder)
+                        FROM pg_catalog.pg_enum e WHERE e.enumtypid = t.oid)
+                   END,
+                   CASE WHEN t.typtype = 'c' THEN
+                       (SELECT array_agg(a.attname || ' ' || pg_catalog.format_type(a.atttypid, a.atttypmod) ORDER BY a.attnum)
+                        FROM pg_catalog.pg_attribute a
+                        WHERE a.attrelid = t.typrelid AND a.attnum > 0 AND NOT a.attisdropped)
+                   END
+            FROM pg_catalog.pg_type t
+            JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+            WHERE n.nspname = @schema
+              AND t.typtype IN ('e', 'c', 'd')
+              AND (t.typrelid = 0
+                   OR EXISTS (SELECT 1 FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid AND c.relkind = 'c'))
+            ORDER BY t.typname
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("schema", schema);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<UserTypeInfo>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new UserTypeInfo(
+                reader.GetString(0),
+                reader.GetString(1)[0],
+                reader.IsDBNull(2) ? null : reader.GetString(2),
+                reader.GetBoolean(3),
+                reader.IsDBNull(4) ? [] : reader.GetFieldValue<string[]>(4),
+                reader.IsDBNull(5) ? [] : reader.GetFieldValue<string[]>(5)));
+        }
+
+        return results;
+    }
+
+    /// <summary>Indexes on a relation, primary key first, each with its full definition for a tooltip.</summary>
+    public async Task<IReadOnlyList<IndexInfo>> GetIndexesAsync(string schema, string table, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT ic.relname, i.indisunique, i.indisprimary, pg_catalog.pg_get_indexdef(i.indexrelid)
+            FROM pg_catalog.pg_index i
+            JOIN pg_catalog.pg_class ic ON ic.oid = i.indexrelid
+            JOIN pg_catalog.pg_class tc ON tc.oid = i.indrelid
+            JOIN pg_catalog.pg_namespace n ON n.oid = tc.relnamespace
+            WHERE n.nspname = @schema AND tc.relname = @table
+            ORDER BY i.indisprimary DESC, ic.relname
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("schema", schema);
+        command.Parameters.AddWithValue("table", table);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<IndexInfo>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new IndexInfo(
+                reader.GetString(0),
+                reader.GetBoolean(1),
+                reader.GetBoolean(2),
+                reader.GetString(3)));
+        }
+
+        return results;
+    }
+
+    /// <summary>User (non-internal) triggers on a relation. Constraint/FK-enforcement triggers are excluded via tgisinternal.</summary>
+    public async Task<IReadOnlyList<TriggerInfo>> GetTriggersAsync(string schema, string table, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT t.tgname, pg_catalog.pg_get_triggerdef(t.oid, true), (t.tgenabled <> 'D')
+            FROM pg_catalog.pg_trigger t
+            JOIN pg_catalog.pg_class c ON c.oid = t.tgrelid
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = @schema AND c.relname = @table AND NOT t.tgisinternal
+            ORDER BY t.tgname
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("schema", schema);
+        command.Parameters.AddWithValue("table", table);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<TriggerInfo>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new TriggerInfo(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetBoolean(2)));
         }
 
         return results;


### PR DESCRIPTION
## What

Curated expansion of the schema sidebar — the object types a Postgres-first daily driver actually reaches for — plus the icon/tooltip polish to match the type-aware SQL results work (#146). All new groups sit behind the **existing** "advanced objects" toggle, so the default (tables-only) view is unchanged and no new always-visible control is added (UI rule 1).

Deliberately **not** copied from pgAdmin (kept out to avoid overload): Casts, Catalogs, Event Triggers, FDW/Foreign Tables, Languages, Publications/Subscriptions, Operators, Collations, FTS*, Tablespaces, Replica Nodes.

## New object types

`SchemaService` reads `pg_catalog` directly (rule 3):

- **Sequences** (per schema) — `pg_sequences`; tooltip with increment / current value / range; owned identity sequences show as `bigint` (null `last_value`).
- **Types** (per schema) — user **enums / composites / domains**, reusing the column type-family icons (enum & composite glyphs; a domain reads as its base type's family). Detail shows label/field count, or `domain → base · NOT NULL`.
- **Indexes** (per table / matview / partitioned parent) — `pg_get_indexdef`; `primary key` / `unique` tag; PK-first.
- **Triggers** (per table / view / partitioned parent) — user (non-internal) triggers only; `disabled` tag; full `pg_get_triggerdef` on hover.

## Polish

- Relation rows now render a **distinct `PathIcon` per kind** (table / view / materialized view / partitioned table) with the exact kind on hover, via a new `RelationKindVisuals` converter — replacing the near-identical `▤▥▦▧` box glyphs that carried no tooltip. Same one-icon-plus-tooltip language the column type family already speaks.

## Behavior

- The advanced toggle flips every group **in place** (schema-level Functions/Sequences/Types and per-table Indexes/Triggers) with no refetch — same pattern as the existing Functions/Extensions toggle. Groups stay lazy.
- Empty groups render a dim italic `(none)` leaf.

## Verification

- `dotnet build` clean (compiled bindings validate every new binding path).
- 445/445 Core tests pass.
- Seeded a `postgres:17` with a schema covering every new type (enum, domain, composite, sequences incl. an identity-owned one, unique/plain indexes, a table trigger, a view, a matview): all four new catalog queries return correct rows, and the live UI renders every new node with the right icon and detail text (screenshotted via the Avalonia DevTools MCP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)