### PR TITLE
Smarter EXPLAIN: plan analysis, BUFFERS, time-heat, and a rollback guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,25 @@ and wrong project memory is worse than none.
    it shows the error, the on-disk log path, and a "Report on GitHub" button
    that opens a pre-filled new-issue URL (title/body/labels query params,
    including version + OS).
+6. **Query plans are parsed, analyzed, and heat-mapped — not dumped raw.**
+   `ExplainService` runs `EXPLAIN (FORMAT JSON …)` and parses it into an
+   `ExplainNode` tree; the ANALYZE path always asks for `BUFFERS` and
+   `SETTINGS` (buffers are the most-requested EXPLAIN option and what the
+   spill/lossy analysis reads — zero-valued buffer lines are dropped so the
+   text view stays clean). `Monitoring`-style separation applies:
+   `Query/PlanAnalyzer` is a **Core-pure, unit-tested** walker (a read-only
+   sibling of `Json/JsonTree` and `Monitoring/BlockingTree`) that emits named
+   `PlanWarning`s — bad row estimates, disk-spilled sorts/hashes, wasteful
+   sequential scans, lossy bitmap heap blocks — each with an actionable
+   one-liner and a conservative threshold constant. The App wraps them in
+   `PlanWarningViewModel` (glyph + severity brush) for the warnings strip;
+   `ExplainNodeViewModel` computes each node's exclusive **self time** so the
+   tree's bar becomes a time-heat profile (falling back to cost when there's
+   no ANALYZE timing) and tints the single slowest node as the bottleneck.
+   The design doc + competitive research is in
+   [`docs/design/explain-improvements.md`](docs/design/explain-improvements.md)
+   (it also tracks the deferred follow-ups: write-statement `ROLLBACK` guard,
+   paste-a-plan, copy/export, re-color-by-metric).
 
 ## UI design rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,10 +130,14 @@ and wrong project memory is worse than none.
    `ExplainNodeViewModel` computes each node's exclusive **self time** so the
    tree's bar becomes a time-heat profile (falling back to cost when there's
    no ANALYZE timing) and tints the single slowest node as the bottleneck.
-   The design doc + competitive research is in
+   `EXPLAIN ANALYZE` always runs inside a transaction `ExplainService` rolls
+   back, so analyzing an INSERT/UPDATE/DELETE/MERGE (or a data-modifying CTE)
+   never persists — `SqlStatementInspector.IsDataModifying` (Core-pure,
+   unit-tested) drives the "rolled back" info note in the warnings strip. The
+   design doc + competitive research is in
    [`docs/design/explain-improvements.md`](docs/design/explain-improvements.md)
-   (it also tracks the deferred follow-ups: write-statement `ROLLBACK` guard,
-   paste-a-plan, copy/export, re-color-by-metric).
+   (it also tracks the deferred follow-ups: paste-a-plan, copy/export,
+   re-color-by-metric).
 
 ## UI design rules
 

--- a/PgNimbus.App/ViewModels/ExplainNodeViewModel.cs
+++ b/PgNimbus.App/ViewModels/ExplainNodeViewModel.cs
@@ -4,9 +4,11 @@ namespace PgNimbus.App.ViewModels;
 
 /// <summary>
 /// Presentation wrapper around a single <see cref="ExplainNode"/>: formats the
-/// cost/row/timing figures Postgres reports and derives a bar width (relative
-/// to the plan's total cost) so the tree reads as a rough visual profile, not
-/// just a wall of numbers.
+/// cost/row/timing figures Postgres reports and derives a bar width so the tree
+/// reads as a rough visual profile, not just a wall of numbers. With ANALYZE
+/// timing present the bar tracks each node's <see cref="SelfTimeMs"/> (exclusive
+/// time) — the quantity that actually points at the bottleneck — falling back to
+/// the cost estimate otherwise.
 /// </summary>
 public sealed class ExplainNodeViewModel
 {
@@ -17,13 +19,27 @@ public sealed class ExplainNodeViewModel
         Node = node;
         Children = node.Children.Select(c => new ExplainNodeViewModel(c, rootTotalCost)).ToList();
         BarWidth = rootTotalCost > 0 ? Math.Clamp(node.TotalCost / rootTotalCost, 0, 1) * MaxBarWidth : 0;
+
+        // Exclusive time: this node's total wall time (per-loop × loops) minus the
+        // same for its children. Clamped at 0 for the odd rounding case.
+        var inclusive = InclusiveMs(node);
+        var childrenInclusive = node.Children.Sum(InclusiveMs);
+        SelfTimeMs = node.ActualTotalTimeMs is null ? 0 : Math.Max(0, inclusive - childrenInclusive);
     }
 
     public ExplainNode Node { get; }
 
     public IReadOnlyList<ExplainNodeViewModel> Children { get; }
 
-    public double BarWidth { get; }
+    public double BarWidth { get; private set; }
+
+    /// <summary>Exclusive (self) execution time — 0 when the plan carries no ANALYZE timing.</summary>
+    public double SelfTimeMs { get; }
+
+    public bool HasTiming => Node.ActualTotalTimeMs is not null;
+
+    /// <summary>The single slowest node by self time — tinted as the plan's bottleneck.</summary>
+    public bool IsBottleneck { get; private set; }
 
     public string Title => ExplainTextFormatter.HeaderFor(Node);
 
@@ -31,5 +47,49 @@ public sealed class ExplainNodeViewModel
 
     public string? ActualLabel => Node.ActualTotalTimeMs is { } total
         ? $"actual time={Node.ActualStartupTimeMs:F3}..{total:F3} ms rows={Node.ActualRows:0.##} loops={Node.ActualLoops}"
+            + (SelfTimeMs > 0 ? $"   self={SelfTimeMs:F3} ms" : null)
         : null;
+
+    /// <summary>
+    /// Re-bases the bar on self time and marks the slowest node. Called once on the
+    /// root after the tree is built; no-op when the plan has no timing (plain EXPLAIN).
+    /// </summary>
+    public void ApplyTimeHeat()
+    {
+        var maxSelf = MaxSelfTime();
+        if (maxSelf <= 0)
+        {
+            return;
+        }
+
+        ApplyTimeHeat(maxSelf);
+    }
+
+    private void ApplyTimeHeat(double maxSelf)
+    {
+        if (HasTiming)
+        {
+            BarWidth = Math.Clamp(SelfTimeMs / maxSelf, 0, 1) * MaxBarWidth;
+            IsBottleneck = SelfTimeMs >= maxSelf;
+        }
+
+        foreach (var child in Children)
+        {
+            child.ApplyTimeHeat(maxSelf);
+        }
+    }
+
+    private double MaxSelfTime()
+    {
+        var max = SelfTimeMs;
+        foreach (var child in Children)
+        {
+            max = Math.Max(max, child.MaxSelfTime());
+        }
+
+        return max;
+    }
+
+    private static double InclusiveMs(ExplainNode node) =>
+        node.ActualTotalTimeMs is { } total ? total * (node.ActualLoops ?? 1) : 0;
 }

