### PR TITLE
Collapse the activity window into one band of chrome

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,11 +291,28 @@ and wrong project memory is worse than none.
    (outline red — a secondary destructive action sitting next to a
    non-destructive primary: Delete a profile, Drop a column, Discard all,
    the activity window's Terminate), and `chip` (small toggle/close pills).
+   `ToggleButton.soft` is the on/off variant of `soft`, for a toggle that
+   belongs in the same button group as its neighbours (the activity window's
+   "Auto" beside "Refresh") — a `chip` there sits at a different height and
+   radius, and its checked blue wash reads as a *selected tab*, which the
+   segmented strip beside it already means.
    Horizontal tab strips use `TabControl.segmented` — a retemplated
    macOS-style segmented capsule (the monitoring windows' Backends/Blocking
    and Database Overview's tabs); the bare global `TabItem` style is the
-   *vertical* left-nav look and must stay untouched. Destructive colors come
-   from the `AppDanger*` tokens (theme-independent fixed red). This
+   *vertical* left-nav look and must stay untouched. Its header line also
+   carries a **trailing actions region**: whatever a window puts in the
+   `TabControl`'s `Tag` is presented right-aligned on the tab baseline (hosted
+   by a `ContentPresenter` inside the template, so it inherits the
+   TabControl's DataContext and bindings resolve normally). That's what keeps
+   a monitoring window to one band of chrome instead of stacking a toolbar
+   above the tabs — the 2026-07 activity-window polish collapsed three bands
+   (Refresh/Auto, the tab strip, and a per-tab Cancel/Terminate pair) into
+   one, which is also why `ActivityViewModel` resolves a single `TargetPid`
+   from the visible tab's selection rather than carrying a command pair per
+   tab. Destructive colors come from the `AppDanger*` tokens
+   (theme-independent fixed red) and attention-but-not-danger amber (a
+   lock-waiting backend, a seq-scan-heavy table, `TextBlock.statusText.warn`)
+   from the single `AppWarningBrush` token — never a hand-rolled hex. This
    vocabulary is app-wide across the secondary windows and dialogs; the main
    window's command bar deliberately keeps its flat minimalist `toolbar`
    buttons (rule 1) and is the one surface exempt.

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -76,6 +76,14 @@
             <SolidColorBrush x:Key="AppDangerWashBrush" Color="#22E5484D" />
             <SolidColorBrush x:Key="AppDangerBorderBrush" Color="#66E5484D" />
 
+            <!-- Attention, not danger: a monitoring row worth spotting (a backend
+                 stuck on a lock, a table read mostly by seq scan) and the warn
+                 status text. One fixed amber for all of them — dark enough to
+                 stay legible on a white grid row, warm enough to read as amber
+                 on dark. Deliberately a token: hand-rolled #E5A50A/#D9822B
+                 literals used to drift apart between the two monitoring windows. -->
+            <SolidColorBrush x:Key="AppWarningBrush" Color="#D9822B" />
+
         <CornerRadius x:Key="CardCornerRadius">8</CornerRadius>
         <CornerRadius x:Key="ControlCornerRadius">6</CornerRadius>
         <CornerRadius x:Key="PillCornerRadius">16</CornerRadius>
@@ -439,7 +447,7 @@
     </Style>
     <!-- Fixed amber that stays legible on both light and dark surfaces -->
     <Style Selector="TextBlock.statusText.warn">
-        <Setter Property="Foreground" Value="#D9822B" />
+        <Setter Property="Foreground" Value="{StaticResource AppWarningBrush}" />
         <Setter Property="Opacity" Value="1" />
     </Style>
     <Style Selector="Rectangle.statusSeparator">
@@ -632,24 +640,38 @@
          is untouched. The header strip is a subtle capsule; each segment is a
          centered pill that fades to the brand-blue wash when selected. Fully
          retemplated so it doesn't inherit the left-nav geometry or Fluent's
-         underline pipe. -->
+         underline pipe.
+
+         The header line also carries a trailing actions region: whatever is
+         put in the TabControl's Tag is presented right-aligned on the same
+         baseline as the segments. That's what keeps a monitoring window to a
+         single band of chrome instead of stacking a toolbar above the tabs.
+         Tag content is hosted by a ContentPresenter *inside* the template, so
+         it joins the logical tree under the TabControl and inherits its
+         DataContext - bindings in there resolve exactly like normal content.
+         A window that sets no Tag renders nothing there. -->
     <Style Selector="TabControl.segmented">
         <Setter Property="Padding" Value="0" />
         <Setter Property="Template">
             <ControlTemplate>
                 <DockPanel>
-                    <!-- The header strip: a subtle capsule that hugs its segments -->
-                    <Border DockPanel.Dock="Top"
-                            Background="{StaticResource CardBackgroundBrush}"
-                            BorderBrush="{StaticResource CardBorderBrush}"
-                            BorderThickness="1"
-                            CornerRadius="9"
-                            Padding="3"
-                            Margin="0,0,0,2"
-                            HorizontalAlignment="Left">
-                        <ItemsPresenter Name="PART_ItemsPresenter"
-                                        ItemsPanel="{TemplateBinding ItemsPanel}" />
-                    </Border>
+                    <Grid DockPanel.Dock="Top" ColumnDefinitions="Auto,*" Margin="0,0,0,2">
+                        <!-- The header strip: a subtle capsule that hugs its segments -->
+                        <Border Grid.Column="0"
+                                Background="{StaticResource CardBackgroundBrush}"
+                                BorderBrush="{StaticResource CardBorderBrush}"
+                                BorderThickness="1"
+                                CornerRadius="9"
+                                Padding="3"
+                                HorizontalAlignment="Left">
+                            <ItemsPresenter Name="PART_ItemsPresenter"
+                                            ItemsPanel="{TemplateBinding ItemsPanel}" />
+                        </Border>
+                        <ContentPresenter Grid.Column="1"
+                                          Content="{TemplateBinding Tag}"
+                                          HorizontalAlignment="Right"
+                                          VerticalAlignment="Center" />
+                    </Grid>
                     <ContentPresenter Name="PART_SelectedContentHost"
                                       Content="{TemplateBinding SelectedContent}"
                                       ContentTemplate="{TemplateBinding SelectedContentTemplate}"
@@ -750,6 +772,72 @@
     <Style Selector="Button.soft.danger:pressed /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="{StaticResource AppDangerWashBrush}" />
         <Setter Property="BorderBrush" Value="{StaticResource AppDangerBorderBrush}" />
+    </Style>
+    <!-- A disabled destructive button must not still shout red: .soft:disabled's
+         0.4 opacity over AppDangerBrush lands on a washed-out pink that reads as
+         "broken", not "unavailable". Drop back to the ordinary foreground so it
+         dims like every other disabled button. -->
+    <Style Selector="Button.soft.danger:disabled">
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
+    <Style Selector="Button.soft.danger:disabled PathIcon">
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
+
+    <!-- Toggle variant of .soft, for an on/off action that belongs in the same
+         button group as its neighbours (the activity window's "Auto" refresh
+         next to "Refresh"). A .chip there would sit at a different height and
+         radius, and its checked blue wash reads as a *selected tab* - which is
+         exactly what the segmented strip beside it already means. This keeps
+         the .soft pill geometry and marks "on" with the accent border + wash.
+         Fluent repaints PART_ContentPresenter for every ToggleButton state, so
+         each state is pinned at the template part (same trick as .searchpill),
+         and selectors match by style key so ToggleButton needs its own rules
+         rather than inheriting the Button.soft ones. -->
+    <Style Selector="ToggleButton.soft">
+        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="11,6" />
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
+    <Style Selector="ToggleButton.soft /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="Transitions">
+            <Transitions>
+                <BrushTransition Property="Background" Duration="0:0:0.12" />
+                <BrushTransition Property="BorderBrush" Duration="0:0:0.12" />
+            </Transitions>
+        </Setter>
+    </Style>
+    <Style Selector="ToggleButton.soft:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+    <Style Selector="ToggleButton.soft:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+    <Style Selector="ToggleButton.soft:checked">
+        <Setter Property="Foreground" Value="{StaticResource AppAccentBrush}" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+    <Style Selector="ToggleButton.soft:checked /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+    <Style Selector="ToggleButton.soft:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+    <Style Selector="ToggleButton.soft:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+    <Style Selector="ToggleButton.soft:disabled">
+        <Setter Property="Opacity" Value="0.4" />
     </Style>
 
     <!-- Lists / trees: rounded row selection instead of edge-to-edge highlight bars -->

--- a/PgNimbus.App/ViewModels/ActivityViewModel.cs
+++ b/PgNimbus.App/ViewModels/ActivityViewModel.cs
@@ -123,22 +123,57 @@ public sealed partial class ActivityViewModel : ObservableObject
     private readonly ActivityService _service;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TargetPid))]
