### PR TITLE
Fix the connection dialog's accent color picker

### DIFF
--- a/PgNimbus.App/Views/ConnectionDialog.axaml.cs
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using PgNimbus.App.ViewModels;
 using PgNimbus.Core.Connections;
@@ -99,8 +100,16 @@ public partial class ConnectionDialog : Window
         }
     }
 
-    /// <summary>Picking a swatch is the whole point of the flyout — close it rather than making the user click away.</summary>
-    private void OnAccentSwatchClick(object? sender, RoutedEventArgs e) => AccentButton.Flyout?.Hide();
+    /// <summary>
+    /// Picking a swatch is the whole point of the flyout — close it rather than
+    /// making the user click away. Deferred to the next dispatcher pass on
+    /// purpose: <c>Button.OnClick</c> raises Click *before* it invokes Command,
+    /// and hiding the flyout detaches the swatch from the tree, which tears down
+    /// its <c>Command</c> binding — so a synchronous Hide() here swallows the
+    /// selection entirely and the accent color never changes.
+    /// </summary>
+    private void OnAccentSwatchClick(object? sender, RoutedEventArgs e) =>
+        Dispatcher.UIThread.Post(() => AccentButton.Flyout?.Hide());
 
     private void OnProfilesPointerPressed(object? sender, PointerPressedEventArgs e)
     {


### PR DESCRIPTION
Picking a color from the connection dialog's accent swatch flyout did nothing. The flyout closed and the color stayed unset, for every swatch and for the "no accent" clear button.

## Cause

Each swatch had both a `Click` handler and a bound `Command`. Avalonia''s `Button.OnClick` raises the `Click` event *before* it invokes `Command`:

```csharp
RaiseEvent(e);
if (!e.Handled && Command?.CanExecute(CommandParameter) == true) { ... }
```

`OnAccentSwatchClick` called `AccentButton.Flyout?.Hide()` synchronously. That detaches the flyout content from the tree, which tears down the swatch''s `Command` binding, so `Command` was already null by the time `OnClick` got to it.

## Fix

Defer the hide to the next dispatcher pass, so the command runs first. The reasoning is captured in a comment, since nothing in the XAML hints at the ordering.

`MainWindow.ActivateSelectedTabFromList` has the same shape but is safe: it does its work in code-behind before calling `Hide()`.

## Verification

Driven against the running app on Windows:

- Red swatch: the button turns red, flyout closes
- Blue swatch: the button turns blue
- Empty circle: clears back to no accent

Build is clean at zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)