### PR TITLE
Begin MainWindow decomposition: extract the two sidebar panels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,27 @@ and wrong project memory is worse than none.
    vocabulary is app-wide across the secondary windows and dialogs; the main
    window's command bar deliberately keeps its flat minimalist `toolbar`
    buttons (rule 1) and is the one surface exempt.
+7. **Views compose from focused `UserControl`s — no god-view.** Following
+   Avalonia's MVVM guidance (<https://docs.avaloniaui.net/docs/fundamentals/architecture>):
+   code-behind is the *right* home for purely visual interaction logic that
+   touches `Control` types directly — tab drag-reorder, completion popups,
+   `DataGrid` column building, syntax-highlighting theming, cell-edit events,
+   pointer/scroll handlers. Pushing that into a ViewModel would be *worse*: it
+   leaks `Avalonia.*` types into the layer that (per hard rule 1) must stay
+   engine-clean. So the smell to watch is **not** "code in code-behind" — it's
+   **one code-behind owning many unrelated responsibilities**. When a view's
+   code-behind approaches god-class size (schema tree + tabs + completion +
+   cell editing + import/export + palette + follow-FK all in one file), split
+   the view into `UserControl`s, each with its own `.axaml` + `.axaml.cs` that
+   owns *its* interaction logic and binds to a focused sub-ViewModel. Genuine
+   business operations invoked from a handler (import/export orchestration,
+   value-cast conversion) belong in a service the ViewModel calls, not inline
+   in the handler. `MainWindow` is the standing decomposition target
+   (2026-07): the panels to peel off are `SchemaTreePanel`,
+   `SavedQueriesPanel`, `NotifyMonitorPanel`, `QueryEditorPanel` (editor +
+   completion + highlighting), and `ResultsGridPanel` (grid + column build +
+   cell edit + follow-FK + inspector + export) — do it incrementally, one
+   panel per PR, each `verify`-checked, not one big-bang rewrite.
 
 ## Platform window chrome
 

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -4,7 +4,6 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:ae="using:AvaloniaEdit"
         xmlns:vm="using:PgNimbus.App.ViewModels"
-        xmlns:query="using:PgNimbus.Core.Query"
         xmlns:conv="using:Avalonia.Data.Converters"
         xmlns:conv2="using:PgNimbus.App.Converters"
         xmlns:json="using:PgNimbus.Core.Json"
@@ -415,99 +414,7 @@
                                    IsVisible="{Binding $parent[TabControl].Bounds.Width, Converter={x:Static conv2:MinWidthVisibilityConverter.Instance}, ConverterParameter=300}" />
                     </StackPanel>
                 </TabItem.Header>
