### PR TITLE
Fix Explain on multi-statement buffers; render a hand-written EXPLAIN as a plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,25 @@ and wrong project memory is worse than none.
    exclusive self-time, self-cost, output rows, and self-buffers (buffer counts
    read from `ExplainNode.Details`, cumulative like time, so exclusive = node
    minus children); `ApplyMetric` rescales bars and re-marks the hottest node in
-   place. The design doc + competitive research is in
+   place. **Every route to a plan lands in the same views** (2026-07), through one
+   `QueryViewModel.ShowPlan`: the Explain commands, an import, *and* a hand-written
+   `EXPLAIN` the user simply Runs. That last one used to dump `QUERY PLAN` text into
+   the grid; now `TryParsePlanOutput` feeds the output back through
+   `ExplainService.Import` (so both `FORMAT TEXT` and `FORMAT JSON` work — JSON also
+   keeps the plan's JSON export and the Buffers metric, which the text form can't
+   carry), and shows the plan with the rows still behind it, one ✕ away. It works
+   per script section too — `ScriptResultViewModel` carries the parsed
+   `ImportedPlan`, so selecting the EXPLAIN section of a `SET …; EXPLAIN …` script
+   shows its plan while the other sections show their grid. Unlike the Explain
+   command, a Run *executes* the statement, so an `ANALYZE` of a write is not
+   rolled back — that gets its own warning-strip note, mirroring the Explain path's
+   "rolled back" one. **What the Explain commands explain**: the selection, else the
+   statement the caret sits in (`ExplainTarget`, mirroring Run's targeting via
+   `SqlScriptSplitter.StatementAt` + the view-pushed `QueryViewModel.CaretOffset`),
+   with any existing `EXPLAIN` prefix removed by `SqlStatementInspector.StripExplain`.
+   Both matter because `EXPLAIN` takes exactly one un-nested statement: handing it a
+   whole script failed at the second one ("syntax error at or near SET"). The design
+   doc + competitive research is in
    [`docs/design/explain-improvements.md`](docs/design/explain-improvements.md).
 
 ## UI design rules

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -53,6 +53,14 @@ public sealed partial class QueryViewModel : ObservableObject
     /// </summary>
     public string? SelectedSql { get; set; }
 
+    /// <summary>
+    /// The SQL editor's caret offset, pushed from the view as the caret moves.
+    /// Read by the Explain commands to pick the statement to explain when nothing
+    /// is selected (see <see cref="ExplainTarget"/>). Not observable — pure
+    /// view→VM input state, like <see cref="SelectedSql"/>.
+    /// </summary>
+    public int CaretOffset { get; set; }
+
     [ObservableProperty]
     private string _status = "Ready";
 
@@ -576,11 +584,18 @@ public sealed partial class QueryViewModel : ObservableObject
                     break;
             }
 
+            // A hand-written EXPLAIN gets the plan views, not a grid of QUERY PLAN
+            // text rows — the same tree/heat/warnings the Explain command produces.
+            if (result is ResultSet or MaterializedResultSet
+                && TryParsePlanOutput(executedSql, ColumnNames, Rows) is { } plan)
+            {
+                ShowRunPlan(executedSql, plan);
+            }
             // A hand-typed statement whose columns map cleanly onto one table
             // gets the same inline editing browse mode has. Browse pages skip
             // this — RunBrowseSqlAsync re-establishes their context itself, from
             // metadata it already holds.
-            if (result is ResultSet or MaterializedResultSet && Browse is null)
+            else if (result is ResultSet or MaterializedResultSet && Browse is null)
             {
                 await TryEnableEditingForQueryAsync(ct);
             }
@@ -725,6 +740,18 @@ public sealed partial class QueryViewModel : ObservableObject
         TimingText = value.TimingText;
         CapText = value.CapText;
 
+        // An EXPLAIN section shows its plan (tree, heat, warnings) instead of the raw
+        // QUERY PLAN rows; every other section shows the grid. Selecting between them
+        // switches the pane, and the plan header's ✕ still falls back to the rows.
+        if (value.Plan is { } plan)
+        {
+            ShowRunPlan(value.Sql, plan);
+        }
+        else
+        {
+            IsShowingPlan = false;
+        }
+
         // Script sections never get an edit context (statements share one
         // session; results are materialized snapshots) — say so, but only for
         // sections that actually show a grid someone might try to edit.