+    [NotifyPropertyChangedFor(nameof(TargetLabel))]
+    [NotifyPropertyChangedFor(nameof(HasTarget))]
     private ActivityRow? _selectedRow;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TargetPid))]
+    [NotifyPropertyChangedFor(nameof(TargetLabel))]
+    [NotifyPropertyChangedFor(nameof(HasTarget))]
     private BlockingNode? _selectedBlockingNode;
+
+    /// <summary>
+    /// Which tab is showing. The cancel/terminate buttons live once on the
+    /// window's header line rather than once per tab, so they need to know
+    /// whose selection they act on — see <see cref="TargetPid"/>.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TargetPid))]
+    [NotifyPropertyChangedFor(nameof(TargetLabel))]
+    [NotifyPropertyChangedFor(nameof(HasTarget))]
+    [NotifyPropertyChangedFor(nameof(ActiveStatus))]
+    private int _selectedTab;
 
     [ObservableProperty]
     private bool _autoRefresh = true;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ActiveStatus))]
     private string _status = "";
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ActiveStatus))]
     private string _blockingStatus = "No lock waits.";
 
     [ObservableProperty]
     private bool _hasLockWaits;
+
+    /// <summary>The backend the header actions act on: whatever the visible tab has selected.</summary>
+    public int? TargetPid => SelectedTab == BlockingTab ? SelectedBlockingNode?.Pid : SelectedRow?.Pid;
+
+    /// <summary>"alice@shop" for the confirm prompt; "" when nothing is selected.</summary>
+    public string TargetLabel => SelectedTab == BlockingTab
+        ? SelectedBlockingNode?.Identity ?? ""
+        : SelectedRow is { } row ? $"{row.User}@{row.Database}" : "";
+
+    public bool HasTarget => TargetPid is not null;
+
+    /// <summary>The visible tab's status line — the window shows one status bar, not one per tab.</summary>
+    public string ActiveStatus => SelectedTab == BlockingTab ? BlockingStatus : Status;
+
+    private const int BlockingTab = 1;
 
     public ObservableCollection<ActivityRow> Rows { get; } = [];
 
