### PR TITLE
Route no-assignment-cast column types through a server-side cast on inline edit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,8 +280,9 @@ csproj / WiX / MSIX manifest reference them unchanged:
   XAML `Binding`. Both the main SQL editor (`_suppressEditorSync`) and the
   cell inspector's JSON editor (`_suppressInspectorSync`) follow this pattern.
 - **json/jsonb are a first-class editable type.** `ColumnValueEditorClassifier`
-  maps them to `ColumnValueEditor.Json` (jsonpath/hstore stay `Text` — not
-  JSON-shaped), which does two things every edit path (inline F2, staged edits,
+  maps them to `ColumnValueEditor.Json` (jsonpath isn't JSON-shaped so it takes
+  the plain-cast `CastText` path below; hstore stays `Text` — its display needs
+  an extension mapping), which does two things every edit path (inline F2, staged edits,
   the Add-row dialog) honors: the value is validated client-side by
   `PgValueSyntax.ValidateJson` (a `JsonDocument.Parse` structure check — a bare
   scalar is valid json, so it accepts any JSON value) and stored via
@@ -295,6 +296,31 @@ csproj / WiX / MSIX manifest reference them unchanged:
   highlighted by `Assets/Json.xshd`). Completion carries the jsonb function
   family (`SqlCompletionProvider.Functions`); JSON operators (`->`, `@>`, `?`,
   `@?`, …) are punctuation, out of the identifier-triggered completion model.
+- **Cell edits round-trip through a server-side cast, not a CLR conversion, for
+  types Postgres won't assign from text.** Inline edits send the cell text as a
+  parameter and let the engine convert it (`QueryViewModel.ConvertEditedValue`:
+  string/Guid/DateOnly/TimeOnly/TimeSpan/DateTime — the last with deliberate
+  `DateTime.Kind` handling for timestamp vs timestamptz — and the IConvertible
+  numeric family). That path is *wrong* for any type with no implicit text→type
+  assignment cast: Npgsql returns it as `string` (xml, tsvector, tsquery,
+  jsonpath, pg_lsn) or a non-`IConvertible` CLR type (inet→IPAddress,
+  cidr→IPNetwork, macaddr→PhysicalAddress, bytea→byte[], ranges→NpgsqlRange,
+  geometric→Npgsql* structs, bit/varbit→BitArray), and an uncast parameter fails
+  with "column is of type X but expression is of type text". These are classified
+  `ColumnValueEditor.CastText` (whole pg_type categories — network `I`, geometric
+  `G`, range/multirange `R`, bit-string `V` — plus named category-`U` types), and
+  every edit path (inline F2, staged edits, Add-row) routes them through
+  `CAST(@value AS <declared type>)`, exactly as enum/array/composite/json already
+  do — no client-side syntax check (Postgres is the parser; the cast surfaces a
+  precise error). `money` and `uuid` deliberately stay `Text` (they round-trip
+  through decimal/Guid). The value shown in the grid must itself be a valid input
+  literal for the cast to accept the round-trip, so `RowIndexConverter` formats
+  the CLR types whose `ToString` is useless: `byte[]`→`\x`-hex (capped preview),
+  `Array`→Postgres `{…}` literal (`PgValueSyntax.FormatArray`), and
+  `BitArray`→bit string (`10110001`, MSB first). Known edge: a `bit(1)` column
+  surfaces from Npgsql as `bool` (displays `True`/`False`), so an inline edit of
+  it fails loudly at the cast rather than corrupting — the inspector or a `bit(n)`
+  column edits cleanly.
 - `SqlFormatter` follows <https://www.sqlstyle.guide/> ("river" layout: root
   keywords right-aligned to a common column, content to its right). The tests
   in `PgNimbus.Core.Tests` assert exact spacing — a deliberate layout change

--- a/PgNimbus.App/Converters/RowIndexConverter.cs
+++ b/PgNimbus.App/Converters/RowIndexConverter.cs
@@ -33,6 +33,11 @@ public sealed class RowIndexConverter : IValueConverter
                 // the cell inspector uses, which carries the full value) rather
                 // than materializing megabytes of hex for a large blob inline.
                 byte[] bytes => FormatByteaPreview(bytes),
