### PR TITLE
Edit any free-text cell from the inspector, via a View/Edit tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,9 +324,25 @@ csproj / WiX / MSIX manifest reference them unchanged:
   cast, so an uncast `UPDATE`/`INSERT` of a json column fails with a type error.
   The cell inspector (`CellInspectorViewModel`) pretty-prints JSON, offers a
   read-only collapsible tree (`PgNimbus.Core.Json.JsonTree` builds the node
-  model — pure Core, unit-tested), and for an editable json cell edits in place
-  (Format / Minify / client-side validation / Save through the same cast path,
-  highlighted by `Assets/Json.xshd`). Completion carries the jsonb function
+  model — pure Core, unit-tested), and edits an editable cell in place via a
+  **View / Edit** segmented-tab header (one click each way; the in-progress edit
+  buffer survives a hop to View and back — the `_editSeeded` flag reseeds only on
+  first entry or a Cancel/Save). Editing is offered for the **free-text editor
+  kinds** (`MainWindow.IsFreeTextEditor`: `Text`/`Array`/`Composite`/`Json`/
+  `CastText`) — everything the commit path can take as typed text — but **not**
+  the typed-widget kinds (`Boolean`/`Enum`/`Date`/`Timestamp`), which stay
+  inline-only (a text box is a downgrade from their checkbox/dropdown/picker).
+  JSON keeps its extras: Format / Minify / client-side validation / `Json.xshd`
+  highlighting / the tree toggle, all gated on *json-ness*. Crucially, validation
+  is **type-derived** (`validatesAsJson`, set from the column's `Json` editor),
+  not content-derived (`IsJson`, which merely reflects whether the value parses)
+  — so a plain `text` column holding a JSON-looking string still accepts any
+  string. A double-click on an editable json/jsonb cell opens the inspector
+  straight on the Edit tab (`OpenCellInspector(..., startEditing: true)`), since
+  json is unusable in a one-line inline editor; `MainWindow.OnResultsGridBeginningEdit`
+  cancels the grid's own inline edit for that gesture. Other editable types keep
+  their fast inline double-click; the inspector's Edit tab is reached via Space /
+  "Inspect cell…". Completion carries the jsonb function
   family (`SqlCompletionProvider.Functions`); JSON operators (`->`, `@>`, `?`,
   `@?`, …) are punctuation, out of the identifier-triggered completion model.
 - **Cell edits round-trip through a server-side cast, not a CLR conversion, for

--- a/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
+++ b/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
@@ -38,14 +38,12 @@ public sealed partial class CellInspectorViewModel : ObservableObject
 
     /// <summary>True when this cell can be edited (an editable, JSON-typed cell in a keyed result set).</summary>
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(CanShowEdit))]
     private bool _canEdit;
 
     /// <summary>True while the inline JSON editor is showing instead of the read-only value.</summary>
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ShowText))]
     [NotifyPropertyChangedFor(nameof(ShowTree))]
-    [NotifyPropertyChangedFor(nameof(CanShowEdit))]
     [NotifyPropertyChangedFor(nameof(CanShowTreeToggle))]
     [NotifyPropertyChangedFor(nameof(ValidationError))]
     [NotifyPropertyChangedFor(nameof(HasValidationError))]
@@ -82,10 +80,7 @@ public sealed partial class CellInspectorViewModel : ObservableObject
     /// <summary>The Text/Tree toggle only makes sense for a JSON value in read mode.</summary>
     public bool CanShowTreeToggle => IsJson && !IsEditing;
 
-    /// <summary>The Edit chip shows only for an editable cell that isn't already being edited.</summary>
-    public bool CanShowEdit => CanEdit && !IsEditing;
-
-    // Parse the tree lazily the first time it's shown (and only for JSON), then cache it.
+// Parse the tree lazily the first time it's shown (and only for JSON), then cache it.
     partial void OnIsTreeViewChanged(bool value)
     {
         if (value && IsJson && TreeRoots.Count == 0 && JsonTree.Parse(DisplayText) is { } root)
@@ -94,8 +89,10 @@ public sealed partial class CellInspectorViewModel : ObservableObject
         }
     }
 