@@ -234,24 +269,19 @@ public sealed partial class ActivityViewModel : ObservableObject
         return null;
     }
 
+    /// <summary>
+    /// Stop the target's running statement but keep its session. On the Blocking
+    /// tab the target is the selected node, so aiming at a lock holder releases
+    /// everyone waiting beneath it.
+    /// </summary>
     [RelayCommand]
-    private Task CancelBackendAsync() =>
-        SelectedRow is { } row ? SignalCancelAsync(row.Pid) : Task.CompletedTask;
+    private Task CancelAsync() =>
+        TargetPid is { } pid ? SignalCancelAsync(pid) : Task.CompletedTask;
 
     /// <summary>The view confirms first — this kills the whole session, not just the statement.</summary>
     [RelayCommand]
-    private Task TerminateBackendAsync() =>
-        SelectedRow is { } row ? SignalTerminateAsync(row.Pid) : Task.CompletedTask;
-
-    /// <summary>Cancel the selected node's statement — aimed at the lock holder to release the wait.</summary>
-    [RelayCommand]
-    private Task CancelBlockerAsync() =>
-        SelectedBlockingNode is { } node ? SignalCancelAsync(node.Pid) : Task.CompletedTask;
-
-    /// <summary>The view confirms first — terminate the selected node's whole session.</summary>
-    [RelayCommand]
-    private Task TerminateBlockerAsync() =>
-        SelectedBlockingNode is { } node ? SignalTerminateAsync(node.Pid) : Task.CompletedTask;
+    private Task TerminateAsync() =>
+        TargetPid is { } pid ? SignalTerminateAsync(pid) : Task.CompletedTask;
 
     private async Task SignalCancelAsync(int pid)
     {

--- a/PgNimbus.App/Views/ActivityWindow.axaml
+++ b/PgNimbus.App/Views/ActivityWindow.axaml
@@ -9,51 +9,73 @@
         WindowStartupLocation="CenterOwner"
         FontFamily="{StaticResource InterFont}">
 
-    <Grid RowDefinitions="Auto,*" Margin="12">
+    <Grid RowDefinitions="*,Auto">
 
-        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="6" Margin="0,0,0,10">
-            <Button Classes="soft" Command="{Binding RefreshCommand}" ToolTip.Tip="Refresh now">
-                <StackPanel Orientation="Horizontal" Spacing="7">
-                    <PathIcon Data="{StaticResource RefreshIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                    <TextBlock Text="Refresh" VerticalAlignment="Center" />
+        <!--
+            One band of chrome: the segmented tabs on the left, every action
+            right-aligned on the same line (TabControl.Tag is the strip's
+            trailing region — see Theme.axaml). Both tabs act on "the selected
+            backend", so cancel/terminate live here once rather than being
+            duplicated into each tab above its own grid.
+        -->
+        <TabControl Grid.Row="0" Classes="segmented" Margin="12,12,12,0"
+                    SelectedIndex="{Binding SelectedTab, Mode=TwoWay}">
+            <TabControl.Tag>
+                <StackPanel Orientation="Horizontal" Spacing="6">
+                    <Button Classes="soft" Command="{Binding CancelCommand}"
+                            IsEnabled="{Binding HasTarget}"
+                            ToolTip.Tip="Stop the selected backend's running statement but keep the session (pg_cancel_backend). On the Blocking tab, aim at a lock holder to release everyone waiting beneath it.">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <PathIcon Data="{StaticResource StopIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                            <TextBlock Text="Cancel query" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <Button Classes="soft danger" Click="OnTerminateClick"
+                            IsEnabled="{Binding HasTarget}"
+                            ToolTip.Tip="Kill the selected backend's whole session (pg_terminate_backend)">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <PathIcon Data="{StaticResource CloseIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                            <TextBlock Text="Terminate…" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+
+                    <!-- Acting on a backend and controlling the polling are two
+                         different jobs — keep them visibly apart. -->
+                    <Rectangle Classes="statusSeparator" Margin="5,0" />
+
+                    <Button Classes="soft" Command="{Binding RefreshCommand}" ToolTip.Tip="Refresh now">
+                        <StackPanel Orientation="Horizontal" Spacing="7">
+                            <PathIcon Data="{StaticResource RefreshIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                            <TextBlock Text="Refresh" VerticalAlignment="Center" />
+                        </StackPanel>
+                    </Button>
+                    <ToggleButton Classes="soft" IsChecked="{Binding AutoRefresh}"
+                                  ToolTip.Tip="Refresh every 2 seconds while this window is open">
+                        <TextBlock Text="Auto" VerticalAlignment="Center" />
+                    </ToggleButton>
                 </StackPanel>
-            </Button>
-            <ToggleButton Classes="chip" IsChecked="{Binding AutoRefresh}" Padding="10,6"
-                          ToolTip.Tip="Refresh every 2 seconds while this window is open">
-                <TextBlock Text="Auto" FontSize="12" />
-            </ToggleButton>
-        </StackPanel>
-
-        <TabControl Grid.Row="1" Classes="segmented">
+            </TabControl.Tag>
 
             <!-- Every client backend, live -->
             <TabItem Header="Backends">
-                <Grid RowDefinitions="Auto,*,Auto" Margin="0,8,0,0">
-
-                    <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="6" Margin="0,0,0,10">
-                        <Button Classes="soft" Command="{Binding CancelBackendCommand}"
-                                IsEnabled="{Binding SelectedRow, Converter={x:Static ObjectConverters.IsNotNull}}"
-                                ToolTip.Tip="Stop the running statement but keep the session (pg_cancel_backend)">
-                            <StackPanel Orientation="Horizontal" Spacing="7">
-                                <PathIcon Data="{StaticResource StopIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                                <TextBlock Text="Cancel query" VerticalAlignment="Center" />
-                            </StackPanel>
-                        </Button>
-                        <Button Classes="soft danger" Click="OnTerminateClick"
-                                IsEnabled="{Binding SelectedRow, Converter={x:Static ObjectConverters.IsNotNull}}"
-                                ToolTip.Tip="Kill the whole session (pg_terminate_backend)">
-                            <StackPanel Orientation="Horizontal" Spacing="7">
-                                <PathIcon Data="{StaticResource CloseIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                                <TextBlock Text="Terminate..." VerticalAlignment="Center" />
-                            </StackPanel>
-                        </Button>
-                    </StackPanel>
-
-                    <DataGrid Grid.Row="1" ItemsSource="{Binding Rows}" SelectedItem="{Binding SelectedRow, Mode=TwoWay}"
+                <!-- Framed content pane so both tabs read as the same surface;
+                     clipped so the grid's header and last row respect the radius. -->
+                <Border Margin="0,8,0,0" ClipToBounds="True"
+                        BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                        CornerRadius="{StaticResource CardCornerRadius}">
+                    <DataGrid ItemsSource="{Binding Rows}" SelectedItem="{Binding SelectedRow, Mode=TwoWay}"
                               IsReadOnly="True" SelectionMode="Single" CanUserResizeColumns="True"
                               GridLinesVisibility="Horizontal" HeadersVisibility="Column">
                         <DataGrid.Columns>
-                            <DataGridTextColumn Header="PID" Binding="{Binding Pid}" Width="70" />
+                            <DataGridTemplateColumn Header="PID" Width="70">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate x:DataType="vm:ActivityRow">
+                                        <!-- Monospace, like the pid badge in the blocking tree -->
+                                        <TextBlock Text="{Binding Pid}" Margin="12,0" VerticalAlignment="Center"
+                                                   FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="12" />
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
                             <DataGridTextColumn Header="User" Binding="{Binding User}" Width="90" />
                             <DataGridTextColumn Header="Database" Binding="{Binding Database}" Width="100" />
                             <DataGridTextColumn Header="Application" Binding="{Binding Application}" Width="110" />
@@ -65,7 +87,7 @@
                                         <Panel Margin="12,0">
                                             <!-- Lock waits are the rows worth spotting instantly - amber + bold -->
                                             <TextBlock Text="{Binding Wait}" VerticalAlignment="Center"
-                                                       Foreground="#E5A50A" FontWeight="SemiBold"
+                                                       Foreground="{StaticResource AppWarningBrush}" FontWeight="SemiBold"
                                                        IsVisible="{Binding IsWaitingOnLock}" />
                                             <TextBlock Text="{Binding Wait}" VerticalAlignment="Center" Opacity="0.7"
                                                        IsVisible="{Binding !IsWaitingOnLock}" />
@@ -84,82 +106,64 @@
                             </DataGridTemplateColumn>
                         </DataGrid.Columns>
                     </DataGrid>
-
-                    <TextBlock Grid.Row="2" Text="{Binding Status}" FontSize="11" Opacity="0.7" Margin="2,8,2,0" />
-                </Grid>
+                </Border>
             </TabItem>
 
             <!-- Who blocks whom: lock holders at the top, waiters nested beneath -->
             <TabItem Header="Blocking">
-                <Grid RowDefinitions="Auto,*,Auto" Margin="0,8,0,0">
-
-                    <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="6" Margin="0,0,0,10">
-                        <Button Classes="soft" Command="{Binding CancelBlockerCommand}"
-                                IsEnabled="{Binding SelectedBlockingNode, Converter={x:Static ObjectConverters.IsNotNull}}"
-                                ToolTip.Tip="Cancel the selected backend's statement to release everyone waiting on its lock (pg_cancel_backend)">
-                            <StackPanel Orientation="Horizontal" Spacing="7">
-                                <PathIcon Data="{StaticResource StopIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                                <TextBlock Text="Cancel blocker" VerticalAlignment="Center" />
-                            </StackPanel>
-                        </Button>
-                        <Button Classes="soft danger" Click="OnTerminateBlockerClick"
-                                IsEnabled="{Binding SelectedBlockingNode, Converter={x:Static ObjectConverters.IsNotNull}}"
-                                ToolTip.Tip="Kill the selected backend's whole session (pg_terminate_backend)">
-                            <StackPanel Orientation="Horizontal" Spacing="7">
-                                <PathIcon Data="{StaticResource CloseIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
-                                <TextBlock Text="Terminate..." VerticalAlignment="Center" />
-                            </StackPanel>
-                        </Button>
-                    </StackPanel>
-
-                    <Border Grid.Row="1" BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1" CornerRadius="4">
-                        <Panel>
-                            <TreeView ItemsSource="{Binding BlockingRoots}"
-                                      SelectedItem="{Binding SelectedBlockingNode, Mode=TwoWay}"
-                                      IsVisible="{Binding HasLockWaits}">
-                                <!-- Expand every node by default: the whole wait chain should be
-                                     visible at a glance, and it survives the 2s auto-refresh rebuild. -->
-                                <TreeView.Styles>
-                                    <Style Selector="TreeViewItem">
-                                        <Setter Property="IsExpanded" Value="True" />
-                                    </Style>
-                                </TreeView.Styles>
-                                <TreeView.ItemTemplate>
-                                    <TreeDataTemplate x:DataType="vm:BlockingNode" ItemsSource="{Binding Children}">
-                                        <StackPanel Spacing="1" Margin="0,3">
-                                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                                <Border Background="{StaticResource CardBorderBrush}" CornerRadius="3" Padding="5,1" VerticalAlignment="Center">
-                                                    <TextBlock Text="{Binding Pid}" FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="11" />
-                                                </Border>
-                                                <TextBlock Text="{Binding Identity}" VerticalAlignment="Center" FontWeight="SemiBold" />
-                                                <!-- Amber = this backend is itself stuck waiting on a lock -->
-                                                <TextBlock Text="{Binding WaitLabel}" VerticalAlignment="Center"
-                                                           Foreground="#E5A50A" FontSize="12"
-                                                           IsVisible="{Binding IsBlocked}" />
-                                                <TextBlock Text="{Binding BlockingLabel}" VerticalAlignment="Center"
-                                                           Opacity="0.6" FontSize="12"
-                                                           IsVisible="{Binding IsBlocker}" />
-                                            </StackPanel>
-                                            <TextBlock Text="{Binding Query}" Opacity="0.6" FontSize="11"
-                                                       TextTrimming="CharacterEllipsis" MaxWidth="820" HorizontalAlignment="Left"
-                                                       ToolTip.Tip="{Binding Query}" />
+                <Border Margin="0,8,0,0" ClipToBounds="True"
+                        BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                        CornerRadius="{StaticResource CardCornerRadius}">
+                    <Panel>
+                        <TreeView ItemsSource="{Binding BlockingRoots}"
+                                  SelectedItem="{Binding SelectedBlockingNode, Mode=TwoWay}"
+                                  IsVisible="{Binding HasLockWaits}">
+                            <!-- Expand every node by default: the whole wait chain should be
+                                 visible at a glance, and it survives the 2s auto-refresh rebuild. -->
+                            <TreeView.Styles>
+                                <Style Selector="TreeViewItem">
+                                    <Setter Property="IsExpanded" Value="True" />
+                                </Style>
+                            </TreeView.Styles>
+                            <TreeView.ItemTemplate>
+                                <TreeDataTemplate x:DataType="vm:BlockingNode" ItemsSource="{Binding Children}">
+                                    <StackPanel Spacing="1" Margin="0,3">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <Border Background="{StaticResource CardBorderBrush}" CornerRadius="3" Padding="5,1" VerticalAlignment="Center">
+                                                <TextBlock Text="{Binding Pid}" FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="11" />
+                                            </Border>
+                                            <TextBlock Text="{Binding Identity}" VerticalAlignment="Center" FontWeight="SemiBold" />
+                                            <!-- Amber = this backend is itself stuck waiting on a lock -->
+                                            <TextBlock Text="{Binding WaitLabel}" VerticalAlignment="Center"
+                                                       Foreground="{StaticResource AppWarningBrush}" FontSize="12"
+                                                       IsVisible="{Binding IsBlocked}" />
+                                            <TextBlock Text="{Binding BlockingLabel}" VerticalAlignment="Center"
+                                                       Opacity="0.6" FontSize="12"
+                                                       IsVisible="{Binding IsBlocker}" />
                                         </StackPanel>
-                                    </TreeDataTemplate>
-                                </TreeView.ItemTemplate>
-                            </TreeView>
+                                        <TextBlock Text="{Binding Query}" Opacity="0.6" FontSize="11"
+                                                   TextTrimming="CharacterEllipsis" MaxWidth="820" HorizontalAlignment="Left"
+                                                   ToolTip.Tip="{Binding Query}" />
+                                    </StackPanel>
+                                </TreeDataTemplate>
+                            </TreeView.ItemTemplate>
+                        </TreeView>
 
-                            <!-- Nothing blocked: the calm, common case -->
-                            <TextBlock Text="No backend is waiting on a lock right now."
-                                       Opacity="0.55" HorizontalAlignment="Center" VerticalAlignment="Center"
-                                       IsVisible="{Binding !HasLockWaits}" />
-                        </Panel>
-                    </Border>
-
-                    <TextBlock Grid.Row="2" Text="{Binding BlockingStatus}" FontSize="11" Opacity="0.7" Margin="2,8,2,0" />
-                </Grid>
+                        <!-- Nothing blocked: the calm, common case -->
+                        <TextBlock Text="No backend is waiting on a lock right now."
+                                   Opacity="0.55" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                   IsVisible="{Binding !HasLockWaits}" />
+                    </Panel>
+                </Border>
             </TabItem>
 
         </TabControl>
+
+        <!-- One status strip flush along the window's bottom edge, showing the
+             visible tab's line — not a floating caption per tab. -->
+        <Border Grid.Row="1" Classes="statusBar" Margin="0,12,0,0">
+            <TextBlock Classes="statusText dim" Text="{Binding ActiveStatus}" />
+        </Border>
 
     </Grid>
 

--- a/PgNimbus.App/Views/ActivityWindow.axaml.cs
+++ b/PgNimbus.App/Views/ActivityWindow.axaml.cs
@@ -36,31 +36,18 @@ public partial class ActivityWindow : Window
         Closed += (_, _) => _timer.Stop();
     }
 