@@ -780,6 +807,42 @@ public sealed partial class QueryViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Puts a parsed plan on screen — tree, text pane, heat, and warnings strip — for
+    /// every source of one: the Explain commands, a hand-written EXPLAIN that was Run
+    /// (see <see cref="TryParsePlanOutput"/>), and a pasted import. <paramref name="displayText"/>
+    /// is what the text pane shows; <paramref name="summaryPrefix"/> leads the header line
+    /// ("Imported plan"); <paramref name="leadingWarnings"/> are pinned above the analyzer's
+    /// findings (the rolled-back / ran-for-real notes).
+    /// </summary>
+    private void ShowPlan(
+        ExplainResult result,
+        string displayText,
+        string? planJson,
+        string? summaryPrefix = null,
+        IReadOnlyList<PlanWarningViewModel>? leadingWarnings = null)
+    {
+        var root = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
+        ExplainRoot = root;
+        ApplyPlanHeat(root);
+
+        var warnings = new List<PlanWarningViewModel>();
+        if (leadingWarnings is not null)
+        {
+            warnings.AddRange(leadingWarnings);
+        }
+
+        warnings.AddRange(PlanAnalyzer.Analyze(result).Select(w => new PlanWarningViewModel(w)));
+        PlanWarnings = warnings;
+
+        ExplainText = displayText;
+        PlanJson = planJson;
+        var planningFragment = result.PlanningTimeMs is { } planMs ? $"Planning: {planMs:F3} ms" : null;
+        var executionFragment = result.ExecutionTimeMs is { } execMs ? $"Execution: {execMs:F3} ms" : null;
+        ExplainSummary = string.Join("   ", new[] { summaryPrefix, planningFragment, executionFragment }.Where(f => f is not null));
+        IsShowingPlan = true;
+    }
+
+    /// <summary>
     /// Shows a plan that was imported from pasted text rather than run against the DB
     /// (see <see cref="ExplainService.Import"/>) — same views, heat, and warnings strip
     /// as a live plan, no round-trip. <paramref name="displayText"/> is what the text
