### PR TITLE
Smarter EXPLAIN follow-ups: paste-a-plan, copy/export, re-color-by-metric, aggregated Buffers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,10 +133,21 @@ and wrong project memory is worse than none.
    `EXPLAIN ANALYZE` always runs inside a transaction `ExplainService` rolls
    back, so analyzing an INSERT/UPDATE/DELETE/MERGE (or a data-modifying CTE)
    never persists — `SqlStatementInspector.IsDataModifying` (Core-pure,
-   unit-tested) drives the "rolled back" info note in the warnings strip. The
-   design doc + competitive research is in
+   unit-tested) drives the "rolled back" info note in the warnings strip.
+   **Paste-a-plan** rides the same views with no DB round-trip:
+   `ExplainService.Import(raw)` auto-detects JSON vs text and returns an
+   `ImportedPlan` (parsed tree + display text). JSON parsing is tolerant of the
+   shapes external tools emit (the `[{ "Plan": … }]` array, a lone
+   `{ "Plan": … }` object, or a bare `{ "Node Type": … }` node); `FORMAT TEXT`
+   is parsed best-effort by `Query/ExplainPlanTextParser` (another Core-pure,
+   unit-tested sibling of `PlanAnalyzer`, which also strips psql framing). The
+   command palette's "Import query plan…" opens `ImportPlanDialog` and, on a
+   successful parse, shows the plan in a **new tab**
+   (`MainViewModel.OpenImportedPlan` → `QueryViewModel.ShowImportedPlan`) — same
+   warnings strip and time-heat as a live plan. The design doc + competitive
+   research is in
    [`docs/design/explain-improvements.md`](docs/design/explain-improvements.md)
-   (it also tracks the deferred follow-ups: paste-a-plan, copy/export,
+   (it also tracks the remaining deferred follow-ups: copy/export,
    re-color-by-metric).
 
 ## UI design rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,9 +148,14 @@ and wrong project memory is worse than none.
    header's "Export ▾" flyout copies/saves the plan as JSON or rendered text —
    `ExplainService.ExplainAsync` returns an `ExplainRun` that keeps the raw
    server JSON, carried on `QueryViewModel.PlanJson` (null, and the JSON actions
-   hidden, for a text import). The design doc + competitive research is in
-   [`docs/design/explain-improvements.md`](docs/design/explain-improvements.md)
-   (it also tracks the remaining deferred follow-up: re-color-by-metric).
+   hidden, for a text import). **Re-color by metric**: the plan header (tree view)
+   has a "Color:" segmented toggle — Time / Rows / Cost / Buffers — that rescales
+   the heat bars. `ExplainNodeViewModel` is observable and holds each node's
+   exclusive self-time, self-cost, output rows, and self-buffers (buffer counts
+   read from `ExplainNode.Details`, cumulative like time, so exclusive = node
+   minus children); `ApplyMetric` rescales bars and re-marks the hottest node in
+   place. The design doc + competitive research is in
+   [`docs/design/explain-improvements.md`](docs/design/explain-improvements.md).
 
 ## UI design rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,11 @@ and wrong project memory is worse than none.
    `ExplainNode` tree; the ANALYZE path always asks for `BUFFERS` and
    `SETTINGS` (buffers are the most-requested EXPLAIN option and what the
    spill/lossy analysis reads — zero-valued buffer lines are dropped so the
-   text view stays clean). `Monitoring`-style separation applies:
+   text view stays clean, and `ExplainTextFormatter` folds the per-pool block
+   counters onto one `Buffers:` line — plus an `I/O Timings:` line — to match
+   `EXPLAIN (FORMAT TEXT)`, while the individual counters stay in
+   `ExplainNode.Details` for the re-color "Buffers" metric). `Monitoring`-style
+   separation applies:
    `Query/PlanAnalyzer` is a **Core-pure, unit-tested** walker (a read-only
    sibling of `Json/JsonTree` and `Monitoring/BlockingTree`) that emits named
    `PlanWarning`s — bad row estimates, disk-spilled sorts/hashes, wasteful

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,11 +144,13 @@ and wrong project memory is worse than none.
    command palette's "Import query plan…" opens `ImportPlanDialog` and, on a
    successful parse, shows the plan in a **new tab**
    (`MainViewModel.OpenImportedPlan` → `QueryViewModel.ShowImportedPlan`) — same
-   warnings strip and time-heat as a live plan. The design doc + competitive
-   research is in
+   warnings strip and time-heat as a live plan. **Sharing back out**: the plan
+   header's "Export ▾" flyout copies/saves the plan as JSON or rendered text —
+   `ExplainService.ExplainAsync` returns an `ExplainRun` that keeps the raw
+   server JSON, carried on `QueryViewModel.PlanJson` (null, and the JSON actions
+   hidden, for a text import). The design doc + competitive research is in
    [`docs/design/explain-improvements.md`](docs/design/explain-improvements.md)
-   (it also tracks the remaining deferred follow-ups: copy/export,
-   re-color-by-metric).
+   (it also tracks the remaining deferred follow-up: re-color-by-metric).
 
 ## UI design rules
 

--- a/PgNimbus.App/ViewModels/ExplainNodeViewModel.cs
+++ b/PgNimbus.App/ViewModels/ExplainNodeViewModel.cs
@@ -1,45 +1,82 @@
+using CommunityToolkit.Mvvm.ComponentModel;
 using PgNimbus.Core.Query;
 
 namespace PgNimbus.App.ViewModels;
 
+/// <summary>Which quantity the plan tree's heat bar is scaled by (pev2-style re-color).</summary>
+public enum PlanMetric
+{
+    /// <summary>Exclusive execution time — the default when ANALYZE timing is present.</summary>
+    SelfTime,
+    Rows,
+    Cost,
+    Buffers,
+}
+
 /// <summary>
 /// Presentation wrapper around a single <see cref="ExplainNode"/>: formats the
 /// cost/row/timing figures Postgres reports and derives a bar width so the tree
-/// reads as a rough visual profile, not just a wall of numbers. With ANALYZE
-/// timing present the bar tracks each node's <see cref="SelfTimeMs"/> (exclusive
-/// time) — the quantity that actually points at the bottleneck — falling back to
-/// the cost estimate otherwise.
+/// reads as a rough visual profile, not just a wall of numbers. The bar re-scales
+/// live by the chosen <see cref="PlanMetric"/> (self time, rows, cost, or buffers)
+/// via <see cref="ApplyMetric(PlanMetric)"/>; <see cref="IsBottleneck"/> marks the
+/// single hottest node in that metric. Observable so the toggle updates the tree
+/// in place without rebuilding it (which would drop expansion state).
 /// </summary>
