### PR TITLE
Fix Switch-connection UI deadlock (compositor / DestroyWindow)

### DIFF
--- a/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
@@ -143,14 +143,22 @@ public partial class ResultsGridPanel : UserControl
 
     protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
-        // Give the inspector back before the panel leaves the tree, so a
-        // re-attach re-hoists cleanly and the root isn't left holding a
-        // detached child.
-        if (_inspectorOverlayHost is not null)
-        {
-            _inspectorOverlayHost.Children.Remove(CellInspectorOverlay);
-            _inspectorOverlayHost = null;
-        }
+        // Deliberately do NOT remove the hoisted overlay from the window root
+        // here. In practice this panel only ever detaches when its window is
+        // closing, and mutating the root's Children mid-teardown is a deadlock:
+        // the root is itself detaching, so Remove() serializes a compositor
+        // change onto a window whose native handle DestroyWindow is already
+        // tearing down — the UI thread blocks in DestroyWindow waiting on the
+        // render thread, which is waiting to drain that change. (The regression
+        // that broke "Switch connection": closing the previous window hung the
+        // whole UI. Introduced with the hoist in 3d0b8e0.) Letting the window
+        // teardown dispose the overlay with the rest of the tree is exactly the
+        // pre-extraction behavior, when the overlay was a static child of
+        // MainWindow's root grid. We only drop our claim on it so that if the
+        // panel is ever reparented into a live window, HoistCellInspectorToWindowRoot
+        // re-hoists (it already reparents the overlay off whatever old parent it
+        // still has).
+        _inspectorOverlayHost = null;
 
         base.OnDetachedFromVisualTree(e);
     }

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Prioritized by how much it advances the thesis (fast + open + modern, PostgreSQL
 - [ ] **Row detail sidebar** — a vertical name/value view of the selected row, doubling as a form-style editor.
 - [ ] **winget-pkgs submission** — manifests are generated and validated per release; the first manual community-source PR is pending (the `msstore` source already covers `winget install`).
 - [ ] **Windows polish** — Mica/acrylic backdrop; per-action hotkey remapping.
+- [ ] **UI-thread watchdog** — a background timer that notices when the dispatcher stops responding for N seconds, captures a dump/log, and surfaces it (the crash reporter only catches thrown exceptions, not deadlocks/hangs — see the `Switch connection` compositor-deadlock fix).
 
 **Bigger bets**
 


### PR DESCRIPTION
## The bug

Switching connections (connect → **Switch connection** → connect to another DB) froze the whole UI on Windows: the window went **Not Responding** and then disappeared. No crash window, empty log — a **hang, not an exception**, which is why the crash reporter (it only catches thrown exceptions) stayed silent.

This is a **regression from the MainWindow decomposition**, not the window lifecycle itself.

## Root cause

The cell-inspector overlay is *defined* inside `ResultsGridPanel` but, since the panel sits in the editor/results split row, it was **hoisted into the window's root `Grid`** so its scrim can dim the whole window (commit 3d0b8e0). The same commit added an `OnDetachedFromVisualTree` override that **removed the overlay from that root** "to give it back before the panel leaves the tree."

But `ResultsGridPanel` only ever detaches when its **window is closing** — and by then the root is detaching too. So `root.Children.Remove(...)` mid-teardown serializes a compositor change onto a window whose native handle `DestroyWindow` is already destroying. The dump shows exactly that rendezvous:

- **UI thread** — blocked in native `DestroyWindow` ← `WindowImpl.Dispose` ← `Window.Close` ← `previousWindow.Close()` (from `App.BuildConnectionDialog`) ← the Connect click.
- **Render thread** — parked in `WinUiCompositorConnection.OnAfterMessageWithoutLock`.

It also explains why the earlier attempts failed — deferring the close (`Dispatcher.Post`), closing the old window first under `OnExplicitShutdown`, and `CompositionMode=RedirectionSurface` all leave the **detach-time tree mutation** in place; the trigger is *what the panel does during detach*, not *when the close runs*.

## The fix

Stop removing the overlay on detach. Before the extraction the overlay was a static child of `MainWindow`'s root grid and the **window teardown disposed it with the rest of the tree** — no manual removal, no deadlock. This restores that behavior. We still null out `_inspectorOverlayHost` so that if the panel were ever reparented into a *live* window, `HoistCellInspectorToWindowRoot` re-hoists it (it already reparents the overlay off whatever old parent it still has), so the reparent path the removal was meant to protect stays correct.

One structural point worth noting: among the five decomposition panels, `ResultsGridPanel` was the **only** one whose teardown mutated a visual tree — the other four either have no window-teardown code or (QueryEditorPanel) symmetrically add/remove a `window.Deactivated` handler without touching the tree.

## Verification

- `dotnet build PgNimbus.App -c Debug` — clean.
- Also lands a roadmap note for a **UI-thread watchdog** (a hang like this produces no crash-reporter output today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)