+                // bit/varbit arrive as a BitArray, whose default ToString is
+                // "System.Collections.BitArray". Render the bit string ("10110001",
+                // most-significant bit first, matching Postgres) so it reads and,
+                // for an editable table, round-trips through CAST(text AS bit(n)).
+                System.Collections.BitArray bits => FormatBits(bits),
                 // Array columns render in Postgres's literal syntax ("{a,b}")
                 // instead of the CLR default ("System.String[]") — readable,
                 // and editable in place since the cell editor pre-fills from
@@ -49,6 +54,17 @@ public sealed class RowIndexConverter : IValueConverter
         bytes.Length <= ByteaPreviewBytes
             ? "\\x" + System.Convert.ToHexString(bytes)
             : "\\x" + System.Convert.ToHexString(bytes.AsSpan(0, ByteaPreviewBytes)) + "…";
+
+    private static string FormatBits(System.Collections.BitArray bits)
+    {
+        var chars = new char[bits.Count];
+        for (var i = 0; i < bits.Count; i++)
+        {
+            chars[i] = bits[i] ? '1' : '0';
+        }
+
+        return new string(chars);
+    }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/PgNimbus.App/ViewModels/NewRowField.cs
+++ b/PgNimbus.App/ViewModels/NewRowField.cs
@@ -36,7 +36,8 @@ public sealed partial class NewRowField : ObservableObject
     /// <summary>The resolved base type when the declared type is a domain; null otherwise.</summary>
     public string? DomainBaseType { get; init; }
 
-    public bool IsTextEditor => Editor is ColumnValueEditor.Text or ColumnValueEditor.Array or ColumnValueEditor.Composite or ColumnValueEditor.Json;
+    public bool IsTextEditor => Editor is ColumnValueEditor.Text or ColumnValueEditor.Array
+        or ColumnValueEditor.Composite or ColumnValueEditor.Json or ColumnValueEditor.CastText;
 
     public bool IsBooleanEditor => Editor == ColumnValueEditor.Boolean;
 

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -1057,14 +1057,18 @@ public sealed partial class QueryViewModel : ObservableObject
         }
 
         // Postgres-native values a CLR conversion can't express — enum labels,
-        // array/composite literals (and domains over them) — travel as raw
-        // text and get parsed server-side via a cast to the declared type,
-        // the same mechanism the Add-row dialog uses for every value. A cheap
-        // client-side structure check catches malformed hand-typed literals
-        // before anything is sent.
+        // array/composite/json literals, and the CastText family (network,
+        // geometric, range, bit-string, xml, tsvector/tsquery, jsonpath, bytea,
+        // …, all of which Postgres won't implicitly assign from text) — travel
+        // as raw text and get parsed server-side via a cast to the declared
+        // type, the same mechanism the Add-row dialog uses for every value.
+        // A cheap client-side structure check catches malformed hand-typed
+        // array/composite/json literals before anything is sent; the CastText
+        // types have no cheap check and defer to Postgres (the cast's error).
         var columnMeta = context.Column(columnName);
         var castType = columnMeta?.Editor
-            is ColumnValueEditor.Enum or ColumnValueEditor.Array or ColumnValueEditor.Composite or ColumnValueEditor.Json
+            is ColumnValueEditor.Enum or ColumnValueEditor.Array or ColumnValueEditor.Composite
+               or ColumnValueEditor.Json or ColumnValueEditor.CastText
             ? columnMeta.DataType
             : null;
 

--- a/PgNimbus.Core.Tests/Schema/ColumnValueEditorClassifierTests.cs
+++ b/PgNimbus.Core.Tests/Schema/ColumnValueEditorClassifierTests.cs
@@ -23,15 +23,43 @@ public class ColumnValueEditorClassifierTests
     [Arguments('b', 'S', "text")]
     [Arguments('b', 'N', "int4")]
     [Arguments('b', 'N', "numeric")]
-    [Arguments('b', 'U', "uuid")]
-    [Arguments('b', 'U', "jsonpath")] // a jsonpath expression isn't JSON-shaped — stays text
-    [Arguments('b', 'U', "hstore")]   // hstore's "k"=>"v" literal isn't JSON — stays text
+    [Arguments('b', 'N', "money")]    // round-trips through its CLR decimal — no cast needed
+    [Arguments('b', 'U', "uuid")]     // round-trips through Guid — no cast needed
+    [Arguments('b', 'U', "hstore")]   // display needs an extension mapping — stays text, not CastText
     [Arguments('b', 'D', "time")]     // no seconds-capable picker — stays text
     [Arguments('b', 'T', "interval")]