-    /// <summary>Client-side JSON validation of the in-progress edit — null when it parses or is blank.</summary>
-    public string? ValidationError => IsEditing ? PgValueSyntax.ValidateJson(EditText) : null;
+    /// <summary>Client-side JSON validation of the in-progress edit — null when it parses
+    /// or is blank. Only JSON cells are pre-validated; other free-text types (plain text,
+    /// arrays, xml, …) are parsed server-side on save (the cast surfaces a precise error).</summary>
+    public string? ValidationError => IsEditing && _validatesAsJson ? PgValueSyntax.ValidateJson(EditText) : null;
 
     public bool HasValidationError => ValidationError is not null;
 
@@ -103,6 +100,17 @@ public sealed partial class CellInspectorViewModel : ObservableObject
     // success, or an error message to show inline) and which grid column it is.
     private Func<int, string, Task<string?>>? _commit;
     private int _columnIndex = -1;
+
+    // Whether the edit buffer has been seeded from the displayed value since the
+    // inspector opened. Lets the View/Edit tabs switch back and forth without
+    // discarding an in-progress edit — only the first entry into edit mode (or a
+    // Cancel/Save reset) reseeds EditText from DisplayText.
+    private bool _editSeeded;
+
+    // Whether the column's declared type is json/jsonb (type-derived, unlike the
+    // content-derived IsJson). Only then is the edit client-side JSON-validated -
+    // a plain text column holding a JSON-looking string must accept any string.
+    private bool _validatesAsJson;
 
     private static readonly JsonSerializerOptions PrettyPrintOptions = new()
     {
@@ -127,27 +135,39 @@ public sealed partial class CellInspectorViewModel : ObservableObject
     /// Opens the inspector for one cell. When <paramref name="canEdit"/> is true a
     /// <paramref name="commit"/> delegate persists edits (returning null on success
     /// or an error message); <paramref name="columnIndex"/> identifies the grid
-    /// column that delegate targets.
+    /// column that delegate targets. <paramref name="validatesAsJson"/> is set when the
+    /// column's declared type is json/jsonb, gating client-side JSON validation.
     /// </summary>
-    public void Open(string columnName, object? value, int columnIndex, bool canEdit, Func<int, string, Task<string?>>? commit)
+    public void Open(string columnName, object? value, int columnIndex, bool canEdit, Func<int, string, Task<string?>>? commit, bool validatesAsJson = false, bool startEditing = false)
     {
         ColumnName = columnName;
         _columnIndex = columnIndex;
         _commit = commit;
         CanEdit = canEdit && commit is not null;
+        _validatesAsJson = validatesAsJson;
 
         IsEditing = false;
         IsTreeView = false;
         SaveError = null;
+        _editSeeded = false;
 
         (DisplayText, IsJson) = Format(value);
         TreeRoots = [];
         IsOpen = true;
+
+        // A double-click on an editable json cell means "let me edit this" -
+        // drop straight into the editor rather than the read view.
+        if (startEditing)
+        {
+            Edit();
+        }
     }
 
     [RelayCommand]
     private void Close() => IsOpen = false;
 
+    /// <summary>Switch to the Edit tab. Seeds the editor from the current value only
+    /// on first entry, so toggling back to View and returning keeps in-progress edits.</summary>
     [RelayCommand]
     private void Edit()
     {
@@ -158,14 +178,29 @@ public sealed partial class CellInspectorViewModel : ObservableObject
 
         SaveError = null;
         IsTreeView = false;
-        EditText = DisplayText;
+        if (!_editSeeded)
+        {
+            EditText = DisplayText;
+            _editSeeded = true;
+        }
         IsEditing = true;
+    }
+
+    /// <summary>Switch to the View tab. Leaves the edit buffer intact so the Edit tab
+    /// can be re-selected without losing changes (Cancel is the explicit discard).</summary>
+    [RelayCommand]
+    private void ViewText()
+    {
+        IsEditing = false;
+        IsTreeView = false;
+        SaveError = null;
     }
 
     [RelayCommand]
     private void CancelEdit()
     {
         IsEditing = false;
+        _editSeeded = false;
         SaveError = null;
     }
 
@@ -216,6 +251,7 @@ public sealed partial class CellInspectorViewModel : ObservableObject
         TreeRoots = [];
         SaveError = null;
         IsEditing = false;
+        _editSeeded = false;
     }
 
     private static bool TryReformat(string text, JsonSerializerOptions options, out string result)

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -1151,6 +1151,15 @@
                     <TextBlock Grid.Column="0" Text="{Binding ColumnName}" FontWeight="SemiBold" FontSize="14"
                                VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
                     <StackPanel Grid.Column="1" Orientation="Horizontal">