--- a/PgNimbus.App/ViewModels/PlanWarningViewModel.cs
+++ b/PgNimbus.App/ViewModels/PlanWarningViewModel.cs
@@ -1,0 +1,42 @@
+using Avalonia.Media;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.App.ViewModels;
+
+/// <summary>
+/// Presentation wrapper mapping a Core <see cref="PlanWarning"/> to a severity
+/// glyph and accent brush. Keeps <see cref="PlanWarning"/> itself UI-free
+/// (hard rule 1) while the warnings strip binds glyph/brush directly.
+/// </summary>
+public sealed class PlanWarningViewModel
+{
+    public PlanWarningViewModel(PlanWarning warning)
+    {
+        Warning = warning;
+    }
+
+    public PlanWarning Warning { get; }
+
+    public string Title => Warning.Title;
+
+    public string Detail => Warning.Detail;
+
+    public string Glyph => Warning.Severity switch
+    {
+        PlanWarningSeverity.Critical => "⛔", // ⛔
+        PlanWarningSeverity.Warning => "⚠",  // ⚠
+        _ => "ℹ",                            // ℹ
+    };
+
+    public IBrush AccentBrush => Warning.Severity switch
+    {
+        PlanWarningSeverity.Critical => Danger,
+        PlanWarningSeverity.Warning => Amber,
+        _ => Accent,
+    };
+
+    // Fixed tokens so severity color is theme-independent, matching the AppDanger* approach.
+    private static readonly IBrush Danger = new SolidColorBrush(Color.FromRgb(0xE5, 0x48, 0x4D));
+    private static readonly IBrush Amber = new SolidColorBrush(Color.FromRgb(0xE0, 0x8A, 0x1E));
+    private static readonly IBrush Accent = new SolidColorBrush(Color.FromRgb(0x2D, 0x7F, 0xF9));
+}

--- a/PgNimbus.App/ViewModels/PlanWarningViewModel.cs
+++ b/PgNimbus.App/ViewModels/PlanWarningViewModel.cs
@@ -35,8 +35,19 @@ public sealed class PlanWarningViewModel
         _ => Accent,
     };
 
+    /// <summary>Low-alpha row background matching the severity, so an info note isn't shown on a danger wash.</summary>
+    public IBrush WashBrush => Warning.Severity switch
+    {
+        PlanWarningSeverity.Critical => DangerWash,
+        PlanWarningSeverity.Warning => AmberWash,
+        _ => AccentWash,
+    };
+
     // Fixed tokens so severity color is theme-independent, matching the AppDanger* approach.
     private static readonly IBrush Danger = new SolidColorBrush(Color.FromRgb(0xE5, 0x48, 0x4D));
     private static readonly IBrush Amber = new SolidColorBrush(Color.FromRgb(0xE0, 0x8A, 0x1E));
     private static readonly IBrush Accent = new SolidColorBrush(Color.FromRgb(0x2D, 0x7F, 0xF9));
+    private static readonly IBrush DangerWash = new SolidColorBrush(Color.FromArgb(0x22, 0xE5, 0x48, 0x4D));
+    private static readonly IBrush AmberWash = new SolidColorBrush(Color.FromArgb(0x22, 0xE0, 0x8A, 0x1E));
+    private static readonly IBrush AccentWash = new SolidColorBrush(Color.FromArgb(0x1E, 0x2D, 0x7F, 0xF9));
 }

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -745,7 +745,23 @@ public sealed partial class QueryViewModel : ObservableObject
             var root = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
             root.ApplyTimeHeat();
             ExplainRoot = root;
-            PlanWarnings = PlanAnalyzer.Analyze(result).Select(w => new PlanWarningViewModel(w)).ToList();
+
+            var warnings = new List<PlanWarningViewModel>();
+            // Reassure the user their data is intact: ANALYZE ran the write, but ExplainService
+            // rolled it back. Leads the strip so it's the first thing seen for a write plan.
+            if (analyze && SqlStatementInspector.IsDataModifying(Sql))
+            {
+                warnings.Add(new PlanWarningViewModel(new PlanWarning(
+                    PlanWarningSeverity.Info,
+                    "Data-modifying statement rolled back",
+                    "EXPLAIN ANALYZE executed this statement inside a transaction and rolled it back, "
+                        + "so no changes were persisted.",
+                    result.Root.NodeType,
+                    null)));
+            }
+
+            warnings.AddRange(PlanAnalyzer.Analyze(result).Select(w => new PlanWarningViewModel(w)));
+            PlanWarnings = warnings;
             ExplainText = ExplainTextFormatter.Format(result);
             var planningFragment = result.PlanningTimeMs is { } planMs ? $"Planning: {planMs:F3} ms" : null;
             var executionFragment = result.ExecutionTimeMs is { } execMs ? $"Execution: {execMs:F3} ms" : null;

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -162,6 +162,10 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private ExplainNodeViewModel? _explainRoot;
 
+    /// <summary>Named plan problems from <see cref="PlanAnalyzer"/> — the warnings strip above the plan.</summary>
+    [ObservableProperty]
+    private IReadOnlyList<PlanWarningViewModel> _planWarnings = [];
+
     [ObservableProperty]
     private string? _explainSummary;
 
@@ -189,6 +193,11 @@ public sealed partial class QueryViewModel : ObservableObject
     public IReadOnlyList<ExplainNodeViewModel> ExplainRoots => ExplainRoot is null ? [] : [ExplainRoot];
 
     partial void OnExplainRootChanged(ExplainNodeViewModel? value) => OnPropertyChanged(nameof(ExplainRoots));
+
+    /// <summary>Drives the warnings strip's visibility — hidden entirely when a plan has no findings.</summary>
+    public bool HasPlanWarnings => PlanWarnings.Count > 0;
+
+    partial void OnPlanWarningsChanged(IReadOnlyList<PlanWarningViewModel> value) => OnPropertyChanged(nameof(HasPlanWarnings));
 
     /// <summary>
     /// One entry per statement when the editor holds a multi-statement script;