-public sealed class ExplainNodeViewModel
+public sealed partial class ExplainNodeViewModel : ObservableObject
 {
     private const double MaxBarWidth = 200;
+
+    // Buffer-usage counters are cumulative (like actual time), so exclusive
+    // self-buffers subtract the children's — and they're prefixed by their pool.
+    private static readonly string[] BufferPrefixes = ["Shared ", "Local ", "Temp "];
 
     public ExplainNodeViewModel(ExplainNode node, double rootTotalCost)
     {
         Node = node;
         Children = node.Children.Select(c => new ExplainNodeViewModel(c, rootTotalCost)).ToList();
-        BarWidth = rootTotalCost > 0 ? Math.Clamp(node.TotalCost / rootTotalCost, 0, 1) * MaxBarWidth : 0;
 
-        // Exclusive time: this node's total wall time (per-loop × loops) minus the
-        // same for its children. Clamped at 0 for the odd rounding case.
-        var inclusive = InclusiveMs(node);
-        var childrenInclusive = node.Children.Sum(InclusiveMs);
-        SelfTimeMs = node.ActualTotalTimeMs is null ? 0 : Math.Max(0, inclusive - childrenInclusive);
+        // Exclusive (self) quantities: this node's total minus the same for its
+        // children, clamped at 0 for the odd rounding case. Time and buffers are
+        // cumulative in the plan JSON, so both need the subtraction; cost likewise
+        // (Total Cost includes children). Rows aren't additive down the tree, so
+        // the "rows" metric uses the node's own output row count.
+        var inclusiveMs = InclusiveMs(node);
+        SelfTimeMs = node.ActualTotalTimeMs is null ? 0 : Math.Max(0, inclusiveMs - node.Children.Sum(InclusiveMs));
+        SelfCost = Math.Max(0, node.TotalCost - node.Children.Sum(c => c.TotalCost));
+        SelfBuffers = Math.Max(0, BufferBlocks(node) - node.Children.Sum(BufferBlocks));
+        RowCount = node.ActualRows is { } actual ? actual * (node.ActualLoops ?? 1) : node.PlanRows;
+
+        // A sensible starting bar before the first ApplyMetric (cost profile).
+        BarWidth = rootTotalCost > 0 ? Math.Clamp(node.TotalCost / rootTotalCost, 0, 1) * MaxBarWidth : 0;
     }
 
     public ExplainNode Node { get; }
 
     public IReadOnlyList<ExplainNodeViewModel> Children { get; }
 
-    public double BarWidth { get; private set; }
+    [ObservableProperty]
+    private double _barWidth;
+
+    /// <summary>The hottest node in the currently-selected metric — tinted as the plan's bottleneck.</summary>
+    [ObservableProperty]
+    private bool _isBottleneck;
 
     /// <summary>Exclusive (self) execution time — 0 when the plan carries no ANALYZE timing.</summary>
     public double SelfTimeMs { get; }
 
+    /// <summary>Exclusive (self) planner cost — <c>Total Cost</c> minus the children's.</summary>
+    public double SelfCost { get; }
+
+    /// <summary>Rows this node produced (actual × loops when analyzed, else the estimate).</summary>
+    public double RowCount { get; }
+
+    /// <summary>Exclusive (self) buffer blocks touched — 0 when the plan carries no BUFFERS data.</summary>
+    public double SelfBuffers { get; }
+
     public bool HasTiming => Node.ActualTotalTimeMs is not null;
 
-    /// <summary>The single slowest node by self time — tinted as the plan's bottleneck.</summary>
-    public bool IsBottleneck { get; private set; }
+    /// <summary>True when this node or any descendant reports buffer usage — gates the "Buffers" toggle.</summary>
+    public bool HasAnyBuffers => SelfBuffers > 0 || Children.Any(c => c.HasAnyBuffers);
 
     public string Title => ExplainTextFormatter.HeaderFor(Node);
 
@@ -51,40 +88,46 @@ public sealed class ExplainNodeViewModel
         : null;
 
     /// <summary>
-    /// Re-bases the bar on self time and marks the slowest node. Called once on the
-    /// root after the tree is built; no-op when the plan has no timing (plain EXPLAIN).
+    /// Re-scales the whole subtree's bars by <paramref name="metric"/> and re-marks the
+    /// hottest node. Called on the root; when "self time" is asked for but the plan has
+    /// no timing (plain EXPLAIN) it falls back to cost, matching the old heat behavior.
     /// </summary>
-    public void ApplyTimeHeat()
+    public void ApplyMetric(PlanMetric metric)
     {
-        var maxSelf = MaxSelfTime();
-        if (maxSelf <= 0)
-        {
-            return;
-        }
+        var effective = metric == PlanMetric.SelfTime && MaxOf(PlanMetric.SelfTime) <= 0
+            ? PlanMetric.Cost
+            : metric;
 
-        ApplyTimeHeat(maxSelf);
+        ApplyMetric(effective, MaxOf(effective));
     }
 
-    private void ApplyTimeHeat(double maxSelf)
+    private void ApplyMetric(PlanMetric metric, double max)
     {
-        if (HasTiming)
-        {
-            BarWidth = Math.Clamp(SelfTimeMs / maxSelf, 0, 1) * MaxBarWidth;
-            IsBottleneck = SelfTimeMs >= maxSelf;
-        }
+        var value = ValueFor(metric);
+        BarWidth = max > 0 ? Math.Clamp(value / max, 0, 1) * MaxBarWidth : 0;
+        IsBottleneck = max > 0 && value >= max;
 
         foreach (var child in Children)
         {
-            child.ApplyTimeHeat(maxSelf);
+            child.ApplyMetric(metric, max);
         }
     }
 
-    private double MaxSelfTime()
+    private double ValueFor(PlanMetric metric) => metric switch
     {
-        var max = SelfTimeMs;
+        PlanMetric.SelfTime => SelfTimeMs,
+        PlanMetric.Rows => RowCount,
+        PlanMetric.Cost => SelfCost,
+        PlanMetric.Buffers => SelfBuffers,
+        _ => SelfTimeMs,
+    };
+
+    private double MaxOf(PlanMetric metric)
+    {
+        var max = ValueFor(metric);
         foreach (var child in Children)
         {
-            max = Math.Max(max, child.MaxSelfTime());
+            max = Math.Max(max, child.MaxOf(metric));
         }
 
         return max;
@@ -92,4 +135,21 @@ public sealed class ExplainNodeViewModel
 
     private static double InclusiveMs(ExplainNode node) =>
         node.ActualTotalTimeMs is { } total ? total * (node.ActualLoops ?? 1) : 0;
+
+    /// <summary>Sum of the node's buffer-usage counters (shared/local/temp hit/read/dirtied/written blocks).</summary>
+    private static double BufferBlocks(ExplainNode node)
+    {
+        double sum = 0;
+        foreach (var (key, value) in node.Details)
+        {
+            if (key.EndsWith(" Blocks", StringComparison.Ordinal)
+                && Array.Exists(BufferPrefixes, p => key.StartsWith(p, StringComparison.Ordinal))
+                && double.TryParse(value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var blocks))
+            {
+                sum += blocks;
+            }
+        }
+
+        return sum;
+    }
 }

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -574,7 +574,7 @@ public sealed partial class MainViewModel : ObservableObject
     {
         var tab = NewTab();
         tab.TitleOverride = "Imported plan";
-        tab.ShowImportedPlan(plan.Result, plan.DisplayText);
+        tab.ShowImportedPlan(plan.Result, plan.DisplayText, plan.RawJson);
     }
 
     /// <summary>CREATE/DROP EXTENSION, then reload the Extensions group so the list reflects reality. Errors land in the sidebar's message strip.</summary>

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -59,6 +59,9 @@ public sealed partial class MainViewModel : ObservableObject
     // Raised to open the editor's find / find & replace panel (the view owns
     // the AvaloniaEdit SearchPanel). The bool is "replace mode".
     public event Action<bool>? FindRequested;
+    // Raised to open the "paste an EXPLAIN plan" dialog; MainWindow owns the modal
+    // and calls OpenImportedPlan on success (no DB round-trip).
+    public event Action? ImportPlanRequested;
     // Raised to open (or focus) the Server Activity window, which the view owns.
     public event Action? ActivityRequested;
     // Raised to open (or focus) the Database Overview window, which the view owns.
@@ -562,6 +565,18 @@ public sealed partial class MainViewModel : ObservableObject
         tab.Sql = ddl;
     }
 