+                        <!-- View / Edit segmented tabs for an editable JSON cell: one
+                             click switches either way, and the edit buffer survives a
+                             hop to View and back (see CellInspectorViewModel). -->
+                        <Button Content="View" Classes="chip" Classes.active="{Binding !IsEditing}"
+                                IsVisible="{Binding CanEdit}"
+                                Command="{Binding ViewTextCommand}" ToolTip.Tip="View the value" />
+                        <Button Content="Edit" Classes="chip" Margin="6,0,0,0" Classes.active="{Binding IsEditing}"
+                                IsVisible="{Binding CanEdit}"
+                                Command="{Binding EditCommand}" ToolTip.Tip="Edit this JSON value" />
                         <ToggleButton Content="Tree" Classes="chip" Margin="6,0,0,0"
                                       IsVisible="{Binding CanShowTreeToggle}"
                                       IsChecked="{Binding IsTreeView}"
@@ -1158,9 +1167,6 @@
                         <ToggleButton Content="Wrap" Classes="chip" Margin="6,0,0,0"
                                       IsVisible="{Binding ShowText}"
                                       IsChecked="{Binding WordWrap}" ToolTip.Tip="Toggle word wrap" />
-                        <Button Content="Edit" Classes="chip" Margin="6,0,0,0"
-                                IsVisible="{Binding CanShowEdit}"
-                                Command="{Binding EditCommand}" ToolTip.Tip="Edit this JSON value" />
                         <Button Content="Copy" Classes="chip" Margin="6,0,0,0"
                                 IsVisible="{Binding !IsEditing}"
                                 Click="OnCellInspectorCopyClick" />
@@ -1213,9 +1219,9 @@
                                TextWrapping="Wrap" FontSize="12" />
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="6">
                         <Button Content="Format" Classes="chip" Command="{Binding FormatCommand}"
-                                ToolTip.Tip="Pretty-print" />
+                                IsVisible="{Binding IsJson}" ToolTip.Tip="Pretty-print" />
                         <Button Content="Minify" Classes="chip" Command="{Binding MinifyCommand}"
-                                ToolTip.Tip="Collapse to one line" />
+                                IsVisible="{Binding IsJson}" ToolTip.Tip="Collapse to one line" />
                         <Button Content="Cancel" Classes="chip" Command="{Binding CancelEditCommand}" />
                         <Button Content="Save" Classes="chip" Command="{Binding SaveCommand}"
                                 IsEnabled="{Binding !HasValidationError}" />

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -69,6 +69,11 @@ public partial class MainWindow : Window
     // space bar - a TextBox doesn't mark Space's KeyDown handled, it inserts
     // the space on TextInput, so the key would otherwise bubble up here.
     private bool _isCellEditing;
+    // One-shot: set when a double-click lands on an editable json/jsonb cell,
+    // consumed by OnResultsGridBeginningEdit to cancel the grid's inline edit so
+    // the click opens the cell inspector's JSON editor instead (see
+    // OnResultsGridCellPointerPressed).
+    private bool _suppressJsonInlineEdit;
     private readonly BracketHighlightRenderer _bracketRenderer;
 
     private const double MinEditorFontSize = 8;
@@ -174,6 +179,7 @@ public partial class MainWindow : Window
         SqlEditor.AddHandler(DragDrop.DropEvent, OnEditorDrop);
         ResultsGrid.CellEditEnding += OnCellEditEnding;
         ResultsGrid.CellEditEnded += OnCellEditEnded;
+        ResultsGrid.BeginningEdit += OnResultsGridBeginningEdit;
         ResultsGrid.PreparingCellForEdit += OnPreparingCellForEdit;
         ResultsGrid.KeyDown += OnResultsGridKeyDown;
         ResultsGrid.Sorting += OnResultsGridSorting;
@@ -570,9 +576,18 @@ public partial class MainWindow : Window
         SetHighlightColor(_jsonHighlighting, "Number", dark ? "#B5CEA8" : "#098658");
         SetHighlightColor(_jsonHighlighting, "Keyword", dark ? "#569CD6" : "#0000E0");
 