@@ -733,7 +742,10 @@ public sealed partial class QueryViewModel : ObservableObject
         try
         {
             var result = await _explainService.ExplainAsync(Sql, analyze, ct);
-            ExplainRoot = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
+            var root = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
+            root.ApplyTimeHeat();
+            ExplainRoot = root;
+            PlanWarnings = PlanAnalyzer.Analyze(result).Select(w => new PlanWarningViewModel(w)).ToList();
             ExplainText = ExplainTextFormatter.Format(result);
             var planningFragment = result.PlanningTimeMs is { } planMs ? $"Planning: {planMs:F3} ms" : null;
             var executionFragment = result.ExecutionTimeMs is { } execMs ? $"Execution: {execMs:F3} ms" : null;

--- a/PgNimbus.App/Views/ResultsGridPanel.axaml
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml
@@ -147,7 +147,7 @@
                                       IsVisible="{Binding ActiveTab.HasPlanWarnings}" Margin="4,0,4,4">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate DataType="vm:PlanWarningViewModel">
-                                    <Border Background="{DynamicResource AppDangerWashBrush}" CornerRadius="4"
+                                    <Border Background="{Binding WashBrush}" CornerRadius="4"
                                             Padding="8,5" Margin="0,2">
                                         <StackPanel Orientation="Horizontal" Spacing="8">
                                             <TextBlock Text="{Binding Glyph}" Foreground="{Binding AccentBrush}"

--- a/PgNimbus.App/Views/ResultsGridPanel.axaml
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml
@@ -119,7 +119,7 @@
                             Run a query with <Run FontWeight="SemiBold">Ctrl+Enter</Run> or <Run FontWeight="SemiBold">F5</Run>
                         </TextBlock>
                     </StackPanel>
-                    <Grid RowDefinitions="Auto,*" IsVisible="{Binding ActiveTab.IsShowingPlan}">
+                    <Grid RowDefinitions="Auto,Auto,*" IsVisible="{Binding ActiveTab.IsShowingPlan}">
                         <DockPanel Grid.Row="0" Margin="4">
                             <!-- pgAdmin-style plan view switch: raw text (default) vs graphical tree -->
                             <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="2">
@@ -139,19 +139,51 @@
                             <TextBlock Text="{Binding ActiveTab.ExplainSummary}" FontSize="12" Opacity="0.8"
                                        VerticalAlignment="Center" />
                         </DockPanel>
-                        <ScrollViewer Grid.Row="1" IsVisible="{Binding ActiveTab.IsPlanTextView}"
+
+                        <!-- Named plan problems (bad estimates, disk spills, wasteful seq scans,
+                             lossy bitmaps) from PlanAnalyzer — the thing pgAdmin leaves the user
+                             to spot. Hidden entirely when the plan is clean. -->
+                        <ItemsControl Grid.Row="1" ItemsSource="{Binding ActiveTab.PlanWarnings}"
+                                      IsVisible="{Binding ActiveTab.HasPlanWarnings}" Margin="4,0,4,4">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="vm:PlanWarningViewModel">
+                                    <Border Background="{DynamicResource AppDangerWashBrush}" CornerRadius="4"
+                                            Padding="8,5" Margin="0,2">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <TextBlock Text="{Binding Glyph}" Foreground="{Binding AccentBrush}"
+                                                       FontSize="13" VerticalAlignment="Top" />
+                                            <StackPanel Spacing="1">
+                                                <TextBlock Text="{Binding Title}" FontWeight="SemiBold" FontSize="12.5" />
+                                                <TextBlock Text="{Binding Detail}" FontSize="11.5" Opacity="0.8"
+                                                           TextWrapping="Wrap" />
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+
+                        <ScrollViewer Grid.Row="2" IsVisible="{Binding ActiveTab.IsPlanTextView}"
                                       HorizontalScrollBarVisibility="Auto">
                             <SelectableTextBlock Text="{Binding ActiveTab.ExplainText}" Margin="8,4"
                                                  FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="12.5" />
                         </ScrollViewer>
-                        <ScrollViewer Grid.Row="1" IsVisible="{Binding !ActiveTab.IsPlanTextView}">
+                        <ScrollViewer Grid.Row="2" IsVisible="{Binding !ActiveTab.IsPlanTextView}">
                             <TreeView ItemsSource="{Binding ActiveTab.ExplainRoots}" Margin="4">
                                 <TreeView.ItemTemplate>
                                     <TreeDataTemplate DataType="vm:ExplainNodeViewModel" ItemsSource="{Binding Children}">
                                         <StackPanel Margin="0,2">
                                             <StackPanel Orientation="Horizontal" Spacing="6">
+                                                <!-- Self-time (heat) bar; the slowest node is tinted danger-red as the bottleneck. -->
                                                 <Rectangle Width="{Binding BarWidth}" Height="10" RadiusX="2" RadiusY="2"
-                                                           Fill="{DynamicResource AppAccentBrush}" VerticalAlignment="Center" />
+                                                           Classes.hot="{Binding IsBottleneck}"
+                                                           Fill="{DynamicResource AppAccentBrush}" VerticalAlignment="Center">
+                                                    <Rectangle.Styles>
+                                                        <Style Selector="Rectangle.hot">
+                                                            <Setter Property="Fill" Value="{DynamicResource AppDangerBrush}" />
+                                                        </Style>
+                                                    </Rectangle.Styles>
+                                                </Rectangle>
                                                 <TextBlock Text="{Binding Title}" FontWeight="SemiBold" />
                                             </StackPanel>
                                             <TextBlock Text="{Binding CostLabel}" FontSize="11" Opacity="0.7" Margin="16,0,0,0" />

--- a/PgNimbus.Core.Tests/Query/PlanAnalyzerTests.cs
+++ b/PgNimbus.Core.Tests/Query/PlanAnalyzerTests.cs
@@ -1,0 +1,197 @@
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Tests.Query;
+
+/// <summary>
+/// Heuristic tests for <see cref="PlanAnalyzer"/> over captured
+/// `EXPLAIN (ANALYZE, FORMAT JSON, BUFFERS)` shapes — one case per rule, plus a
+/// clean plan that must stay silent and the row-estimate boundary/direction.
+/// </summary>
+public class PlanAnalyzerTests
+{
+    // Seq scan reading 100k rows and filtering all but 5 away → both "discards most rows"
+    // and a huge under-estimate (planner guessed 5, hit 100000).
+    private const string SeqScanFilterJson = """
+        [
+          {
+            "Plan": {
+              "Node Type": "Seq Scan",
+              "Parallel Aware": false,
+              "Relation Name": "events",
+              "Alias": "events",
+              "Startup Cost": 0.00,
+              "Total Cost": 1834.00,
+              "Plan Rows": 5,
+              "Plan Width": 8,
+              "Actual Startup Time": 0.020,
+              "Actual Total Time": 25.000,
+              "Actual Rows": 5.00,
+              "Actual Loops": 1,
+              "Filter": "(status = 'x')",
+              "Rows Removed by Filter": 99995
+            },
+            "Planning Time": 0.100,
+            "Execution Time": 25.500
+          }
+        ]
+        """;
+
+    // Planner expected 5 output rows, the node actually returned 100000 → a 20000× under-estimate.
+    private const string MisestimateJson = """
+        [
+          {
+            "Plan": {
+              "Node Type": "Seq Scan",
+              "Parallel Aware": false,
+              "Relation Name": "orders",
+              "Alias": "orders",
+              "Startup Cost": 0.00,
+              "Total Cost": 1834.00,
+              "Plan Rows": 5,
+              "Plan Width": 8,
+              "Actual Startup Time": 0.020,
+              "Actual Total Time": 25.000,
+              "Actual Rows": 100000.00,
+              "Actual Loops": 1
+            },
+            "Planning Time": 0.100,
+            "Execution Time": 25.500
+          }
+        ]
+        """;
+
+    private const string DiskSortJson = """
+        [
+          {
+            "Plan": {
+              "Node Type": "Sort",
+              "Parallel Aware": false,
+              "Startup Cost": 10.00,
+              "Total Cost": 20.00,
+              "Plan Rows": 100000,
+              "Plan Width": 8,
+              "Actual Startup Time": 50.0,
+              "Actual Total Time": 60.0,
+              "Actual Rows": 100000,
+              "Actual Loops": 1,
+              "Sort Key": ["n"],
+              "Sort Method": "external merge",
+              "Sort Space Used": 2048,
+              "Sort Space Type": "Disk"
+            },
+            "Planning Time": 0.1,
+            "Execution Time": 70.0
+          }
+        ]
+        """;
+
+    private const string LossyBitmapJson = """
+        [
+          {
+            "Plan": {
+              "Node Type": "Bitmap Heap Scan",
+              "Parallel Aware": false,
+              "Relation Name": "big",
+              "Alias": "big",
+              "Startup Cost": 10.00,
+              "Total Cost": 20.00,
+              "Plan Rows": 50000,
+              "Plan Width": 8,
+              "Actual Startup Time": 5.0,
+              "Actual Total Time": 15.0,
+              "Actual Rows": 50000,
+              "Actual Loops": 1,
+              "Exact Heap Blocks": 100,
+              "Lossy Heap Blocks": 4200
+            },
+            "Planning Time": 0.1,
+            "Execution Time": 20.0
+          }
+        ]
+        """;
+
+    // A small, well-estimated index scan — the analyzer must stay silent.
+    private const string CleanPlanJson = """
+        [
+          {
+            "Plan": {
+              "Node Type": "Index Scan",
+              "Parallel Aware": false,
+              "Scan Direction": "Forward",
+              "Index Name": "t_pkey",
+              "Relation Name": "t",
+              "Alias": "t",
+              "Startup Cost": 0.00,
+              "Total Cost": 8.30,
+              "Plan Rows": 10,
+              "Plan Width": 8,
+              "Actual Startup Time": 0.010,
+              "Actual Total Time": 0.020,
+              "Actual Rows": 10.00,
+              "Actual Loops": 1
+            },
+            "Planning Time": 0.1,
+            "Execution Time": 0.05
+          }
+        ]
+        """;
+
+    [Test]
+    public async Task SeqScanDiscardingMostRowsIsFlagged()
+    {
+        var warnings = PlanAnalyzer.Analyze(ExplainService.Parse(SeqScanFilterJson));
+
+        await Assert.That(warnings.Any(w => w.Title == "Sequential scan discards most rows")).IsTrue();
+        await Assert.That(warnings.Any(w => w.Relation == "events")).IsTrue();
+    }
+
+    [Test]
+    public async Task LargeRowMisestimateIsFlaggedAsCritical()
+    {
+        var warnings = PlanAnalyzer.Analyze(ExplainService.Parse(MisestimateJson));
+        var estimate = warnings.SingleOrDefault(w => w.Title.StartsWith("Row estimate off by"));
+
+        await Assert.That(estimate).IsNotNull();
+        await Assert.That(estimate!.Severity).IsEqualTo(PlanWarningSeverity.Critical);
+        // Planner guessed 5, saw 100000 → an under-estimate.
+        await Assert.That(estimate.Detail).Contains("underestimated");
+    }
+
+    [Test]
+    public async Task DiskSortIsFlaggedWithWorkMemHint()
+    {
+        var warnings = PlanAnalyzer.Analyze(ExplainService.Parse(DiskSortJson));
+        var sort = warnings.SingleOrDefault(w => w.Title == "Sort spilled to disk");
+
+        await Assert.That(sort).IsNotNull();
+        await Assert.That(sort!.Detail).Contains("work_mem");
+    }
+
+    [Test]
+    public async Task LossyBitmapIsFlagged()
+    {
+        var warnings = PlanAnalyzer.Analyze(ExplainService.Parse(LossyBitmapJson));
+
+        await Assert.That(warnings.Any(w => w.Title == "Bitmap scan went lossy")).IsTrue();
+    }
+
+    [Test]
+    public async Task CleanPlanProducesNoWarnings()
+    {
+        var warnings = PlanAnalyzer.Analyze(ExplainService.Parse(CleanPlanJson));
+
+        await Assert.That(warnings).IsEmpty();
+    }
+
+    [Test]
+    public async Task SmallCountsBelowThresholdAreNotFlagged()
+    {
+        // Estimated 1, actual 50 — a 50× ratio, but both below the 100-row floor, so it's noise.
+        var json = CleanPlanJson
+            .Replace("\"Plan Rows\": 10", "\"Plan Rows\": 1")
+            .Replace("\"Actual Rows\": 10.00", "\"Actual Rows\": 50.00");
+        var warnings = PlanAnalyzer.Analyze(ExplainService.Parse(json));
+
+        await Assert.That(warnings).IsEmpty();
+    }
+}

--- a/PgNimbus.Core.Tests/Query/SqlStatementInspectorTests.cs
+++ b/PgNimbus.Core.Tests/Query/SqlStatementInspectorTests.cs
@@ -1,0 +1,38 @@
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Tests.Query;
+
+/// <summary>
+/// Lexical write-detection used to note that an EXPLAIN ANALYZE was rolled back.
+/// </summary>
+public class SqlStatementInspectorTests
+{
+    [Test]
+    [Arguments("INSERT INTO t VALUES (1)")]
+    [Arguments("update t set n = 1")]
+    [Arguments("DELETE FROM t WHERE id = 1")]
+    [Arguments("MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN DELETE")]
+    [Arguments("  \n  delete from t")]
+    [Arguments("-- a comment\nUPDATE t SET n = 1")]
+    [Arguments("/* block */ INSERT INTO t DEFAULT VALUES")]
+    [Arguments("WITH moved AS (DELETE FROM src RETURNING *) INSERT INTO dst SELECT * FROM moved")]
+    public async Task WritesAreDetected(string sql)
+    {
+        await Assert.That(SqlStatementInspector.IsDataModifying(sql)).IsTrue();
+    }
+
+    [Test]
+    [Arguments("SELECT * FROM t")]
+    [Arguments("  select 1")]
+    [Arguments("-- delete everything?\nSELECT * FROM t")]
+    [Arguments("SELECT updated_at FROM t ORDER BY updated_at")]
+    [Arguments("WITH recent AS (SELECT * FROM t) SELECT * FROM recent")]
+    [Arguments("TABLE t")]
+    [Arguments("VALUES (1), (2)")]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task ReadsAreNotDetected(string sql)
+    {
+        await Assert.That(SqlStatementInspector.IsDataModifying(sql)).IsFalse();
+    }
+}

--- a/PgNimbus.Core/Query/ExplainService.cs
+++ b/PgNimbus.Core/Query/ExplainService.cs
@@ -56,9 +56,24 @@ public sealed class ExplainService
         var explainSql = $"EXPLAIN ({options}) {sql}";
 
         await using var connection = await _dataSource.OpenConnectionAsync(ct);
-        await using var command = new NpgsqlCommand(explainSql, connection);
-        var json = (string)(await command.ExecuteScalarAsync(ct))!;
 
+        // Plain EXPLAIN only plans — it never executes the statement, so no guard is needed.
+        if (!analyze)
+        {
+            await using var command = new NpgsqlCommand(explainSql, connection);
+            return Parse((string)(await command.ExecuteScalarAsync(ct))!);
+        }
+
+        // EXPLAIN ANALYZE *runs* the statement. Wrap it in a transaction we always
+        // roll back, so an ANALYZE of an INSERT/UPDATE/DELETE/MERGE (or a
+        // data-modifying CTE) never persists its changes — harmless for reads, since
+        // a read-only statement has nothing to commit either way. (Non-transactional
+        // side effects like nextval() still can't be undone; that's inherent to
+        // EXPLAIN ANALYZE.)
+        await using var transaction = await connection.BeginTransactionAsync(ct);
+        await using var analyzeCommand = new NpgsqlCommand(explainSql, connection, transaction);
+        var json = (string)(await analyzeCommand.ExecuteScalarAsync(ct))!;
+        await transaction.RollbackAsync(ct);
         return Parse(json);
     }
 