-                <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0" x:DataType="vm:SavedQueriesViewModel" DataContext="{Binding SavedQueries}">
-                    <TextBlock Grid.Row="0" Classes="sectionHeader" Text="SAVED QUERIES" Margin="4,0,4,6" />
-                    <Border Grid.Row="1" Classes="card" MinHeight="80">
-                        <Grid>
-                            <ListBox Name="SavedQueriesList" ItemsSource="{Binding SavedQueries}">
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate x:DataType="query:SavedQuery">
-                                        <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Sql}" />
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                            </ListBox>
-                            <TextBlock IsVisible="{Binding HasNoSavedQueries}" IsHitTestVisible="False"
-                                       Text="Name a query above and Save to keep it here"
-                                       TextWrapping="Wrap" TextAlignment="Center" Opacity="0.4" FontSize="12"
-                                       Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                        </Grid>
-                    </Border>
-                    <TextBox Grid.Row="2" Name="NewQueryNameBox" Text="{Binding NewQueryName}" PlaceholderText="Query name" Margin="0,8,0,0" />
-                    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
-                        <Button Content="Save" Command="{Binding SaveCurrentQueryCommand}" />
-                        <Button Content="Load" Command="{Binding LoadSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}"
-                                ToolTip.Tip="Open the selected query in a new tab (or double-click it)" />
-                        <Button Content="Delete" Command="{Binding DeleteSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}" />
-                    </StackPanel>
-                    <TextBlock Grid.Row="4" Classes="sectionHeader" Text="HISTORY" Margin="4,16,4,6" />
-                    <!-- Search + per-connection scope toggle -->
-                    <DockPanel Grid.Row="5" Margin="0,0,0,6">
-                        <ToggleButton DockPanel.Dock="Right" Classes="chip" Padding="5" Margin="6,0,0,0"
-                                      VerticalAlignment="Center" IsChecked="{Binding ScopeHistoryToConnection}"
-                                      ToolTip.Tip="Only queries run against the current connection">
-                            <PathIcon Data="{StaticResource DatabaseIconGeometry}" Width="12" Height="12" />
-                        </ToggleButton>
-                        <TextBox FontSize="12" Text="{Binding HistoryFilter, Mode=TwoWay}"
-                                 PlaceholderText="Search history…">
-                            <TextBox.InnerLeftContent>
-                                <PathIcon Data="{StaticResource MagnifyIconGeometry}" Width="13" Height="13"
-                                          Opacity="0.5" Margin="8,0,0,0" VerticalAlignment="Center" />
-                            </TextBox.InnerLeftContent>
-                            <TextBox.InnerRightContent>
-                                <Button Classes="chip" Margin="0,0,4,0" VerticalAlignment="Center"
-                                        Command="{Binding ClearHistoryFilterCommand}"
-                                        ToolTip.Tip="Clear search"
-                                        IsVisible="{Binding HistoryFilter, Converter={x:Static conv:StringConverters.IsNotNullOrEmpty}}">
-                                    <PathIcon Data="{StaticResource CloseIconGeometry}" Width="11" Height="11" />
-                                </Button>
-                            </TextBox.InnerRightContent>
-                        </TextBox>
-                    </DockPanel>
-                    <Border Grid.Row="6" Classes="card" MinHeight="80">
-                        <Grid>
-                            <ListBox Name="HistoryList" ItemsSource="{Binding FilteredHistory}">
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate x:DataType="query:QueryHistoryEntry">
-                                        <DockPanel>
-                                            <Button DockPanel.Dock="Right" Classes="chip" Padding="4" VerticalAlignment="Center"
-                                                    Command="{Binding $parent[ListBox].((vm:SavedQueriesViewModel)DataContext).TogglePinCommand}"
-                                                    CommandParameter="{Binding}"
-                                                    ToolTip.Tip="Pin — pinned entries stay on top and survive Clear">
-                                                <Panel>
-                                                    <PathIcon Data="{StaticResource PinIconGeometry}" Width="11" Height="11"
-                                                              Foreground="{DynamicResource AppAccentBrush}" IsVisible="{Binding Pinned}" />
-                                                    <PathIcon Data="{StaticResource PinIconGeometry}" Width="11" Height="11"
-                                                              Opacity="0.35" IsVisible="{Binding !Pinned}" />
-                                                </Panel>
-                                            </Button>
-                                            <StackPanel>
-                                                <TextBlock Text="{Binding Sql}" TextTrimming="CharacterEllipsis" MaxLines="2" TextWrapping="Wrap" FontSize="12" />
-                                                <StackPanel Orientation="Horizontal" Spacing="6">
-                                                    <TextBlock Text="{Binding ExecutedAt}" Opacity="0.6" FontSize="10" />
-                                                    <TextBlock Text="{Binding Connection}" Opacity="0.45" FontSize="10"
-                                                               IsVisible="{Binding Connection, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
-                                                </StackPanel>
-                                            </StackPanel>
-                                        </DockPanel>
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                            </ListBox>
-                            <TextBlock IsVisible="{Binding HasNoHistory}" IsHitTestVisible="False"
-                                       Text="Queries you run will appear here"
-                                       TextWrapping="Wrap" TextAlignment="Center" Opacity="0.4" FontSize="12"
-                                       Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                            <TextBlock IsVisible="{Binding HasNoHistoryMatches}" IsHitTestVisible="False"
-                                       Text="Nothing in history matches"
-                                       TextWrapping="Wrap" TextAlignment="Center" Opacity="0.4" FontSize="12"
-                                       Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
-                        </Grid>
-                    </Border>
-                    <StackPanel Grid.Row="7" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
-                        <Button Content="Load selected" Command="{Binding LoadHistoryEntryCommand}" CommandParameter="{Binding #HistoryList.SelectedItem}"
-                                ToolTip.Tip="Open the selected entry in a new tab (or double-click it)" />
-                        <Button Content="Clear history" Command="{Binding ClearHistoryCommand}" />
-                    </StackPanel>
-                </Grid>
+                <views:SavedQueriesPanel DataContext="{Binding SavedQueries}" />
             </TabItem>
             <TabItem ToolTip.Tip="Notify">
                 <TabItem.Header>

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -5,11 +5,10 @@
         xmlns:ae="using:AvaloniaEdit"
         xmlns:vm="using:PgNimbus.App.ViewModels"
         xmlns:query="using:PgNimbus.Core.Query"