-        // Reassigning drops the TextView's cached line visuals so the new brushes take.
+        UpdateInspectorHighlighting();
+    }
+
+    // JSON highlighting only applies to a json/jsonb cell — the inspector now
+    // edits any free-text type (plain text, arrays, xml, …) where colored JSON
+    // tokens would be noise, so a non-JSON cell gets the bare editor. Reassigning
+    // (null then set) drops the TextView's cached line visuals so the change takes.
+    private void UpdateInspectorHighlighting()
+    {
+        var json = _viewModel?.CellInspector.IsJson == true ? _jsonHighlighting : null;
         JsonInspectorEditor.SyntaxHighlighting = null;
-        JsonInspectorEditor.SyntaxHighlighting = _jsonHighlighting;
+        JsonInspectorEditor.SyntaxHighlighting = json;
     }
 
     // ViewModel → editor half of the inspector's manual two-way sync: when the
@@ -580,6 +595,13 @@ public partial class MainWindow : Window
     // into AvaloniaEdit under the re-entrancy guard so the echo back doesn't loop.
     private void OnCellInspectorPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
+        // IsJson flips per opened cell; the editor's highlighting follows it.
+        if (e.PropertyName == nameof(CellInspectorViewModel.IsJson))
+        {
+            UpdateInspectorHighlighting();
+            return;
+        }
+
         if (e.PropertyName != nameof(CellInspectorViewModel.EditText) || _viewModel is null)
         {
             return;
@@ -2079,9 +2101,56 @@ public partial class MainWindow : Window
         _lastPressedRow = row;
         _lastPressedColumnIndex = e.Column.DisplayIndex;
 
-        if (e.PointerPressedEventArgs.ClickCount == 2 && ResultsGrid.IsReadOnly)
+        if (e.PointerPressedEventArgs.ClickCount == 2)
         {
-            OpenCellInspector(row, e.Column.DisplayIndex);
+            if (ResultsGrid.IsReadOnly)
+            {
+                OpenCellInspector(row, e.Column.DisplayIndex);
+            }
+            else if (IsJsonColumn(e.Column.DisplayIndex))
+            {
+                // json/jsonb is unusable in a one-line inline editor, so a
+                // double-click opens the cell inspector's JSON editor instead.
+                // The DataGrid begins its own inline edit from this same
+                // gesture (marking the pointer event handled doesn't stop it),
+                // so flag the imminent BeginningEdit to cancel it.
+                _suppressJsonInlineEdit = true;
+                OpenCellInspector(row, e.Column.DisplayIndex, startEditing: true);
+            }
+        }
+    }
+
+    // json/jsonb cells route double-click to the inspector rather than inline
+    // editing - the editor metadata is the same Json classification the
+    // inspector's own edit path keys off (see OpenCellInspector).
+    private bool IsJsonColumn(int columnIndex)
+    {
+        if (_queryViewModel is not { } query || columnIndex >= query.ColumnNames.Count)
+        {
+            return false;
+        }
+
+        var name = query.ColumnNames[columnIndex];
+        return query.EditContext?.Column(name)?.Editor == ColumnValueEditor.Json;
+    }
+
+    // Which editor kinds the cell inspector can edit: the free-text ones, all of
+    // which reduce to typing a value the commit path converts/casts. The
+    // typed-widget kinds (boolean/enum/date/timestamp) are excluded - a plain
+    // text box would be a downgrade from their inline checkbox/dropdown/picker.
+    private static bool IsFreeTextEditor(ColumnValueEditor editor) => editor is
+        ColumnValueEditor.Text or ColumnValueEditor.Array or ColumnValueEditor.Composite
+        or ColumnValueEditor.Json or ColumnValueEditor.CastText;
+
+    // Cancels the inline edit the DataGrid tries to start after a double-click
+    // on a json/jsonb cell - OnResultsGridCellPointerPressed has already opened
+    // the inspector for it.
+    private void OnResultsGridBeginningEdit(object? sender, DataGridBeginningEditEventArgs e)
+    {
+        if (_suppressJsonInlineEdit)
+        {
+            _suppressJsonInlineEdit = false;
+            e.Cancel = true;
         }
     }
 
@@ -2230,7 +2299,7 @@ public partial class MainWindow : Window
         _ = vm.PreviewTableAsync(hop.TargetSchema, hop.TargetTable, filter);
     }
 