+    /// <summary>
+    /// Opens an imported plan (parsed from pasted EXPLAIN JSON/text, no DB round-trip)
+    /// in a new tab showing the plan views + warnings strip — never overwriting the
+    /// active tab, per the "loading never overwrites" rule.
+    /// </summary>
+    public void OpenImportedPlan(ImportedPlan plan)
+    {
+        var tab = NewTab();
+        tab.TitleOverride = "Imported plan";
+        tab.ShowImportedPlan(plan.Result, plan.DisplayText);
+    }
+
     /// <summary>CREATE/DROP EXTENSION, then reload the Extensions group so the list reflects reality. Errors land in the sidebar's message strip.</summary>
     public async Task SetExtensionInstalledAsync(ExtensionNode extension, bool install)
     {
@@ -717,6 +732,7 @@ public sealed partial class MainViewModel : ObservableObject
         yield return new PaletteItem("Cancel query", "Action", "■", Invoke(() => ActiveTab.CancelCommand), "Esc");
         yield return new PaletteItem("Explain", "Action", "⚡", Invoke(() => ActiveTab.ExplainCommand));
         yield return new PaletteItem("Explain Analyze", "Action", "⚡", Invoke(() => ActiveTab.ExplainAnalyzeCommand));
+        yield return new PaletteItem("Import query plan (paste EXPLAIN JSON or text)…", "Action", "⭳", () => { ImportPlanRequested?.Invoke(); return Task.CompletedTask; });
         yield return new PaletteItem("Begin transaction", "Action", "⛃", Invoke(() => BeginTransactionCommand));
         yield return new PaletteItem("Commit transaction", "Action", "✓", Invoke(() => CommitTransactionCommand));
         yield return new PaletteItem("Rollback transaction", "Action", "↺", Invoke(() => RollbackTransactionCommand));

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -173,6 +173,19 @@ public sealed partial class QueryViewModel : ObservableObject
     [ObservableProperty]
     private string? _explainText;
 
+    /// <summary>
+    /// The raw `FORMAT JSON` plan payload behind the current plan, kept so it can be
+    /// copied/exported verbatim into external tools (pev2, depesz). Null for a plan
+    /// imported from text (no JSON to hand out) or when no plan is showing.
+    /// </summary>
+    [ObservableProperty]
+    private string? _planJson;
+
+    /// <summary>Drives the "Copy/Save as JSON" plan-export actions — hidden when there's no JSON (a text import).</summary>
+    public bool HasPlanJson => PlanJson is not null;
+
+    partial void OnPlanJsonChanged(string? value) => OnPropertyChanged(nameof(HasPlanJson));
+
     /// <summary>Plan pane mode: true = text layout (default), false = the graphical tree.</summary>
     [ObservableProperty]
     private bool _isPlanTextView = true;
@@ -733,7 +746,7 @@ public sealed partial class QueryViewModel : ObservableObject
     /// import). Opened into its own tab by <see cref="MainViewModel.OpenImportedPlan"/>,
     /// so it never overwrites another tab's results.
     /// </summary>
-    public void ShowImportedPlan(ExplainResult result, string displayText)
+    public void ShowImportedPlan(ExplainResult result, string displayText, string? planJson)
     {
         var root = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
         root.ApplyTimeHeat();
@@ -741,6 +754,7 @@ public sealed partial class QueryViewModel : ObservableObject
 
         PlanWarnings = PlanAnalyzer.Analyze(result).Select(w => new PlanWarningViewModel(w)).ToList();
         ExplainText = displayText;
+        PlanJson = planJson;
         var planningFragment = result.PlanningTimeMs is { } planMs ? $"Planning: {planMs:F3} ms" : null;
         var executionFragment = result.ExecutionTimeMs is { } execMs ? $"Execution: {execMs:F3} ms" : null;
         ExplainSummary = string.Join("   ", new[] { "Imported plan", planningFragment, executionFragment }.Where(f => f is not null));
@@ -764,7 +778,9 @@ public sealed partial class QueryViewModel : ObservableObject
 
         try
         {
-            var result = await _explainService.ExplainAsync(Sql, analyze, ct);
+            var run = await _explainService.ExplainAsync(Sql, analyze, ct);
+            var result = run.Result;
+            PlanJson = run.Json;
             var root = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
             root.ApplyTimeHeat();
             ExplainRoot = root;

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -725,6 +725,29 @@ public sealed partial class QueryViewModel : ObservableObject
     [RelayCommand]
     private void ShowPlanAsTree() => IsPlanTextView = false;
 
+    /// <summary>
+    /// Shows a plan that was imported from pasted text rather than run against the DB
+    /// (see <see cref="ExplainService.Import"/>) — same views, heat, and warnings strip
+    /// as a live plan, no round-trip. <paramref name="displayText"/> is what the text
+    /// pane shows (the canonical layout for a JSON import, the pasted text for a text
+    /// import). Opened into its own tab by <see cref="MainViewModel.OpenImportedPlan"/>,
+    /// so it never overwrites another tab's results.
+    /// </summary>
+    public void ShowImportedPlan(ExplainResult result, string displayText)
+    {
+        var root = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
+        root.ApplyTimeHeat();
+        ExplainRoot = root;
+
+        PlanWarnings = PlanAnalyzer.Analyze(result).Select(w => new PlanWarningViewModel(w)).ToList();
+        ExplainText = displayText;
+        var planningFragment = result.PlanningTimeMs is { } planMs ? $"Planning: {planMs:F3} ms" : null;
+        var executionFragment = result.ExecutionTimeMs is { } execMs ? $"Execution: {execMs:F3} ms" : null;
+        ExplainSummary = string.Join("   ", new[] { "Imported plan", planningFragment, executionFragment }.Where(f => f is not null));
+        IsShowingPlan = true;
+        Status = "Imported plan";
+    }
+
     private async Task RunExplainAsync(bool analyze)
     {
         // Own a CTS so the Cancel button (enabled by IsRunning) actually cancels

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -186,6 +186,36 @@ public sealed partial class QueryViewModel : ObservableObject
 
     partial void OnPlanJsonChanged(string? value) => OnPropertyChanged(nameof(HasPlanJson));
 
+    /// <summary>Which metric the plan tree's heat bar is scaled by (pev2-style re-color toggle).</summary>
+    [ObservableProperty]
+    private PlanMetric _planMetric = PlanMetric.SelfTime;
+
+    /// <summary>True when the plan carries ANALYZE timing — gates the Time/Buffers metric toggles.</summary>
+    [ObservableProperty]
+    private bool _planHasTiming;
+
+    /// <summary>True when the plan carries BUFFERS data — gates the Buffers metric toggle.</summary>
+    [ObservableProperty]
+    private bool _planHasBuffers;
+
+    public bool IsMetricSelfTime => PlanMetric == PlanMetric.SelfTime;
+    public bool IsMetricRows => PlanMetric == PlanMetric.Rows;
+    public bool IsMetricCost => PlanMetric == PlanMetric.Cost;
+    public bool IsMetricBuffers => PlanMetric == PlanMetric.Buffers;
+
+    partial void OnPlanMetricChanged(PlanMetric value)
+    {
+        OnPropertyChanged(nameof(IsMetricSelfTime));
+        OnPropertyChanged(nameof(IsMetricRows));
+        OnPropertyChanged(nameof(IsMetricCost));
+        OnPropertyChanged(nameof(IsMetricBuffers));
+        ExplainRoot?.ApplyMetric(value);
+    }
+
+    /// <summary>Re-scales the plan tree's bars by <paramref name="metric"/> (the header's segmented toggle).</summary>
+    [RelayCommand]
+    private void SetPlanMetric(PlanMetric metric) => PlanMetric = metric;
+
     /// <summary>Plan pane mode: true = text layout (default), false = the graphical tree.</summary>
     [ObservableProperty]
     private bool _isPlanTextView = true;
@@ -738,6 +768,17 @@ public sealed partial class QueryViewModel : ObservableObject
     [RelayCommand]
     private void ShowPlanAsTree() => IsPlanTextView = false;
 
+    // Sets the metric-toggle availability, picks the default metric (self time when the
+    // plan was analyzed, else cost), and paints the initial heat. Shared by live and
+    // imported plans so both light up the same way.
+    private void ApplyPlanHeat(ExplainNodeViewModel root)
+    {
+        PlanHasTiming = root.HasTiming;
+        PlanHasBuffers = root.HasAnyBuffers;
+        PlanMetric = root.HasTiming ? PlanMetric.SelfTime : PlanMetric.Cost;
+        root.ApplyMetric(PlanMetric); // explicit: OnPlanMetricChanged is a no-op when the value didn't change
+    }
+
     /// <summary>
     /// Shows a plan that was imported from pasted text rather than run against the DB
     /// (see <see cref="ExplainService.Import"/>) — same views, heat, and warnings strip
@@ -749,8 +790,8 @@ public sealed partial class QueryViewModel : ObservableObject
     public void ShowImportedPlan(ExplainResult result, string displayText, string? planJson)
     {
         var root = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
-        root.ApplyTimeHeat();
         ExplainRoot = root;
+        ApplyPlanHeat(root);
 
         PlanWarnings = PlanAnalyzer.Analyze(result).Select(w => new PlanWarningViewModel(w)).ToList();
         ExplainText = displayText;
@@ -782,8 +823,8 @@ public sealed partial class QueryViewModel : ObservableObject
             var result = run.Result;
             PlanJson = run.Json;
             var root = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
-            root.ApplyTimeHeat();
             ExplainRoot = root;
+            ApplyPlanHeat(root);
 
             var warnings = new List<PlanWarningViewModel>();
             // Reassure the user their data is intact: ANALYZE ran the write, but ExplainService

--- a/PgNimbus.App/Views/ImportPlanDialog.axaml
+++ b/PgNimbus.App/Views/ImportPlanDialog.axaml
@@ -20,7 +20,7 @@
                      ScrollViewer.HorizontalScrollBarVisibility="Auto"
                      ScrollViewer.VerticalScrollBarVisibility="Auto"
                      FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="12.5"
-                     Watermark="[ { &quot;Plan&quot;: { … } } ]  — or —  Seq Scan on t  (cost=…) (actual …)"
+                     PlaceholderText="[ { &quot;Plan&quot;: { … } } ]  — or —  Seq Scan on t  (cost=…) (actual …)"
                      BorderThickness="0" Background="Transparent" />
         </Border>
 

--- a/PgNimbus.App/Views/ImportPlanDialog.axaml
+++ b/PgNimbus.App/Views/ImportPlanDialog.axaml
@@ -1,0 +1,38 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="PgNimbus.App.Views.ImportPlanDialog"
+        Title="Import query plan"
+        Width="640" Height="520"
+        MinWidth="420" MinHeight="320"
+        WindowStartupLocation="CenterOwner"
+        FontFamily="{StaticResource InterFont}">
+
+    <Grid Margin="20" RowDefinitions="Auto,*,Auto,Auto">
+        <StackPanel Grid.Row="0" Spacing="4" Margin="0,0,0,10">
+            <TextBlock Text="Paste an EXPLAIN plan" FontWeight="SemiBold" FontSize="14" />
+            <TextBlock TextWrapping="Wrap" FontSize="12" Opacity="0.7"
+                       Text="Paste EXPLAIN output in JSON (FORMAT JSON — most reliable) or the plain text layout. It's parsed locally and shown with the warnings strip and time-heat tree; the database isn't touched." />
+        </StackPanel>
+
+        <Border Grid.Row="1" BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1" CornerRadius="6">
+            <TextBox Name="PlanInput"
+                     AcceptsReturn="True" AcceptsTab="True" TextWrapping="NoWrap"
+                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                     ScrollViewer.VerticalScrollBarVisibility="Auto"
+                     FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="12.5"
+                     Watermark="[ { &quot;Plan&quot;: { … } } ]  — or —  Seq Scan on t  (cost=…) (actual …)"
+                     BorderThickness="0" Background="Transparent" />
+        </Border>
+
+        <TextBlock Name="ErrorText" Grid.Row="2" IsVisible="False" Margin="0,10,0,0"
+                   Foreground="{DynamicResource SystemControlErrorTextForegroundBrush}"
+                   TextWrapping="Wrap" FontSize="12" />
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8"
+                    HorizontalAlignment="Right" Margin="0,14,0,0">
+            <Button Classes="accent" Content="Import" Click="OnImportClick" />
+            <Button Classes="soft" Content="Cancel" Click="OnCancelClick" />
+        </StackPanel>
+    </Grid>
+
+</Window>

--- a/PgNimbus.App/Views/ImportPlanDialog.axaml.cs
+++ b/PgNimbus.App/Views/ImportPlanDialog.axaml.cs
@@ -1,0 +1,37 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.App.Views;
+
+/// <summary>
+/// Modal for pasting an externally-produced EXPLAIN plan (JSON or text). Parses on
+/// Import via <see cref="ExplainService.Import"/>; a parse failure is shown inline and
+/// the dialog stays open. Returns the parsed <see cref="ImportedPlan"/> (or null when
+/// cancelled) via <c>ShowDialog&lt;ImportedPlan?&gt;</c>.
+/// </summary>
+public partial class ImportPlanDialog : Window
+{
+    public ImportPlanDialog()
+    {
+        InitializeComponent();
+        ThemedWindowChrome.Attach(this);
+        Opened += (_, _) => PlanInput.Focus();
+    }
+
+    private void OnImportClick(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var imported = ExplainService.Import(PlanInput.Text ?? string.Empty);
+            Close(imported);
+        }
+        catch (FormatException ex)
+        {
+            ErrorText.Text = ex.Message;
+            ErrorText.IsVisible = true;
+        }
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e) => Close(null);
+}

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Styling;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using PgNimbus.App.ViewModels;
+using PgNimbus.Core.Query;
 
 namespace PgNimbus.App.Views;
 
@@ -421,7 +422,8 @@ public partial class MainWindow : Window
             _viewModel.ShortcutsRequested -= ShowShortcutsWindow;
             _viewModel.SwitchConnectionRequested -= SwitchConnection;
             _viewModel.NewWindowRequested -= OpenNewWindow;
-            _viewModel.ActivityRequested -= ShowActivityWindow;
+            _viewModel.ImportPlanRequested -= ShowImportPlanDialog;
+        _viewModel.ActivityRequested -= ShowActivityWindow;
             _viewModel.DatabaseOverviewRequested -= ShowDatabaseOverviewWindow;
             _viewModel.SidebarToggleRequested -= ToggleSidebar;
             _viewModel.PreferencesRequested -= ShowPreferencesWindow;
@@ -438,6 +440,7 @@ public partial class MainWindow : Window
         _viewModel.NewWindowRequested += OpenNewWindow;
         // FormatSqlRequested / ExpandStarRequested / FindRequested are handled by
         // QueryEditorPanel, which subscribes to them off its own DataContext.
+        _viewModel.ImportPlanRequested += ShowImportPlanDialog;
         _viewModel.ActivityRequested += ShowActivityWindow;
         _viewModel.DatabaseOverviewRequested += ShowDatabaseOverviewWindow;
         _viewModel.SidebarToggleRequested += ToggleSidebar;
@@ -849,6 +852,24 @@ public partial class MainWindow : Window
         _preferencesWindow = new PreferencesWindow { DataContext = new PreferencesViewModel(_viewModel) };
         _preferencesWindow.Closed += (_, _) => _preferencesWindow = null;
         _preferencesWindow.Show(this);
+    }
+
+    private void ShowImportPlanDialog() => _ = ShowImportPlanDialogAsync();
+
+    // Opens the paste-a-plan modal; on a successful parse the plan opens in a new tab
+    // (MainViewModel.OpenImportedPlan) with no DB round-trip.
+    private async Task ShowImportPlanDialogAsync()
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        var dialog = new ImportPlanDialog();
+        if (await dialog.ShowDialog<ImportedPlan?>(this) is { } imported)
+        {
+            _viewModel.OpenImportedPlan(imported);
+        }
     }
 
     private ActivityWindow? _activityWindow;

--- a/PgNimbus.App/Views/ResultsGridPanel.axaml
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml
@@ -121,6 +121,32 @@
                     </StackPanel>
                     <Grid RowDefinitions="Auto,Auto,*" IsVisible="{Binding ActiveTab.IsShowingPlan}">
                         <DockPanel Grid.Row="0" Margin="4">
+                            <!-- pev2-style re-color toggle: re-scale the tree bars by a chosen metric.
+                                 Tree-view only (the bars live there); Time/Buffers gated on the plan
+                                 actually carrying ANALYZE timing / BUFFERS data. -->
+                            <StackPanel DockPanel.Dock="Left" Orientation="Horizontal" Spacing="2"
+                                        VerticalAlignment="Center" Margin="0,0,12,0"
+                                        IsVisible="{Binding !ActiveTab.IsPlanTextView}">
+                                <TextBlock Text="Color:" FontSize="11" Opacity="0.7" VerticalAlignment="Center" Margin="0,0,4,0" />
+                                <Button Classes="chip" Content="Time" FontSize="11" Padding="8,2"
+                                        Classes.active="{Binding ActiveTab.IsMetricSelfTime}"
+                                        IsEnabled="{Binding ActiveTab.PlanHasTiming}"
+                                        Command="{Binding ActiveTab.SetPlanMetricCommand}"
+                                        CommandParameter="{x:Static vm:PlanMetric.SelfTime}" />
+                                <Button Classes="chip" Content="Rows" FontSize="11" Padding="8,2"
+                                        Classes.active="{Binding ActiveTab.IsMetricRows}"
+                                        Command="{Binding ActiveTab.SetPlanMetricCommand}"
+                                        CommandParameter="{x:Static vm:PlanMetric.Rows}" />
+                                <Button Classes="chip" Content="Cost" FontSize="11" Padding="8,2"
+                                        Classes.active="{Binding ActiveTab.IsMetricCost}"
+                                        Command="{Binding ActiveTab.SetPlanMetricCommand}"
+                                        CommandParameter="{x:Static vm:PlanMetric.Cost}" />
+                                <Button Classes="chip" Content="Buffers" FontSize="11" Padding="8,2"
+                                        Classes.active="{Binding ActiveTab.IsMetricBuffers}"
+                                        IsEnabled="{Binding ActiveTab.PlanHasBuffers}"
+                                        Command="{Binding ActiveTab.SetPlanMetricCommand}"
+                                        CommandParameter="{x:Static vm:PlanMetric.Buffers}" />
+                            </StackPanel>
                             <!-- pgAdmin-style plan view switch: raw text (default) vs graphical tree -->
                             <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="2">
                                 <!-- Share the plan into external tools (pev2, depesz). Plan-scoped,

--- a/PgNimbus.App/Views/ResultsGridPanel.axaml
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml
@@ -123,6 +123,22 @@
                         <DockPanel Grid.Row="0" Margin="4">
                             <!-- pgAdmin-style plan view switch: raw text (default) vs graphical tree -->
                             <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="2">
+                                <!-- Share the plan into external tools (pev2, depesz). Plan-scoped,
+                                     shown only while a plan is on screen — not a main-toolbar control. -->
+                                <Button Classes="chip" Content="Export ▾" FontSize="11" Padding="8,2" Margin="0,0,6,0"
+                                        ToolTip.Tip="Copy or save this plan">
+                                    <Button.Flyout>
+                                        <MenuFlyout>
+                                            <MenuItem Header="Copy as JSON" Click="OnCopyPlanJson"
+                                                      IsVisible="{Binding ActiveTab.HasPlanJson}" />
+                                            <MenuItem Header="Copy as text" Click="OnCopyPlanText" />
+                                            <Separator />
+                                            <MenuItem Header="Save as .json…" Click="OnSavePlanJson"
+                                                      IsVisible="{Binding ActiveTab.HasPlanJson}" />
+                                            <MenuItem Header="Save as .txt…" Click="OnSavePlanText" />
+                                        </MenuFlyout>
+                                    </Button.Flyout>
+                                </Button>
                                 <Button Classes="chip" Classes.active="{Binding ActiveTab.IsPlanTextView}"
                                         Command="{Binding ActiveTab.ShowPlanAsTextCommand}"
                                         Content="Text" FontSize="11" Padding="8,2" />

--- a/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
@@ -1073,6 +1073,73 @@ public partial class ResultsGridPanel : UserControl
         await Task.Run(() => write(stream));
     }
 
+    // --- Plan copy / export ------------------------------------------------
+    // Share the current query plan into external tools (pev2, depesz, an issue).
+    // JSON is the interchange format; the rendered text is the human-readable one.
+    // The JSON actions are hidden (see the flyout) when the plan came from a text
+    // import, which has no JSON to hand out.
+
+    private void OnCopyPlanJson(object? sender, RoutedEventArgs e) => _ = CopyToClipboardAsync(_activeQuery?.PlanJson);
+
+    private void OnCopyPlanText(object? sender, RoutedEventArgs e) => _ = CopyToClipboardAsync(_activeQuery?.ExplainText);
+
+    private void OnSavePlanJson(object? sender, RoutedEventArgs e) =>
+        _ = SavePlanAsync(_activeQuery?.PlanJson, "json", "JSON", ["*.json"]);
+
+    private void OnSavePlanText(object? sender, RoutedEventArgs e) =>
+        _ = SavePlanAsync(_activeQuery?.ExplainText, "txt", "Text", ["*.txt"]);
+
+    private async Task CopyToClipboardAsync(string? text)
+    {
+        if (string.IsNullOrEmpty(text) || TopLevel.GetTopLevel(this)?.Clipboard is not { } clipboard)
+        {
+            return;
+        }
+
+        await clipboard.SetTextAsync(text);
+        if (_activeQuery is not null)
+        {
+            _activeQuery.Status = "Plan copied to clipboard";
+        }
+    }
+
+    private async Task SavePlanAsync(string? content, string extension, string typeName, string[] patterns)
+    {
+        if (string.IsNullOrEmpty(content) || TopLevel.GetTopLevel(this)?.StorageProvider is not { } storageProvider)
+        {
+            return;
+        }
+
+        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Save query plan",
+            SuggestedFileName = $"plan.{extension}",
+            DefaultExtension = extension,
+            FileTypeChoices = [new FilePickerFileType(typeName) { Patterns = patterns }],
+        });
+
+        if (file is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await using var stream = await file.OpenWriteAsync();
+            await using var writer = new StreamWriter(stream);
+            await writer.WriteAsync(content);
+            if (_activeQuery is not null)
+            {
+                _activeQuery.Status = $"Plan saved to {file.Name}";
+            }
+        }
+        catch (Exception ex) when (_activeQuery is not null)
+        {
+            _activeQuery.Status = $"Save failed: {ex.Message}";
+            _activeQuery.HasError = true;
+        }
+    }
+
     // --- Column building ---------------------------------------------------
 
     // The column Binding has an empty Path - it passes the row array straight