@@ -789,18 +852,83 @@ public sealed partial class QueryViewModel : ObservableObject
     /// </summary>
     public void ShowImportedPlan(ExplainResult result, string displayText, string? planJson)
     {
-        var root = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
-        ExplainRoot = root;
-        ApplyPlanHeat(root);
-
-        PlanWarnings = PlanAnalyzer.Analyze(result).Select(w => new PlanWarningViewModel(w)).ToList();
-        ExplainText = displayText;
-        PlanJson = planJson;
-        var planningFragment = result.PlanningTimeMs is { } planMs ? $"Planning: {planMs:F3} ms" : null;
-        var executionFragment = result.ExecutionTimeMs is { } execMs ? $"Execution: {execMs:F3} ms" : null;
-        ExplainSummary = string.Join("   ", new[] { "Imported plan", planningFragment, executionFragment }.Where(f => f is not null));
-        IsShowingPlan = true;
+        ShowPlan(result, displayText, planJson, summaryPrefix: "Imported plan");
         Status = "Imported plan";
+    }
+
+    /// <summary>
+    /// Turns the output of a hand-written EXPLAIN — one typed into the editor and Run,
+    /// rather than invoked through the Explain command — back into a plan tree, so it
+    /// lands in the plan views instead of a grid of <c>QUERY PLAN</c> text rows. Reuses
+    /// the paste-a-plan importer, so both formats it understands work: <c>FORMAT TEXT</c>
+    /// (the default, arriving as one row per plan line) and <c>FORMAT JSON</c> (one row
+    /// holding the whole payload, which also gives the plan's JSON export). Returns null
+    /// for anything else — <c>FORMAT XML</c>/<c>YAML</c>, or a plan the best-effort text
+    /// parser can't place — leaving the raw rows as the result. Shared with
+    /// <see cref="ScriptResultViewModel"/>, which parses the same way per script section.
+    /// </summary>
+    internal static ImportedPlan? TryParsePlanOutput(
+        string sql,
+        IReadOnlyList<string> columnNames,
+        IReadOnlyList<object?[]> rows)
+    {
+        if (columnNames.Count != 1 || rows.Count == 0 || !SqlStatementInspector.IsExplain(sql))
+        {
+            return null;
+        }
+
+        var text = string.Join('\n', rows.Select(row => row.Length > 0 ? row[0]?.ToString() : null));
+        try
+        {
+            return ExplainService.Import(text);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Shows the plan a Run-executed EXPLAIN produced. The rows stay in the grid behind
+    /// it (the plan header's ✕ switches back), and an <c>ANALYZE</c> of a write gets a
+    /// note: unlike the Explain command, Run doesn't wrap it in a rolled-back
+    /// transaction, so those changes really were applied.
+    /// </summary>
+    private void ShowRunPlan(string sql, ImportedPlan plan)
+    {
+        var analyzed = plan.Result.Root.ActualLoops is not null || plan.Result.ExecutionTimeMs is not null;
+        var notes = analyzed && SqlStatementInspector.IsDataModifying(SqlStatementInspector.StripExplain(sql))
+            ? new List<PlanWarningViewModel>
+            {
+                new(new PlanWarning(
+                    PlanWarningSeverity.Warning,
+                    "EXPLAIN ANALYZE executed this write",
+                    "Run executes the statement as written, so its changes were applied (subject to the "
+                        + "surrounding transaction). The Explain command analyzes a write inside a "
+                        + "transaction it always rolls back.",
+                    plan.Result.Root.NodeType,
+                    null)),
+            }
+            : null;
+
+        ShowPlan(plan.Result, plan.DisplayText, plan.RawJson, leadingWarnings: notes);
+    }
+
+    /// <summary>
+    /// The statement the Explain commands actually explain. Mirrors <see cref="RunAsync"/>'s
+    /// targeting — the selection when there is one, otherwise the statement the caret sits
+    /// in — because <c>EXPLAIN</c> takes exactly one statement: handing it a whole script
+    /// fails at the second one (a buffer starting with <c>SET work_mem = …;</c> errored with
+    /// "syntax error at or near SET"). An already-EXPLAIN statement is unwrapped, since
+    /// nesting two EXPLAINs is itself a syntax error.
+    /// </summary>
+    private string ExplainTarget()
+    {
+        var candidate = string.IsNullOrWhiteSpace(SelectedSql)
+            ? SqlScriptSplitter.StatementAt(Sql, CaretOffset) ?? Sql
+            : SelectedSql;
+
+        return SqlStatementInspector.StripExplain(candidate);
     }
 
     private async Task RunExplainAsync(bool analyze)
@@ -819,34 +947,26 @@ public sealed partial class QueryViewModel : ObservableObject
 
         try
         {
-            var run = await _explainService.ExplainAsync(Sql, analyze, ct);
+            var target = ExplainTarget();
+            var run = await _explainService.ExplainAsync(target, analyze, ct);
             var result = run.Result;
-            PlanJson = run.Json;
-            var root = new ExplainNodeViewModel(result.Root, result.Root.TotalCost);
-            ExplainRoot = root;
-            ApplyPlanHeat(root);
 
-            var warnings = new List<PlanWarningViewModel>();
             // Reassure the user their data is intact: ANALYZE ran the write, but ExplainService
             // rolled it back. Leads the strip so it's the first thing seen for a write plan.
-            if (analyze && SqlStatementInspector.IsDataModifying(Sql))
-            {
-                warnings.Add(new PlanWarningViewModel(new PlanWarning(
-                    PlanWarningSeverity.Info,
-                    "Data-modifying statement rolled back",
-                    "EXPLAIN ANALYZE executed this statement inside a transaction and rolled it back, "
-                        + "so no changes were persisted.",
-                    result.Root.NodeType,
-                    null)));
-            }
+            var notes = analyze && SqlStatementInspector.IsDataModifying(target)
+                ? new List<PlanWarningViewModel>
+                {
+                    new(new PlanWarning(
+                        PlanWarningSeverity.Info,
+                        "Data-modifying statement rolled back",
+                        "EXPLAIN ANALYZE executed this statement inside a transaction and rolled it back, "
+                            + "so no changes were persisted.",
+                        result.Root.NodeType,
+                        null)),
+                }
+                : null;
 
-            warnings.AddRange(PlanAnalyzer.Analyze(result).Select(w => new PlanWarningViewModel(w)));
-            PlanWarnings = warnings;
-            ExplainText = ExplainTextFormatter.Format(result);
-            var planningFragment = result.PlanningTimeMs is { } planMs ? $"Planning: {planMs:F3} ms" : null;
-            var executionFragment = result.ExecutionTimeMs is { } execMs ? $"Execution: {execMs:F3} ms" : null;
-            ExplainSummary = string.Join("   ", new[] { planningFragment, executionFragment }.Where(f => f is not null));
-            IsShowingPlan = true;
+            ShowPlan(result, ExplainTextFormatter.Format(result), run.Json, leadingWarnings: notes);
             Status = "Plan ready";
         }
         catch (OperationCanceledException)

--- a/PgNimbus.App/ViewModels/ScriptResultViewModel.cs
+++ b/PgNimbus.App/ViewModels/ScriptResultViewModel.cs
@@ -12,6 +12,7 @@ public sealed class ScriptResultViewModel
 {
     private ScriptResultViewModel(
         int index,
+        string sql,
         string label,
         string summary,
         bool hasError,
@@ -21,9 +22,11 @@ public sealed class ScriptResultViewModel
         AvaloniaList<object?[]> rows,
         string? rowCountText,
         string? timingText,
-        string? capText)
+        string? capText,
+        ImportedPlan? plan = null)
     {
         Index = index;
+        Sql = sql;
         Label = label;
         Summary = summary;
         HasError = hasError;
@@ -34,10 +37,14 @@ public sealed class ScriptResultViewModel
         RowCountText = rowCountText;
         TimingText = timingText;
         CapText = capText;
+        Plan = plan;
     }
 
     /// <summary>1-based position of this statement in the script.</summary>
     public int Index { get; }
+
+    /// <summary>The statement that produced this section, as it appeared in the script.</summary>
+    public string Sql { get; }
 
     /// <summary>Short strip label — "1 · SELECT" (statement number + command keyword).</summary>
     public string Label { get; }
@@ -56,6 +63,14 @@ public sealed class ScriptResultViewModel
     public string? RowCountText { get; }
     public string? TimingText { get; }
     public string? CapText { get; }
+
+    /// <summary>
+    /// The plan this statement's output parses into when it was an <c>EXPLAIN</c>; null
+    /// for every other statement. Selecting such a section shows the plan views rather
+    /// than the section's <c>QUERY PLAN</c> text rows, so an EXPLAIN inside a script
+    /// (the `SET work_mem = …; EXPLAIN …` shape) reads like one run on its own.
+    /// </summary>
+    public ImportedPlan? Plan { get; }
 
     public const int MaxDisplayRows = QueryViewModel.MaxDisplayRows;
 
@@ -77,6 +92,7 @@ public sealed class ScriptResultViewModel
 
                 return new ScriptResultViewModel(
                     index,
+                    sql,
                     $"{index} · {keyword}",
                     $"{rowText} · {timeText}",
                     hasError: false,
@@ -86,7 +102,8 @@ public sealed class ScriptResultViewModel
                     rows: new AvaloniaList<object?[]>(set.Rows),
                     rowCountText: rowText,
                     timingText: timeText,
-                    capText: capText);
+                    capText: capText,
+                    plan: QueryViewModel.TryParsePlanOutput(sql, names, set.Rows));
             }
 
             case CommandResult command:
