### PR TITLE
Add critical-error logging and a crash handler window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,32 @@ and wrong project memory is worse than none.
    permission-restricted file fallback elsewhere via
    `PlainFileCredentialStore`) at connect time, never persisted on the
    profile record itself.
+5. **Crashes are logged and shown, never silent.** Critical/unhandled errors
+   append to a plain-text log at `<appdata>/pgNimbus/logs/pgnimbus.log`
+   (`PgNimbus.Core.Diagnostics.CrashLog` does the file I/O — directory-injectable
+   and unit-tested — with the process-wide `CrashLogger` static as the facade;
+   1 MiB rolling to `pgnimbus.log.old`, every write swallows its own failure so
+   logging a crash can never itself throw). The App wires three global hooks in
+   `PgNimbus.App/Diagnostics/CrashReporter.cs`: `AppDomain.UnhandledException`
+   and `TaskScheduler.UnobservedTaskException` (log only — off the UI thread,
+   the process is usually already terminating), plus
+   `Dispatcher.UIThread.UnhandledException` (`AttachToDispatcher`, called from
+   `App.OnFrameworkInitializationCompleted`) which is the real UI-thread net —
+   it sets `e.Handled` and shows the crash window, then shuts the app down when
+   it's dismissed. A startup/setup crash that escapes the message loop entirely
+   is caught in `Program.Main`'s try/catch → `HandleFatal`, which shows the same
+   `CrashWindow` by pumping a nested `DispatcherFrame` (the primary loop is gone
+   by then). Landmines learned the hard way: a second `AppBuilder.Configure`
+   throws "Setup was already called", so the crash window must reuse the
+   already-initialized platform, never stand up a fresh Avalonia app; and
+   `DispatcherTimer.Tick` exceptions are swallowed by Avalonia and never reach
+   `Dispatcher.UnhandledException` (async-void handlers / posted continuations
+   do), so don't rely on a timer to smoke-test the reporter. `CrashWindow`
+   (`Views/CrashWindow.axaml`) is deliberately self-contained (no view model,
+   touches no app services — it must render with the rest of the app broken):
+   it shows the error, the on-disk log path, and a "Report on GitHub" button
+   that opens a pre-filled new-issue URL (title/body/labels query params,
+   including version + OS).
 
 ## UI design rules
 

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -151,6 +151,11 @@ public partial class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        // Catch exceptions thrown on the UI thread once the loop is running
+        // (event handlers, async-void continuations, posted jobs) so they
+        // surface in the crash window instead of taking the app down silently.
+        Diagnostics.CrashReporter.AttachToDispatcher();
+
         // Restore the saved light/dark choice before any window resolves its
         // ActualThemeVariant, so the first frame already paints in the right theme.
         ApplyPersistedTheme();

