### PR TITLE
Use the brand-blue selection wash for all selectable text

### DIFF
--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -785,6 +785,13 @@
     <Style Selector="TextBox">
         <Setter Property="SelectionBrush" Value="{StaticResource AppTextSelectionBrush}" />
     </Style>
+    <!-- Read-only selectable text (cell-inspector Wrap view, EXPLAIN output, the
+         pending-changes SQL preview) shares the same brand-blue wash - otherwise
+         it falls back to FluentTheme's grey OS-accent default and selection reads
+         differently there than in the SQL editor / TextBoxes. -->
+    <Style Selector="SelectableTextBlock">
+        <Setter Property="SelectionBrush" Value="{StaticResource AppTextSelectionBrush}" />
+    </Style>
 
     <!-- Results grid: soft horizontal rules instead of a full grid -->
     <Style Selector="DataGrid">

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -212,6 +212,9 @@ public partial class MainWindow : Window
             && selectionBrush is IBrush brush)
         {
             SqlEditor.TextArea.SelectionBrush = brush;
+            // Same wash for the cell inspector's JSON editor, so a selection
+            // there reads identically to the SQL editor and every plain TextBox.
+            JsonInspectorEditor.TextArea.SelectionBrush = brush;
         }
         SqlEditor.TextArea.Caret.PositionChanged += (_, _) => UpdateBracketHighlight();
         SqlEditor.AddHandler(PointerWheelChangedEvent, OnSqlEditorPointerWheel, RoutingStrategies.Tunnel);


### PR DESCRIPTION
## What

Makes selected-text color consistent across the app. Two surfaces in the cell inspector fell back to Fluent's / AvaloniaEdit's grey OS-accent default instead of the shared brand-blue `AppTextSelectionBrush` that the SQL editor and every plain `TextBox` already use, so a selection there looked different from everywhere else.

- **`JsonInspectorEditor` (inspector Edit mode)** — now gets the same `TextArea.SelectionBrush` the SQL editor is assigned, reusing the brush already resolved a line above.
- **Global `SelectableTextBlock` style** — sets `SelectionBrush` to `AppTextSelectionBrush`. `SelectionBrush` isn't inherited per-control-type, so this one style covers the inspector's **Wrap** view plus the other two read-only selectable-text surfaces: the EXPLAIN output and the pending-changes SQL preview.

## Why

Reported inconsistency: text selection in the JSON cell inspector (both Wrap and Edit) rendered a grey wash while the SQL editor and text fields render brand blue. Now every selection surface — SQL editor, JSON inspector (Wrap + Edit), all `TextBox` fields, and every `SelectableTextBlock` — reads the same `AppTextSelectionBrush`.

## Notes for reviewer

- No new tokens; reuses the existing `AppTextSelectionBrush` in `Theme.axaml`.
- `SelectionBrush` must be set per control type (not inherited), which is why the `SelectableTextBlock` style is separate from the existing `TextBox` one — same pattern already documented there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)