### PR TITLE
Make jsonb a first-class editable type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,7 +277,24 @@ csproj / WiX / MSIX manifest reference them unchanged:
   `AvaloniaProperty` — it's a plain CLR property backed by a `TextDocument`.
   Two-way sync with the ViewModel is done manually in `MainWindow.axaml.cs`
   (via `TextChanged` + `PropertyChanged`, with a re-entrancy guard), not via
-  XAML `Binding`.
+  XAML `Binding`. Both the main SQL editor (`_suppressEditorSync`) and the
+  cell inspector's JSON editor (`_suppressInspectorSync`) follow this pattern.
+- **json/jsonb are a first-class editable type.** `ColumnValueEditorClassifier`
+  maps them to `ColumnValueEditor.Json` (jsonpath/hstore stay `Text` — not
+  JSON-shaped), which does two things every edit path (inline F2, staged edits,
+  the Add-row dialog) honors: the value is validated client-side by
+  `PgValueSyntax.ValidateJson` (a `JsonDocument.Parse` structure check — a bare
+  scalar is valid json, so it accepts any JSON value) and stored via
+  `CAST(@value AS jsonb)`. The cast is **load-bearing**: Npgsql surfaces
+  json/jsonb as `string`, and Postgres has no implicit text→json[b] assignment
+  cast, so an uncast `UPDATE`/`INSERT` of a json column fails with a type error.
+  The cell inspector (`CellInspectorViewModel`) pretty-prints JSON, offers a
+  read-only collapsible tree (`PgNimbus.Core.Json.JsonTree` builds the node
+  model — pure Core, unit-tested), and for an editable json cell edits in place
+  (Format / Minify / client-side validation / Save through the same cast path,
+  highlighted by `Assets/Json.xshd`). Completion carries the jsonb function
+  family (`SqlCompletionProvider.Functions`); JSON operators (`->`, `@>`, `?`,
+  `@?`, …) are punctuation, out of the identifier-triggered completion model.
 - `SqlFormatter` follows <https://www.sqlstyle.guide/> ("river" layout: root
   keywords right-aligned to a common column, content to its right). The tests
   in `PgNimbus.Core.Tests` assert exact spacing — a deliberate layout change

--- a/PgNimbus.App/Assets/Json.xshd
+++ b/PgNimbus.App/Assets/Json.xshd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    JSON syntax highlighting for the cell inspector's edit mode. The foreground
+    values baked in here are the dark-theme palette; MainWindow recolors the
+    named colors at runtime for the light theme (and back), so keep the color
+    names in sync with ApplyJsonHighlightingTheme.
+-->
+<SyntaxDefinition name="JSON" extensions=".json" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
+    <Color name="Property" foreground="#9CDCFE" />
+    <Color name="String" foreground="#CE9178" />
+    <Color name="Number" foreground="#B5CEA8" />
+    <Color name="Keyword" foreground="#569CD6" fontWeight="bold" />
+
+    <RuleSet>
+        <!-- A quoted string immediately followed by a colon is an object key.
+             Defined before the value-string span so keys win at the same offset. -->
+        <Rule color="Property">
+            "(\\.|[^"\\])*"(?=\s*:)
+        </Rule>
+
+        <!-- Value strings; a backslash escape keeps the closing quote from ending early. -->
+        <Span color="String">
+            <Begin>"</Begin>
+            <End>"</End>
+            <RuleSet>
+                <Span begin="\\" end="." />
+            </RuleSet>
+        </Span>
+
+        <Keywords color="Keyword">
+            <Word>true</Word>
+            <Word>false</Word>
+            <Word>null</Word>
+        </Keywords>
+
+        <Rule color="Number">
+            -?\b\d+(\.\d+)?([eE][-+]?\d+)?\b
+        </Rule>
+    </RuleSet>
+</SyntaxDefinition>

--- a/PgNimbus.App/Completion/SqlCompletionProvider.cs
+++ b/PgNimbus.App/Completion/SqlCompletionProvider.cs
@@ -71,10 +71,23 @@ public sealed class SqlCompletionProvider
         // date/time
         "now", "age", "date_trunc", "date_part", "extract", "to_char",
         "to_date", "to_timestamp", "make_date", "justify_interval",
-        // arrays / sets / json
+        // arrays / sets
         "unnest", "generate_series", "array_length", "cardinality",
-        "array_to_string", "string_to_array", "to_json", "to_jsonb",
-        "jsonb_build_object", "jsonb_array_elements",
+        "array_to_string", "string_to_array",
+        // json / jsonb: construction, inspection, mutation, and expansion
+        "to_json", "to_jsonb", "json_build_object", "jsonb_build_object",
+        "json_build_array", "jsonb_build_array", "json_object", "jsonb_object",
+        "row_to_json", "array_to_json",
+        "jsonb_array_elements", "json_array_elements",
+        "jsonb_array_elements_text", "jsonb_array_length", "json_array_length",
+        "jsonb_each", "jsonb_each_text", "jsonb_object_keys",
+        "jsonb_extract_path", "jsonb_extract_path_text", "jsonb_typeof",
+        "jsonb_set", "jsonb_set_lax", "jsonb_insert", "jsonb_pretty",
+        "jsonb_strip_nulls", "jsonb_populate_record", "json_populate_record",
+        "jsonb_to_record", "jsonb_to_recordset",
+        // jsonpath (SQL/JSON path queries)
+        "jsonb_path_query", "jsonb_path_query_array", "jsonb_path_query_first",
+        "jsonb_path_exists", "jsonb_path_match",
         // misc
         "md5", "gen_random_uuid", "pg_typeof",
     ];

--- a/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
+++ b/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
@@ -1,16 +1,21 @@
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Unicode;
+using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core.Json;
+using PgNimbus.Core.Schema;
 
 namespace PgNimbus.App.ViewModels;
 
 /// <summary>