--- a/PgNimbus.App/Diagnostics/CrashReporter.cs
+++ b/PgNimbus.App/Diagnostics/CrashReporter.cs
@@ -1,0 +1,170 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
+using PgNimbus.App.Views;
+using PgNimbus.Core.Diagnostics;
+
+namespace PgNimbus.App.Diagnostics;
+
+/// <summary>
+/// The app's global crash handling. Two concerns:
+/// <list type="number">
+/// <item><b>Logging</b> — every critical/unhandled error is appended to a log
+/// file (<see cref="CrashLogger"/>), whatever thread it surfaces on.</item>
+/// <item><b>Surfacing</b> — a fatal unhandled exception is shown to the user in
+/// a <see cref="CrashWindow"/> that points at the log and offers a pre-filled
+/// GitHub issue, instead of the app just vanishing.</item>
+/// </list>
+/// There are two paths a fatal exception can take, and both are covered:
+/// one thrown while the Avalonia message loop is running is caught by the
+/// dispatcher's <see cref="Dispatcher.UnhandledException"/> hook (see
+/// <see cref="AttachToDispatcher"/>); one thrown during startup/shutdown —
+/// before or around the loop — escapes to <c>Program.Main</c>'s catch and
+/// arrives at <see cref="HandleFatal"/>.
+/// </summary>
+public static class CrashReporter
+{
+    private static int _installed;
+    private static int _handling;
+
+    /// <summary>
+    /// Installs the process-wide handlers for exceptions that surface off the
+    /// UI thread — background-thread crashes and unobserved faulted tasks.
+    /// These can only be logged (the process is usually already terminating).
+    /// Called from <c>Program.Main</c> before the app starts. Idempotent.
+    /// </summary>
+    public static void Install()
+    {
+        if (Interlocked.Exchange(ref _installed, 1) == 1)
+        {
+            return;
+        }
+
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+            CrashLogger.LogCritical(
+                $"Unhandled exception on a background thread (terminating={e.IsTerminating})",
+                e.ExceptionObject as Exception);
+
+        TaskScheduler.UnobservedTaskException += (_, e) =>
+        {
+            CrashLogger.LogCritical("Unobserved task exception", e.Exception);
+            // Mark observed so a background logging/telemetry fault doesn't, by
+            // itself, tear the process down on top of whatever already went wrong.
+            e.SetObserved();
+        };
+    }
+
+    /// <summary>
+    /// Hooks the UI-thread dispatcher so an exception thrown while the message
+    /// loop is running (an event handler, an async-void continuation, a posted
+    /// job) is logged and shown in the crash window rather than killing the
+    /// process. Must be called once the dispatcher exists — from
+    /// <see cref="App.OnFrameworkInitializationCompleted"/>. Note: Avalonia
+    /// swallows exceptions thrown directly in a <c>DispatcherTimer.Tick</c>
+    /// before they reach this hook, so don't rely on a timer to test it.
+    /// </summary>
+    public static void AttachToDispatcher()
+    {
+        Dispatcher.UIThread.UnhandledException += (_, e) =>
+        {
+            // Mark handled so the dispatcher doesn't also tear the process down:
+            // we're taking over — show the window, then shut the app down cleanly
+            // once the user has seen it.
+            e.Handled = true;
+            ReportAndShutdown(e.Exception);
+        };
+    }
+
+    /// <summary>
+    /// Handles an exception that escaped the message loop entirely (caught in
+    /// <c>Program.Main</c>): logs it and shows the crash window on the
+    /// already-initialized platform via a nested dispatcher frame, since the
+    /// primary loop is no longer running to render it.
+    /// </summary>
+    public static void HandleFatal(Exception exception)
+    {
+        var logPath = CrashLogger.LogCritical("Fatal unhandled exception (app is shutting down)", exception)
+                      ?? CrashLogger.LogFilePath;
+
+        if (Interlocked.Exchange(ref _handling, 1) == 1)
+        {
+            return; // already reporting a crash — don't stack a second window
+        }
+
+        try
+        {
+            ShowCrashWindowNested(exception, logPath);
+        }
+        catch (Exception dialogException)
+        {
+            LogToConsole(exception, logPath, dialogException);
+        }
+    }
+
+    /// <summary>
+    /// The in-loop path: log the crash, show the window on the running
+    /// dispatcher, and shut the app down when it's dismissed. The app is in an
+    /// unknown state after an unhandled exception, so we don't try to keep it
+    /// running — the window's job is to explain and point at the log.
+    /// </summary>
+    private static void ReportAndShutdown(Exception exception)
+    {
+        var logPath = CrashLogger.LogCritical("Fatal unhandled exception (UI thread)", exception)
+                      ?? CrashLogger.LogFilePath;
+
+        if (Interlocked.Exchange(ref _handling, 1) == 1)
+        {
+            return; // a crash window is already up
+        }
+
+        try
+        {
+            var window = new CrashWindow(exception, logPath);
+            window.Closed += (_, _) => Shutdown();
+            window.Show();
+        }
+        catch (Exception dialogException)
+        {
+            LogToConsole(exception, logPath, dialogException);
+            Shutdown();
+        }
+    }
+
+    /// <summary>
+    /// Shows the crash dialog on the already-initialized platform and blocks
+    /// until dismissed, by pumping a nested dispatcher frame. Used from the
+    /// <c>Program.Main</c> path, where the primary loop has already ended.
+    /// A second <see cref="AppBuilder"/> is not an option — Avalonia allows
+    /// exactly one setup per process.
+    /// </summary>
+    private static void ShowCrashWindowNested(Exception exception, string logPath)
+    {
+        if (Application.Current is null)
+        {
+            // The exception escaped before Avalonia finished initializing, so
+            // there is no UI thread to draw on. Fall back to the console.
+            throw new InvalidOperationException("Avalonia platform is not initialized; cannot show the crash window.");
+        }
+
+        var window = new CrashWindow(exception, logPath);
+        var frame = new DispatcherFrame();
+        window.Closed += (_, _) => frame.Continue = false;
+        window.Show();
+        Dispatcher.UIThread.PushFrame(frame);
+    }
+
+    private static void Shutdown()
+    {
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.Shutdown();
+        }
+    }
+
+    private static void LogToConsole(Exception original, string logPath, Exception dialogException)
+    {
+        CrashLogger.LogCritical("Failed to show the crash window", dialogException);
+        Console.Error.WriteLine($"pgNimbus crashed: {original}");
+        Console.Error.WriteLine($"A log was written to: {logPath}");
+    }
+}