-        xmlns:notify="using:PgNimbus.Core.Notifications"
-        xmlns:sys="using:System"
         xmlns:conv="using:Avalonia.Data.Converters"
         xmlns:conv2="using:PgNimbus.App.Converters"
         xmlns:json="using:PgNimbus.Core.Json"
+        xmlns:views="using:PgNimbus.App.Views"
         mc:Ignorable="d"
         d:DesignWidth="1000" d:DesignHeight="650"
         x:Class="PgNimbus.App.Views.MainWindow"
@@ -518,59 +517,7 @@
                                    IsVisible="{Binding $parent[TabControl].Bounds.Width, Converter={x:Static conv2:MinWidthVisibilityConverter.Instance}, ConverterParameter=300}" />
                     </StackPanel>
                 </TabItem.Header>
-                <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0" x:DataType="vm:NotifyMonitorViewModel" DataContext="{Binding NotifyMonitor}">
-                    <TextBlock Grid.Row="0" Classes="sectionHeader" Text="CHANNELS" Margin="4,0,4,6" />
-                    <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="6">
-                        <TextBox Text="{Binding ChannelName}" PlaceholderText="Channel name" Width="140" />
-                        <Button Content="Add" Command="{Binding AddChannelCommand}" />
-                    </StackPanel>
-                    <Border Grid.Row="2" Classes="card" MinHeight="60" Margin="0,8,0,0">
-                        <ListBox ItemsSource="{Binding Channels}">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate x:DataType="sys:String">
-                                    <StackPanel Orientation="Horizontal" Spacing="6">
-                                        <TextBlock Text="{Binding}" VerticalAlignment="Center" />
-                                        <Button Classes="chip" Content="✕" FontSize="10" Tag="{Binding}" Click="OnRemoveChannelClick" />
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
-                    </Border>
-                    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
-                        <Button Classes="accent" Content="Start listening" Command="{Binding StartListeningCommand}" />
-                        <Button Content="Stop" Command="{Binding StopListeningCommand}" />
-                    </StackPanel>
-                    <StackPanel Grid.Row="4" Margin="4,8,4,0">
-                        <StackPanel Orientation="Horizontal" Spacing="6">
-                            <Ellipse Width="8" Height="8" VerticalAlignment="Center"
-                                     Fill="{Binding IsListening, Converter={x:Static conv2:ListeningDotBrushConverter.Instance}}" />
-                            <TextBlock Text="{Binding ListeningStatus}" FontSize="11" Opacity="0.8" />
-                        </StackPanel>
-                        <TextBlock Text="{Binding ErrorMessage}" Foreground="IndianRed" TextWrapping="Wrap" FontSize="11"
-                                   IsVisible="{Binding ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
-                    </StackPanel>
-                    <Grid Grid.Row="5" RowDefinitions="Auto,*" Margin="0,8,0,0">
-                        <TextBlock Grid.Row="0" Classes="sectionHeader" Text="NOTIFICATIONS" Margin="4,0,4,6" />
-                        <Border Grid.Row="1" Classes="card" MinHeight="80">
-                            <ListBox ItemsSource="{Binding Notifications}">
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate x:DataType="notify:DatabaseNotification">
-                                        <StackPanel>
-                                            <!-- Long payloads wrap (capped) instead of clipping at the panel edge -->
-                                            <TextBlock FontSize="12" TextWrapping="Wrap" MaxLines="4"
-                                                       TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Payload}">
-                                                <Run Text="{Binding Channel}" FontWeight="SemiBold" />
-                                                <Run Text="{Binding Payload}" />
-                                            </TextBlock>
-                                            <TextBlock Text="{Binding ReceivedAt}" Opacity="0.6" FontSize="10" />
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                            </ListBox>
-                        </Border>
-                    </Grid>
-                    <Button Grid.Row="6" Content="Clear" Command="{Binding ClearNotificationsCommand}" Margin="0,8,0,0" />
-                </Grid>
+                <views:NotifyMonitorPanel DataContext="{Binding NotifyMonitor}" />
             </TabItem>
         </TabControl>
 

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1364,14 +1364,6 @@ public partial class MainWindow : Window
         _databaseOverviewWindow.Show(this);
     }
 