-/// Backs the results-grid cell inspector overlay: a read-only, copyable detail
-/// view of one cell's full value, opened when a <c>text</c>/<c>jsonb</c> value
-/// is too long to read inline. <c>jsonb</c>/<c>json</c> values are
-/// pretty-printed; everything else is shown as its plain string form.
+/// Backs the results-grid cell inspector overlay: a detail view of one cell's
+/// full value, opened when a <c>text</c>/<c>jsonb</c> value is too long to read
+/// inline. <c>jsonb</c>/<c>json</c> values are pretty-printed and can be browsed
+/// as a collapsible tree; when the cell belongs to an editable result set they
+/// can also be edited in place — formatted, minified, validated client-side, and
+/// saved through the same cast-to-<c>jsonb</c> path an inline grid edit uses.
 /// </summary>
 public sealed partial class CellInspectorViewModel : ObservableObject
 {
@@ -23,13 +28,81 @@ public sealed partial class CellInspectorViewModel : ObservableObject
     [ObservableProperty]
     private string _displayText = string.Empty;
 
-    /// <summary>True when <see cref="DisplayText"/> is pretty-printed JSON - drives monospace display in the view.</summary>
+    /// <summary>True when <see cref="DisplayText"/> is pretty-printed JSON - drives monospace display and enables the tree view.</summary>
     [ObservableProperty]
     private bool _isJson;
 
     /// <summary>Whether the inspector wraps long lines, Notepad++-style. On by default so a long text/jsonb value never scrolls off-screen horizontally.</summary>
     [ObservableProperty]
     private bool _wordWrap = true;
+
+    /// <summary>True when this cell can be edited (an editable, JSON-typed cell in a keyed result set).</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanShowEdit))]
+    private bool _canEdit;
+
+    /// <summary>True while the inline JSON editor is showing instead of the read-only value.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowText))]
+    [NotifyPropertyChangedFor(nameof(ShowTree))]
+    [NotifyPropertyChangedFor(nameof(CanShowEdit))]
+    [NotifyPropertyChangedFor(nameof(CanShowTreeToggle))]
+    [NotifyPropertyChangedFor(nameof(ValidationError))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    private bool _isEditing;
+
+    /// <summary>True to show the collapsible tree instead of the raw/pretty text (read mode only, JSON only).</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowText))]
+    [NotifyPropertyChangedFor(nameof(ShowTree))]
+    private bool _isTreeView;
+
+    /// <summary>True when the value is JSON - drives monospace display; also gated on edit mode for the tree toggle's visibility.</summary>
+    partial void OnIsJsonChanged(bool value) => OnPropertyChanged(nameof(CanShowTreeToggle));
+
+    /// <summary>The editable JSON text, two-way-synced with the AvaloniaEdit editor in the view.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ValidationError))]
+    [NotifyPropertyChangedFor(nameof(HasValidationError))]
+    private string _editText = string.Empty;
+
+    /// <summary>A save failure surfaced inline in the editor (null when the last save succeeded or none was attempted).</summary>
+    [ObservableProperty]
+    private string? _saveError;
+
+    /// <summary>The parsed document tree the tree view binds to (single-element: the root); empty when the value isn't JSON.</summary>
+    [ObservableProperty]
+    private IReadOnlyList<JsonTreeNode> _treeRoots = [];
+
+    // Read mode shows text unless the tree is toggled on; edit mode replaces both.
+    public bool ShowText => !IsEditing && !IsTreeView;
+
+    public bool ShowTree => !IsEditing && IsTreeView;
+
+    /// <summary>The Text/Tree toggle only makes sense for a JSON value in read mode.</summary>
+    public bool CanShowTreeToggle => IsJson && !IsEditing;
+
+    /// <summary>The Edit chip shows only for an editable cell that isn't already being edited.</summary>
+    public bool CanShowEdit => CanEdit && !IsEditing;
+
+    // Parse the tree lazily the first time it's shown (and only for JSON), then cache it.
+    partial void OnIsTreeViewChanged(bool value)
+    {
+        if (value && IsJson && TreeRoots.Count == 0 && JsonTree.Parse(DisplayText) is { } root)
+        {
+            TreeRoots = [root];
+        }
+    }
+
+    /// <summary>Client-side JSON validation of the in-progress edit — null when it parses or is blank.</summary>
+    public string? ValidationError => IsEditing ? PgValueSyntax.ValidateJson(EditText) : null;
+
+    public bool HasValidationError => ValidationError is not null;
+
+    // Set when the cell is editable: how to persist a new value (returns null on
+    // success, or an error message to show inline) and which grid column it is.
+    private Func<int, string, Task<string?>>? _commit;
+    private int _columnIndex = -1;
 
     private static readonly JsonSerializerOptions PrettyPrintOptions = new()
     {
@@ -40,15 +113,125 @@ public sealed partial class CellInspectorViewModel : ObservableObject
         Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
     };
 
-    public void Open(string columnName, object? value)
+    private static readonly JsonSerializerOptions MinifyOptions = new()
+    {
+        WriteIndented = false,
+        Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+    };
+
+    /// <summary>Opens the inspector read-only (non-editable result sets, text cells).</summary>
+    public void Open(string columnName, object? value) =>
+        Open(columnName, value, columnIndex: -1, canEdit: false, commit: null);
+
+    /// <summary>
+    /// Opens the inspector for one cell. When <paramref name="canEdit"/> is true a
+    /// <paramref name="commit"/> delegate persists edits (returning null on success
+    /// or an error message); <paramref name="columnIndex"/> identifies the grid
+    /// column that delegate targets.
+    /// </summary>
+    public void Open(string columnName, object? value, int columnIndex, bool canEdit, Func<int, string, Task<string?>>? commit)
     {
         ColumnName = columnName;
+        _columnIndex = columnIndex;
+        _commit = commit;
+        CanEdit = canEdit && commit is not null;
+
+        IsEditing = false;
+        IsTreeView = false;
+        SaveError = null;
+
         (DisplayText, IsJson) = Format(value);
+        TreeRoots = [];
         IsOpen = true;
     }
 
     [RelayCommand]
     private void Close() => IsOpen = false;
+
+    [RelayCommand]
+    private void Edit()
+    {
+        if (!CanEdit)
+        {
+            return;
+        }
+
+        SaveError = null;
+        IsTreeView = false;
+        EditText = DisplayText;
+        IsEditing = true;
+    }
+
+    [RelayCommand]
+    private void CancelEdit()
+    {
+        IsEditing = false;
+        SaveError = null;
+    }
+
+    /// <summary>Pretty-print the in-progress edit; a no-op if it isn't valid JSON.</summary>
+    [RelayCommand]
+    private void Format()
+    {
+        if (TryReformat(EditText, PrettyPrintOptions, out var formatted))
+        {
+            EditText = formatted;
+        }
+    }
+
+    /// <summary>Collapse the in-progress edit onto a single line; a no-op if it isn't valid JSON.</summary>
+    [RelayCommand]
+    private void Minify()
+    {
+        if (TryReformat(EditText, MinifyOptions, out var minified))
+        {
+            EditText = minified;
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        if (!CanEdit || _commit is null)
+        {
+            return;
+        }
+
+        if (ValidationError is { } error)
+        {
+            SaveError = error;
+            return;
+        }
+
+        var failure = await _commit(_columnIndex, EditText);
+        if (failure is not null)
+        {
+            SaveError = failure;
+            return;
+        }
+
+        // Persisted. Reflect the saved value (pretty-printed, same as the grid's
+        // stored text) and drop back to the read view, tree cache invalidated.
+        (DisplayText, IsJson) = Format(EditText);
+        TreeRoots = [];
+        SaveError = null;
+        IsEditing = false;
+    }
+
+    private static bool TryReformat(string text, JsonSerializerOptions options, out string result)
+    {
+        result = text;
+        try
+        {
+            using var document = JsonDocument.Parse(text);
+            result = JsonSerializer.Serialize(document, options);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
 
     private static (string Text, bool IsJson) Format(object? value)
     {
@@ -57,7 +240,7 @@ public sealed partial class CellInspectorViewModel : ObservableObject
             null => "NULL",
             byte[] bytes => $"\\x{Convert.ToHexString(bytes)}",
             // Same Postgres-literal rendering the grid uses — never "System.String[]".
-            Array array => PgNimbus.Core.Schema.PgValueSyntax.FormatArray(array),
+            Array array => PgValueSyntax.FormatArray(array),
             _ => value.ToString() ?? string.Empty,
         };
 

--- a/PgNimbus.App/ViewModels/NewRowField.cs
+++ b/PgNimbus.App/ViewModels/NewRowField.cs
@@ -36,7 +36,7 @@ public sealed partial class NewRowField : ObservableObject
     /// <summary>The resolved base type when the declared type is a domain; null otherwise.</summary>
     public string? DomainBaseType { get; init; }
 
-    public bool IsTextEditor => Editor is ColumnValueEditor.Text or ColumnValueEditor.Array or ColumnValueEditor.Composite;
+    public bool IsTextEditor => Editor is ColumnValueEditor.Text or ColumnValueEditor.Array or ColumnValueEditor.Composite or ColumnValueEditor.Json;
 
     public bool IsBooleanEditor => Editor == ColumnValueEditor.Boolean;
 
@@ -114,6 +114,7 @@ public sealed partial class NewRowField : ObservableObject
     {
         ColumnValueEditor.Array => PgValueSyntax.ValidateArray(Value),
         ColumnValueEditor.Composite => PgValueSyntax.ValidateComposite(Value),
+        ColumnValueEditor.Json => PgValueSyntax.ValidateJson(Value),
         ColumnValueEditor.Text => PgValueSyntax.ValidateScalar(DomainBaseType ?? DataType, Value),
         _ => null,
     };

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -1031,14 +1031,14 @@ public sealed partial class QueryViewModel : ObservableObject
     /// place doesn't raise a UI change notification); on failure it simply
     /// does nothing, since the row was never touched.
     /// </summary>
-    public async Task CommitCellEditAsync(object?[] row, int columnIndex, string newValueText)
+    public async Task<bool> CommitCellEditAsync(object?[] row, int columnIndex, string newValueText)
     {
         HasError = false;
 
         if (EditContext is not { } context)
         {
             Status = "Editing isn't available for this result set.";
-            return;
+            return false;
         }
 
         var columnName = ColumnNames[columnIndex];
@@ -1046,14 +1046,14 @@ public sealed partial class QueryViewModel : ObservableObject
         if (context.PrimaryKeyColumns.Contains(columnName))
         {
             Status = "Editing primary key columns isn't supported yet.";
-            return;
+            return false;
         }
 
         var pkIndexes = context.PrimaryKeyColumns.Select(pk => ColumnNames.IndexOf(pk)).ToList();
         if (pkIndexes.Any(i => i < 0))
         {
             Status = "Cannot edit: primary key column isn't present in this result set.";
-            return;
+            return false;
         }
 
         // Postgres-native values a CLR conversion can't express — enum labels,
@@ -1064,7 +1064,7 @@ public sealed partial class QueryViewModel : ObservableObject
         // before anything is sent.
         var columnMeta = context.Column(columnName);
         var castType = columnMeta?.Editor
-            is ColumnValueEditor.Enum or ColumnValueEditor.Array or ColumnValueEditor.Composite
+            is ColumnValueEditor.Enum or ColumnValueEditor.Array or ColumnValueEditor.Composite or ColumnValueEditor.Json
             ? columnMeta.DataType
             : null;
 
@@ -1075,6 +1075,7 @@ public sealed partial class QueryViewModel : ObservableObject
             {
                 ColumnValueEditor.Array => PgValueSyntax.ValidateArray(newValueText),
                 ColumnValueEditor.Composite => PgValueSyntax.ValidateComposite(newValueText),
+                ColumnValueEditor.Json => PgValueSyntax.ValidateJson(newValueText),
                 _ => null,
             };
 
@@ -1082,7 +1083,7 @@ public sealed partial class QueryViewModel : ObservableObject
             {
                 Status = $"Invalid value for {columnName}: {syntaxError}";
                 HasError = true;
-                return;
+                return false;
             }
 
             newValue = newValueText;
@@ -1097,14 +1098,14 @@ public sealed partial class QueryViewModel : ObservableObject
             {
                 Status = $"Invalid value for {columnName}: {ex.Message}";
                 HasError = true;
-                return;
+                return false;
             }
         }
 
         if (ShouldStageChanges)
         {
             StageCellValue(context, row, pkIndexes, columnIndex, columnName, newValue, castType);
-            return;
+            return true;
         }
 
         var whereClause = string.Join(
@@ -1129,11 +1130,13 @@ public sealed partial class QueryViewModel : ObservableObject
             await _engine.ExecuteNonQueryAsync(sql, parameters, CancellationToken.None);
             ReplaceRowCell(row, columnIndex, newValue);
             Status = $"Saved {context.Schema}.{context.Table}.{columnName}";
+            return true;
         }
         catch (Exception ex)
         {
             Status = $"Update failed: {ex.Message}";
             HasError = true;
+            return false;
         }
     }
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -9,6 +9,7 @@
         xmlns:sys="using:System"
         xmlns:conv="using:Avalonia.Data.Converters"
         xmlns:conv2="using:PgNimbus.App.Converters"
+        xmlns:json="using:PgNimbus.Core.Json"
         mc:Ignorable="d"
         d:DesignWidth="1000" d:DesignHeight="650"
         x:Class="PgNimbus.App.Views.MainWindow"
@@ -1064,36 +1065,97 @@
         Cell inspector: Space on the current cell, double-click (read-only
         results - in editable grids double-click starts the inline edit), or
         the context menu. Shows the full value - readable and copyable without
-        inline-edit tricks, with jsonb/json pretty-printed. Same
-        centered-overlay-over-scrim shape as the command palette, closed by the
-        scrim, the × button, or Esc.
+        inline-edit tricks, with jsonb/json pretty-printed, browsable as a tree,
+        and (for an editable jsonb/json cell) editable in place: Format, Minify,
+        client-side validation, and Save through the same cast-to-jsonb path an
+        inline grid edit uses. Same centered-overlay-over-scrim shape as the
+        command palette, closed by the scrim, the × button, or Esc.
     -->
     <Border Name="CellInspectorOverlay"
             IsVisible="{Binding CellInspector.IsOpen}"
             Background="#66000000"
             PointerPressed="OnCellInspectorScrimPressed">
-        <Border Width="640" MaxHeight="520" MinHeight="120" VerticalAlignment="Center"
+        <Border Width="660" MaxHeight="580" MinHeight="120" VerticalAlignment="Center"
                 Background="{DynamicResource SystemControlPageBackgroundAltHighBrush}"
                 BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
                 CornerRadius="10" BoxShadow="0 12 32 0 #40000000"
                 PointerPressed="OnCellInspectorCardPressed"
                 x:DataType="vm:CellInspectorViewModel" DataContext="{Binding CellInspector}">
-            <Grid RowDefinitions="Auto,*" Margin="14">
-                <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto,Auto" Margin="0,0,0,10">
+            <Grid RowDefinitions="Auto,*,Auto" Margin="14">
+                <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,10">
                     <TextBlock Grid.Column="0" Text="{Binding ColumnName}" FontWeight="SemiBold" FontSize="14"
                                VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
-                    <ToggleButton Grid.Column="1" Content="Wrap" Classes="chip" Margin="6,0,0,0"
-                                  IsChecked="{Binding WordWrap}" ToolTip.Tip="Toggle word wrap" />
-                    <Button Grid.Column="2" Content="Copy" Classes="chip" Margin="6,0,0,0"
-                            Click="OnCellInspectorCopyClick" />
-                    <Button Grid.Column="3" Content="✕" Classes="chip" Margin="6,0,0,0"
-                            Command="{Binding CloseCommand}" />
+                    <StackPanel Grid.Column="1" Orientation="Horizontal">
+                        <ToggleButton Content="Tree" Classes="chip" Margin="6,0,0,0"
+                                      IsVisible="{Binding CanShowTreeToggle}"
+                                      IsChecked="{Binding IsTreeView}"
+                                      ToolTip.Tip="Toggle tree / text view" />
+                        <ToggleButton Content="Wrap" Classes="chip" Margin="6,0,0,0"
+                                      IsVisible="{Binding ShowText}"
+                                      IsChecked="{Binding WordWrap}" ToolTip.Tip="Toggle word wrap" />
+                        <Button Content="Edit" Classes="chip" Margin="6,0,0,0"
+                                IsVisible="{Binding CanShowEdit}"
+                                Command="{Binding EditCommand}" ToolTip.Tip="Edit this JSON value" />
+                        <Button Content="Copy" Classes="chip" Margin="6,0,0,0"
+                                IsVisible="{Binding !IsEditing}"
+                                Click="OnCellInspectorCopyClick" />
+                        <Button Content="✕" Classes="chip" Margin="6,0,0,0"
+                                Command="{Binding CloseCommand}" />
+                    </StackPanel>
                 </Grid>
-                <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
+
+                <!-- Read: pretty/raw text -->
+                <ScrollViewer Grid.Row="1" IsVisible="{Binding ShowText}"
+                              HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto">
                     <SelectableTextBlock Text="{Binding DisplayText}"
                                           TextWrapping="{Binding WordWrap, Converter={x:Static conv2:BoolToTextWrappingConverter.Instance}}"
                                           FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="13" />
                 </ScrollViewer>
+
+                <!-- Read: collapsible document tree (JSON only) -->
+                <TreeView Grid.Row="1" IsVisible="{Binding ShowTree}"
+                          ItemsSource="{Binding TreeRoots}"
+                          Background="Transparent" BorderThickness="0">
+                    <TreeView.ItemTemplate>
+                        <TreeDataTemplate ItemsSource="{Binding Children}" x:DataType="json:JsonTreeNode">
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"
+                                           FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="12" />
+                                <TextBlock Text="{Binding ValuePreview}" Opacity="0.75"
+                                           FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="12"
+                                           TextTrimming="CharacterEllipsis" />
+                            </StackPanel>
+                        </TreeDataTemplate>
+                    </TreeView.ItemTemplate>
+                </TreeView>
+
+                <!-- Edit: AvaloniaEdit JSON editor (two-way synced in code-behind) -->
+                <Border Grid.Row="1" IsVisible="{Binding IsEditing}"
+                        BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1" CornerRadius="6">
+                    <ae:TextEditor Name="JsonInspectorEditor"
+                                   ShowLineNumbers="True" WordWrap="True"
+                                   FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="13" />
+                </Border>
+
+                <!-- Edit action bar + inline validation/save messages -->
+                <StackPanel Grid.Row="2" IsVisible="{Binding IsEditing}" Spacing="6" Margin="0,10,0,0">
+                    <TextBlock Text="{Binding ValidationError}" IsVisible="{Binding HasValidationError}"
+                               Foreground="{DynamicResource SystemControlErrorTextForegroundBrush}"
+                               TextWrapping="Wrap" FontSize="12" />
+                    <TextBlock Text="{Binding SaveError}"
+                               IsVisible="{Binding SaveError, Converter={x:Static conv:ObjectConverters.IsNotNull}}"
+                               Foreground="{DynamicResource SystemControlErrorTextForegroundBrush}"
+                               TextWrapping="Wrap" FontSize="12" />
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="6">
+                        <Button Content="Format" Classes="chip" Command="{Binding FormatCommand}"
+                                ToolTip.Tip="Pretty-print" />
+                        <Button Content="Minify" Classes="chip" Command="{Binding MinifyCommand}"
+                                ToolTip.Tip="Collapse to one line" />
+                        <Button Content="Cancel" Classes="chip" Command="{Binding CancelEditCommand}" />
+                        <Button Content="Save" Classes="chip" Command="{Binding SaveCommand}"
+                                IsEnabled="{Binding !HasValidationError}" />
+                    </StackPanel>
+                </StackPanel>
             </Grid>
         </Border>
     </Border>

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -35,6 +35,10 @@ public partial class MainWindow : Window
     private MainViewModel? _viewModel;
     private QueryViewModel? _queryViewModel;
     private bool _suppressEditorSync;
+    // Re-entrancy guard for the cell inspector's JSON editor, same shape as
+    // _suppressEditorSync: the ViewModel↔AvaloniaEdit two-way sync is manual
+    // (AvaloniaEdit's Text isn't a bindable AvaloniaProperty).
+    private bool _suppressInspectorSync;
     private object?[]? _pendingEditRow;
     private int _pendingEditColumnIndex;
     private string? _pendingEditText;
@@ -50,6 +54,8 @@ public partial class MainWindow : Window
     private char _pendingAutoCloser;
     private ShortcutsWindow? _shortcutsWindow;
     private IHighlightingDefinition? _sqlHighlighting;
+    // JSON highlighting for the cell inspector's edit mode (theme-neutral palette).
+    private IHighlightingDefinition? _jsonHighlighting;
     // AvaloniaEdit's stock find/replace panel, installed on the SQL editor;
     // opened via Ctrl+F / Ctrl+H (see OnKeyDown) or the command palette.
     private SearchPanel? _searchPanel;
@@ -103,6 +109,7 @@ public partial class MainWindow : Window
         ActualThemeVariantChanged += (_, _) =>
         {
             ApplySqlHighlightingTheme();
+            ApplyJsonHighlightingTheme();
             UpdateThemeIcon();
             // ShellBackdropBrush is theme-split, so re-resolve on a theme flip.
             ApplyBackdrop();
@@ -121,6 +128,19 @@ public partial class MainWindow : Window
 
             _queryViewModel.Sql = SqlEditor.Text;
         };
+
+        // Cell-inspector JSON editor: same manual two-way sync as the SQL editor.
+        // Editor → ViewModel here; ViewModel → editor in OnCellInspectorPropertyChanged.
+        JsonInspectorEditor.TextChanged += (_, _) =>
+        {
+            if (_viewModel is null || _suppressInspectorSync)
+            {
+                return;
+            }
+
+            _viewModel.CellInspector.EditText = JsonInspectorEditor.Text;
+        };
+        LoadJsonHighlighting();
 
         // Feed the editor's live selection to the active tab so "Run" executes
         // just the highlighted SQL when there is a selection (see RunAsync).
@@ -527,6 +547,55 @@ public partial class MainWindow : Window
         ApplySqlHighlightingTheme();
     }
 
+    // The cell inspector's JSON editor gets its own highlighting, theme-rewritten
+    // the same way the SQL editor's is (the XSHD bakes in the dark palette).
+    private void LoadJsonHighlighting()
+    {
+        using var stream = AssetLoader.Open(new Uri("avares://PgNimbus.App/Assets/Json.xshd"));
+        using var reader = XmlReader.Create(stream);
+        _jsonHighlighting = HighlightingLoader.Load(reader, HighlightingManager.Instance);
+        ApplyJsonHighlightingTheme();
+    }
+
+    private void ApplyJsonHighlightingTheme()
+    {
+        if (_jsonHighlighting is null)
+        {
+            return;
+        }
+
+        var dark = ActualThemeVariant == ThemeVariant.Dark;
+        SetHighlightColor(_jsonHighlighting, "Property", dark ? "#9CDCFE" : "#0451A5");
+        SetHighlightColor(_jsonHighlighting, "String", dark ? "#CE9178" : "#A31515");
+        SetHighlightColor(_jsonHighlighting, "Number", dark ? "#B5CEA8" : "#098658");
+        SetHighlightColor(_jsonHighlighting, "Keyword", dark ? "#569CD6" : "#0000E0");
+
+        // Reassigning drops the TextView's cached line visuals so the new brushes take.
+        JsonInspectorEditor.SyntaxHighlighting = null;
+        JsonInspectorEditor.SyntaxHighlighting = _jsonHighlighting;
+    }
+
+    // ViewModel → editor half of the inspector's manual two-way sync: when the
+    // ViewModel changes EditText (entering edit mode, Format, Minify), push it
+    // into AvaloniaEdit under the re-entrancy guard so the echo back doesn't loop.
+    private void OnCellInspectorPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(CellInspectorViewModel.EditText) || _viewModel is null)
+        {
+            return;
+        }
+
+        var text = _viewModel.CellInspector.EditText;
+        if (JsonInspectorEditor.Text == text)
+        {
+            return;
+        }
+
+        _suppressInspectorSync = true;
+        JsonInspectorEditor.Text = text;
+        _suppressInspectorSync = false;
+    }
+
     // The XSHD bakes in the dark palette; the highlighter has no theme
     // awareness of its own, so the named colors are rewritten whenever the
     // actual theme variant resolves or changes.
@@ -606,9 +675,11 @@ public partial class MainWindow : Window
         }
     }
 