-    [Arguments('r', 'R', "int4range")]
     public async Task EverythingElseStaysText(char typtype, char typcategory, string typname)
     {
         await Assert.That(ColumnValueEditorClassifier.Classify(typtype, typcategory, typname)).IsEqualTo(ColumnValueEditor.Text);
+    }
+
+    [Test]
+    // Types Postgres won't implicitly assign from text (no text→type assignment
+    // cast) round-trip an inline edit through CAST(text AS type). Whole
+    // categories qualify — network ('I'), geometric ('G'), range/multirange
+    // ('R'), bit-string ('V') — including user-defined ranges; a handful of
+    // category-'U' types are named individually.
+    [Arguments('b', 'I', "inet")]
+    [Arguments('b', 'I', "cidr")]
+    [Arguments('b', 'G', "point")]
+    [Arguments('b', 'G', "box")]
+    [Arguments('b', 'G', "polygon")]
+    [Arguments('r', 'R', "int4range")]
+    [Arguments('m', 'R', "int4multirange")]
+    [Arguments('r', 'R', "myrange")]   // a user-defined range, caught by category not name
+    [Arguments('b', 'V', "bit")]
+    [Arguments('b', 'V', "varbit")]
+    [Arguments('b', 'U', "xml")]
+    [Arguments('b', 'U', "tsvector")]
+    [Arguments('b', 'U', "tsquery")]
+    [Arguments('b', 'U', "jsonpath")]  // not JSON-shaped, but still needs a server-side cast
+    [Arguments('b', 'U', "macaddr")]
+    [Arguments('b', 'U', "macaddr8")]
+    [Arguments('b', 'U', "pg_lsn")]
+    [Arguments('b', 'U', "bytea")]
+    public async Task NoAssignmentCastTypesUseCastText(char typtype, char typcategory, string typname)
+    {
+        await Assert.That(ColumnValueEditorClassifier.Classify(typtype, typcategory, typname)).IsEqualTo(ColumnValueEditor.CastText);
     }
 
     [Test]

--- a/PgNimbus.Core.Tests/Schema/PgTypeCategorizerTests.cs
+++ b/PgNimbus.Core.Tests/Schema/PgTypeCategorizerTests.cs
@@ -105,6 +105,10 @@ public class PgTypeCategorizerTests
     [Arguments("integer", ColumnValueEditor.Text, PgTypeCategory.Numeric)]
     [Arguments("boolean", ColumnValueEditor.Boolean, PgTypeCategory.Boolean)]
     [Arguments("jsonb", ColumnValueEditor.Json, PgTypeCategory.Json)]
+    // CastText (server-side-cast types) keeps the name-based family for its icon.
+    [Arguments("inet", ColumnValueEditor.CastText, PgTypeCategory.Network)]
+    [Arguments("int4range", ColumnValueEditor.CastText, PgTypeCategory.Range)]
+    [Arguments("bit(8)", ColumnValueEditor.CastText, PgTypeCategory.BitString)]
     public async Task CategorizeColumnUsesEditorForEnumAndComposite(string declared, ColumnValueEditor editor, PgTypeCategory expected)
     {
         await Assert.That(PgTypeCategorizer.CategorizeColumn(declared, null, editor)).IsEqualTo(expected);

--- a/PgNimbus.Core/Schema/ColumnValueEditor.cs
+++ b/PgNimbus.Core/Schema/ColumnValueEditor.cs
@@ -32,6 +32,22 @@ public enum ColumnValueEditor
 
     /// <summary>json / jsonb — free text with client-side JSON validation, parsed and stored server-side via a cast to the declared type.</summary>
     Json,
+
+    /// <summary>
+    /// A type Postgres won't implicitly assign from text (it has no text→type
+    /// assignment cast) but whose displayed value is already a valid input
+    /// literal — network addresses, geometric types, ranges/multiranges, bit
+    /// strings, xml, full-text search vectors/queries, bytea, and the like.
+    /// Edited as free text (plain box, no dedicated widget) and parsed
+    /// server-side via <c>CAST(@value AS declared-type)</c>, the same mechanism
+    /// <see cref="Enum"/>/<see cref="Array"/>/<see cref="Composite"/>/<see cref="Json"/>
+    /// use. No client-side syntax check — Postgres is the parser (the cast
+    /// surfaces a precise error), since these literal grammars are too varied to
+    /// pre-validate cheaply. Distinct from <see cref="Text"/>, which is for
+    /// types that round-trip through a bare (uncast) text parameter or a CLR
+    /// conversion (text/varchar, the numeric family, uuid, date/time).
+    /// </summary>
+    CastText,
 }
 
 public static class ColumnValueEditorClassifier