-    private void OnRemoveChannelClick(object? sender, RoutedEventArgs e)
-    {
-        if (sender is Button { Tag: string channel })
-        {
-            _viewModel?.NotifyMonitor.RemoveChannelCommand.Execute(channel);
-        }
-    }
-
     private void OnAlterTableClick(object? sender, RoutedEventArgs e)
     {
         if (sender is not MenuItem { Tag: TableNode table } || _viewModel is null)

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -271,13 +271,6 @@ public partial class MainWindow : Window
             }
         };
 
-        // Double-click on a saved query or history entry opens it in a new tab
-        // (the same action as its Load button - see SavedQueriesViewModel).
-        SavedQueriesList.DoubleTapped += (_, e) => OnQueryListDoubleTapped(e,
-            item => _viewModel?.SavedQueries.LoadSavedQueryCommand.Execute(item as SavedQuery));
-        HistoryList.DoubleTapped += (_, e) => OnQueryListDoubleTapped(e,
-            item => _viewModel?.SavedQueries.LoadHistoryEntryCommand.Execute(item as QueryHistoryEntry));
-
         // On Windows, popups are native always-on-top windows, and one left
         // open while the user Alt+Tabs (or clicks) into another program keeps
         // floating above that program. Close every popup we own the moment
@@ -1446,19 +1439,6 @@ public partial class MainWindow : Window
     // Shared double-click handling for the saved-query and history lists:
     // resolve the double-clicked row's item and load it, ignoring taps that
     // land on an inline button (e.g. the history pin) - those own their clicks.
-    private void OnQueryListDoubleTapped(TappedEventArgs e, Action<object?> load)
-    {
-        var source = e.Source as Visual;
-        if (source?.FindAncestorOfType<Button>(includeSelf: true) is not null)
-        {
-            return;
-        }
-
-        if (source?.FindAncestorOfType<ListBoxItem>(includeSelf: true) is { DataContext: { } item })
-        {
-            load(item);
-        }
-    }
 
     private void OnPreparingCellForEdit(object? sender, DataGridPreparingCellForEditEventArgs e)
     {

--- a/PgNimbus.App/Views/NotifyMonitorPanel.axaml
+++ b/PgNimbus.App/Views/NotifyMonitorPanel.axaml
@@ -1,0 +1,65 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:PgNimbus.App.ViewModels"
+             xmlns:notify="using:PgNimbus.Core.Notifications"
+             xmlns:sys="using:System"
+             xmlns:conv="using:Avalonia.Data.Converters"
+             xmlns:conv2="using:PgNimbus.App.Converters"
+             x:Class="PgNimbus.App.Views.NotifyMonitorPanel"
+             x:DataType="vm:NotifyMonitorViewModel">
+    <!-- LISTEN/NOTIFY monitor: channel subscriptions + a live notification feed.
+         DataContext is the MainViewModel's NotifyMonitor, supplied by the host. -->
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0">
+        <TextBlock Grid.Row="0" Classes="sectionHeader" Text="CHANNELS" Margin="4,0,4,6" />
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="6">
+            <TextBox Text="{Binding ChannelName}" PlaceholderText="Channel name" Width="140" />
+            <Button Content="Add" Command="{Binding AddChannelCommand}" />
+        </StackPanel>
+        <Border Grid.Row="2" Classes="card" MinHeight="60" Margin="0,8,0,0">
+            <ListBox ItemsSource="{Binding Channels}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="sys:String">
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <TextBlock Text="{Binding}" VerticalAlignment="Center" />
+                            <Button Classes="chip" Content="✕" FontSize="10" Tag="{Binding}" Click="OnRemoveChannelClick" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </Border>
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
+            <Button Classes="accent" Content="Start listening" Command="{Binding StartListeningCommand}" />
+            <Button Content="Stop" Command="{Binding StopListeningCommand}" />
+        </StackPanel>
+        <StackPanel Grid.Row="4" Margin="4,8,4,0">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <Ellipse Width="8" Height="8" VerticalAlignment="Center"
+                         Fill="{Binding IsListening, Converter={x:Static conv2:ListeningDotBrushConverter.Instance}}" />
+                <TextBlock Text="{Binding ListeningStatus}" FontSize="11" Opacity="0.8" />
+            </StackPanel>
+            <TextBlock Text="{Binding ErrorMessage}" Foreground="IndianRed" TextWrapping="Wrap" FontSize="11"
+                       IsVisible="{Binding ErrorMessage, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
+        </StackPanel>
+        <Grid Grid.Row="5" RowDefinitions="Auto,*" Margin="0,8,0,0">
+            <TextBlock Grid.Row="0" Classes="sectionHeader" Text="NOTIFICATIONS" Margin="4,0,4,6" />
+            <Border Grid.Row="1" Classes="card" MinHeight="80">
+                <ListBox ItemsSource="{Binding Notifications}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="notify:DatabaseNotification">
+                            <StackPanel>
+                                <!-- Long payloads wrap (capped) instead of clipping at the panel edge -->
+                                <TextBlock FontSize="12" TextWrapping="Wrap" MaxLines="4"
+                                           TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Payload}">
+                                    <Run Text="{Binding Channel}" FontWeight="SemiBold" />
+                                    <Run Text="{Binding Payload}" />
+                                </TextBlock>
+                                <TextBlock Text="{Binding ReceivedAt}" Opacity="0.6" FontSize="10" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Border>
+        </Grid>
+        <Button Grid.Row="6" Content="Clear" Command="{Binding ClearNotificationsCommand}" Margin="0,8,0,0" />
+    </Grid>
+</UserControl>