-    private void SetHighlightColor(string name, string hex)
+    private void SetHighlightColor(string name, string hex) => SetHighlightColor(_sqlHighlighting, name, hex);
+
+    private static void SetHighlightColor(IHighlightingDefinition? highlighting, string name, string hex)
     {
-        if (_sqlHighlighting!.GetNamedColor(name) is { } color)
+        if (highlighting?.GetNamedColor(name) is { } color)
         {
             color.Foreground = new SimpleHighlightingBrush(Color.Parse(hex));
         }
@@ -687,6 +758,7 @@ public partial class MainWindow : Window
         if (_viewModel is not null)
         {
             _viewModel.PropertyChanged -= OnMainViewModelPropertyChanged;
+            _viewModel.CellInspector.PropertyChanged -= OnCellInspectorPropertyChanged;
             _viewModel.ThemeToggleRequested -= ToggleTheme;
             _viewModel.ShortcutsRequested -= ShowShortcutsWindow;
             _viewModel.SwitchConnectionRequested -= SwitchConnection;
@@ -705,6 +777,7 @@ public partial class MainWindow : Window
 
         _viewModel = vm;
         _viewModel.PropertyChanged += OnMainViewModelPropertyChanged;
+        _viewModel.CellInspector.PropertyChanged += OnCellInspectorPropertyChanged;
         // Palette actions that touch the window are handled here.
         _viewModel.ThemeToggleRequested += ToggleTheme;
         _viewModel.ShortcutsRequested += ShowShortcutsWindow;
@@ -2165,7 +2238,27 @@ public partial class MainWindow : Window
             return;
         }
 
-        _viewModel.CellInspector.Open(_queryViewModel.ColumnNames[columnIndex], row[columnIndex]);
+        var query = _queryViewModel;
+        var name = query.ColumnNames[columnIndex];
+
+        // A json/jsonb cell is editable in the inspector under the same
+        // conditions an inline grid edit is: a keyed, editable result set, a
+        // non-PK column whose type gets the Json editor, and the table's whole
+        // primary key present in the result so the UPDATE can target the row.
+        var editorMeta = query.EditContext?.Column(name);
+        var canEdit = query.IsEditable
+            && query.EditContext is { } ctx
+            && editorMeta?.Editor == ColumnValueEditor.Json
+            && !ctx.PrimaryKeyColumns.Contains(name)
+            && ctx.PrimaryKeyColumns.All(pk => query.ColumnNames.Contains(pk));
+
+        // Commit through the same path an inline edit uses; return null on
+        // success or the resulting status text so the inspector can show it.
+        Func<int, string, Task<string?>>? commit = canEdit
+            ? async (col, text) => await query.CommitCellEditAsync(row, col, text) ? null : query.Status
+            : null;
+
+        _viewModel.CellInspector.Open(name, row[columnIndex], columnIndex, canEdit, commit);
     }
 
     private async void OnCellInspectorCopyClick(object? sender, RoutedEventArgs e)