--- a/PgNimbus.App/Program.cs
+++ b/PgNimbus.App/Program.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using PgNimbus.App.Diagnostics;
 
 namespace PgNimbus.App;
 
@@ -6,8 +7,23 @@ internal static class Program
 {
     // Avalonia configuration, don't remove; also used by visual designer.
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args)
+    {
+        // Log background-thread / unobserved-task faults from the very start.
+        CrashReporter.Install();
+
+        try
+        {
+            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+        }
+        catch (Exception ex)
+        {
+            // An exception escaping the message loop means the app is going
+            // down. Log the crash and show the user the error window (with the
+            // log path and a one-click GitHub issue) before the process exits.
+            CrashReporter.HandleFatal(ex);
+        }
+    }
 
     public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>()
         .UsePlatformDetect()

--- a/PgNimbus.App/Views/CrashWindow.axaml
+++ b/PgNimbus.App/Views/CrashWindow.axaml
@@ -1,0 +1,42 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="PgNimbus.App.Views.CrashWindow"
+        Title="pgNimbus — Unexpected Error"
+        Width="520" SizeToContent="Height" MinHeight="300"
+        CanResize="False"
+        WindowStartupLocation="CenterScreen">
+    <!-- Shown when an unhandled exception has already taken the app down (see
+         CrashReporter). Tells the user what happened, points at the saved log,
+         and offers a one-click, pre-filled GitHub issue. Deliberately
+         self-contained: no DataContext / view model, since it has to render
+         even when the rest of the app is in an unknown state. -->
+    <StackPanel Margin="28" Spacing="14">
+        <TextBlock Text="pgNimbus ran into an unexpected error"
+                   FontSize="18" FontWeight="SemiBold" TextWrapping="Wrap" />
+        <TextBlock Text="The application hit a critical error and has to close. Nothing you were doing was necessarily lost — reopen pgNimbus to carry on."
+                   FontSize="13" Opacity="0.8" TextWrapping="Wrap" />
+
+        <Border Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}"
+                CornerRadius="4" Padding="12,10">
+            <TextBox Name="ErrorText" IsReadOnly="True" BorderThickness="0"
+                     Background="Transparent" TextWrapping="Wrap"
+                     FontFamily="Consolas, Menlo, monospace" FontSize="12"
+                     MaxHeight="140" />
+        </Border>
+
+        <StackPanel Spacing="4">
+            <TextBlock Text="A detailed log was saved to:" FontSize="12" Opacity="0.7" />
+            <TextBox Name="LogPathText" IsReadOnly="True" BorderThickness="0"
+                     Background="Transparent" FontSize="12" TextWrapping="Wrap" Padding="0" />
+        </StackPanel>
+
+        <TextBlock Text="Please report this so it can be fixed — the button below opens a pre-filled GitHub issue. Attaching the log file above helps a lot."
+                   FontSize="12" Opacity="0.8" TextWrapping="Wrap" />
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+            <Button Content="Open Log File" Click="OnOpenLogClick" />
+            <Button Content="Report on GitHub" Click="OnReportClick" Classes="accent" />
+            <Button Content="Close" Click="OnCloseClick" IsDefault="True" />
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/PgNimbus.App/Views/CrashWindow.axaml.cs
+++ b/PgNimbus.App/Views/CrashWindow.axaml.cs
@@ -111,10 +111,18 @@ public partial class CrashWindow : Window
             ?.InformationalVersion.Split('+')[0] ?? "unknown";
 
         var title = $"Crash: {_errorSummary.Split('\n')[0]}";