--- a/PgNimbus.App/Views/NotifyMonitorPanel.axaml.cs
+++ b/PgNimbus.App/Views/NotifyMonitorPanel.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using PgNimbus.App.ViewModels;
+
+namespace PgNimbus.App.Views;
+
+/// <summary>Sidebar panel for the LISTEN/NOTIFY monitor. Binds to a
+/// <see cref="NotifyMonitorViewModel"/> supplied as its DataContext by the host window.</summary>
+public partial class NotifyMonitorPanel : UserControl
+{
+    public NotifyMonitorPanel()
+    {
+        InitializeComponent();
+    }
+
+    private void OnRemoveChannelClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is Button { Tag: string channel } && DataContext is NotifyMonitorViewModel vm)
+        {
+            vm.RemoveChannelCommand.Execute(channel);
+        }
+    }
+}

--- a/PgNimbus.App/Views/SavedQueriesPanel.axaml
+++ b/PgNimbus.App/Views/SavedQueriesPanel.axaml
@@ -1,0 +1,105 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:PgNimbus.App.ViewModels"
+             xmlns:query="using:PgNimbus.Core.Query"
+             xmlns:conv="using:Avalonia.Data.Converters"
+             xmlns:conv2="using:PgNimbus.App.Converters"
+             x:Class="PgNimbus.App.Views.SavedQueriesPanel"
+             x:DataType="vm:SavedQueriesViewModel">
+    <!-- Saved queries + run history sidebar tab. DataContext is the
+         MainViewModel's SavedQueries, supplied by the host. Double-tapping a
+         list row opens it in a new tab (wired in code-behind). -->
+    <Grid RowDefinitions="Auto,*,Auto,Auto,Auto,Auto,*,Auto" Margin="0,8,0,0">
+        <TextBlock Grid.Row="0" Classes="sectionHeader" Text="SAVED QUERIES" Margin="4,0,4,6" />
+        <Border Grid.Row="1" Classes="card" MinHeight="80">
+            <Grid>
+                <ListBox Name="SavedQueriesList" ItemsSource="{Binding SavedQueries}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="query:SavedQuery">
+                            <TextBlock Text="{Binding Name}" TextTrimming="CharacterEllipsis" ToolTip.Tip="{Binding Sql}" />
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+                <TextBlock IsVisible="{Binding HasNoSavedQueries}" IsHitTestVisible="False"
+                           Text="Name a query above and Save to keep it here"
+                           TextWrapping="Wrap" TextAlignment="Center" Opacity="0.4" FontSize="12"
+                           Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Grid>
+        </Border>
+        <TextBox Grid.Row="2" Name="NewQueryNameBox" Text="{Binding NewQueryName}" PlaceholderText="Query name" Margin="0,8,0,0" />
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
+            <Button Content="Save" Command="{Binding SaveCurrentQueryCommand}" />
+            <Button Content="Load" Command="{Binding LoadSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}"
+                    ToolTip.Tip="Open the selected query in a new tab (or double-click it)" />
+            <Button Content="Delete" Command="{Binding DeleteSavedQueryCommand}" CommandParameter="{Binding #SavedQueriesList.SelectedItem}" />
+        </StackPanel>
+        <TextBlock Grid.Row="4" Classes="sectionHeader" Text="HISTORY" Margin="4,16,4,6" />
+        <!-- Search + per-connection scope toggle -->
+        <DockPanel Grid.Row="5" Margin="0,0,0,6">
+            <ToggleButton DockPanel.Dock="Right" Classes="chip" Padding="5" Margin="6,0,0,0"
+                          VerticalAlignment="Center" IsChecked="{Binding ScopeHistoryToConnection}"
+                          ToolTip.Tip="Only queries run against the current connection">
+                <PathIcon Data="{StaticResource DatabaseIconGeometry}" Width="12" Height="12" />
+            </ToggleButton>
+            <TextBox FontSize="12" Text="{Binding HistoryFilter, Mode=TwoWay}"
+                     PlaceholderText="Search history…">
+                <TextBox.InnerLeftContent>
+                    <PathIcon Data="{StaticResource MagnifyIconGeometry}" Width="13" Height="13"
+                              Opacity="0.5" Margin="8,0,0,0" VerticalAlignment="Center" />
+                </TextBox.InnerLeftContent>
+                <TextBox.InnerRightContent>
+                    <Button Classes="chip" Margin="0,0,4,0" VerticalAlignment="Center"
+                            Command="{Binding ClearHistoryFilterCommand}"
+                            ToolTip.Tip="Clear search"
+                            IsVisible="{Binding HistoryFilter, Converter={x:Static conv:StringConverters.IsNotNullOrEmpty}}">
+                        <PathIcon Data="{StaticResource CloseIconGeometry}" Width="11" Height="11" />
+                    </Button>
+                </TextBox.InnerRightContent>
+            </TextBox>
+        </DockPanel>
+        <Border Grid.Row="6" Classes="card" MinHeight="80">
+            <Grid>
+                <ListBox Name="HistoryList" ItemsSource="{Binding FilteredHistory}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="query:QueryHistoryEntry">
+                            <DockPanel>
+                                <Button DockPanel.Dock="Right" Classes="chip" Padding="4" VerticalAlignment="Center"
+                                        Command="{Binding $parent[ListBox].((vm:SavedQueriesViewModel)DataContext).TogglePinCommand}"
+                                        CommandParameter="{Binding}"
+                                        ToolTip.Tip="Pin — pinned entries stay on top and survive Clear">
+                                    <Panel>
+                                        <PathIcon Data="{StaticResource PinIconGeometry}" Width="11" Height="11"
+                                                  Foreground="{DynamicResource AppAccentBrush}" IsVisible="{Binding Pinned}" />
+                                        <PathIcon Data="{StaticResource PinIconGeometry}" Width="11" Height="11"
+                                                  Opacity="0.35" IsVisible="{Binding !Pinned}" />
+                                    </Panel>
+                                </Button>
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Sql}" TextTrimming="CharacterEllipsis" MaxLines="2" TextWrapping="Wrap" FontSize="12" />
+                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                        <TextBlock Text="{Binding ExecutedAt}" Opacity="0.6" FontSize="10" />
+                                        <TextBlock Text="{Binding Connection}" Opacity="0.45" FontSize="10"
+                                                   IsVisible="{Binding Connection, Converter={x:Static conv:ObjectConverters.IsNotNull}}" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </DockPanel>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+                <TextBlock IsVisible="{Binding HasNoHistory}" IsHitTestVisible="False"
+                           Text="Queries you run will appear here"
+                           TextWrapping="Wrap" TextAlignment="Center" Opacity="0.4" FontSize="12"
+                           Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                <TextBlock IsVisible="{Binding HasNoHistoryMatches}" IsHitTestVisible="False"
+                           Text="Nothing in history matches"
+                           TextWrapping="Wrap" TextAlignment="Center" Opacity="0.4" FontSize="12"
+                           Margin="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            </Grid>
+        </Border>
+        <StackPanel Grid.Row="7" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
+            <Button Content="Load selected" Command="{Binding LoadHistoryEntryCommand}" CommandParameter="{Binding #HistoryList.SelectedItem}"
+                    ToolTip.Tip="Open the selected entry in a new tab (or double-click it)" />
+            <Button Content="Clear history" Command="{Binding ClearHistoryCommand}" />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/PgNimbus.App/Views/SavedQueriesPanel.axaml.cs
+++ b/PgNimbus.App/Views/SavedQueriesPanel.axaml.cs
@@ -1,0 +1,42 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
+using PgNimbus.App.ViewModels;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.App.Views;
+
+/// <summary>Sidebar panel for saved queries and run history. Binds to a
+/// <see cref="SavedQueriesViewModel"/> supplied as its DataContext by the host
+/// window. Double-tapping a saved query or history row opens it in a new tab —
+/// the same action as its Load button.</summary>
+public partial class SavedQueriesPanel : UserControl
+{
+    public SavedQueriesPanel()
+    {
+        InitializeComponent();
+
+        SavedQueriesList.DoubleTapped += (_, e) => OnQueryListDoubleTapped(e,
+            item => Model?.LoadSavedQueryCommand.Execute(item as SavedQuery));
+        HistoryList.DoubleTapped += (_, e) => OnQueryListDoubleTapped(e,
+            item => Model?.LoadHistoryEntryCommand.Execute(item as QueryHistoryEntry));
+    }
+
+    private SavedQueriesViewModel? Model => DataContext as SavedQueriesViewModel;
+
+    private void OnQueryListDoubleTapped(TappedEventArgs e, Action<object?> load)
+    {
+        var source = e.Source as Visual;
+        if (source?.FindAncestorOfType<Button>(includeSelf: true) is not null)
+        {
+            return;
+        }
+
+        if (source?.FindAncestorOfType<ListBoxItem>(includeSelf: true) is { DataContext: { } item })
+        {
+            load(item);
+        }
+    }
+}