+    /// <summary>Terminate whatever the visible tab has selected — the view model resolves the target.</summary>
     private async void OnTerminateClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is not ActivityViewModel { SelectedRow: { } row } vm)
+        if (DataContext is not ActivityViewModel { TargetPid: { } pid } vm)
         {
             return;
         }
 
-        var confirm = new ConfirmDialog($"Terminate backend {row.Pid} ({row.User}@{row.Database})? Its session and any open transaction die with it.", "Terminate");
+        var confirm = new ConfirmDialog($"Terminate backend {pid} ({vm.TargetLabel})? Its session and any open transaction die with it.", "Terminate");
         if (await confirm.ShowDialog<bool>(this))
         {
-            await vm.TerminateBackendCommand.ExecuteAsync(null);
-        }
-    }
-
-    private async void OnTerminateBlockerClick(object? sender, RoutedEventArgs e)
-    {
-        if (DataContext is not ActivityViewModel { SelectedBlockingNode: { } node } vm)
-        {
-            return;
-        }
-
-        var confirm = new ConfirmDialog($"Terminate backend {node.Pid} ({node.Identity})? Its session and any open transaction die with it.", "Terminate");
-        if (await confirm.ShowDialog<bool>(this))
-        {
-            await vm.TerminateBlockerCommand.ExecuteAsync(null);
+            await vm.TerminateCommand.ExecuteAsync(null);
         }
     }
 }