@@ -95,6 +112,7 @@ public sealed class ScriptResultViewModel
                 var timeText = $"{ms:F0} ms";
                 return new ScriptResultViewModel(
                     index,
+                    sql,
                     $"{index} · {command.CommandTag}",
                     $"{affected} affected · {timeText}",
                     hasError: false,
@@ -111,6 +129,7 @@ public sealed class ScriptResultViewModel
             {
                 return new ScriptResultViewModel(
                     index,
+                    sql,
                     $"{index} · {keyword}",
                     "Error",
                     hasError: true,
@@ -127,7 +146,7 @@ public sealed class ScriptResultViewModel
 
             default:
                 return new ScriptResultViewModel(
-                    index, $"{index}", string.Empty, false, string.Empty, [], [], [], null, null, null);
+                    index, sql, $"{index}", string.Empty, false, string.Empty, [], [], [], null, null, null);
         }
     }
 

--- a/PgNimbus.App/Views/QueryEditorPanel.axaml.cs
+++ b/PgNimbus.App/Views/QueryEditorPanel.axaml.cs
@@ -128,7 +128,16 @@ public partial class QueryEditorPanel : UserControl
         {
             SqlEditor.TextArea.SelectionBrush = brush;
         }
-        SqlEditor.TextArea.Caret.PositionChanged += (_, _) => UpdateBracketHighlight();
+        SqlEditor.TextArea.Caret.PositionChanged += (_, _) =>
+        {
+            UpdateBracketHighlight();
+            // Feed the caret to the active tab too: with no selection, Explain uses it
+            // to pick which statement of the buffer to explain (see ExplainTarget).
+            if (_activeQuery is not null)
+            {
+                _activeQuery.CaretOffset = SqlEditor.CaretOffset;
+            }
+        };
         SqlEditor.AddHandler(PointerWheelChangedEvent, OnSqlEditorPointerWheel, RoutingStrategies.Tunnel);
 
         // Find & replace: AvaloniaEdit's SearchPanel handles matching,