+
+        // Keep the URL well under the ~2000-char limit browsers/the Windows shell
+        // impose on Process.Start, or a long message would make the button a
+        // silent no-op. The full detail is in the attached log anyway.
+        var errorDetails = _errorSummary.Length > 1000
+            ? _errorSummary[..1000] + "\n… (truncated — see the attached log)"
+            : _errorSummary;
+
         var body =
             "**What happened**\n\n" +
             "pgNimbus crashed with an unhandled error.\n\n" +
-            "**Error**\n\n```\n" + _errorSummary + "\n```\n\n" +
+            "**Error**\n\n```\n" + errorDetails + "\n```\n\n" +
             $"**Version:** {version}\n" +
             $"**OS:** {Environment.OSVersion}\n\n" +
             "**Steps to reproduce**\n\n" +

--- a/PgNimbus.App/Views/CrashWindow.axaml.cs
+++ b/PgNimbus.App/Views/CrashWindow.axaml.cs
@@ -1,0 +1,146 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+namespace PgNimbus.App.Views;
+
+/// <summary>
+/// The last-resort error window shown after an unhandled exception has already
+/// crashed the app (see <see cref="PgNimbus.App.Diagnostics.CrashReporter"/>).
+/// It reports what happened, points at the log file on disk, and opens a
+/// pre-filled GitHub issue so a report is one click away. It carries no view
+/// model and touches no app services on purpose — it must render even when the
+/// rest of the app is in a broken state.
+/// </summary>
+public partial class CrashWindow : Window
+{
+    private const string RepositoryUrl = "https://github.com/Shman4ik/pgNimbus";
+
+    private readonly string _logPath;
+    private readonly string _errorSummary;
+
+    // Parameterless ctor for the XAML designer / Avalonia's loader only.
+    public CrashWindow() : this(null, CrashLoggerLogPathFallback()) { }
+
+    public CrashWindow(Exception? exception, string logPath)
+    {
+        InitializeComponent();
+        ThemedWindowChrome.Attach(this);
+
+        _logPath = logPath;
+        _errorSummary = DescribeException(exception);
+
+        ErrorText.Text = _errorSummary;
+        LogPathText.Text = _logPath;
+
+        KeyDown += (_, e) =>
+        {
+            if (e.Key == Key.Escape)
+            {
+                Close();
+            }
+        };
+    }
+
+    private static string CrashLoggerLogPathFallback() =>
+        PgNimbus.Core.Diagnostics.CrashLogger.LogFilePath;
+
+    /// <summary>A short, human-readable one/two-line summary of the failure for the window.</summary>
+    private static string DescribeException(Exception? exception)
+    {
+        if (exception is null)
+        {
+            return "An unknown error occurred.";
+        }
+
+        var summary = new StringBuilder();
+        summary.Append(exception.GetType().Name).Append(": ").Append(exception.Message);
+        if (exception.InnerException is { } inner)
+        {
+            summary.Append('\n').Append("→ ").Append(inner.GetType().Name).Append(": ").Append(inner.Message);
+        }
+
+        return summary.ToString();
+    }
+
+    private void OnOpenLogClick(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            // Open the containing folder rather than the file itself: there's no
+            // guaranteed default handler for a ".log" extension, but every
+            // platform can open a directory.
+            var directory = Path.GetDirectoryName(_logPath);
+            OpenExternal(string.IsNullOrEmpty(directory) ? _logPath : directory);
+        }
+        catch
+        {
+            // The path is shown in the window regardless; failing to launch a
+            // file browser is not worth another error dialog.
+        }
+    }
+
+    private void OnReportClick(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            OpenExternal(BuildIssueUrl());
+        }
+        catch
+        {
+            // No browser to hand off to — the repo URL is still discoverable
+            // from the About box, so swallow rather than cascade.
+        }
+    }
+
+    private void OnCloseClick(object? sender, RoutedEventArgs e) => Close();
+
+    /// <summary>
+    /// Builds a "new issue" URL for the repo with the title and body pre-filled
+    /// from the crash summary, so reporting is a single click. GitHub reads the
+    /// <c>title</c>/<c>body</c>/<c>labels</c> query parameters on the new-issue
+    /// form.
+    /// </summary>
+    private string BuildIssueUrl()
+    {
+        var version = Assembly.GetEntryAssembly()
+            ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion.Split('+')[0] ?? "unknown";
+
+        var title = $"Crash: {_errorSummary.Split('\n')[0]}";
+        var body =
+            "**What happened**\n\n" +
+            "pgNimbus crashed with an unhandled error.\n\n" +
+            "**Error**\n\n```\n" + _errorSummary + "\n```\n\n" +
+            $"**Version:** {version}\n" +
+            $"**OS:** {Environment.OSVersion}\n\n" +
+            "**Steps to reproduce**\n\n" +
+            "1. \n2. \n\n" +
+            $"_Please attach the log file: `{_logPath}`_\n";
+
+        return $"{RepositoryUrl}/issues/new" +
+               $"?labels=crash" +
+               $"&title={Uri.EscapeDataString(title)}" +
+               $"&body={Uri.EscapeDataString(body)}";
+    }
+
+    /// <summary>Hands a file path or URL to the OS default handler, cross-platform.</summary>
+    private static void OpenExternal(string target)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Process.Start(new ProcessStartInfo(target) { UseShellExecute = true });
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            Process.Start("open", target);
+        }
+        else
+        {
+            Process.Start("xdg-open", target);
+        }
+    }
+}