--- a/PgNimbus.App/Views/DatabaseOverviewWindow.axaml
+++ b/PgNimbus.App/Views/DatabaseOverviewWindow.axaml
@@ -77,7 +77,7 @@
                                     <Panel Margin="12,0">
                                         <!-- A big table read mostly sequentially is worth spotting - amber + bold -->
                                         <TextBlock Text="{Binding IndexScanPercent}" VerticalAlignment="Center"
-                                                   Foreground="#E5A50A" FontWeight="SemiBold"
+                                                   Foreground="{StaticResource AppWarningBrush}" FontWeight="SemiBold"
                                                    IsVisible="{Binding IsSeqScanHeavy}" />
                                         <TextBlock Text="{Binding IndexScanPercent}" VerticalAlignment="Center"
                                                    IsVisible="{Binding !IsSeqScanHeavy}" />


### PR DESCRIPTION
The Server Activity window stacked three rows of controls above its content: Refresh/Auto, the segmented tab strip, then a per-tab Cancel/Terminate pair duplicated into both tabs. All of it hugged the left edge, so the window read top-heavy with a wide empty band beside it.

## Layout

The segmented tab strip now carries a **trailing actions region** - whatever a window puts in the `TabControl`'s `Tag` is presented right-aligned on the tab baseline, hosted by a `ContentPresenter` inside the template so it inherits the DataContext and bindings resolve normally. A window that sets no `Tag` (Database Overview) renders nothing there.