--- a/PgNimbus.Core.Tests/Json/JsonTreeTests.cs
+++ b/PgNimbus.Core.Tests/Json/JsonTreeTests.cs
@@ -1,0 +1,110 @@
+using PgNimbus.Core.Json;
+
+namespace PgNimbus.Core.Tests.Json;
+
+public class JsonTreeTests
+{
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
+    [Arguments("not json")]
+    [Arguments("{unclosed")]
+    [Arguments("{\"a\": 1,}")] // trailing comma
+    public async Task NonJsonReturnsNull(string text)
+    {
+        await Assert.That(JsonTree.Parse(text)).IsNull();
+    }
+
+    [Test]
+    public async Task RootScalarIsALeaf()
+    {
+        var root = JsonTree.Parse("42");
+
+        await Assert.That(root).IsNotNull();
+        await Assert.That(root!.Name).IsEqualTo("$");
+        await Assert.That(root.Kind).IsEqualTo(JsonNodeKind.Number);
+        await Assert.That(root.ValuePreview).IsEqualTo("42");
+        await Assert.That(root.HasChildren).IsFalse();
+    }
+
+    [Test]
+    public async Task StringLeafIsQuoted()
+    {
+        var root = JsonTree.Parse("\"hi\"");
+
+        await Assert.That(root!.Kind).IsEqualTo(JsonNodeKind.String);
+        await Assert.That(root.ValuePreview).IsEqualTo("\"hi\"");
+    }
+
+    [Test]
+    public async Task NullLeafHasNullKind()
+    {
+        var root = JsonTree.Parse("null");
+
+        await Assert.That(root!.Kind).IsEqualTo(JsonNodeKind.Null);
+        await Assert.That(root.ValuePreview).IsEqualTo("null");
+    }
+
+    [Test]
+    public async Task ObjectMembersKeyedByPropertyName()
+    {
+        var root = JsonTree.Parse("""{"a": 1, "b": true, "c": null}""");
+
+        await Assert.That(root!.Kind).IsEqualTo(JsonNodeKind.Object);
+        await Assert.That(root.HasChildren).IsTrue();
+        await Assert.That(root.Children.Count).IsEqualTo(3);
+        await Assert.That(root.ValuePreview).IsEqualTo("{ 3 fields }");
+
+        await Assert.That(root.Children[0].Name).IsEqualTo("a");
+        await Assert.That(root.Children[0].Kind).IsEqualTo(JsonNodeKind.Number);
+        await Assert.That(root.Children[1].Name).IsEqualTo("b");
+        await Assert.That(root.Children[1].Kind).IsEqualTo(JsonNodeKind.Boolean);
+        await Assert.That(root.Children[2].Name).IsEqualTo("c");
+        await Assert.That(root.Children[2].Kind).IsEqualTo(JsonNodeKind.Null);
+    }
+
+    [Test]
+    public async Task ArrayElementsNamedByIndex()
+    {
+        var root = JsonTree.Parse("""["x", "y", "z"]""");
+
+        await Assert.That(root!.Kind).IsEqualTo(JsonNodeKind.Array);
+        await Assert.That(root.ValuePreview).IsEqualTo("[ 3 items ]");
+        await Assert.That(root.Children[0].Name).IsEqualTo("[0]");
+        await Assert.That(root.Children[2].Name).IsEqualTo("[2]");
+        await Assert.That(root.Children[2].ValuePreview).IsEqualTo("\"z\"");
+    }
+
+    [Test]
+    public async Task NestedStructureRecurses()
+    {
+        var root = JsonTree.Parse("""{"user": {"name": "Ada", "roles": ["admin", "dev"]}}""");
+
+        var user = root!.Children[0];
+        await Assert.That(user.Name).IsEqualTo("user");
+        await Assert.That(user.Kind).IsEqualTo(JsonNodeKind.Object);
+
+        var roles = user.Children[1];
+        await Assert.That(roles.Name).IsEqualTo("roles");
+        await Assert.That(roles.Kind).IsEqualTo(JsonNodeKind.Array);
+        await Assert.That(roles.Children.Count).IsEqualTo(2);
+        await Assert.That(roles.Children[0].ValuePreview).IsEqualTo("\"admin\"");
+    }
+
+    [Test]
+    public async Task SingularSummariesReadNaturally()
+    {
+        await Assert.That(JsonTree.Parse("""{"only": 1}""")!.ValuePreview).IsEqualTo("{ 1 field }");
+        await Assert.That(JsonTree.Parse("[1]")!.ValuePreview).IsEqualTo("[ 1 item ]");
+    }
+
+    [Test]
+    public async Task LongStringLeafIsTruncated()
+    {
+        var big = new string('x', 500);
+        var root = JsonTree.Parse($"\"{big}\"");
+
+        await Assert.That(root!.ValuePreview.Length).IsLessThan(big.Length);
+        await Assert.That(root.ValuePreview.EndsWith('…')).IsTrue();
+    }
+}