--- a/PgNimbus.Core.Tests/Diagnostics/CrashLogTests.cs
+++ b/PgNimbus.Core.Tests/Diagnostics/CrashLogTests.cs
@@ -1,0 +1,106 @@
+using PgNimbus.Core.Diagnostics;
+
+namespace PgNimbus.Core.Tests.Diagnostics;
+
+public class CrashLogTests
+{
+    private static string NewTempDir() =>
+        Path.Combine(Path.GetTempPath(), "pgnimbus-crashlog-tests", Guid.NewGuid().ToString("N"));
+
+    [Test]
+    public async Task WritesEntryWithContextAndException()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var log = new CrashLog(dir);
+            Exception caught;
+            try
+            {
+                throw new InvalidOperationException("boom");
+            }
+            catch (Exception e)
+            {
+                caught = e;
+            }
+
+            var returnedPath = log.LogCritical("Something failed", caught);
+
+            await Assert.That(returnedPath).IsEqualTo(log.FilePath);
+            await Assert.That(File.Exists(log.FilePath)).IsTrue();
+
+            var contents = await File.ReadAllTextAsync(log.FilePath);
+            await Assert.That(contents).Contains("CRITICAL");
+            await Assert.That(contents).Contains("Something failed");
+            await Assert.That(contents).Contains("System.InvalidOperationException");
+            await Assert.That(contents).Contains("boom");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task CreatesLogDirectoryOnDemand()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            // The directory does not exist yet — logging must create it.
+            await Assert.That(Directory.Exists(dir)).IsFalse();
+
+            var log = new CrashLog(dir);
+            log.LogCritical("first error", null);
+
+            await Assert.That(Directory.Exists(dir)).IsTrue();
+            await Assert.That(File.Exists(log.FilePath)).IsTrue();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task AppendsRatherThanOverwrites()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var log = new CrashLog(dir);
+            log.LogCritical("first error", null);
+            log.LogCritical("second error", null);
+
+            var contents = await File.ReadAllTextAsync(log.FilePath);
+            await Assert.That(contents).Contains("first error");
+            await Assert.That(contents).Contains("second error");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task UnwindsInnerExceptions()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var log = new CrashLog(dir);
+            var exception = new InvalidOperationException("outer", new FormatException("inner cause"));
+
+            log.LogCritical("wrapped failure", exception);
+
+            var contents = await File.ReadAllTextAsync(log.FilePath);
+            await Assert.That(contents).Contains("outer");
+            await Assert.That(contents).Contains("System.FormatException");
+            await Assert.That(contents).Contains("inner cause");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/PgNimbus.Core.Tests/Diagnostics/CrashLogTests.cs
+++ b/PgNimbus.Core.Tests/Diagnostics/CrashLogTests.cs
@@ -83,6 +83,31 @@ public class CrashLogTests
     }
 
     [Test]