--- a/PgNimbus.Core/Query/ExplainService.cs
+++ b/PgNimbus.Core/Query/ExplainService.cs
@@ -47,7 +47,12 @@ public sealed class ExplainService
     {
         // Plain EXPLAIN omits "Planning Time" unless SUMMARY is requested explicitly
         // (ANALYZE defaults SUMMARY to true already, so it's fine either way there).
-        var options = analyze ? "ANALYZE, FORMAT JSON, BUFFERS false, TIMING true" : "FORMAT JSON, SUMMARY";
+        // BUFFERS (I/O counters) is the most-requested EXPLAIN option and is what the
+        // disk-spill / lossy-bitmap analysis reads; SETTINGS surfaces the non-default
+        // planner GUCs that shaped the plan. Both are cheap to always ask for.
+        var options = analyze
+            ? "ANALYZE, FORMAT JSON, BUFFERS true, TIMING true, SETTINGS"
+            : "FORMAT JSON, SUMMARY, SETTINGS";
         var explainSql = $"EXPLAIN ({options}) {sql}";
 
         await using var connection = await _dataSource.OpenConnectionAsync(ct);
@@ -104,6 +109,15 @@ public sealed class ExplainService
 
             // PG 18 stamps "Disabled": false on every node — only a true value is worth a line.
             if (property.Name == "Disabled" && property.Value.ValueKind == JsonValueKind.False)
+            {
+                continue;
+            }
+
+            // BUFFERS emits every counter in FORMAT JSON even when zero (unlike FORMAT TEXT,
+            // which hides them). Drop the zero-valued buffer lines so the text view stays clean.
+            if (property.Name.EndsWith("Blocks", StringComparison.Ordinal)
+                && property.Value.ValueKind == JsonValueKind.Number
+                && property.Value.GetDouble() == 0)
             {
                 continue;
             }

--- a/PgNimbus.Core/Query/PlanAnalyzer.cs
+++ b/PgNimbus.Core/Query/PlanAnalyzer.cs
@@ -1,0 +1,179 @@
+using System.Globalization;
+
+namespace PgNimbus.Core.Query;
+
+public enum PlanWarningSeverity
+{
+    Info,
+    Warning,
+    Critical,
+}
+
+/// <summary>
+/// A single named problem found in a query plan — the thing pgAdmin/DBeaver
+/// leave the user to spot for themselves. <see cref="Detail"/> is an actionable
+/// one-liner (e.g. "raising work_mem may keep this sort in memory").
+/// </summary>
+public sealed record PlanWarning(
+    PlanWarningSeverity Severity,
+    string Title,
+    string Detail,
+    string NodeType,
+    string? Relation);
+
+/// <summary>
+/// Walks a parsed <see cref="ExplainResult"/> and reports well-known plan
+/// problems (bad row estimates, disk spills, wasteful sequential scans, lossy
+/// bitmap heap blocks). Pure and deterministic — no DB round-trip, no clock —
+/// so it unit-tests against captured JSON exactly like <see cref="ExplainService.Parse"/>,
+/// and a read-only sibling of <c>BlockingTree</c>/<c>JsonTree</c> per hard rule 1.
+/// </summary>
+public static class PlanAnalyzer
+{
+    // Deliberately conservative so the warnings strip stays high-signal, not noise.
+    private const double EstimateFactorThreshold = 10;   // estimated vs actual rows off by this much
+    private const double EstimateCriticalFactor = 100;
+    private const double EstimateMinRows = 100;           // ignore misestimates on tiny counts
+    private const double SeqScanMinScanned = 1000;        // ignore small seq scans
+    private const double SeqScanRemovedFraction = 0.9;    // "filters most rows" = discards ≥ 90%
+
+    public static IReadOnlyList<PlanWarning> Analyze(ExplainResult result)
+    {
+        var warnings = new List<PlanWarning>();
+        Walk(result.Root, warnings);
+        return warnings;
+    }
+
+    private static void Walk(ExplainNode node, List<PlanWarning> acc)
+    {
+        InspectRowEstimate(node, acc);
+        InspectDiskSpills(node, acc);
+        InspectSeqScanFilter(node, acc);
+        InspectLossyBitmap(node, acc);
+
+        foreach (var child in node.Children)
+        {
+            Walk(child, acc);
+        }
+    }
+
+    /// <summary>Estimated vs actual rows (both per-loop) diverging by ≥ 10× — the classic driver of bad join choices.</summary>
+    private static void InspectRowEstimate(ExplainNode node, List<PlanWarning> acc)
+    {
+        // Needs ANALYZE; a never-executed branch (loops = 0) has no meaningful actual count.
+        if (node.ActualRows is not { } actual || node.ActualLoops is not { } loops || loops == 0)
+        {
+            return;
+        }
+
+        double estimated = node.PlanRows;
+        var hi = Math.Max(estimated, actual);
+        var lo = Math.Min(estimated, actual);
+        if (hi < EstimateMinRows)
+        {
+            return;
+        }
+
+        var factor = hi / Math.Max(lo, 1);
+        if (factor < EstimateFactorThreshold)
+        {
+            return;
+        }
+
+        var direction = estimated > actual ? "over" : "under";
+        var severity = factor >= EstimateCriticalFactor ? PlanWarningSeverity.Critical : PlanWarningSeverity.Warning;
+        acc.Add(new PlanWarning(
+            severity,
+            $"Row estimate off by {factor:0}×",
+            $"Planner {direction}estimated {ExplainTextFormatter.HeaderFor(node)}: estimated {estimated:0}, actual {actual:0} rows. "
+                + "Stale statistics or correlated columns can mislead the planner — try ANALYZE or extended statistics.",
+            node.NodeType,
+            node.RelationName));
+    }
+
+    /// <summary>Sorts / hash joins that spilled to disk — usually a work_mem shortfall.</summary>
+    private static void InspectDiskSpills(ExplainNode node, List<PlanWarning> acc)
+    {
+        if (Detail(node, "Sort Method") is { } method && method.Contains("external", StringComparison.OrdinalIgnoreCase))
+        {
+            var used = Detail(node, "Sort Space Used") is { } kb ? $" ({kb} kB)" : string.Empty;
+            acc.Add(new PlanWarning(
+                PlanWarningSeverity.Warning,
+                "Sort spilled to disk",
+                $"This sort used an on-disk method ({method}){used}. Raising work_mem may keep it in memory.",
+                node.NodeType,
+                node.RelationName));
+        }
+
+        if (ParseLong(Detail(node, "Hash Batches")) is { } batches && batches > 1)
+        {
+            acc.Add(new PlanWarning(
+                PlanWarningSeverity.Warning,
+                "Hash spilled to disk",
+                $"The hash used {batches} batches (>1 means it didn't fit in memory). Raising work_mem may reduce batching.",
+                node.NodeType,
+                node.RelationName));
+        }
+    }
+
+    /// <summary>A sequential scan that reads a lot and throws most of it away with a filter — index candidate.</summary>
+    private static void InspectSeqScanFilter(ExplainNode node, List<PlanWarning> acc)
+    {
+        if (node.NodeType != "Seq Scan"
+            || node.ActualRows is not { } returned
+            || node.ActualLoops is not { } loops || loops == 0
+            || ParseDouble(Detail(node, "Rows Removed by Filter")) is not { } removed)
+        {
+            return;
+        }
+
+        var scanned = returned + removed;
+        if (scanned < SeqScanMinScanned || removed < scanned * SeqScanRemovedFraction)
+        {
+            return;
+        }
+
+        var relation = node.RelationName is { } r ? $" on {r}" : string.Empty;
+        acc.Add(new PlanWarning(
+            PlanWarningSeverity.Warning,
+            "Sequential scan discards most rows",
+            $"The scan{relation} read {scanned:0} rows and filtered out {removed:0} of them. "
+                + "An index on the filtered column(s) would let the planner skip the discarded rows.",
+            node.NodeType,
+            node.RelationName));
+    }
+
+    /// <summary>Bitmap heap scan whose bitmap didn't fit in work_mem, so whole pages were rechecked lossily.</summary>
+    private static void InspectLossyBitmap(ExplainNode node, List<PlanWarning> acc)
+    {
+        if (ParseLong(Detail(node, "Lossy Heap Blocks")) is { } lossy && lossy > 0)
+        {
+            acc.Add(new PlanWarning(
+                PlanWarningSeverity.Warning,
+                "Bitmap scan went lossy",
+                $"{lossy} heap blocks were rechecked lossily because the bitmap outgrew work_mem. "
+                    + "Raising work_mem lets more of the bitmap stay exact.",
+                node.NodeType,
+                node.RelationName));
+        }
+    }
+
+    private static string? Detail(ExplainNode node, string key)
+    {
+        foreach (var pair in node.Details)
+        {
+            if (pair.Key == key)
+            {
+                return pair.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static long? ParseLong(string? value) =>
+        long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
+
+    private static double? ParseDouble(string? value) =>
+        double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
+}

--- a/PgNimbus.Core/Query/SqlStatementInspector.cs
+++ b/PgNimbus.Core/Query/SqlStatementInspector.cs
@@ -1,0 +1,89 @@
+using System.Text.RegularExpressions;
+
+namespace PgNimbus.Core.Query;
+
+/// <summary>
+/// Lightweight, lexical inspection of a single SQL statement — enough to tell a
+/// data-modifying statement from a read so the App can note that an
+/// <c>EXPLAIN ANALYZE</c> was rolled back. Deliberately not a full parser: it
+/// strips leading comments/whitespace and looks at the leading keyword (and, for
+/// a CTE, whether a data-modifying keyword appears at all).
+/// </summary>
+public static partial class SqlStatementInspector
+{
+    private static readonly string[] ModifyingKeywords = ["insert", "update", "delete", "merge"];
+
+    /// <summary>
+    /// True when the statement writes rows (INSERT/UPDATE/DELETE/MERGE, or a
+    /// data-modifying CTE). Conservative on the CTE case: a WITH whose body
+    /// mentions a write keyword counts, since the write could hide inside a CTE.
+    /// </summary>
+    public static bool IsDataModifying(string sql)
+    {
+        var stripped = StripLeading(sql);
+        if (stripped.Length == 0)
+        {
+            return false;
+        }
+
+        var leading = LeadingWord(stripped);
+        if (Array.Exists(ModifyingKeywords, k => k.Equals(leading, StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        // A data-modifying CTE: `WITH x AS (DELETE …) SELECT …` still writes.
+        if (leading.Equals("with", StringComparison.OrdinalIgnoreCase))
+        {
+            return WriteKeywordRegex().IsMatch(stripped);
+        }
+
+        return false;
+    }
+
+    /// <summary>Drops leading whitespace and SQL comments so the first real keyword is visible.</summary>
+    private static string StripLeading(string sql)
+    {
+        var index = 0;
+        while (index < sql.Length)
+        {
+            var c = sql[index];
+            if (char.IsWhiteSpace(c))
+            {
+                index++;
+            }
+            else if (c == '-' && index + 1 < sql.Length && sql[index + 1] == '-')
+            {
+                var newline = sql.IndexOf('\n', index);
+                index = newline < 0 ? sql.Length : newline + 1;
+            }
+            else if (c == '/' && index + 1 < sql.Length && sql[index + 1] == '*')
+            {
+                var end = sql.IndexOf("*/", index + 2, StringComparison.Ordinal);
+                index = end < 0 ? sql.Length : end + 2;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return sql[index..];
+    }
+
+    private static string LeadingWord(string sql)
+    {
+        var end = 0;
+        while (end < sql.Length && (char.IsLetter(sql[end]) || sql[end] == '_'))
+        {
+            end++;
+        }
+
+        return sql[..end];
+    }
+
+    // Word-boundary match so a column named "updated_at" or a string doesn't false-trigger the
+    // leading-keyword path; only used for the (already WITH-gated) CTE case.
+    [GeneratedRegex(@"\b(insert|update|delete|merge)\b", RegexOptions.IgnoreCase)]
+    private static partial Regex WriteKeywordRegex();
+}

--- a/docs/design/explain-improvements.md
+++ b/docs/design/explain-improvements.md
@@ -1,0 +1,139 @@
+# Design: Smarter EXPLAIN / query-plan analysis
+
+Status: in progress · Owner: pgNimbus · Created 2026-07-23
+
+## Motivation
+
+pgNimbus already renders `EXPLAIN` / `EXPLAIN ANALYZE` as a classic text
+layout and a graphical cost-bar tree (`ExplainService`,
+`ExplainTextFormatter`, `ExplainNodeViewModel`, the plan pane in
+`ResultsGridPanel`). That puts us at roughly pgAdmin's "graphical tree"
+tier.
+
+The best-in-class plan tools — [pev2/Dalibo](https://github.com/dalibo/pev2),
+[explain.depesz.com](https://explain.depesz.com),
+[pgMustard](https://www.pgmustard.com), pganalyze — win not by drawing a
+prettier tree but by **interpreting** it: they collect `BUFFERS`, heat-map on
+*actual* time, and surface a named, prioritized list of problems (bad row
+estimates, disk spills, seq-scans that filter everything away, lossy bitmap
+heap blocks). Research notes and the competitive landscape are summarized in
+the issue that spawned this work.
+
+Concretely, the gaps in today's implementation:
+
+1. **`BUFFERS` is explicitly disabled** (`ExplainService.cs`,
+   `BUFFERS false`). This is the single most-requested EXPLAIN option across
+   the ecosystem — buffers expose real I/O and are machine-independent, unlike
+   timing.
+2. **No problem detection.** We show raw numbers and leave interpretation to
+   the user. This is the biggest differentiator versus pgAdmin/DBeaver/HeidiSQL.
+3. **The visual bar is cost-based, not time-based.** `BarWidth =
+   TotalCost / rootTotalCost` uses a planner *estimate*, and `TotalCost`
+   includes children, so the bar double-counts down the tree. When ANALYZE
+   data exists, the interesting quantity is each node's *self* (exclusive)
+   time.
+4. **`EXPLAIN ANALYZE` of a write actually runs the write** — no transaction
+   guard. (Tracked here, addressed separately.)
+
+## Scope of this change (v1)
+
+Deliver the three highest-value, lowest-risk pieces as one `verify`-checked
+change:
+
+- **Enable `BUFFERS` (and `SETTINGS`)** on the ANALYZE path; suppress
+  zero-valued buffer detail lines so the text view stays clean.
+- **A pure, unit-tested plan analyzer** in `PgNimbus.Core` that walks the
+  parsed tree and emits named `PlanWarning`s. Same shape as the existing
+  Core-pure, sibling-of-`JsonTree`/`BlockingTree` analyzers.
+- **Time-based heat** in the tree view: the cost bar becomes a *self-time*
+  bar when ANALYZE timing is present (falling back to cost otherwise), and the
+  single slowest node is tinted with the danger color as the bottleneck.
+- **A warnings strip** above the plan views listing the analyzer's findings.
+
+Out of scope for v1 (follow-ups, noted so they aren't forgotten):
+
+- Write-statement safety guard (wrap `EXPLAIN ANALYZE <write>` in
+  `BEGIN … ROLLBACK`).
+- Paste-a-plan / import-external-plan entry point (`ExplainService.Parse` is
+  already static and side-effect-free, so this is cheap later).
+- Copy/export plan (raw JSON/text) for sharing into external tools.
+- Re-color-by-metric toggle (time / rows / cost / buffers), pev2-style.
+- Aggregating buffer counters onto a single `Buffers:` line in the text view
+  to match `EXPLAIN (FORMAT TEXT)` exactly.
+
+## Design
+
+### Core: `PlanAnalyzer` + `PlanWarning`
+
+`PgNimbus.Core/Query/PlanAnalyzer.cs` — a static class with
+`Analyze(ExplainResult) : IReadOnlyList<PlanWarning>` that walks the node tree.
+Pure and deterministic (no DB, no clock), so it is unit-tested against
+captured JSON exactly like `ExplainService.Parse`.
+
+```csharp
+public enum PlanWarningSeverity { Info, Warning, Critical }
+
+public sealed record PlanWarning(
+    PlanWarningSeverity Severity,
+    string Title,
+    string Detail,
+    string NodeType,
+    string? Relation);
+```
+
+Heuristics in v1 (all computable from what we already parse — node type,
+`PlanRows`, `ActualRows`, `ActualLoops`, and the `Details` key/value lines):
+
+| Kind | Trigger | Severity |
+|---|---|---|
+| Row misestimate | `max(est,act) ≥ 100` and estimated-vs-actual (per-loop) off by ≥ 10× | Warning (≥ 100× → Critical) |
+| Sort spilled to disk | `Sort Method` contains `external` | Warning |
+| Hash spilled to disk | `Hash Batches` > 1 | Warning |
+| Seq scan filters most rows | `Seq Scan`, `scanned ≥ 1000`, ≥ 90% removed by filter | Warning |
+| Lossy bitmap heap blocks | `Lossy Heap Blocks` > 0 | Warning |
+
+Each rule names the relation and gives an actionable one-liner (e.g. "raising
+`work_mem` may keep this sort in memory", "consider an index on …"). Thresholds
+are deliberately conservative to avoid noise; they live as named constants so
+they're easy to tune.
+
+### App: time heat
+
+`ExplainNodeViewModel` gains:
+
+- `SelfTimeMs` — exclusive time: `ActualTotalTimeMs × ActualLoops` minus the
+  same for its children (clamped at 0).
+- A post-construction `ApplyTimeHeat(maxSelfMs)` pass that sets `BarWidth` from
+  `SelfTimeMs / maxSelfMs` when timing is present (otherwise the ctor's
+  cost-ratio bar stands).
+- `IsBottleneck` — true for the node with the largest self time, used to tint
+  its bar with `AppDangerBrush`.
+
+`QueryViewModel.RunExplainAsync` builds the VM tree, runs `ApplyTimeHeat`, and
+sets `PlanWarnings` from `PlanAnalyzer.Analyze(result)`.
+
+### App: warnings strip
+
+An `ItemsControl` above the Text/Tree switch in `ResultsGridPanel`, visible
+only when there are warnings, one row per finding: a severity glyph, the
+title, and the detail. A thin `PlanWarningViewModel` wrapper maps severity to a
+glyph/wash brush (keeping `PlanWarning` itself UI-free per hard rule 1).
+
+## Testing
+
+- `PlanAnalyzerTests` (TUnit, Core.Tests): one captured-JSON case per heuristic
+  plus a clean plan that yields no warnings, and the row-estimate
+  threshold/direction boundaries.
+- Existing `ExplainParsingTests` continue to pass (option-string change is
+  runtime-only; `Parse` is unaffected).
+- End-to-end `verify` run against a seeded local Postgres: `EXPLAIN ANALYZE` a
+  query that seq-scans + sorts to disk, confirm the warnings strip and the
+  bottleneck tint render.
+
+## Keeping CLAUDE.md current
+
+`CLAUDE.md` has no dedicated EXPLAIN section today; the query-engine rules
+don't mention plan analysis. Once v1 lands, add a short note under the
+architecture rules describing `PlanAnalyzer` as a Core-pure, unit-tested
+sibling of `BlockingTree`/`JsonTree`, and that `BUFFERS`/`SETTINGS` ride the
+ANALYZE path.

--- a/docs/design/explain-improvements.md
+++ b/docs/design/explain-improvements.md
@@ -52,8 +52,13 @@ change:
 
 Out of scope for v1 (follow-ups, noted so they aren't forgotten):
 
-- Write-statement safety guard (wrap `EXPLAIN ANALYZE <write>` in
-  `BEGIN … ROLLBACK`).
+- ~~Write-statement safety guard~~ — **done** (v1.1): `ExplainService` now runs
+  every `EXPLAIN ANALYZE` inside a transaction it always rolls back, so an
+  ANALYZE of an INSERT/UPDATE/DELETE/MERGE (or a data-modifying CTE) never
+  persists. `SqlStatementInspector.IsDataModifying` (Core-pure, unit-tested)
+  drives an info note in the warnings strip so the user knows their data is
+  intact. Non-transactional side effects (`nextval()`, `dblink`, etc.) remain
+  inherently un-undoable — that's a property of EXPLAIN ANALYZE itself.
 - Paste-a-plan / import-external-plan entry point (`ExplainService.Parse` is
   already static and side-effect-free, so this is cheap later).
 - Copy/export plan (raw JSON/text) for sharing into external tools.


### PR DESCRIPTION
pgNimbus rendered `EXPLAIN` as a text/cost-tree but left interpretation to the user — the gap versus [pev2](https://github.com/dalibo/pev2)/[depesz](https://explain.depesz.com)/[pgMustard](https://www.pgmustard.com) is that they collect `BUFFERS`, heat-map on *actual* time, and name the problems. This PR closes the first slice of that gap. Design + competitive research: [`docs/design/explain-improvements.md`](docs/design/explain-improvements.md).

## What changed

**Interpretation, not just a prettier tree**
- **`BUFFERS` + `SETTINGS` on the ANALYZE path** (`ExplainService`) — the most-requested EXPLAIN option, and what the spill/lossy checks read. Zero-valued buffer lines are dropped so the text view stays clean.
- **`PlanAnalyzer`** — a Core-pure, unit-tested walker (a sibling of `JsonTree`/`BlockingTree`) that emits named `PlanWarning`s, each with an actionable one-liner and a conservative threshold:
  - row estimate off by ≥ 10× (Critical at ≥ 100×)
  - sort/hash spilled to disk → work_mem hint
  - sequential scan discarding most rows → index candidate
  - bitmap scan gone lossy → work_mem hint
- **Time-heat tree** — `ExplainNodeViewModel` computes each node&#39;s exclusive **self time**; the bar tracks self-time (falling back to cost without ANALYZE timing) and the single slowest node is tinted danger-red as the bottleneck.
- **A warnings strip** above the plan views lists the findings (`PlanWarningViewModel` maps severity → glyph + wash brush, keeping `PlanWarning` UI-free per hard rule 1).

**Safety: `EXPLAIN ANALYZE` never mutates data**
- `EXPLAIN ANALYZE` *executes* the statement it analyzes, so analyzing an `INSERT/UPDATE/DELETE/MERGE` (or a data-modifying CTE) was silently writing to the DB. `ExplainService` now runs every ANALYZE inside a transaction it **always rolls back** — harmless for reads, safe for writes. (Non-transactional side effects like `nextval()` remain inherently un-undoable, as with any EXPLAIN ANALYZE.)
- `SqlStatementInspector.IsDataModifying` (Core-pure, unit-tested) drives an **info note** leading the warnings strip so the user knows their data is intact.

## Testing
- **547 Core tests pass** (new `PlanAnalyzerTests` + `SqlStatementInspectorTests`); App builds with 0 warnings.
- **Rollback proven at the DB level**: `EXPLAIN ANALYZE DELETE FROM events WHERE amount &gt; 0` against a 200k-row table leaves the count unchanged (200000 → 200000) while the plan still shows a real `ModifyTable` node — the DELETE ran and was rolled back.
- **Verified in the running app** (headless Xvfb + seeded Postgres): the &#34;Sort spilled to disk&#34; and &#34;Sequential scan discards most rows&#34; warnings render with their hints, `BUFFERS` lines show (zeros suppressed), and the Sort node carries the red bottleneck bar with `self=506 ms`.

## Docs
- New design doc `docs/design/explain-improvements.md` (motivation, landscape, scope, deferred follow-ups).
- `CLAUDE.md` gains architectural rule 6 documenting `PlanAnalyzer`, the buffers/heat behavior, and the ANALYZE rollback guard.

## Follow-ups — all now shipped ✅

The four deferred follow-ups this PR tracked are **complete**. Because this PR had already merged, they landed as four `verify`-checked commits on the follow-up branch **`claude/explain-functional-research-8jgddm-ugi04t`** (not in this PR's merged history) — the design doc and `CLAUDE.md` rule 6 are updated there to match:

- **Paste-a-plan / import external plan** — `ExplainService.Import(raw)` (Core-pure, unit-tested) auto-detects JSON vs text and returns an `ImportedPlan`; JSON parsing is tolerant of the shapes tools emit, `FORMAT TEXT` is parsed best-effort by `ExplainPlanTextParser` (which also strips psql framing). The palette's "Import query plan…" opens `ImportPlanDialog` and shows the parsed plan in a **new tab** — same warnings strip and time-heat as a live plan, no DB round-trip.
- **Copy / export plan** — the plan header's "Export ▾" flyout copies/saves the plan as JSON or rendered text (`ExplainService.ExplainAsync` now returns an `ExplainRun` keeping the raw server JSON; the JSON actions hide for a text import).
- **Re-color-by-metric toggle** — a "Color:" segmented toggle (Time / Rows / Cost / Buffers) rescales the tree's heat bars in place and re-marks the hottest node; `ExplainNodeViewModel` is observable and holds each node's exclusive self-time/self-cost/rows/self-buffers.
- **Aggregate `Buffers:` line** — `ExplainTextFormatter` folds the per-pool block counters (plus `I/O Timings:`) onto single lines to match `EXPLAIN (FORMAT TEXT)`, while the individual counters stay in `ExplainNode.Details` for the re-color "Buffers" metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJEqhU9cNwx7EY2ZqVMiG2