--- a/PgNimbus.Core.Tests/Schema/ColumnValueEditorClassifierTests.cs
+++ b/PgNimbus.Core.Tests/Schema/ColumnValueEditorClassifierTests.cs
@@ -12,6 +12,8 @@ public class ColumnValueEditorClassifierTests
     [Arguments('b', 'D', "date", ColumnValueEditor.Date)]
     [Arguments('b', 'D', "timestamp", ColumnValueEditor.Timestamp)]
     [Arguments('b', 'D', "timestamptz", ColumnValueEditor.Timestamp)]
+    [Arguments('b', 'U', "json", ColumnValueEditor.Json)]
+    [Arguments('b', 'U', "jsonb", ColumnValueEditor.Json)]
     public async Task ClassifiesDedicatedEditors(char typtype, char typcategory, string typname, ColumnValueEditor expected)
     {
         await Assert.That(ColumnValueEditorClassifier.Classify(typtype, typcategory, typname)).IsEqualTo(expected);
@@ -22,7 +24,8 @@ public class ColumnValueEditorClassifierTests
     [Arguments('b', 'N', "int4")]
     [Arguments('b', 'N', "numeric")]
     [Arguments('b', 'U', "uuid")]
-    [Arguments('b', 'U', "jsonb")]
+    [Arguments('b', 'U', "jsonpath")] // a jsonpath expression isn't JSON-shaped — stays text
+    [Arguments('b', 'U', "hstore")]   // hstore's "k"=>"v" literal isn't JSON — stays text
     [Arguments('b', 'D', "time")]     // no seconds-capable picker — stays text
     [Arguments('b', 'T', "interval")]
     [Arguments('r', 'R', "int4range")]

--- a/PgNimbus.Core.Tests/Schema/PgTypeCategorizerTests.cs
+++ b/PgNimbus.Core.Tests/Schema/PgTypeCategorizerTests.cs
@@ -104,7 +104,7 @@ public class PgTypeCategorizerTests
     // Other editors don't override the name-based family.
     [Arguments("integer", ColumnValueEditor.Text, PgTypeCategory.Numeric)]
     [Arguments("boolean", ColumnValueEditor.Boolean, PgTypeCategory.Boolean)]
-    [Arguments("jsonb", ColumnValueEditor.Text, PgTypeCategory.Json)]
+    [Arguments("jsonb", ColumnValueEditor.Json, PgTypeCategory.Json)]
     public async Task CategorizeColumnUsesEditorForEnumAndComposite(string declared, ColumnValueEditor editor, PgTypeCategory expected)
     {
         await Assert.That(PgTypeCategorizer.CategorizeColumn(declared, null, editor)).IsEqualTo(expected);

--- a/PgNimbus.Core.Tests/Schema/PgValueSyntaxTests.cs
+++ b/PgNimbus.Core.Tests/Schema/PgValueSyntaxTests.cs
@@ -137,4 +137,37 @@ public class PgValueSyntaxTests
     {
         await Assert.That(PgValueSyntax.ValidateScalar(dataType, value)).IsNotNull();
     }
+
+    [Test]
+    [Arguments("{}")]
+    [Arguments("[]")]
+    [Arguments("""{"a": 1, "b": [true, null, "x"]}""")]
+    [Arguments("[1, 2, 3]")]
+    [Arguments("  { \"nested\": { \"deep\": 42 } }  ")] // leading/trailing space is fine
+    // json/jsonb both accept a bare scalar, so ValidateJson must too.
+    [Arguments("42")]
+    [Arguments("-3.14")]
+    [Arguments("\"just a string\"")]
+    [Arguments("true")]
+    [Arguments("null")]
+    // Blank defers to the server / column default.
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task AcceptsWellFormedJson(string value)
+    {
+        await Assert.That(PgValueSyntax.ValidateJson(value)).IsNull();
+    }
+
+    [Test]
+    [Arguments("{not really validated}")]
+    [Arguments("""{"a": 1,}""")]          // trailing comma — Postgres rejects it too
+    [Arguments("""{"a": 1""")]            // unclosed brace
+    [Arguments("[1, 2,]")]                 // trailing comma in array
+    [Arguments("'single quotes'")]         // JSON requires double quotes
+    [Arguments("undefined")]
+    [Arguments("{ bare: 1 }")]             // unquoted key
+    public async Task RejectsMalformedJson(string value)
+    {
+        await Assert.That(PgValueSyntax.ValidateJson(value)).IsNotNull();
+    }
 }

--- a/PgNimbus.Core/Json/JsonTree.cs
+++ b/PgNimbus.Core/Json/JsonTree.cs
@@ -1,0 +1,134 @@
+using System.Text;
+using System.Text.Json;
+
+namespace PgNimbus.Core.Json;
+
+/// <summary>The JSON value kind a <see cref="JsonTreeNode"/> holds — drives the per-kind glyph the tree view shows.</summary>
+public enum JsonNodeKind
+{
+    Object,
+    Array,
+    String,
+    Number,
+    Boolean,
+    Null,
+}
+
+/// <summary>
+/// One node in the read-only tree the cell inspector renders for a JSON value:
+/// an object member (keyed by its property name), an array element (named
+/// <c>[i]</c>), or the document root. Containers carry their <see cref="Children"/>;
+/// scalars carry a display-ready <see cref="ValuePreview"/>. Pure data — the App
+/// binds a <c>TreeView</c> to it, but nothing here touches UI (Core stays
+/// Avalonia-free).
+/// </summary>
+public sealed record JsonTreeNode(
+    string Name,
+    JsonNodeKind Kind,
+    string ValuePreview,
+    IReadOnlyList<JsonTreeNode> Children)
+{
+    /// <summary>True for objects and arrays — the nodes a tree view can expand.</summary>
+    public bool HasChildren => Children.Count > 0;
+}
+
+/// <summary>
+/// Builds a <see cref="JsonTreeNode"/> tree from a JSON string for the inspector's
+/// document view. Structure-only and forgiving: returns null when the text isn't
+/// JSON (the inspector then just shows the raw text), never throws.
+/// </summary>
+public static class JsonTree
+{
+    // Leaf string previews are clamped so one giant value can't blow out a row;
+    // the inspector's text view still shows the untruncated value.
+    private const int MaxPreviewLength = 200;
+
+    /// <summary>The parsed tree's root, or null when <paramref name="text"/> isn't well-formed JSON.</summary>
+    public static JsonTreeNode? Parse(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(text);
+            // The root is named "$" (jsonpath's root) so the breadcrumb reads naturally.
+            return BuildNode("$", document.RootElement);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static JsonTreeNode BuildNode(string name, JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+            {
+                var children = new List<JsonTreeNode>();
+                foreach (var property in element.EnumerateObject())
+                {
+                    children.Add(BuildNode(property.Name, property.Value));
+                }
+
+                return new JsonTreeNode(name, JsonNodeKind.Object, SummarizeObject(children.Count), children);
+            }
+
+            case JsonValueKind.Array:
+            {
+                var children = new List<JsonTreeNode>();
+                var index = 0;
+                foreach (var item in element.EnumerateArray())
+                {
+                    children.Add(BuildNode($"[{index++}]", item));
+                }
+
+                return new JsonTreeNode(name, JsonNodeKind.Array, SummarizeArray(children.Count), children);
+            }
+
+            case JsonValueKind.String:
+                return Leaf(name, JsonNodeKind.String, Quote(element.GetString() ?? string.Empty));
+
+            case JsonValueKind.Number:
+                return Leaf(name, JsonNodeKind.Number, element.GetRawText());
+
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                return Leaf(name, JsonNodeKind.Boolean, element.GetRawText());
+
+            default: // Null (and the unreachable Undefined)
+                return Leaf(name, JsonNodeKind.Null, "null");
+        }
+    }
+
+    private static JsonTreeNode Leaf(string name, JsonNodeKind kind, string preview) =>
+        new(name, kind, Truncate(preview), []);
+
+    private static string SummarizeObject(int count) => count == 1 ? "{ 1 field }" : $"{{ {count} fields }}";
+
+    private static string SummarizeArray(int count) => count == 1 ? "[ 1 item ]" : $"[ {count} items ]";
+
+    private static string Quote(string value) => Truncate($"\"{value}\"");
+
+    private static string Truncate(string value)
+    {
+        if (value.Length <= MaxPreviewLength)
+        {
+            return value;
+        }
+
+        // Collapse embedded newlines/tabs so a multi-line string stays one row.
+        var clamped = value[..MaxPreviewLength];
+        var sb = new StringBuilder(clamped.Length + 1);
+        foreach (var ch in clamped)
+        {
+            sb.Append(ch is '\n' or '\r' or '\t' ? ' ' : ch);
+        }
+
+        return sb.Append('…').ToString();
+    }
+}

--- a/PgNimbus.Core/Schema/ColumnValueEditor.cs
+++ b/PgNimbus.Core/Schema/ColumnValueEditor.cs
@@ -5,7 +5,7 @@ namespace PgNimbus.Core.Schema;
 /// column's *base* Postgres type — domains are resolved through
 /// <c>pg_type.typbasetype</c> first, so a domain over an enum still gets the
 /// enum dropdown. Anything without a dedicated editor (text, numerics, uuid,
-/// json, ranges, …) stays <see cref="Text"/>: those already round-trip fine
+/// ranges, …) stays <see cref="Text"/>: those already round-trip fine
 /// through a plain text box.
 /// </summary>
 public enum ColumnValueEditor
@@ -29,6 +29,9 @@ public enum ColumnValueEditor
 
     /// <summary>A composite (row) type — free text with client-side literal validation.</summary>
     Composite,
+
+    /// <summary>json / jsonb — free text with client-side JSON validation, parsed and stored server-side via a cast to the declared type.</summary>
+    Json,
 }
 
 public static class ColumnValueEditorClassifier
