### PR TITLE
Fix the editors' selection color falling back to the OS accent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,7 +310,16 @@ and wrong project memory is worse than none.
    otherwise be clipped to the panel's results-pane row. It ends up a sibling of
    the command-palette overlay there; the root inherits the window's
    `MainViewModel` DataContext, so the `{Binding CellInspector…}` paths resolve
-   unchanged.
+   unchanged. **Extraction landmine: a panel's constructor can't see app-level
+   resources.** `TryFindResource` walks the logical parent chain, and a
+   `UserControl` under construction has none — only a `TopLevel` has the
+   `Application` wired in as its styling parent from the start. So code moved
+   verbatim from a `Window` constructor into a panel constructor silently finds
+   nothing and keeps the framework default (that's how the SQL editor's and the
+   JSON inspector's brand-blue `TextArea.SelectionBrush` reverted to the OS
+   accent after the extraction, twice). Resolve app resources from
+   `OnAttachedToVisualTree` (`ApplyTextSelectionBrush` in both panels), where
+   `ActualThemeVariant` is final too.
 
 ## Platform window chrome
 

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -48,8 +48,11 @@
             <!-- Low-alpha accent for row/pill selection washes; reads on both themes -->
             <SolidColorBrush x:Key="AppSelectionBrush" Color="#282D7FF9" />
             <!--
-                App-wide text-selection wash: the SQL editor (set on
-                TextArea.SelectionBrush in MainWindow.axaml.cs) AND every plain
+                App-wide text-selection wash: the SQL editor and the cell
+                inspector's JSON editor (set on TextArea.SelectionBrush from
+                ApplyTextSelectionBrush in QueryEditorPanel /
+                ResultsGridPanel — on attach, not in the constructor, where an
+                app-level resource isn't reachable yet) AND every plain
                 TextBox (Style below) share this one token, so a selected
                 connection-dialog field reads the same as a selected query. Same
                 fixed brand hue as the rest of the app's selection surfaces (NOT

--- a/PgNimbus.App/Views/QueryEditorPanel.axaml.cs
+++ b/PgNimbus.App/Views/QueryEditorPanel.axaml.cs
@@ -119,17 +119,6 @@ public partial class QueryEditorPanel : UserControl
         // Ctrl+wheel font zoom. The wheel handler tunnels because the
         // TextView claims wheel events for scrolling before they'd bubble.
         SqlEditor.Options.HighlightCurrentLine = true;
-        // Lock the text-selection wash to the fixed brand-blue token
-        // (AppTextSelectionBrush in Theme.axaml, shared with every plain
-        // TextBox's Style setter) instead of AvaloniaEdit's theme/OS-derived
-        // default, so it matches the app's other selection surfaces and reads
-        // the same on both themes. SelectionBrush lives on TextArea, not
-        // TextEditor, so it can't be a XAML attribute on SqlEditor.
-        if (this.TryFindResource("AppTextSelectionBrush", out var selectionBrush)
-            && selectionBrush is IBrush brush)
-        {
-            SqlEditor.TextArea.SelectionBrush = brush;
-        }
         SqlEditor.TextArea.Caret.PositionChanged += (_, _) =>
         {
             UpdateBracketHighlight();
@@ -173,6 +162,7 @@ public partial class QueryEditorPanel : UserControl
     {
         base.OnAttachedToVisualTree(e);
         ApplySqlHighlightingTheme();
+        ApplyTextSelectionBrush();
         if (TopLevel.GetTopLevel(this) is Window window)
         {
             window.Deactivated += OnHostDeactivated;
@@ -327,6 +317,30 @@ public partial class QueryEditorPanel : UserControl
         _suppressEditorSync = true;
         SqlEditor.Text = _activeQuery.Sql;
         _suppressEditorSync = false;
+    }
+
+    /// <summary>
+    /// Locks the text-selection wash to the fixed brand-blue token
+    /// (AppTextSelectionBrush in Theme.axaml, shared with every plain TextBox's
+    /// Style setter) instead of AvaloniaEdit's theme/OS-accent-derived default,
+    /// so it matches the app's other selection surfaces and reads the same on
+    /// both themes. SelectionBrush lives on TextArea, not TextEditor, so it
+    /// can't be a XAML attribute on SqlEditor.
+    ///
+    /// Resolved on *attach*, not in the constructor: the token lives in the
+    /// app-level Styles.Resources, and a detached control's resource lookup
+    /// stops at its own (null) logical parent — only a TopLevel has the
+    /// Application wired in as its styling parent from the start. Doing this in
+    /// the constructor silently found nothing and left the OS-accent default
+    /// (the regression that came with the MainWindow → panel extraction).
+    /// </summary>
+    private void ApplyTextSelectionBrush()
+    {
+        if (this.TryFindResource("AppTextSelectionBrush", ActualThemeVariant, out var selectionBrush)
+            && selectionBrush is IBrush brush)
+        {
+            SqlEditor.TextArea.SelectionBrush = brush;
+        }
     }
 
     // --- Syntax highlighting ---------------------------------------------

--- a/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
@@ -112,17 +112,6 @@ public partial class ResultsGridPanel : UserControl
             gridMenu.Opening += (_, _) => OnResultsGridMenuOpening();
         }
 
-        // Lock the cell inspector's JSON editor selection wash to the fixed
-        // brand-blue token (AppTextSelectionBrush in Theme.axaml, shared with
-        // every plain TextBox's Style setter), so a selection there reads
-        // identically to the SQL editor and every plain TextBox. SelectionBrush
-        // lives on TextArea, not TextEditor, so it can't be a XAML attribute.
-        if (this.TryFindResource("AppTextSelectionBrush", out var selectionBrush)
-            && selectionBrush is IBrush brush)
-        {
-            JsonInspectorEditor.TextArea.SelectionBrush = brush;
-        }
-
         ActualThemeVariantChanged += (_, _) => ApplyJsonHighlightingTheme();
         DataContextChanged += OnDataContextChanged;
     }