-    private void OpenCellInspector(object?[] row, int columnIndex)
+    private void OpenCellInspector(object?[] row, int columnIndex, bool startEditing = false)
     {
         if (_viewModel is null || _queryViewModel is null || columnIndex >= row.Length
             || columnIndex >= _queryViewModel.ColumnNames.Count)
@@ -2241,14 +2310,17 @@ public partial class MainWindow : Window
         var query = _queryViewModel;
         var name = query.ColumnNames[columnIndex];
 
-        // A json/jsonb cell is editable in the inspector under the same
-        // conditions an inline grid edit is: a keyed, editable result set, a
-        // non-PK column whose type gets the Json editor, and the table's whole
-        // primary key present in the result so the UPDATE can target the row.
+        // A cell is editable in the inspector under the same conditions an inline
+        // grid edit is: a keyed, editable result set, a non-PK column, and the
+        // table's whole primary key present in the result so the UPDATE can
+        // target the row. Only free-text editor types get the inspector's roomy
+        // multi-line box - the typed-widget types (boolean/enum/date/timestamp)
+        // are strictly better edited inline with their checkbox/dropdown/picker,
+        // so they stay inline-only here.
         var editorMeta = query.EditContext?.Column(name);
         var canEdit = query.IsEditable
             && query.EditContext is { } ctx
-            && editorMeta?.Editor == ColumnValueEditor.Json
+            && editorMeta is { } meta && IsFreeTextEditor(meta.Editor)
             && !ctx.PrimaryKeyColumns.Contains(name)
             && ctx.PrimaryKeyColumns.All(pk => query.ColumnNames.Contains(pk));
 
@@ -2258,7 +2330,8 @@ public partial class MainWindow : Window
             ? async (col, text) => await query.CommitCellEditAsync(row, col, text) ? null : query.Status
             : null;
 
-        _viewModel.CellInspector.Open(name, row[columnIndex], columnIndex, canEdit, commit);
+        var validatesAsJson = editorMeta?.Editor == ColumnValueEditor.Json;
+        _viewModel.CellInspector.Open(name, row[columnIndex], columnIndex, canEdit, commit, validatesAsJson, startEditing && canEdit);
     }
 
     private async void OnCellInspectorCopyClick(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
## What

Generalizes the cell inspector's editing beyond json/jsonb, and reworks the
edit mode into a proper **View / Edit** tab so switching is one click instead of
entering a modal edit state you had to `Cancel` out of.

Motivated by a session of small UX asks: double-click on jsonb should open the
inspector (not a cramped inline box), that inspector should open straight into
editing, the editor should be a tab rather than a separate-feeling window, and —
if we're there — editing should work for all sensible data types, not just json.

## Changes

- **View/Edit segmented tabs** in the inspector header (reusing the existing
  `Button.chip.active` segmented look). One click each way; the in-progress edit
  buffer survives a hop to View and back — `_editSeeded` reseeds `EditText` only
  on first entry into edit, or after a Cancel/Save.
- **Editing offered for the free-text editor kinds** — `Text` / `Array` /
  `Composite` / `Json` / `CastText` (`MainWindow.IsFreeTextEditor`), everything
  the commit path (`CommitCellEditAsync`) already accepts as typed text. The
  **typed-widget kinds** (`Boolean` / `Enum` / `Date` / `Timestamp`) stay
  inline-only — a text box is a downgrade from their checkbox/dropdown/picker.
- **JSON keeps its extras** (Format / Minify / client-side validation /
  `Json.xshd` highlighting / tree toggle), gated on json-ness. Editor
  highlighting follows the content-derived `IsJson`.
- **Validation is now type-derived** (`validatesAsJson`, from the column's
  `Json` editor) rather than content-derived (`IsJson`, which merely reflects
  whether the value parses). So a plain `text` column holding a JSON-looking
  string still accepts any string on save — previously it would have been
  wrongly rejected as invalid JSON.
- **Double-click** on an editable json/jsonb cell opens the inspector directly
  on the Edit tab (`OpenCellInspector(..., startEditing: true)`);
  `OnResultsGridBeginningEdit` cancels the grid's own inline edit for that
  gesture (marking the pointer event handled doesn't stop it). Other editable
  types keep their fast inline double-click; the inspector's Edit tab is reached
  via Space / "Inspect cell…".
- `CLAUDE.md` updated to document all of the above.

## Reviewer notes

- No `Core` changes — the commit machinery was already type-agnostic
  (`CommitCellEditAsync` is text-in and does the right `CAST`/conversion per the
  `ColumnValueEditor` classification). This PR only relaxes the App-side gate and
  reworks the inspector's mode UI.
- `CanShowEdit` was removed (superseded by the always-visible tab pair).
- Not yet verified in a running app — built clean (`dotnet build`), Core tests
  untouched. Happy to run a headless verify pass if wanted.