@@ -50,6 +53,10 @@ public static class ColumnValueEditorClassifier
             "bool" => ColumnValueEditor.Boolean,
             "date" => ColumnValueEditor.Date,
             "timestamp" or "timestamptz" => ColumnValueEditor.Timestamp,
+            // json/jsonb round-trip as text but need a server-side cast (there is
+            // no implicit text→json[b] assignment cast) plus a JSON structure
+            // check; jsonpath/hstore aren't JSON-shaped and stay plain Text.
+            "json" or "jsonb" => ColumnValueEditor.Json,
             _ => ColumnValueEditor.Text,
         },
     };

--- a/PgNimbus.Core/Schema/PgValueSyntax.cs
+++ b/PgNimbus.Core/Schema/PgValueSyntax.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Numerics;
 using System.Text;
+using System.Text.Json;
 
 namespace PgNimbus.Core.Schema;
 
@@ -36,6 +37,40 @@ public static class PgValueSyntax
 
     /// <summary>Error message for a malformed composite (row) literal, or null when the structure is fine.</summary>
     public static string? ValidateComposite(string text) => Validate(text.Trim(), '(', ')', "A composite");
+
+    /// <summary>
+    /// Error message for a value that isn't well-formed JSON, or null when it
+    /// parses (or is blank — a blank cell defers to the server / column default).
+    /// Postgres remains the real parser via the statement's <c>CAST(… AS jsonb)</c>;
+    /// this only front-runs the obvious mistakes (a stray comma, an unclosed
+    /// brace) so they surface in the editor instead of as a failed statement.
+    /// json/jsonb both accept a bare scalar (<c>42</c>, <c>"hi"</c>, <c>true</c>,
+    /// <c>null</c>), so this validates any JSON value, not just objects/arrays.
+    /// </summary>
+    public static string? ValidateJson(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        try
+        {
+            // AllowTrailingCommas stays off on purpose: Postgres rejects them too,
+            // so catching them here keeps the client check honest.
+            using var _ = JsonDocument.Parse(text);
+            return null;
+        }
+        catch (JsonException ex)
+        {
+            // JsonException carries 0-based line/byte positions; present 1-based
+            // and only when known (they're null for some low-level failures).
+            var where = ex.LineNumber is { } line && ex.BytePositionInLine is { } pos
+                ? $" (line {line + 1}, position {pos + 1})"
+                : string.Empty;
+            return $"Not valid JSON{where}.";
+        }
+    }
 
     /// <summary>
     /// Cheap client-side type check for a hand-typed scalar value against its