@@ -138,6 +127,7 @@ public partial class ResultsGridPanel : UserControl
     {
         base.OnAttachedToVisualTree(e);
         ApplyJsonHighlightingTheme();
+        ApplyTextSelectionBrush();
         HoistCellInspectorToWindowRoot();
     }
 
@@ -324,6 +314,26 @@ public partial class ResultsGridPanel : UserControl
     // The cell inspector's JSON editor gets its own highlighting, theme-rewritten
     // the same way the SQL editor's is in QueryEditorPanel (the XSHD bakes in the
     // dark palette).
+    /// <summary>
+    /// Locks the cell inspector's JSON editor selection wash to the fixed
+    /// brand-blue token (AppTextSelectionBrush in Theme.axaml, shared with every
+    /// plain TextBox's Style setter), so a selection there reads identically to
+    /// the SQL editor and every plain TextBox. SelectionBrush lives on TextArea,
+    /// not TextEditor, so it can't be a XAML attribute.
+    ///
+    /// Resolved on *attach*, not in the constructor — see the same method on
+    /// <see cref="QueryEditorPanel"/> for why a detached control's lookup of an
+    /// app-level resource silently finds nothing.
+    /// </summary>
+    private void ApplyTextSelectionBrush()
+    {
+        if (this.TryFindResource("AppTextSelectionBrush", ActualThemeVariant, out var selectionBrush)
+            && selectionBrush is IBrush brush)
+        {
+            JsonInspectorEditor.TextArea.SelectionBrush = brush;
+        }
+    }
+
     private void LoadJsonHighlighting()
     {
         using var stream = AssetLoader.Open(new Uri("avares://PgNimbus.App/Assets/Json.xshd"));


### PR DESCRIPTION
The SQL editor was drawing selected text with the OS accent color again instead of the app's brand blue. Same for the cell inspector's JSON editor, where it is less obvious.

## What went wrong

Both editors pin `TextArea.SelectionBrush` to `AppTextSelectionBrush`, the one token every plain `TextBox` and `SelectableTextBlock` also uses. Both lookups ran in the panel constructor:

```csharp
if (this.TryFindResource("AppTextSelectionBrush", out var b) && b is IBrush brush)
    SqlEditor.TextArea.SelectionBrush = brush;
```

`TryFindResource` walks the logical parent chain. A `UserControl` still in its constructor has no parent, and the token lives in the app level `Styles.Resources`, so the lookup finds nothing, returns false, and the editor keeps AvaloniaEdit's default, which is derived from the OS accent color.

The code was correct where it was written, in the `MainWindow` constructor: a `TopLevel` has the `Application` wired in as its styling parent from the moment it is built, so the same call reached the app resources. It broke when it moved verbatim into a panel, once with the editor extraction (82f0617) and once with the results grid extraction (2d0b4de).

## The fix

Resolve the brush from `OnAttachedToVisualTree` in both panels, right next to the highlighting re-resolve that is already there for the same reason. `ActualThemeVariant` is final by then too, so the lookup passes it explicitly.

## Anywhere else?

Audited every other candidate:

- `SchemaTreePanel`, `SavedQueriesPanel`, `NotifyMonitorPanel` only wire event handlers in their constructors, nothing that needs the tree.
- The two syntax highlighting passes use literal hex colors, not resources, and both already re-run on attach and on theme change.
- The remaining `TryFindResource` callers are `MainWindow` and `ThemedWindowChrome`, both operating on a `Window`, so both are fine.
- Every other selection surface goes through an app level `Style` setter (`TextBox`, `SelectableTextBlock`, tab and tree and grid row washes), which applies whenever the control is built.

These two editors were the only places, because they are the only ones that have to set the brush from code: `SelectionBrush` lives on `TextArea`, not on `TextEditor`, so it cannot be a XAML attribute on the editor.

`CLAUDE.md` (UI design rule 7) now records the landmine, so the next panel extraction does not revert this a third time.

## Testing

Compiles clean. Not verified on screen: the running app holds a lock on `bin`, so this needs a restart to see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)