### PR TITLE
Stop the cell inspector crashing the AOT build on JSON

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -590,13 +590,29 @@ apt-get install -y clang zlib1g-dev         # only for NativeAOT publish (linux-
 
 The linux-x64 NativeAOT publish works and is the build to use for
 startup-time claims (`dotnet publish PgNimbus.App -c Release -r linux-x64
--p:PublishAot=true`, ~100 ms launch-to-window vs ~700 ms JIT). Two
+-p:PublishAot=true`, ~100 ms launch-to-window vs ~700 ms JIT). Three
 AOT-specific landmines are already handled in the codebase — keep them
 that way: `SatelliteResourceLanguages=en` in the App csproj (a
 culture-named satellite assembly + InvariantGlobalization crashes
 Avalonia's asset resolver at startup under AOT, surfacing as a bogus
-"avares://... not found") and no reflection binding paths (the results
-grid binds columns via `RowIndexConverter`, not `"[i]"` indexer paths).
+"avares://... not found"); no reflection binding paths (the results
+grid binds columns via `RowIndexConverter`, not `"[i]"` indexer paths);
+and **no reflection-based `System.Text.Json`** — AOT turns
+`JsonSerializerIsReflectionEnabledByDefault` off, so any
+`JsonSerializer.Serialize/Deserialize` overload that doesn't take a
+`JsonTypeInfo`/`JsonSerializerContext` throws at runtime ("Reflection-based
+serialization has been disabled for this application"). Every persisted store
+uses a source-generated context (`AppSettingsJsonContext`,
+`WorkspaceJsonContext`, …); everything that touches arbitrary user JSON —
+`ResultExporter`'s JSON export, `JsonTree`, `ExplainService`, and the cell
+inspector's Format/Minify — goes through `JsonDocument` + `Utf8JsonWriter`
+by hand, which needs no type model at all. That's enforced at build time:
+`PgNimbus.Core` carries `IsAotCompatible`, and `PgNimbus.App` sets
+`EnableTrimAnalyzer`/`EnableAotAnalyzer` directly (it's an exe, so
+`IsAotCompatible`'s implied `IsTrimmable` doesn't fit), so an offending call
+surfaces as IL2026/IL3050 on an ordinary `dotnet build` instead of as a crash
+in a shipped release. Both projects are currently at zero IL warnings — keep
+them there.
 
 Then, to actually see and drive the UI:
 

--- a/PgNimbus.App/PgNimbus.App.csproj
+++ b/PgNimbus.App/PgNimbus.App.csproj
@@ -20,6 +20,19 @@
         which surfaces as a bogus "avares://... not found" crash at startup.
     -->
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+    <!--
+        The release build publishes NativeAOT, so trim/AOT-hostile calls are a
+        runtime crash, not a perf note - JsonSerializer's reflection overloads
+        throw "Reflection-based serialization has been disabled for this
+        application" under AOT. Core carries IsAotCompatible (which turns these
+        analyzers on); the App can't (it isn't a library and shouldn't be marked
+        trimmable), so switch the analyzers on directly and get the IL2026/IL3050
+        warning at build time instead of after a release build ships. Deliberately
+        not IsAotCompatible=true - that also sets IsTrimmable, which is a library
+        concept. The App is currently at zero IL warnings; keep it there.
+    -->
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <RuntimeIdentifiers>win-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <Authors>Dmitrii Shmanev</Authors>

--- a/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
+++ b/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Unicode;
@@ -112,18 +114,23 @@ public sealed partial class CellInspectorViewModel : ObservableObject
     // a plain text column holding a JSON-looking string must accept any string.
     private bool _validatesAsJson;
 
-    private static readonly JsonSerializerOptions PrettyPrintOptions = new()
+    // Re-rendering goes through Utf8JsonWriter + JsonDocument.WriteTo, never
+    // JsonSerializer.Serialize(document, ...): the latter is the reflection-based
+    // serializer, which NativeAOT disables outright
+    // ("Reflection-based serialization has been disabled for this application").
+    // Same reason ResultExporter writes its JSON by hand.
+    private static readonly JsonWriterOptions PrettyPrintOptions = new()
     {
-        WriteIndented = true,
-        // Default JsonSerializer escaping is ASCII-only (everything else
-        // becomes \uXXXX) - relax to all Unicode so e.g. Cyrillic values
-        // show as themselves, not escape sequences.
+        Indented = true,
+        // Default escaping is ASCII-only (everything else becomes \uXXXX) -
+        // relax to all Unicode so e.g. Cyrillic values show as themselves,
+        // not escape sequences.
         Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
     };
 
-    private static readonly JsonSerializerOptions MinifyOptions = new()
+    private static readonly JsonWriterOptions MinifyOptions = new()
     {
-        WriteIndented = false,
+        Indented = false,
         Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
     };
 
@@ -254,19 +261,30 @@ public sealed partial class CellInspectorViewModel : ObservableObject
         _editSeeded = false;
     }
 
-    private static bool TryReformat(string text, JsonSerializerOptions options, out string result)
+    private static bool TryReformat(string text, JsonWriterOptions options, out string result)
     {
         result = text;
         try
         {
             using var document = JsonDocument.Parse(text);
-            result = JsonSerializer.Serialize(document, options);
+            result = Render(document, options);
             return true;
         }
         catch (JsonException)
         {
             return false;
         }
+    }
+
+    private static string Render(JsonDocument document, JsonWriterOptions options)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer, options))
+        {
+            document.WriteTo(writer);
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
     }
 
     private static (string Text, bool IsJson) Format(object? value)
@@ -302,7 +320,7 @@ public sealed partial class CellInspectorViewModel : ObservableObject
         try
         {
             using var document = JsonDocument.Parse(text);
-            pretty = JsonSerializer.Serialize(document, PrettyPrintOptions);
+            pretty = Render(document, PrettyPrintOptions);
             return true;
         }
         catch (JsonException)


### PR DESCRIPTION
Opening the cell inspector on a JSON-looking value, or hitting Format / Minify, threw "Reflection-based serialization has been disabled for this application" in the NativeAOT release build.

CellInspectorViewModel reformatted through
JsonSerializer.Serialize(document, options) - the reflection-based overload, which AOT disables outright. Core never had this problem: it carries IsAotCompatible, so its analyzers forced every persisted store onto a source-generated JsonSerializerContext. The App had no such flag, so the call compiled clean and only failed in a shipped release.

Reformat via JsonDocument.WriteTo(Utf8JsonWriter) instead - no type model involved, the same hand-rolled approach ResultExporter already uses. The two static option fields become JsonWriterOptions; the all-Unicode encoder carries over unchanged, so non-ASCII values still display as themselves.

To keep it from recurring, PgNimbus.App now sets EnableTrimAnalyzer and EnableAotAnalyzer, which flag the old call as IL2026/IL3050 on an ordinary dotnet build. Deliberately not IsAotCompatible=true - that also sets IsTrimmable, a library concept that does not fit an exe. Both projects are at zero IL warnings.

Every other System.Text.Json site (ExplainService, PgValueSyntax, JsonTree, TabularFileParser, ResultExporter) is already JsonDocument/Utf8JsonWriter-based. This was the only one.