### PR DESCRIPTION
Bring json/jsonb up to the same footing as arrays/composites/enums, and
give it the polish competitors are repeatedly asked for (DBeaver #711/#21290
/#37091, TablePlus #355, DataGrip pretty-array).

Correctness — inline/staged/Add-row edits of a json/jsonb cell were broken:
Npgsql surfaces these columns as string, so the value was sent as a plain
text parameter with no cast, and Postgres has no text→json[b] assignment
cast, so the UPDATE/INSERT failed with a type error. Classify json/jsonb as
a new ColumnValueEditor.Json (jsonpath/hstore stay Text — not JSON-shaped),
which routes every edit path through CAST(@value AS jsonb) and a client-side
PgValueSyntax.ValidateJson structure check (a bare scalar is valid json).

Cell inspector — the read-only pretty-printer becomes a full JSON surface:
a collapsible document tree (Core/Json/JsonTree, unit-tested, UI-free), and
for an editable json cell an in-place AvaloniaEdit editor with Format /
Minify / live validation / Save through the same cast path, JSON syntax
highlighting (Assets/Json.xshd, theme-rewritten like the SQL editor).

Completion — SqlCompletionProvider carries the full jsonb function family
plus jsonpath (jsonb_set, jsonb_pretty, jsonb_each, jsonb_path_query, …).

CommitCellEditAsync now returns bool so the inspector knows to close on
success. CLAUDE.md documents the jsonb handling; tests updated/added for
the classifier, ValidateJson accept/reject, and JsonTree.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TGeYNJ8yze3fQ7LYXmyzXC