+    public async Task UnwindsEveryBranchOfAnAggregateException()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var log = new CrashLog(dir);
+            var aggregate = new AggregateException(
+                new InvalidOperationException("first branch"),
+                new FormatException("second branch"),
+                new TimeoutException("third branch"));
+
+            log.LogCritical("faulted tasks", aggregate);
+
+            var contents = await File.ReadAllTextAsync(log.FilePath);
+            await Assert.That(contents).Contains("first branch");
+            await Assert.That(contents).Contains("second branch");
+            await Assert.That(contents).Contains("third branch");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task UnwindsInnerExceptions()
     {
         var dir = NewTempDir();

--- a/PgNimbus.Core/Diagnostics/CrashLogger.cs
+++ b/PgNimbus.Core/Diagnostics/CrashLogger.cs
@@ -1,0 +1,129 @@
+using System.Text;
+using PgNimbus.Core.Connections;
+
+namespace PgNimbus.Core.Diagnostics;
+
+/// <summary>
+/// Appends critical/unhandled errors to a plain-text log file. Deliberately
+/// dependency-free and UI-agnostic so it can be called from anywhere — a
+/// background-thread crash handler, the query engine, or the App's global
+/// exception hooks — including from a handler that runs while the process is
+/// already tearing down. Every operation swallows its own failures: a logger
+/// that throws while logging a crash would only mask the original error.
+/// </summary>
+public sealed class CrashLog
+{
+    // Serializes appends across threads. A crash can surface on several threads
+    // at once (UI + a faulted background task), and interleaved writes would
+    // corrupt the file.
+    private readonly object _gate = new();
+
+    // Keep the log from growing without bound. When it crosses this size the
+    // current file is rolled to "pgnimbus.log.old" (one generation kept) before
+    // the next write starts a fresh file.
+    private const long MaxLogBytes = 1024 * 1024; // 1 MiB
+
+    /// <summary>Directory that holds the log file(s). Created on demand.</summary>
+    public string Directory { get; }
+
+    /// <summary>Full path to the current log file, shown to the user in the crash dialog.</summary>
+    public string FilePath { get; }
+
+    public CrashLog(string directory)
+    {
+        Directory = directory;
+        FilePath = Path.Combine(directory, "pgnimbus.log");
+    }
+
+    /// <summary>
+    /// Records a critical error with a short describing context and the
+    /// exception (message, type, and stack trace, unwinding inner exceptions).
+    /// Returns the log path so a caller can surface it to the user, or
+    /// <c>null</c> if even writing the log failed.
+    /// </summary>
+    public string? LogCritical(string context, Exception? exception) => Write(FormatEntry(context, exception));
+
+    /// <summary>Formats a single log entry. Pure — no I/O — so it's unit-testable on its own.</summary>
+    internal static string FormatEntry(string context, Exception? exception)
+    {
+        var entry = new StringBuilder();
+        entry.Append('[').Append(DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss.fff zzz")).Append("]  ");
+        entry.Append("CRITICAL  ").AppendLine(context);
+
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            entry.Append("    ").Append(current.GetType().FullName).Append(": ").AppendLine(current.Message);
+            if (!string.IsNullOrEmpty(current.StackTrace))
+            {
+                entry.AppendLine(current.StackTrace);
+            }
+        }
+
+        entry.AppendLine(new string('-', 72));
+        return entry.ToString();
+    }
+
+    private string? Write(string text)
+    {
+        try
+        {
+            lock (_gate)
+            {
+                System.IO.Directory.CreateDirectory(Directory);
+                RollIfTooLarge();
+                File.AppendAllText(FilePath, text);
+            }
+
+            return FilePath;
+        }
+        catch
+        {
+            // Logging a crash must never itself throw — that would replace the
+            // real error with a logging error and lose both.
+            return null;
+        }
+    }
+
+    private void RollIfTooLarge()
+    {
+        try
+        {
+            var info = new FileInfo(FilePath);
+            if (!info.Exists || info.Length < MaxLogBytes)
+            {
+                return;
+            }
+
+            var archive = FilePath + ".old";
+            File.Delete(archive); // File.Delete is a no-op when the file is absent.
+            File.Move(FilePath, archive);
+        }
+        catch
+        {
+            // If rolling fails, keep appending to the existing file rather than
+            // losing the entry we're about to write.
+        }
+    }
+}
+
+/// <summary>
+/// Process-wide singleton over <see cref="CrashLog"/>, logging under the app
+/// data root (<c>&lt;appdata&gt;/pgNimbus/logs/pgnimbus.log</c>). This is what
+/// the App's crash hooks call; tests drive <see cref="CrashLog"/> directly
+/// against a temp directory.
+/// </summary>
+public static class CrashLogger
+{
+    private static readonly CrashLog Instance =
+        new(Path.Combine(AppDataPaths.GetRootDirectory(), "logs"));
+
+    /// <summary>Directory that holds the log file(s).</summary>
+    public static string LogDirectory => Instance.Directory;
+
+    /// <summary>Full path to the current log file, shown to the user in the crash dialog.</summary>
+    public static string LogFilePath => Instance.FilePath;
+
+    /// <inheritdoc cref="CrashLog.LogCritical"/>
+    public static string? LogCritical(string context, Exception? exception) =>
+        Instance.LogCritical(context, exception);
+}