@@ -55,9 +71,29 @@ public static class ColumnValueEditorClassifier
             "timestamp" or "timestamptz" => ColumnValueEditor.Timestamp,
             // json/jsonb round-trip as text but need a server-side cast (there is
             // no implicit text→json[b] assignment cast) plus a JSON structure
-            // check; jsonpath/hstore aren't JSON-shaped and stay plain Text.
+            // check; jsonpath isn't JSON-shaped so it takes the plain cast path
+            // (below), and hstore stays Text (its display needs an extension mapping).
             "json" or "jsonb" => ColumnValueEditor.Json,
-            _ => ColumnValueEditor.Text,
+            _ => NeedsServerCast(typcategory, typname) ? ColumnValueEditor.CastText : ColumnValueEditor.Text,
         },
     };
+
+    /// <summary>
+    /// Whether a base type must round-trip an inline edit through
+    /// <c>CAST(text AS type)</c> rather than a bare text parameter — true for
+    /// types Postgres won't implicitly assign from text (no text→type
+    /// assignment cast), which otherwise fail with "column is of type X but
+    /// expression is of type text". Whole pg_type categories qualify: network
+    /// addresses ('I': inet/cidr), geometric types ('G'), ranges and
+    /// multiranges ('R'), and bit strings ('V': bit/varbit) — so user-defined
+    /// range types get the same treatment. A handful of category-'U' types share
+    /// the property and are listed by name; uuid and json/jsonb are that
+    /// category's round-trippable exceptions and are classified before this is
+    /// reached. Numeric <c>money</c> deliberately stays <see cref="ColumnValueEditor.Text"/>:
+    /// it round-trips through its CLR <c>decimal</c>.
+    /// </summary>
+    private static bool NeedsServerCast(char typcategory, string typname) =>
+        typcategory is 'I' or 'G' or 'R' or 'V'
+        || typname is "bytea" or "xml" or "tsvector" or "tsquery" or "jsonpath"
+            or "macaddr" or "macaddr8" or "pg_lsn";
 }


### PR DESCRIPTION
Inline cell edits (QueryViewModel.CommitCellEditAsync) sent the edited text as
a bare parameter and let ConvertEditedValue turn it into a CLR value. That works
for text, the numeric family, uuid, and date/time, but fails for every Postgres
type that has no implicit text->type assignment cast: Npgsql surfaces those
either as a plain string (xml, tsvector, tsquery, jsonpath, pg_lsn) or as a
non-IConvertible CLR type (inet/IPAddress, cidr/IPNetwork, macaddr/
PhysicalAddress, bytea/byte[], ranges/NpgsqlRange, geometric/Npgsql* structs,
bit,varbit/BitArray). The uncast parameter then errors with "column is of type
X but expression is of type text" — the same class of bug jsonb had before it
became a first-class editable type.

Classify these as a new ColumnValueEditor.CastText (whole pg_type categories:
network I, geometric G, range/multirange R, bit-string V; plus named category-U
types bytea/xml/tsvector/tsquery/jsonpath/macaddr/macaddr8/pg_lsn) and route
them through CAST(@value AS <declared type>) on every edit path — inline F2,
staged edits (castType already threads through StageEdit), and the Add-row
dialog (IsTextEditor now includes CastText). money and uuid deliberately stay
Text; they round-trip through decimal/Guid.

For the cast to accept the round-trip the grid value must be a valid input
literal, so RowIndexConverter now formats BitArray as a bit string (10110001,
MSB first) instead of "System.Collections.BitArray"; bytea and arrays were
already formatted. bit(1) surfaces from Npgsql as bool and remains a documented
edge (fails loudly at the cast, never corrupts).

Verified against PostgreSQL 16: inet and bit(8) inline edits now generate
CAST(... AS inet)/CAST(... AS bit(8)) and commit; a per-type probe confirmed the
previously-failing types (network, geometric, range, bit, xml, tsvector,
tsquery, jsonpath, pg_lsn, bytea) all round-trip through the cast while the
CLR-path types are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013kUThGhrvn98oxdXhwL6rA