### PR DESCRIPTION
## Why

`MainWindow.axaml.cs` had grown to ~3045 lines with ~90 handlers spanning many
unrelated responsibilities (schema tree, tabs, completion, cell editing,
import/export, palette, follow-FK). Per Avalonia's MVVM guidance, code-behind
is the *right* home for view-only interaction logic — the smell isn't
"code in code-behind", it's **one code-behind owning everything**. This starts
the incremental decomposition into focused `UserControl`s.

## What changed

1. **UI design rule 7** added to `CLAUDE.md` — codifies the compose-from-`UserControl`s
   principle and names the standing `MainWindow` decomposition targets
   (`SchemaTreePanel`, `SavedQueriesPanel`, `NotifyMonitorPanel`,
   `QueryEditorPanel`, `ResultsGridPanel`), one panel per PR.
2. **`NotifyMonitorPanel`** — extracts the LISTEN/NOTIFY sidebar tab (markup +
   its one `Click` handler) into a `UserControl` bound to the existing
   `NotifyMonitorViewModel` via `DataContext`.
3. **`SavedQueriesPanel`** — extracts the saved-queries + history sidebar tab,
   including the double-tap-to-open wiring and the `OnQueryListDoubleTapped`
   helper. The double-tap now resolves the VM from `DataContext` instead of the
   host's `_viewModel` field.

Also drops three now-unused xmlns declarations (`notify:`, `sys:`, `query:`)
from `MainWindow.axaml`.

## Impact

- No behavior change — pure structural move.
- `MainWindow.axaml`: 1230 → ~1080 lines; `MainWindow.axaml.cs`: 3045 → ~3017 lines.
- These are the two lowest-risk, most self-contained panels, chosen to establish
  the extraction pattern. Compiled bindings are on, so each panel's
  `x:DataType` compile-validated every `{Binding}` path against its VM.

## Reviewer notes

- Both panels are deliberately bundled in one PR (both are trivial sidebar tabs).
  The heavier, more entangled panels — `SchemaTreePanel`, `QueryEditorPanel`
  (editor + completion + highlighting), `ResultsGridPanel` (grid + column build
  + cell edit + follow-FK + inspector + export) — will follow one per PR, each
  with real runtime verification, not just a compile check.
- Verified: `dotnet build PgNimbus.App -c Debug` clean (0 warnings) after each step.
  Runtime click-through not yet done on Windows — worth a quick manual check of
  the Queries and Notify sidebar tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)