--- a/PgNimbus.Core/Diagnostics/CrashLogger.cs
+++ b/PgNimbus.Core/Diagnostics/CrashLogger.cs
@@ -50,17 +50,41 @@ public sealed class CrashLog
         entry.Append('[').Append(DateTimeOffset.Now.ToString("yyyy-MM-dd HH:mm:ss.fff zzz")).Append("]  ");
         entry.Append("CRITICAL  ").AppendLine(context);
 
-        for (var current = exception; current is not null; current = current.InnerException)
+        if (exception is not null)
         {
-            entry.Append("    ").Append(current.GetType().FullName).Append(": ").AppendLine(current.Message);
-            if (!string.IsNullOrEmpty(current.StackTrace))
-            {
-                entry.AppendLine(current.StackTrace);
-            }
+            AppendException(entry, exception, "    ");
         }
 
         entry.AppendLine(new string('-', 72));
         return entry.ToString();
+    }
+
+    /// <summary>
+    /// Writes one exception and recurses into its cause(s). Handles
+    /// <see cref="AggregateException"/> by unwinding every entry in
+    /// <see cref="AggregateException.InnerExceptions"/> — the faulted-task and
+    /// unobserved-task paths surface as aggregates, and following only
+    /// <see cref="Exception.InnerException"/> would drop every branch but the first.
+    /// </summary>
+    private static void AppendException(StringBuilder entry, Exception exception, string indent)
+    {
+        entry.Append(indent).Append(exception.GetType().FullName).Append(": ").AppendLine(exception.Message);
+        if (!string.IsNullOrEmpty(exception.StackTrace))
+        {
+            entry.AppendLine(exception.StackTrace);
+        }
+
+        if (exception is AggregateException aggregate)
+        {
+            foreach (var inner in aggregate.InnerExceptions)
+            {
+                AppendException(entry, inner, indent + "  ");
+            }
+        }
+        else if (exception.InnerException is { } cause)
+        {
+            AppendException(entry, cause, indent);
+        }
     }
 
     private string? Write(string text)