Both tabs act on "the selected backend", so `ActivityViewModel` resolves a single `TargetPid`/`TargetLabel` from the visible tab's selection and exposes one `Cancel`/`Terminate` pair instead of two near-identical ones. The code-behind drops a terminate handler with it.

Three bands became one:

```
[Backends | Blocking]        [Cancel query] [Terminate...] | [Refresh] [Auto]
```

## Colors

- **"Auto"** was a `chip` beside a `soft` button - different height, radius and weight, and its checked blue wash read as a *selected tab* right above the strip that already means that. Added `ToggleButton.soft` so it keeps the soft pill geometry and marks "on" with the accent border + wash.
- **Disabled `soft danger`** dimmed `AppDangerBrush` to 0.4 opacity, landing on a washed-out pink that reads as broken rather than unavailable. It falls back to the ordinary foreground now.
- **Two ambers for one role**: the two monitoring windows had drifted onto `#E5A50A` and `#D9822B` for the same "worth spotting" meaning. Both, plus `TextBlock.statusText.warn`, now share a single `AppWarningBrush` token.
- The Backends grid floated on the window background while the Blocking tree sat in a frame; both are framed the same way now, and the status line moved from a floating per-tab caption into one `statusBar` strip flush along the bottom edge.
- PID is monospace in the grid, matching the pid badge in the blocking tree.

`CLAUDE.md`'s UI design rule 6 is updated for the new vocabulary.

## Verification

Built clean (0 warnings), 636 Core tests pass, and driven against a local Postgres - both tabs, selection enabling/disabling the actions, and the Auto toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)