@@ -290,6 +299,10 @@ public partial class QueryEditorPanel : UserControl
         _suppressEditorSync = true;
         SqlEditor.Text = _activeQuery.Sql;
         _suppressEditorSync = false;
+
+        // Seed the newly-attached tab's caret copy from where the editor actually sits,
+        // so Explain doesn't target a statement based on the previous tab's offset.
+        _activeQuery.CaretOffset = SqlEditor.CaretOffset;
     }
 
     // ViewModel → editor half of the manual two-way sync: an external Sql change

--- a/PgNimbus.Core.Tests/Query/ExplainImportTests.cs
+++ b/PgNimbus.Core.Tests/Query/ExplainImportTests.cs
@@ -186,6 +186,43 @@ public class ExplainImportTests
     }
 
     [Test]
+    public async Task BufferedAnalyzePlanParsesAndKeepsTrailerOffTheNodes()
+    {
+        // Exactly what `EXPLAIN (ANALYZE, BUFFERS)` prints — the shape a hand-written
+        // EXPLAIN in the editor produces, now parsed back into the plan views. The
+        // trailing "Planning:" section's buffers describe the statement, not the last
+        // node parsed, so they must not land in that node's details (they feed the
+        // buffers heat metric and the analyzer).
+        var text =
+            "Sort  (cost=27820.64..28320.64 rows=200000 width=4) (actual time=77.770..92.000 rows=200000.00 loops=1)\n" +
+            "  Sort Key: g DESC\n" +
+            "  Sort Method: external merge  Disk: 2400kB\n" +
+            "  Buffers: shared hit=3, temp read=1236 written=1308\n" +
+            "  ->  Function Scan on generate_series g  (cost=0.00..2000.00 rows=200000 width=4) (actual time=20.000..40.000 rows=200000.00 loops=1)\n" +
+            "        Buffers: temp read=342 written=342\n" +
+            "Planning:\n" +
+            "  Buffers: shared hit=9\n" +
+            "Planning Time: 0.079 ms\n" +
+            "Execution Time: 102.734 ms";
+
+        var result = ExplainPlanTextParser.Parse(ExplainPlanTextParser.Clean(text));
+
+        await Assert.That(result.Root.NodeType).IsEqualTo("Sort");
+        await Assert.That(result.ExecutionTimeMs).IsEqualTo(102.734);
+        await Assert.That(result.Root.Details.Select(d => d.Key)).Contains("Sort Method");
+
+        // The function scan keeps its own Buffers line and gains no second one from
+        // the Planning trailer.
+        var scan = result.Root.Children[0];
+        await Assert.That(scan.NodeType).IsEqualTo("Function Scan");
+        await Assert.That(scan.Details.Count(d => d.Key == "Buffers")).IsEqualTo(1);
+        await Assert.That(scan.Details.First(d => d.Key == "Buffers").Value).IsEqualTo("temp read=342 written=342");
+
+        // …and the spill in that sort is exactly what the analyzer should flag.
+        await Assert.That(PlanAnalyzer.Analyze(result).Any(w => w.Title == "Sort spilled to disk")).IsTrue();
+    }
+
+    [Test]
     public async Task NonPlanTextThrows()
     {
         await Assert.That(() => ExplainService.Import("hello world, this is not a plan"))

--- a/PgNimbus.Core.Tests/Query/SqlStatementInspectorTests.cs
+++ b/PgNimbus.Core.Tests/Query/SqlStatementInspectorTests.cs
@@ -3,7 +3,8 @@ using PgNimbus.Core.Query;
 namespace PgNimbus.Core.Tests.Query;
 
 /// <summary>
-/// Lexical write-detection used to note that an EXPLAIN ANALYZE was rolled back.
+/// Lexical write-detection used to note that an EXPLAIN ANALYZE was rolled back, plus
+/// the EXPLAIN recognition/unwrapping the Explain command and the plan-view detection ride on.
 /// </summary>
 public class SqlStatementInspectorTests
 {
@@ -34,5 +35,60 @@ public class SqlStatementInspectorTests
     public async Task ReadsAreNotDetected(string sql)
     {
         await Assert.That(SqlStatementInspector.IsDataModifying(sql)).IsFalse();
+    }
+
+    [Test]
+    [Arguments("EXPLAIN SELECT 1")]
+    [Arguments("explain (analyze) select 1")]
+    [Arguments("  -- plan it\n  EXPLAIN ANALYZE SELECT 1")]
+    public async Task ExplainIsRecognized(string sql)
+    {
+        await Assert.That(SqlStatementInspector.IsExplain(sql)).IsTrue();
+    }
+
+    [Test]
+    [Arguments("SELECT * FROM explain_log")]
+    [Arguments("explaining")]
+    [Arguments("")]
+    public async Task NonExplainIsNotRecognized(string sql)
+    {
+        await Assert.That(SqlStatementInspector.IsExplain(sql)).IsFalse();
+    }
+
+    [Test]
+    // Parenthesized option list, in every spacing/casing shape.
+    [Arguments("EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM t", "SELECT * FROM t")]
+    [Arguments("explain(format json)select 1", "select 1")]
+    [Arguments("EXPLAIN (FORMAT 'json') SELECT ')' AS t", "SELECT ')' AS t")]
+    // Legacy bare-keyword form: ANALYZE and VERBOSE, either or both.
+    [Arguments("EXPLAIN SELECT 1", "SELECT 1")]
+    [Arguments("EXPLAIN ANALYZE SELECT 1", "SELECT 1")]
+    [Arguments("explain verbose select 1", "select 1")]
+    [Arguments("EXPLAIN ANALYZE VERBOSE UPDATE t SET n = 1", "UPDATE t SET n = 1")]
+    // A statement that only looks like an option keyword stays put.
+    [Arguments("EXPLAIN SELECT analyze FROM t", "SELECT analyze FROM t")]
+    public async Task ExplainPrefixIsStripped(string sql, string expected)
+    {
+        await Assert.That(SqlStatementInspector.StripExplain(sql)).IsEqualTo(expected);
+    }
+
+    [Test]
+    [Arguments("SELECT 1")]              // not an EXPLAIN at all
+    [Arguments("EXPLAIN")]               // nothing left to hand back
+    [Arguments("EXPLAIN (ANALYZE)")]
+    public async Task NonWrappingStatementsAreReturnedUnchanged(string sql)
+    {
+        await Assert.That(SqlStatementInspector.StripExplain(sql)).IsEqualTo(sql);
+    }
+
+    [Test]
+    public async Task StrippedExplainAnalyzeExposesTheWriteUnderneath()
+    {
+        // What the plan views key on: `EXPLAIN ANALYZE INSERT …` really writes, and
+        // the write only becomes visible after the EXPLAIN prefix comes off.
+        var sql = "EXPLAIN (ANALYZE) INSERT INTO t VALUES (1)";
+
+        await Assert.That(SqlStatementInspector.IsDataModifying(sql)).IsFalse();
+        await Assert.That(SqlStatementInspector.IsDataModifying(SqlStatementInspector.StripExplain(sql))).IsTrue();
     }
 }

--- a/PgNimbus.Core/Query/ExplainPlanTextParser.cs
+++ b/PgNimbus.Core/Query/ExplainPlanTextParser.cs
@@ -94,6 +94,11 @@ public static class ExplainPlanTextParser
         // lines that follow it; detail lines attach to the top of the stack.
         var stack = new List<(int Indent, ParsedNode Node)>();
 
+        // Set once a top-level trailer section ("Planning:", "JIT:", "Triggers:") starts:
+        // its indented lines describe the statement, not the last node parsed, so they
+        // must not land in that node's details (which feed the buffers heat + analyzer).
+        var inTrailer = false;
+
         foreach (var rawLine in lines)
         {
             if (rawLine.Trim().Length == 0)
@@ -132,8 +137,16 @@ public static class ExplainPlanTextParser
                 continue;
             }
 
+            // A bare top-level section header opens the post-tree trailer (see inTrailer).
+            if (indent == 0 && !isChild && trimmedStart.EndsWith(':') && !trimmedStart.Contains(": ", StringComparison.Ordinal))
+            {
+                inTrailer = true;
+                continue;
+            }
+
             if (isChild)
             {
+                inTrailer = false;
                 var node = ParseHeader(trimmedStart[2..].TrimStart())
                     ?? throw new FormatException($"Couldn't parse a plan node from: {trimmedStart}");
 
@@ -158,7 +171,7 @@ public static class ExplainPlanTextParser
             // node. Bare annotations without a colon (subplan headers, "Workers")
             // aren't first-class detail and are skipped.
             var colon = trimmedStart.IndexOf(": ", StringComparison.Ordinal);
-            if (colon > 0 && stack.Count > 0)
+            if (colon > 0 && stack.Count > 0 && !inTrailer)
             {
                 var key = trimmedStart[..colon];
                 var value = trimmedStart[(colon + 2)..].Trim();

--- a/PgNimbus.Core/Query/SqlStatementInspector.cs
+++ b/PgNimbus.Core/Query/SqlStatementInspector.cs
@@ -5,13 +5,18 @@ namespace PgNimbus.Core.Query;
 /// <summary>
 /// Lightweight, lexical inspection of a single SQL statement — enough to tell a
 /// data-modifying statement from a read so the App can note that an
-/// <c>EXPLAIN ANALYZE</c> was rolled back. Deliberately not a full parser: it
-/// strips leading comments/whitespace and looks at the leading keyword (and, for
-/// a CTE, whether a data-modifying keyword appears at all).
+/// <c>EXPLAIN ANALYZE</c> was rolled back, and to recognize/unwrap a hand-written
+/// <c>EXPLAIN</c>. Deliberately not a full parser: it strips leading
+/// comments/whitespace and looks at the leading keyword (and, for a CTE, whether a
+/// data-modifying keyword appears at all).
 /// </summary>
 public static partial class SqlStatementInspector
 {
     private static readonly string[] ModifyingKeywords = ["insert", "update", "delete", "merge"];
+
+    // The only options the pre-9.0 `EXPLAIN [ANALYZE] [VERBOSE] stmt` form accepts, in
+    // the order it accepts them — everything else requires the parenthesized list.
+    private static readonly string[] LegacyExplainKeywords = ["analyze", "verbose"];
 
     /// <summary>
     /// True when the statement writes rows (INSERT/UPDATE/DELETE/MERGE, or a
@@ -39,6 +44,106 @@ public static partial class SqlStatementInspector
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// True when the statement is itself an <c>EXPLAIN</c> — i.e. it already produces a
+    /// plan rather than a result set, so its output can be parsed back into a plan tree
+    /// instead of being shown as raw <c>QUERY PLAN</c> text rows.
+    /// </summary>
+    public static bool IsExplain(string sql) =>
+        LeadingWord(StripLeading(sql)).Equals("explain", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns the statement an <c>EXPLAIN</c> wraps (<c>EXPLAIN (ANALYZE, BUFFERS)
+    /// SELECT 1</c> → <c>SELECT 1</c>), or <paramref name="sql"/> unchanged when it isn't
+    /// an EXPLAIN. Handles both the parenthesized option list and the legacy bare-keyword
+    /// form (<c>EXPLAIN ANALYZE VERBOSE …</c> — the only two keywords that form accepts).
+    /// Used so re-explaining an already-EXPLAINed statement produces one EXPLAIN rather
+    /// than a nested pair, which Postgres rejects as a syntax error.
+    /// </summary>
+    public static string StripExplain(string sql)
+    {
+        var stripped = StripLeading(sql);
+        if (!LeadingWord(stripped).Equals("explain", StringComparison.OrdinalIgnoreCase))
+        {
+            return sql;
+        }
+
+        var index = "explain".Length;
+        index = SkipWhitespace(stripped, index);
+
+        if (index < stripped.Length && stripped[index] == '(')
+        {
+            index = SkipOptionList(stripped, index);
+        }
+        else
+        {
+            // Legacy form: EXPLAIN [ ANALYZE ] [ VERBOSE ] statement.
+            foreach (var keyword in LegacyExplainKeywords)
+            {
+                var after = SkipWhitespace(stripped, index);
+                if (!LeadingWord(stripped[after..]).Equals(keyword, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                index = after + keyword.Length;
+            }
+        }
+
+        var inner = stripped[SkipWhitespace(stripped, index)..].TrimEnd();
+        // Refuse to hand back nothing: a bare "EXPLAIN" (or one whose option list never
+        // closes) is a broken statement, and the caller's error is clearer than ours.
+        return inner.Length == 0 ? sql : inner;
+    }
+
+    private static int SkipWhitespace(string sql, int index)
+    {
+        while (index < sql.Length && char.IsWhiteSpace(sql[index]))
+        {
+            index++;
+        }
+
+        return index;
+    }
+
+    /// <summary>
+    /// Skips the parenthesized EXPLAIN option list, returning the index just past its
+    /// closing paren (or end-of-string when unterminated). Counts nesting and steps over
+    /// single-quoted values, so an option like <c>FORMAT 'json'</c> can't fool it.
+    /// </summary>
+    private static int SkipOptionList(string sql, int index)
+    {
+        var depth = 0;
+        while (index < sql.Length)
+        {
+            var c = sql[index];
+            if (c == '\'')
+            {
+                index++;
+                while (index < sql.Length && sql[index] != '\'')
+                {
+                    index++;
+                }
+            }
+            else if (c == '(')
+            {
+                depth++;
+            }
+            else if (c == ')')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return index + 1;
+                }
+            }
+
+            index++;
+        }
+
+        return index;
     }
 
     /// <summary>Drops leading whitespace and SQL comments so the first real keyword is visible.</summary>


### PR DESCRIPTION
Two reported bugs, one root cause: `EXPLAIN` takes exactly one un-nested statement.

### 1. `Explain failed: syntax error at or near "SET"`

The Explain command handed the **whole editor buffer** to `EXPLAIN`, so a buffer like

```sql
SET work_mem = '64kB';
EXPLAIN (ANALYZE, BUFFERS)
SELECT * FROM generate_series(1, 200000) AS g ORDER BY g DESC;
```

became `EXPLAIN (FORMAT JSON) SET work_mem = …` and died at the first statement.

`ExplainTarget()` now mirrors Run's targeting — the selection if there is one, otherwise the statement the caret sits in (`SqlScriptSplitter.StatementAt` over a new view-pushed `QueryViewModel.CaretOffset`) — and removes any existing `EXPLAIN` prefix via `SqlStatementInspector.StripExplain`, since `EXPLAIN … EXPLAIN …` is a syntax error too.

### 2. A hand-written EXPLAIN that was Run showed raw `QUERY PLAN` rows

It now lands in the same plan views as the Explain command. `TryParsePlanOutput` feeds the output back through the existing paste-a-plan importer, so both formats work:

- `FORMAT TEXT` (the default) — one row per plan line;
- `FORMAT JSON` — which additionally keeps the plan's JSON export and enables the **Buffers** metric (the text form carries no per-pool counters).

The rows stay in the grid behind the plan, one ✕ away. Script sections get the same treatment: `ScriptResultViewModel` carries the parsed `ImportedPlan`, so the EXPLAIN section of a `SET …; EXPLAIN …` script shows its plan while the other sections show their grid.

One honest difference is surfaced rather than hidden: Run **executes** the statement, so an `ANALYZE` of a write is *not* rolled back the way the Explain command's is. That case gets its own warning-strip note, mirroring the existing "rolled back" note.

All four routes to a plan (Explain, Explain Analyze, import, Run) now go through one `QueryViewModel.ShowPlan`.

### Also

The text-plan parser no longer attributes the trailing `Planning:` section's buffers to the last node of the tree. Those details feed the buffers heat metric and `PlanAnalyzer`, and the text path is now a primary way plans reach the views rather than only an import path.

## Verification

Run against a live Postgres (`postgres:17`), on the exact reported scenario:

- script `SET work_mem='64kB'; EXPLAIN (ANALYZE, BUFFERS) …` → section 2 renders the plan, with the "Sort spilled to disk" warning, the heat tree and the text view;
- **Explain** from the toolbar menu on that same buffer → "Plan ready", no syntax error;
- single `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) …` via Run → plan with the Buffers metric enabled; ✕ falls back to the JSON row in the grid;
- plain `SELECT` and non-EXPLAIN script sections unchanged.

Tests: 573 passed, 0 failed (6 skipped — they need `PGNIMBUS_TEST_CONN`). New coverage for `IsExplain`/`StripExplain` and for parsing real `EXPLAIN (ANALYZE, BUFFERS)` output including the `Planning:` trailer.

`CLAUDE.md`'s EXPLAIN section is updated in the same change, per the repo's keep-it-current rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