@@ -114,8 +138,24 @@ public sealed class CrashLog
 /// </summary>
 public static class CrashLogger
 {
-    private static readonly CrashLog Instance =
-        new(Path.Combine(AppDataPaths.GetRootDirectory(), "logs"));
+    private static readonly CrashLog Instance = CreateInstance();
+
+    // CrashLogger is touched from the global crash handlers, so a throw during
+    // static initialization would surface as a TypeInitializationException
+    // inside the very code meant to report the crash — silently killing it.
+    // Resolving the app-data root already falls back to $HOME/temp, but guard
+    // it anyway and drop to the OS temp directory as a last resort.
+    private static CrashLog CreateInstance()
+    {
+        try
+        {
+            return new CrashLog(Path.Combine(AppDataPaths.GetRootDirectory(), "logs"));
+        }
+        catch
+        {
+            return new CrashLog(Path.Combine(Path.GetTempPath(), "pgNimbus", "logs"));
+        }
+    }
 
     /// <summary>Directory that holds the log file(s).</summary>
     public static string LogDirectory => Instance.Directory;


### PR DESCRIPTION
Unhandled errors were previously silent — the app either vanished or a
faulted UI job was swallowed by the dispatcher, leaving nothing to
diagnose. Add end-to-end crash handling:

- PgNimbus.Core.Diagnostics.CrashLog / CrashLogger: append critical errors
  to <appdata>/pgNimbus/logs/pgnimbus.log (1 MiB rolling, thread-safe,
  never throws while logging). File I/O is directory-injectable and
  unit-tested; the static CrashLogger is the process-wide facade.
- PgNimbus.App/Diagnostics/CrashReporter: three global hooks —
  AppDomain.UnhandledException and TaskScheduler.UnobservedTaskException
  (log only), plus Dispatcher.UIThread.UnhandledException, which shows the
  crash window and shuts down cleanly. Startup/setup crashes that escape
  the message loop are caught in Program.Main and shown via a nested
  DispatcherFrame (reusing the already-initialized platform, since a second
  AppBuilder is not allowed).
- Views/CrashWindow: self-contained error window (no view model) showing
  the error, the on-disk log path, and a "Report on GitHub" button that
  opens a pre-filled new-issue URL with version and OS.

Verified both crash paths render (light + dark) under Xvfb; all 455 Core
tests pass. CLAUDE.md documents the design and the landmines.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ALEgwVPUd5zbYTUDbR9k6Q