--- a/PgNimbus.Core.Tests/Query/ExplainImportTests.cs
+++ b/PgNimbus.Core.Tests/Query/ExplainImportTests.cs
@@ -1,0 +1,182 @@
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Tests.Query;
+
+/// <summary>
+/// Covers the paste-a-plan import path: tolerant JSON parsing (the shapes external
+/// tools produce) and the best-effort <c>FORMAT TEXT</c> parser. The text cases
+/// round-trip against <see cref="ExplainTextFormatter"/> output so the two parsers
+/// stay in agreement.
+/// </summary>
+public class ExplainImportTests
+{
+    private const string StandardJson = """
+        [
+          {
+            "Plan": {
+              "Node Type": "Seq Scan",
+              "Relation Name": "t",
+              "Alias": "t",
+              "Startup Cost": 0.00,
+              "Total Cost": 41.88,
+              "Plan Rows": 850,
+              "Plan Width": 4
+            },
+            "Planning Time": 0.181,
+            "Execution Time": 0.021
+          }
+        ]
+        """;
+
+    [Test]
+    public async Task ImportDetectsJsonAndFormatsDisplayText()
+    {
+        var imported = ExplainService.Import(StandardJson);
+
+        await Assert.That(imported.Result.Root.NodeType).IsEqualTo("Seq Scan");
+        await Assert.That(imported.Result.ExecutionTimeMs).IsEqualTo(0.021);
+        // JSON imports show the canonical text layout, not the raw JSON.
+        await Assert.That(imported.DisplayText).StartsWith("Seq Scan on t  (cost=0.00..41.88");
+    }
+
+    [Test]
+    public async Task BarePlanNodeWithoutWrapperParses()
+    {
+        // Some tools export just the plan node (no [{ "Plan": … }] envelope).
+        var bare = """
+            { "Node Type": "Result", "Startup Cost": 0.00, "Total Cost": 0.01, "Plan Rows": 1, "Plan Width": 4 }
+            """;
+
+        var result = ExplainService.Parse(bare);
+
+        await Assert.That(result.Root.NodeType).IsEqualTo("Result");
+        await Assert.That(result.PlanningTimeMs).IsNull();
+    }
+
+    [Test]
+    public async Task ObjectRootWithPlanParses()
+    {
+        var obj = """
+            { "Plan": { "Node Type": "Result", "Startup Cost": 0, "Total Cost": 0.01, "Plan Rows": 1, "Plan Width": 4 }, "Execution Time": 5.5 }
+            """;
+
+        var result = ExplainService.Parse(obj);
+
+        await Assert.That(result.Root.NodeType).IsEqualTo("Result");
+        await Assert.That(result.ExecutionTimeMs).IsEqualTo(5.5);
+    }
+
+    [Test]
+    public async Task BlankInputThrowsFriendlyError()
+    {
+        await Assert.That(() => ExplainService.Import("   ")).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task InvalidJsonThrowsFormatException()
+    {
+        // Starts with '{' so it's routed to the JSON parser, then fails to parse.
+        await Assert.That(() => ExplainService.Import("{ not json ")).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task TextPlanBuildsTreeCostAndActual()
+    {
+        var text =
+            "Sort  (cost=1.10..1.20 rows=5 width=4) (actual time=0.050..0.060 rows=5 loops=1)\n" +
+            "  Sort Key: t.id\n" +
+            "  Sort Method: external merge  Disk: 2000kB\n" +
+            "  ->  Seq Scan on t  (cost=0.00..1.05 rows=5 width=4) (actual time=0.005..0.010 rows=5 loops=1)\n" +
+            "        Filter: (id > 3)\n" +
+            "        Rows Removed by Filter: 3\n" +
+            "Planning Time: 0.100 ms\n" +
+            "Execution Time: 0.200 ms";
+
+        var result = ExplainPlanTextParser.Parse(text);
+
+        await Assert.That(result.Root.NodeType).IsEqualTo("Sort");
+        await Assert.That(result.Root.TotalCost).IsEqualTo(1.20);
+        await Assert.That(result.Root.ActualTotalTimeMs).IsEqualTo(0.060);
+        await Assert.That(result.Root.ActualRows).IsEqualTo(5.0);
+        await Assert.That(result.PlanningTimeMs).IsEqualTo(0.100);
+        await Assert.That(result.ExecutionTimeMs).IsEqualTo(0.200);
+
+        await Assert.That(result.Root.Children.Count).IsEqualTo(1);
+        var child = result.Root.Children[0];
+        await Assert.That(child.NodeType).IsEqualTo("Seq Scan");
+        await Assert.That(child.RelationName).IsEqualTo("t");
+        await Assert.That(child.Details.Select(d => d.Key)).Contains("Rows Removed by Filter");
+    }
+
+    [Test]
+    public async Task TextPlanRoundTripsThroughTextFormatter()
+    {
+        // Parse the exact text the formatter emits for the join fixture, and the
+        // reconstructed tree must re-format to the same text.
+        var expected =
+            "Hash Left Join  (cost=1.11..2.29 rows=5 width=30)\n" +
+            "  Hash Cond: (o.customer_id = c.id)\n" +
+            "  ->  Seq Scan on orders o  (cost=0.00..1.05 rows=5 width=12)\n" +
+            "  ->  Hash  (cost=1.05..1.05 rows=5 width=22)\n" +
+            "        ->  Index Scan using customers_pkey on customers c  (cost=0.00..1.05 rows=5 width=22)\n" +
+            "Planning Time: 0.120 ms";
+
+        var result = ExplainPlanTextParser.Parse(expected);
+        var reformatted = ExplainTextFormatter.Format(result).ReplaceLineEndings("\n");
+
+        await Assert.That(reformatted).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task TextPlanAnalyzerFiresOnImportedSpill()
+    {
+        // The disk-spill and seq-scan-filter analyzers must work on an imported text
+        // plan, proving the parsed shape feeds PlanAnalyzer the same as a live plan.
+        var text =
+            "Seq Scan on events  (cost=0.00..1000.00 rows=100 width=4) (actual time=0.010..50.000 rows=10 loops=1)\n" +
+            "  Filter: (amount > 100)\n" +
+            "  Rows Removed by Filter: 190000";
+
+        var result = ExplainPlanTextParser.Parse(ExplainPlanTextParser.Clean(text));
+        var warnings = PlanAnalyzer.Analyze(result);
+
+        await Assert.That(warnings.Any(w => w.Title == "Sequential scan discards most rows")).IsTrue();
+    }
+
+    [Test]
+    public async Task CleanStripsPsqlFraming()
+    {
+        var psql =
+            "                          QUERY PLAN\n" +
+            "-----------------------------------------------------------\n" +
+            " Seq Scan on t  (cost=0.00..41.88 rows=850 width=4)\n" +
+            "   Filter: (id > 3)\n" +
+            "(2 rows)";
+
+        var result = ExplainPlanTextParser.Parse(ExplainPlanTextParser.Clean(psql));
+
+        await Assert.That(result.Root.NodeType).IsEqualTo("Seq Scan");
+        await Assert.That(result.Root.RelationName).IsEqualTo("t");
+        await Assert.That(result.Root.Details.Select(d => d.Key)).Contains("Filter");
+    }
+
+    [Test]
+    public async Task NeverExecutedBranchParses()
+    {
+        var text =
+            "Nested Loop  (cost=0.00..5.00 rows=1 width=4) (actual time=0.010..0.020 rows=1 loops=1)\n" +
+            "  ->  Seq Scan on a  (cost=0.00..1.00 rows=1 width=4) (actual time=0.005..0.006 rows=1 loops=1)\n" +
+            "  ->  Index Scan using b_pkey on b  (cost=0.00..1.00 rows=1 width=4) (never executed)";
+
+        var result = ExplainPlanTextParser.Parse(text);
+
+        await Assert.That(result.Root.Children[1].ActualLoops).IsEqualTo(0L);
+    }
+
+    [Test]
+    public async Task NonPlanTextThrows()
+    {
+        await Assert.That(() => ExplainService.Import("hello world, this is not a plan"))
+            .Throws<FormatException>();
+    }
+}

--- a/PgNimbus.Core.Tests/Query/ExplainImportTests.cs
+++ b/PgNimbus.Core.Tests/Query/ExplainImportTests.cs
@@ -40,6 +40,18 @@ public class ExplainImportTests
     }
 
     [Test]
+    public async Task JsonImportKeepsRawJsonTextImportDoesNot()
+    {
+        var json = ExplainService.Import(StandardJson);
+        await Assert.That(json.RawJson).IsNotNull();
+        await Assert.That(json.RawJson!).Contains("\"Node Type\"");
+
+        var text = ExplainService.Import("Seq Scan on t  (cost=0.00..1.05 rows=5 width=4)");
+        // A text import has no JSON to copy/export.
+        await Assert.That(text.RawJson).IsNull();
+    }
+
+    [Test]
     public async Task BarePlanNodeWithoutWrapperParses()
     {
         // Some tools export just the plan node (no [{ "Plan": … }] envelope).

--- a/PgNimbus.Core.Tests/Query/ExplainParsingTests.cs
+++ b/PgNimbus.Core.Tests/Query/ExplainParsingTests.cs
@@ -179,6 +179,45 @@ public class ExplainParsingTests
         await Assert.That(text.ReplaceLineEndings("\n")).IsEqualTo(expected);
     }
 
+    private const string BuffersJson = """
+        [
+          {
+            "Plan": {
+              "Node Type": "Seq Scan",
+              "Relation Name": "t",
+              "Alias": "t",
+              "Startup Cost": 0.00,
+              "Total Cost": 41.88,
+              "Plan Rows": 850,
+              "Plan Width": 4,
+              "Shared Hit Blocks": 100,
+              "Shared Read Blocks": 50,
+              "Shared Dirtied Blocks": 0,
+              "Shared Written Blocks": 0,
+              "Temp Read Blocks": 5,
+              "Temp Written Blocks": 7,
+              "I/O Read Time": 1.234,
+              "I/O Write Time": 0
+            }
+          }
+        ]
+        """;
+
+    [Test]
+    public async Task BufferCountersFoldOntoOneBuffersLine()
+    {
+        var text = ExplainTextFormatter.Format(ExplainService.Parse(BuffersJson)).ReplaceLineEndings("\n");
+
+        // One aggregated line, non-zero counters only, pools comma-separated — matching
+        // EXPLAIN (FORMAT TEXT). Not one line per counter.
+        await Assert.That(text).Contains("Buffers: shared hit=100 read=50, temp read=5 written=7");
+        await Assert.That(text).DoesNotContain("Shared Hit Blocks");
+        await Assert.That(text).DoesNotContain("Shared Dirtied Blocks");
+        // I/O Timings shows only the non-zero direction, 3-decimal.
+        await Assert.That(text).Contains("I/O Timings: read=1.234");
+        await Assert.That(text).DoesNotContain("write=");
+    }
+
     [Test]
     public async Task FractionalActualRowsKeepTheirDecimals()
     {

--- a/PgNimbus.Core/Query/ExplainPlanTextParser.cs
+++ b/PgNimbus.Core/Query/ExplainPlanTextParser.cs
@@ -1,0 +1,349 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace PgNimbus.Core.Query;
+
+/// <summary>
+/// Parses a pasted <c>EXPLAIN (FORMAT TEXT)</c> plan into the same
+/// <see cref="ExplainResult"/> tree the JSON parser produces, so an imported
+/// text plan flows through the exact same views, heat, and <see cref="PlanAnalyzer"/>
+/// as a live one — no DB round-trip. Core-pure, deterministic, and unit-tested,
+/// a read-only sibling of <see cref="ExplainService.Parse"/>.
+///
+/// Text is the lossy interchange format (JSON is preferred and robust), so this is
+/// deliberately best-effort: it reconstructs the tree, cost/row/timing figures, and
+/// the indented detail lines the analyzer reads (Sort Method, Rows Removed by Filter,
+/// …), enough for the warnings and heat to work on the common node shapes. Anything
+/// it genuinely can't make sense of raises <see cref="FormatException"/> so the import
+/// UI can steer the user to the JSON form.
+/// </summary>
+public static class ExplainPlanTextParser
+{
+    // "  (cost=0.00..41.88 rows=850 width=4)"
+    private static readonly Regex CostRegex = new(
+        @"\(cost=(?<startup>[\d.]+)\.\.(?<total>[\d.]+)\s+rows=(?<rows>\d+)\s+width=(?<width>\d+)\)",
+        RegexOptions.Compiled);
+
+    // "(actual time=0.009..0.021 rows=7.00 loops=1)" — the time= clause is absent
+    // when ANALYZE ran with TIMING OFF, so it's optional here.
+    private static readonly Regex ActualRegex = new(
+        @"\(actual\s+(?:time=(?<startup>[\d.]+)\.\.(?<total>[\d.]+)\s+)?rows=(?<rows>[\d.]+)\s+loops=(?<loops>\d+)\)",
+        RegexOptions.Compiled);
+
+    // Lines that end the plan tree and carry summary figures rather than nodes.
+    private static readonly Regex PlanningTimeRegex = new(@"^Planning Time:\s*([\d.]+)\s*ms", RegexOptions.Compiled);
+    private static readonly Regex ExecutionTimeRegex = new(@"^Execution Time:\s*([\d.]+)\s*ms", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Strips psql's framing from pasted output so the bare plan lines remain:
+    /// a leading <c>QUERY PLAN</c> header and its <c>-----</c> underline, the trailing
+    /// <c>(N rows)</c> count, and the single leading space psql pads every value line
+    /// with (removed uniformly so relative indentation — which encodes the tree — is
+    /// preserved). A plan copied straight from a tool without that framing is unaffected.
+    /// </summary>
+    public static string Clean(string raw)
+    {
+        var lines = raw.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n').ToList();
+
+        // Drop a leading blank run.
+        while (lines.Count > 0 && lines[0].Trim().Length == 0)
+        {
+            lines.RemoveAt(0);
+        }
+
+        // psql column header + underline.
+        if (lines.Count > 0 && lines[0].Trim() == "QUERY PLAN")
+        {
+            lines.RemoveAt(0);
+            if (lines.Count > 0 && lines[0].TrimStart().StartsWith('-'))
+            {
+                lines.RemoveAt(0);
+            }
+        }
+
+        // Trailing "(N rows)" / "(N row)" psql row count, and any trailing blanks.
+        while (lines.Count > 0 && lines[^1].Trim().Length == 0)
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+
+        if (lines.Count > 0 && Regex.IsMatch(lines[^1].Trim(), @"^\(\d+\s+rows?\)$"))
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+
+        // psql pads every content line with one leading space; strip it uniformly so
+        // the root sits at column 0 and child indentation stays relative.
+        if (lines.Where(l => l.Length > 0).All(l => l.StartsWith(' ')))
+        {
+            lines = lines.Select(l => l.Length > 0 ? l[1..] : l).ToList();
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    public static ExplainResult Parse(string text)
+    {
+        var lines = text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+
+        ParsedNode? root = null;
+        double? planningTime = null;
+        double? executionTime = null;
+
+        // Stack of (indent, node): a node's children are the deeper-indented "-> …"
+        // lines that follow it; detail lines attach to the top of the stack.
+        var stack = new List<(int Indent, ParsedNode Node)>();
+
+        foreach (var rawLine in lines)
+        {
+            if (rawLine.Trim().Length == 0)
+            {
+                continue;
+            }
+
+            var trimmedStart = rawLine.TrimStart();
+
+            // Summary trailers close the tree.
+            if (PlanningTimeRegex.Match(trimmedStart) is { Success: true } pt)
+            {
+                planningTime = double.Parse(pt.Groups[1].Value, CultureInfo.InvariantCulture);
+                continue;
+            }
+
+            if (ExecutionTimeRegex.Match(trimmedStart) is { Success: true } et)
+            {
+                executionTime = double.Parse(et.Groups[1].Value, CultureInfo.InvariantCulture);
+                continue;
+            }
+
+            var indent = rawLine.Length - trimmedStart.Length;
+            var isChild = trimmedStart.StartsWith("->", StringComparison.Ordinal);
+
+            if (root is null)
+            {
+                // First non-summary line is the root node header.
+                root = ParseHeader(trimmedStart);
+                if (root is null)
+                {
+                    throw new FormatException("This doesn't look like an EXPLAIN text plan — the first line has no plan node.");
+                }
+
+                stack.Add((indent, root));
+                continue;
+            }
+
+            if (isChild)
+            {
+                var node = ParseHeader(trimmedStart[2..].TrimStart())
+                    ?? throw new FormatException($"Couldn't parse a plan node from: {trimmedStart}");
+
+                // Pop shallower/sibling frames so the new node hangs off the nearest
+                // strictly-shallower ancestor.
+                while (stack.Count > 0 && stack[^1].Indent >= indent)
+                {
+                    stack.RemoveAt(stack.Count - 1);
+                }
+
+                if (stack.Count == 0)
+                {
+                    throw new FormatException("The plan's indentation is inconsistent — couldn't place a child node.");
+                }
+
+                stack[^1].Node.Children.Add(node);
+                stack.Add((indent, node));
+                continue;
+            }
+
+            // A non-arrow, non-summary line is a detail ("Key: value") of the current
+            // node. Bare annotations without a colon (subplan headers, "Workers")
+            // aren't first-class detail and are skipped.
+            var colon = trimmedStart.IndexOf(": ", StringComparison.Ordinal);
+            if (colon > 0 && stack.Count > 0)
+            {
+                var key = trimmedStart[..colon];
+                var value = trimmedStart[(colon + 2)..].Trim();
+                stack[^1].Node.Details.Add(new KeyValuePair<string, string>(key, value));
+            }
+        }
+
+        if (root is null)
+        {
+            throw new FormatException("No plan node found in the pasted text.");
+        }
+
+        return new ExplainResult(root.ToExplainNode(), planningTime, executionTime);
+    }
+
+    /// <summary>
+    /// Parses one node header line — the operator name plus the <c>(cost=…)</c> and
+    /// <c>(actual …)</c> parentheticals — into a partial node. Returns null when the line
+    /// carries no cost group (so it can't be a node), letting the caller reject it.
+    /// </summary>
+    private static ParsedNode? ParseHeader(string line)
+    {
+        var cost = CostRegex.Match(line);
+        if (!cost.Success)
+        {
+            return null;
+        }
+
+        var name = line[..cost.Index].Trim();
+        var (nodeType, relation, alias, indexName, scanDirection, parallelAware) = DecomposeName(name);
+
+        var node = new ParsedNode
+        {
+            NodeType = nodeType,
+            RelationName = relation,
+            Alias = alias,
+            IndexName = indexName,
+            ScanDirection = scanDirection,
+            ParallelAware = parallelAware,
+            StartupCost = double.Parse(cost.Groups["startup"].Value, CultureInfo.InvariantCulture),
+            TotalCost = double.Parse(cost.Groups["total"].Value, CultureInfo.InvariantCulture),
+            PlanRows = long.Parse(cost.Groups["rows"].Value, CultureInfo.InvariantCulture),
+            PlanWidth = int.Parse(cost.Groups["width"].Value, CultureInfo.InvariantCulture),
+        };
+
+        if (line.Contains("(never executed)", StringComparison.Ordinal))
+        {
+            node.ActualLoops = 0;
+        }
+        else if (ActualRegex.Match(line) is { Success: true } actual)
+        {
+            if (actual.Groups["total"].Success)
+            {
+                node.ActualStartupTimeMs = double.Parse(actual.Groups["startup"].Value, CultureInfo.InvariantCulture);
+                node.ActualTotalTimeMs = double.Parse(actual.Groups["total"].Value, CultureInfo.InvariantCulture);
+            }
+
+            node.ActualRows = double.Parse(actual.Groups["rows"].Value, CultureInfo.InvariantCulture);
+            node.ActualLoops = long.Parse(actual.Groups["loops"].Value, CultureInfo.InvariantCulture);
+        }
+
+        return node;
+    }
+
+    /// <summary>
+    /// Reverses the display-name assembly <see cref="ExplainTextFormatter.HeaderFor"/>
+    /// does, enough to recover the base node type and scan target the analyzer keys on
+    /// (e.g. "Parallel Seq Scan on t" → type "Seq Scan", relation "t"). Join/aggregate
+    /// composite names ("Hash Left Join", "GroupAggregate") are kept whole as the node
+    /// type — the analyzer doesn't special-case them, and <c>HeaderFor</c> round-trips
+    /// them unchanged since their structured fields stay null.
+    /// </summary>
+    private static (string NodeType, string? Relation, string? Alias, string? IndexName, string? ScanDirection, bool ParallelAware)
+        DecomposeName(string name)
+    {
+        var parallelAware = false;
+        if (name.StartsWith("Parallel ", StringComparison.Ordinal))
+        {
+            parallelAware = true;
+            name = name["Parallel ".Length..];
+        }
+
+        string? relation = null;
+        string? alias = null;
+        string? indexName = null;
+        string? scanDirection = null;
+
+        // "Index Scan [Backward] using <index> on <relation> [alias]"
+        var usingIdx = name.IndexOf(" using ", StringComparison.Ordinal);
+        if (usingIdx >= 0)
+        {
+            var head = name[..usingIdx];
+            var tail = name[(usingIdx + " using ".Length)..];
+
+            if (head.EndsWith(" Backward", StringComparison.Ordinal))
+            {
+                scanDirection = "Backward";
+                head = head[..^" Backward".Length];
+            }
+
+            var onIdx = tail.IndexOf(" on ", StringComparison.Ordinal);
+            if (onIdx >= 0)
+            {
+                indexName = tail[..onIdx];
+                (relation, alias) = SplitTarget(tail[(onIdx + " on ".Length)..]);
+            }
+            else
+            {
+                indexName = tail;
+            }
+
+            return (head, relation, alias, indexName, scanDirection, parallelAware);
+        }
+
+        // "<Node Type> on <target>" — for a bitmap index scan the target is the index,
+        // for everything else it's the scanned relation.
+        var onlyOn = name.IndexOf(" on ", StringComparison.Ordinal);
+        if (onlyOn >= 0)
+        {
+            var head = name[..onlyOn];
+            var target = name[(onlyOn + " on ".Length)..];
+            if (head == "Bitmap Index Scan")
+            {
+                indexName = target;
+            }
+            else
+            {
+                (relation, alias) = SplitTarget(target);
+            }
+
+            return (head, relation, alias, indexName, scanDirection, parallelAware);
+        }
+
+        return (name, null, null, null, null, parallelAware);
+    }
+
+    /// <summary>"orders o" → ("orders", "o"); "public.orders" → ("public.orders", null).</summary>
+    private static (string Relation, string? Alias) SplitTarget(string target)
+    {
+        target = target.Trim();
+        var space = target.IndexOf(' ');
+        return space < 0 ? (target, null) : (target[..space], target[(space + 1)..].Trim());
+    }
+
+    /// <summary>Mutable builder mirroring the immutable <see cref="ExplainNode"/> record.</summary>
+    private sealed class ParsedNode
+    {
+        public string NodeType { get; init; } = "";
+        public string? RelationName { get; init; }
+        public string? Alias { get; init; }
+        public string? IndexName { get; init; }
+        public string? ScanDirection { get; init; }
+        public bool ParallelAware { get; init; }
+        public double StartupCost { get; init; }
+        public double TotalCost { get; init; }
+        public long PlanRows { get; init; }
+        public int PlanWidth { get; init; }
+        public double? ActualStartupTimeMs { get; set; }
+        public double? ActualTotalTimeMs { get; set; }
+        public double? ActualRows { get; set; }
+        public long? ActualLoops { get; set; }
+        public List<KeyValuePair<string, string>> Details { get; } = [];
+        public List<ParsedNode> Children { get; } = [];
+
+        public ExplainNode ToExplainNode() => new(
+            NodeType,
+            RelationName,
+            Alias,
+            IndexName,
+            JoinType: null,
+            ScanDirection,
+            SubplanName: null,
+            Strategy: null,
+            PartialMode: null,
+            Operation: null,
+            ParallelAware,
+            StartupCost,
+            TotalCost,
+            PlanRows,
+            PlanWidth,
+            ActualStartupTimeMs,
+            ActualTotalTimeMs,
+            ActualRows,
+            ActualLoops,
+            Details,
+            Children.Select(c => c.ToExplainNode()).ToList());
+    }
+}

--- a/PgNimbus.Core/Query/ExplainService.cs
+++ b/PgNimbus.Core/Query/ExplainService.cs
@@ -30,11 +30,19 @@ public sealed record ExplainNode(
 public sealed record ExplainResult(ExplainNode Root, double? PlanningTimeMs, double? ExecutionTimeMs);
 
 /// <summary>
-/// A plan imported from pasted text (<see cref="ExplainService.Import"/>): the parsed
-/// tree plus the text the plan pane should display (canonical layout for JSON, the
-/// pasted text verbatim for a text import).
+/// The outcome of a live <see cref="ExplainService.ExplainAsync"/>: the parsed tree and
+/// the raw <c>FORMAT JSON</c> payload the server returned (kept so the plan can be copied
+/// or exported as JSON into external tools like pev2, unchanged).
 /// </summary>
-public sealed record ImportedPlan(ExplainResult Result, string DisplayText);
+public sealed record ExplainRun(ExplainResult Result, string Json);
+
+/// <summary>
+/// A plan imported from pasted text (<see cref="ExplainService.Import"/>): the parsed
+/// tree, the text the plan pane should display (canonical layout for JSON, the pasted
+/// text verbatim for a text import), and the raw JSON when the import was JSON (null for
+/// a text import, which has no JSON to copy/export).
+/// </summary>
+public sealed record ImportedPlan(ExplainResult Result, string DisplayText, string? RawJson);
 
 /// <summary>
 /// Runs `EXPLAIN (FORMAT JSON [, ANALYZE])` and parses the resulting plan
@@ -50,7 +58,7 @@ public sealed class ExplainService
         _dataSource = dataSource;
     }
 
-    public async Task<ExplainResult> ExplainAsync(string sql, bool analyze, CancellationToken ct)
+    public async Task<ExplainRun> ExplainAsync(string sql, bool analyze, CancellationToken ct)
     {
         // Plain EXPLAIN omits "Planning Time" unless SUMMARY is requested explicitly
         // (ANALYZE defaults SUMMARY to true already, so it's fine either way there).
@@ -68,7 +76,8 @@ public sealed class ExplainService
         if (!analyze)
         {
             await using var command = new NpgsqlCommand(explainSql, connection);
-            return Parse((string)(await command.ExecuteScalarAsync(ct))!);
+            var planJson = (string)(await command.ExecuteScalarAsync(ct))!;
+            return new ExplainRun(Parse(planJson), planJson);
         }
 
         // EXPLAIN ANALYZE *runs* the statement. Wrap it in a transaction we always
@@ -81,7 +90,7 @@ public sealed class ExplainService
         await using var analyzeCommand = new NpgsqlCommand(explainSql, connection, transaction);
         var json = (string)(await analyzeCommand.ExecuteScalarAsync(ct))!;
         await transaction.RollbackAsync(ct);
-        return Parse(json);
+        return new ExplainRun(Parse(json), json);
     }
 
     /// <summary>
@@ -149,11 +158,11 @@ public sealed class ExplainService
                 throw new FormatException($"That doesn't look like valid EXPLAIN JSON: {ex.Message}", ex);
             }
 
-            return new ImportedPlan(result, ExplainTextFormatter.Format(result));
+            return new ImportedPlan(result, ExplainTextFormatter.Format(result), trimmed);
         }
 
         var cleaned = ExplainPlanTextParser.Clean(raw);
-        return new ImportedPlan(ExplainPlanTextParser.Parse(cleaned), cleaned);
+        return new ImportedPlan(ExplainPlanTextParser.Parse(cleaned), cleaned, RawJson: null);
     }
 
     /// <summary>

--- a/PgNimbus.Core/Query/ExplainService.cs
+++ b/PgNimbus.Core/Query/ExplainService.cs
@@ -30,6 +30,13 @@ public sealed record ExplainNode(
 public sealed record ExplainResult(ExplainNode Root, double? PlanningTimeMs, double? ExecutionTimeMs);
 
 /// <summary>
+/// A plan imported from pasted text (<see cref="ExplainService.Import"/>): the parsed
+/// tree plus the text the plan pane should display (canonical layout for JSON, the
+/// pasted text verbatim for a text import).
+/// </summary>
+public sealed record ImportedPlan(ExplainResult Result, string DisplayText);
+
+/// <summary>
 /// Runs `EXPLAIN (FORMAT JSON [, ANALYZE])` and parses the resulting plan
 /// into a navigable tree, rather than leaving callers to parse Postgres's
 /// raw JSON shape themselves.
@@ -77,15 +84,76 @@ public sealed class ExplainService
         return Parse(json);
     }
 
-    /// <summary>Parses the raw `EXPLAIN (FORMAT JSON)` payload. Split out from the DB round-trip for testability.</summary>
+    /// <summary>
+    /// Parses the raw `EXPLAIN (FORMAT JSON)` payload. Split out from the DB round-trip
+    /// for testability. Tolerant of the shapes external tools/pastes produce: the
+    /// standard <c>[{ "Plan": … }]</c> array, a single <c>{ "Plan": … }</c> object, or a
+    /// bare plan node (<c>{ "Node Type": … }</c>, with or without the array wrapper).
+    /// </summary>
     public static ExplainResult Parse(string json)
     {
         using var document = JsonDocument.Parse(json);
-        var planEntry = document.RootElement[0];
-        var planningTime = planEntry.TryGetProperty("Planning Time", out var pt) ? pt.GetDouble() : (double?)null;
-        var executionTime = planEntry.TryGetProperty("Execution Time", out var et) ? et.GetDouble() : (double?)null;
+        var root = document.RootElement;
+        var entry = root.ValueKind == JsonValueKind.Array
+            ? (root.GetArrayLength() > 0 ? root[0] : throw new FormatException("The EXPLAIN JSON array is empty."))
+            : root;
 
-        return new ExplainResult(ParseNode(planEntry.GetProperty("Plan")), planningTime, executionTime);
+        // The entry is either the wrapper ({ "Plan": …, "Planning Time": … }) or the
+        // plan node itself ({ "Node Type": … }) when a tool exported just the tree.
+        JsonElement planElement;
+        if (entry.TryGetProperty("Plan", out var plan))
+        {
+            planElement = plan;
+        }
+        else if (entry.TryGetProperty("Node Type", out _))
+        {
+            planElement = entry;
+        }
+        else
+        {
+            throw new FormatException("Unrecognized EXPLAIN JSON: no \"Plan\" or \"Node Type\" element found.");
+        }
+
+        var planningTime = entry.TryGetProperty("Planning Time", out var pt) ? pt.GetDouble() : (double?)null;
+        var executionTime = entry.TryGetProperty("Execution Time", out var et) ? et.GetDouble() : (double?)null;
+
+        return new ExplainResult(ParseNode(planElement), planningTime, executionTime);
+    }
+
+    /// <summary>
+    /// Imports an externally-produced plan pasted by the user — no DB round-trip. Accepts
+    /// either <c>FORMAT JSON</c> (the robust interchange format) or <c>FORMAT TEXT</c>
+    /// (best-effort, via <see cref="ExplainPlanTextParser"/>), auto-detecting which from
+    /// the first non-blank character. <see cref="ImportedPlan.DisplayText"/> is what the
+    /// plan pane should show: the canonical text layout for a JSON import, or the pasted
+    /// text verbatim for a text import. Throws <see cref="FormatException"/> with a
+    /// human-readable message on anything it can't parse, so the import UI can surface it.
+    /// </summary>
+    public static ImportedPlan Import(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            throw new FormatException("Nothing to import — paste an EXPLAIN plan first.");
+        }
+
+        var trimmed = raw.TrimStart();
+        if (trimmed.StartsWith('[') || trimmed.StartsWith('{'))
+        {
+            ExplainResult result;
+            try
+            {
+                result = Parse(trimmed);
+            }
+            catch (JsonException ex)
+            {
+                throw new FormatException($"That doesn't look like valid EXPLAIN JSON: {ex.Message}", ex);
+            }
+
+            return new ImportedPlan(result, ExplainTextFormatter.Format(result));
+        }
+
+        var cleaned = ExplainPlanTextParser.Clean(raw);
+        return new ImportedPlan(ExplainPlanTextParser.Parse(cleaned), cleaned);
     }
 
     /// <summary>

--- a/PgNimbus.Core/Query/ExplainTextFormatter.cs
+++ b/PgNimbus.Core/Query/ExplainTextFormatter.cs
@@ -145,7 +145,24 @@ public static class ExplainTextFormatter
         var detailIndent = new string(' ', textIndent + 2);
         foreach (var (key, value) in node.Details)
         {
+            // Buffer counters and I/O timings are folded into single aggregate lines
+            // below (matching EXPLAIN (FORMAT TEXT)) rather than one line per counter.
+            if (IsBufferBlockKey(key) || key is "I/O Read Time" or "I/O Write Time")
+            {
+                continue;
+            }
+
             sb.Append(detailIndent).Append(key).Append(": ").AppendLine(value);
+        }
+
+        if (FormatBuffers(node.Details) is { } buffers)
+        {
+            sb.Append(detailIndent).AppendLine(buffers);
+        }
+
+        if (FormatIoTimings(node.Details) is { } ioTimings)
+        {
+            sb.Append(detailIndent).AppendLine(ioTimings);
         }
 
         foreach (var child in node.Children)
@@ -159,6 +176,83 @@ public static class ExplainTextFormatter
 
             AppendNode(sb, child, textIndent + 6, isRoot: false);
         }
+    }
+
+    private static readonly string[] BufferPools = ["Shared ", "Local ", "Temp "];
+
+    private static bool IsBufferBlockKey(string key) =>
+        key.EndsWith(" Blocks", StringComparison.Ordinal)
+        && Array.Exists(BufferPools, p => key.StartsWith(p, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Folds the per-pool buffer counters into the one `Buffers:` line
+    /// `EXPLAIN (FORMAT TEXT)` emits — <c>shared hit=… read=…, local …, temp read=… written=…</c> —
+    /// showing only non-zero counters and only pools that have any (the parser already
+    /// drops zero-valued block lines). Null when the node reports no buffer usage.
+    /// </summary>
+    private static string? FormatBuffers(IReadOnlyList<KeyValuePair<string, string>> details)
+    {
+        var groups = new List<string>();
+        AddGroup(groups, details, "shared", ("hit", "Shared Hit Blocks"), ("read", "Shared Read Blocks"),
+            ("dirtied", "Shared Dirtied Blocks"), ("written", "Shared Written Blocks"));
+        AddGroup(groups, details, "local", ("hit", "Local Hit Blocks"), ("read", "Local Read Blocks"),
+            ("dirtied", "Local Dirtied Blocks"), ("written", "Local Written Blocks"));
+        AddGroup(groups, details, "temp", ("read", "Temp Read Blocks"), ("written", "Temp Written Blocks"));
+
+        return groups.Count == 0 ? null : "Buffers: " + string.Join(", ", groups);
+    }
+
+    private static void AddGroup(
+        List<string> groups,
+        IReadOnlyList<KeyValuePair<string, string>> details,
+        string label,
+        params (string Suffix, string Key)[] members)
+    {
+        var parts = new List<string>();
+        foreach (var (suffix, key) in members)
+        {
+            if (Detail(details, key) is { } value && value != "0")
+            {
+                parts.Add($"{suffix}={value}");
+            }
+        }
+
+        if (parts.Count > 0)
+        {
+            groups.Add($"{label} {string.Join(" ", parts)}");
+        }
+    }
+
+    /// <summary>The `I/O Timings:` line (only when track_io_timing was on), 3-decimal like Postgres.</summary>
+    private static string? FormatIoTimings(IReadOnlyList<KeyValuePair<string, string>> details)
+    {
+        var parts = new List<string>();
+        AppendIoTiming(parts, details, "read", "I/O Read Time");
+        AppendIoTiming(parts, details, "write", "I/O Write Time");
+        return parts.Count == 0 ? null : "I/O Timings: " + string.Join(" ", parts);
+    }
+
+    private static void AppendIoTiming(List<string> parts, IReadOnlyList<KeyValuePair<string, string>> details, string label, string key)
+    {
+        if (Detail(details, key) is { } value
+            && double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var ms)
+            && ms != 0)
+        {
+            parts.Add(Invariant($"{label}={ms:F3}"));
+        }
+    }
+
+    private static string? Detail(IReadOnlyList<KeyValuePair<string, string>> details, string key)
+    {
+        foreach (var pair in details)
+        {
+            if (pair.Key == key)
+            {
+                return pair.Value;
+            }
+        }
+
+        return null;
     }
 
     private static string Invariant(FormattableString value) => value.ToString(CultureInfo.InvariantCulture);

--- a/docs/design/explain-improvements.md
+++ b/docs/design/explain-improvements.md
@@ -80,7 +80,16 @@ Out of scope for v1 (follow-ups, noted so they aren't forgotten):
   out verbatim; `QueryViewModel.PlanJson` carries it (null for a text import,
   which hides the JSON actions via `HasPlanJson`). Copy/save live in
   `ResultsGridPanel` alongside the existing grid copy/export.
-- Re-color-by-metric toggle (time / rows / cost / buffers), pev2-style.
+- ~~Re-color-by-metric toggle (time / rows / cost / buffers), pev2-style~~ —
+  **done** (v1.2): the plan header (tree view only) carries a "Color:" segmented
+  toggle — Time / Rows / Cost / Buffers. `ExplainNodeViewModel` is now observable
+  and holds each node's exclusive self-time, self-cost, output rows, and
+  self-buffers (buffer counts read from `ExplainNode.Details`, which are
+  cumulative like time, so exclusive = node minus children); `ApplyMetric` rescales
+  every bar and re-marks the single hottest node as the bottleneck in place, no
+  tree rebuild. Time/Buffers are disabled when the plan lacks ANALYZE timing /
+  BUFFERS data (`PlanHasTiming`/`PlanHasBuffers`), and "self time" falls back to
+  cost for a plain EXPLAIN, preserving the old default.
 - Aggregating buffer counters onto a single `Buffers:` line in the text view
   to match `EXPLAIN (FORMAT TEXT)` exactly.
 

--- a/docs/design/explain-improvements.md
+++ b/docs/design/explain-improvements.md
@@ -90,8 +90,17 @@ Out of scope for v1 (follow-ups, noted so they aren't forgotten):
   tree rebuild. Time/Buffers are disabled when the plan lacks ANALYZE timing /
   BUFFERS data (`PlanHasTiming`/`PlanHasBuffers`), and "self time" falls back to
   cost for a plain EXPLAIN, preserving the old default.
-- Aggregating buffer counters onto a single `Buffers:` line in the text view
-  to match `EXPLAIN (FORMAT TEXT)` exactly.
+- ~~Aggregating buffer counters onto a single `Buffers:` line in the text view
+  to match `EXPLAIN (FORMAT TEXT)` exactly~~ — **done** (v1.2):
+  `ExplainTextFormatter` folds the per-pool block counters into one
+  `Buffers: shared hit=… read=…, temp read=… written=…` line (non-zero counters
+  and non-empty pools only) and the I/O timings into an `I/O Timings:` line
+  (3-decimal), instead of one detail line per counter. The individual counters
+  stay in `ExplainNode.Details` (the re-color "Buffers" metric reads them) — only
+  the text rendering aggregates.
+
+All five deferred follow-ups are now shipped; nothing remains out of scope for
+the EXPLAIN feature.
 
 ## Design
 

--- a/docs/design/explain-improvements.md
+++ b/docs/design/explain-improvements.md
@@ -72,7 +72,14 @@ Out of scope for v1 (follow-ups, noted so they aren't forgotten):
   (`MainViewModel.OpenImportedPlan` → `QueryViewModel.ShowImportedPlan`) with the
   same views, time-heat, and warnings strip as a live plan. Parse failures raise
   `FormatException` with a human-readable message, shown inline in the dialog.
-- Copy/export plan (raw JSON/text) for sharing into external tools.
+- ~~Copy/export plan (raw JSON/text) for sharing into external tools~~ —
+  **done** (v1.2): the plan header carries an "Export ▾" flyout (plan-scoped,
+  shown only while a plan is on screen — not a main-toolbar control) with Copy
+  as JSON / Copy as text and Save as .json / .txt. `ExplainService.ExplainAsync`
+  now returns an `ExplainRun` that keeps the raw server JSON so it can be handed
+  out verbatim; `QueryViewModel.PlanJson` carries it (null for a text import,
+  which hides the JSON actions via `HasPlanJson`). Copy/save live in
+  `ResultsGridPanel` alongside the existing grid copy/export.
 - Re-color-by-metric toggle (time / rows / cost / buffers), pev2-style.
 - Aggregating buffer counters onto a single `Buffers:` line in the text view
   to match `EXPLAIN (FORMAT TEXT)` exactly.

--- a/docs/design/explain-improvements.md
+++ b/docs/design/explain-improvements.md
@@ -59,8 +59,19 @@ Out of scope for v1 (follow-ups, noted so they aren't forgotten):
   drives an info note in the warnings strip so the user knows their data is
   intact. Non-transactional side effects (`nextval()`, `dblink`, etc.) remain
   inherently un-undoable — that's a property of EXPLAIN ANALYZE itself.
-- Paste-a-plan / import-external-plan entry point (`ExplainService.Parse` is
-  already static and side-effect-free, so this is cheap later).
+- ~~Paste-a-plan / import-external-plan entry point~~ — **done** (v1.2):
+  `ExplainService.Import(raw)` (Core-pure, unit-tested) auto-detects JSON vs
+  text and returns an `ImportedPlan` (parsed tree + the text to display), no DB
+  round-trip. JSON parsing is tolerant of the shapes tools/pastes produce (the
+  standard `[{ "Plan": … }]` array, a single `{ "Plan": … }` object, or a bare
+  `{ "Node Type": … }` node); `FORMAT TEXT` is parsed best-effort by
+  `ExplainPlanTextParser` (a read-only sibling of `PlanAnalyzer`), which also
+  strips psql framing (`QUERY PLAN` header, `(N rows)` footer, the leading-space
+  pad) via `Clean`. The command palette's "Import query plan…" opens
+  `ImportPlanDialog`; a successful parse opens the plan in a **new tab**
+  (`MainViewModel.OpenImportedPlan` → `QueryViewModel.ShowImportedPlan`) with the
+  same views, time-heat, and warnings strip as a live plan. Parse failures raise
+  `FormatException` with a human-readable message, shown inline in the dialog.
 - Copy/export plan (raw JSON/text) for sharing into external tools.
 - Re-color-by-metric toggle (time / rows / cost / buffers), pev2-style.
 - Aggregating buffer counters onto a single `Buffers:` line in the text view


### PR DESCRIPTION
Finishes the four deferred follow-ups from the "Smarter EXPLAIN" work (PR #158, now merged). Each is its own `verify`-checked commit; the design doc ([`docs/design/explain-improvements.md`](docs/design/explain-improvements.md)) and `CLAUDE.md` rule 6 are updated alongside the code, so nothing remains out of scope for the EXPLAIN feature.

## What changed

**1. Paste-a-plan / import an external plan** — the highest-value item
- `ExplainService.Import(raw)` (Core-pure, unit-tested) auto-detects JSON vs text and returns an `ImportedPlan` (parsed tree + the text to display + raw JSON when available), no DB round-trip.
- JSON parsing is now tolerant of the shapes tools/pastes produce: the standard `[{ "Plan": … }]` array, a lone `{ "Plan": … }` object, or a bare `{ "Node Type": … }` node.
- New `ExplainPlanTextParser` (a read-only sibling of `PlanAnalyzer`) parses `FORMAT TEXT` best-effort — the tree, cost/row/timing figures, and the indented detail lines the analyzer reads — and strips psql framing (`QUERY PLAN` header, `(N rows)` footer, the leading-space pad).
- The command palette's "Import query plan…" opens `ImportPlanDialog`; a successful parse opens the plan in a **new tab** (never overwriting the active one), with the same warnings strip and time-heat as a live plan. Parse failures raise `FormatException` with a readable message, shown inline in the dialog.

**2. Copy / export plan**
- The plan header's "Export ▾" flyout (plan-scoped, shown only while a plan is on screen — not a main-toolbar control) offers Copy as JSON / Copy as text and Save as .json / .txt, straight into pev2, depesz, or an issue.
- `ExplainService.ExplainAsync` now returns an `ExplainRun` (parsed tree + the raw `FORMAT JSON` the server returned) so the JSON is handed out verbatim; `QueryViewModel.PlanJson` carries it, and `HasPlanJson` hides the JSON actions for a plan imported from text.

**3. Re-color-by-metric toggle (pev2-style)**
- A "Color:" segmented toggle in the plan header (tree view) rescales the heat bars by self time / output rows / self cost / self buffers and re-marks the hottest node as the bottleneck.
- `ExplainNodeViewModel` is now observable and precomputes each node's exclusive self-time, self-cost, output rows, and self-buffers (buffer counts read from `ExplainNode.Details`, cumulative like time, so exclusive = node minus children). `ApplyMetric` rescales bars in place — no tree rebuild, so expansion state survives a toggle. Time/Buffers are gated on the plan carrying ANALYZE timing / BUFFERS data; "self time" falls back to cost for a plain EXPLAIN.

**4. Aggregate `Buffers:` line in the text plan** (the optional polish)
- `ExplainTextFormatter` folds the per-pool block counters onto one `Buffers: shared hit=… read=…, temp read=… written=…` line (non-zero counters and non-empty pools only), plus a 3-decimal `I/O Timings:` line, matching `EXPLAIN (FORMAT TEXT)`. The individual counters stay in `ExplainNode.Details` untouched — the re-color "Buffers" metric reads them — so only the text rendering changes.

## Testing
- **554 Core tests pass** (14 new `ExplainImportTests` + `ExplainParsingTests` cases: tolerant JSON shapes, the text parser's tree/cost/actual/details, a psql-framed paste, never-executed branches, a text round-trip through `ExplainTextFormatter`, the analyzer firing on an imported plan, `RawJson` retention, and the aggregated `Buffers:` line); 6 DB-integration tests skipped. Full solution builds with 0 warnings.
- **Verified in the running app** (headless Xvfb + seeded Postgres): imported a real `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` plan → new "Imported plan" tab opened without touching the active tab, the "Sort spilled to disk" warning fired, the Tree view showed the "Color:" toggle with the Sort node's red bottleneck bar; switching to **Buffers** re-scaled the bars; the text view showed the aggregated `Buffers: shared hit=471, temp read=754 written=823`; and "Copy as JSON" placed the plan on the clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rrf152sbAAWmAuNeYmrPTD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rrf152sbAAWmAuNeYmrPTD)_