### PR TITLE
Add a headless screenshot harness for visual verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,16 @@ jobs:
         env:
           PGNIMBUS_TEST_CONN: "Host=localhost;Port=5432;Database=postgres;Username=postgres;Password=postgres"
         run: dotnet test --project PgNimbus.Core.Tests -c Release
+
+      # Renders every UI scenario through Avalonia.Headless (no display, no
+      # database — see CLAUDE.md "Headless screenshot harness"). It doubles as a
+      # smoke test: a view that throws while loading, or one that renders no
+      # frame at all, fails the run instead of shipping quietly. The PNGs ride
+      # along as an artifact so a UI change can be eyeballed from the PR.
+      - name: Screenshots
+        run: dotnet run --project tools/Screenshot -c Release -- "${{ runner.temp }}/screenshots"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: ${{ runner.temp }}/screenshots

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -693,6 +693,49 @@ Notes:
 - This is how the Avalonia 11→12 upgrade and the PowerToys-style UI polish
   were actually verified (not just built) in a Claude Code sandbox with no
   prior .NET/GUI tooling.
+- For a *visual* check the live sandbox above is the heavy path — prefer the
+  headless harness below, which needs no display, no input tool and no
+  database. The live path is still the one for anything interactive
+  (completion popups, drag-reorder, real catalog shapes).
+
+## Headless screenshot harness (`tools/Screenshot`)
+
+Renders the real Views bound to fixture ViewModels through `Avalonia.Headless`
+(Skia software rendering, `UseHeadlessDrawing = false`) and writes PNGs — one
+`<scenario>.<light|dark>.png` per scenario × theme. Works on Windows, Linux and
+CI alike, with no display, no Xvfb/xdotool, and **no Postgres**:
+
+```bash
+dotnet run --project tools/Screenshot -- <outputDir> [scenario-substring]
+```
+
+Pass a scratch directory — nothing it writes is committed. Omit the filter to
+render every scenario in `Program.cs`'s `scenarios` array. `ci.yml` runs the
+whole set on every PR and uploads the PNGs as the `screenshots` artifact, so the
+harness doubles as a smoke test (a view that throws while loading, or renders no
+frame, fails the run) and as a visual diff a reviewer can actually look at.
+
+How the fixtures work, and why they're shaped this way:
+
+- **The data source is offline but unroutable.** Every service takes an
+  `NpgsqlDataSource`, and `NpgsqlDataSource.Create` opens no socket, so the whole
+  graph constructs with no server. `Fixtures` points it at TEST-NET-3
+  (`203.0.113.1`) rather than a closed local port on purpose: windows that
+  refresh when they open (activity, database overview, schema tree) would get a
+  fast connection-refused back from a closed port and overwrite the seeded status
+  line with an error a fraction of a second after the window shows. An address
+  that never answers leaves the seeded state alone.
+- **Scenarios drive the public ViewModel surface**, the same properties and
+  commands production sets — not the views. Two seams exist purely for this:
+  `SchemaTreeNode.SeedChildren` (fills a node's children and marks it loaded, so
+  expanding never reaches for the catalog) and `QueryViewModel.SeedResult`
+  (points the grid at a result set that was never run). Both are documented as
+  harness-only; production still goes through the lazy-load and run paths.
+- **Nothing reads or writes the developer's real app data.** No workspace is
+  restored and no settings are persisted, and because `MainViewModel` news up its
+  own `SavedQueryStore`/`QueryHistoryStore`, `Fixtures` clears what those loaded
+  before seeding its own — otherwise a screenshot would carry whatever is in the
+  running developer's saved queries and history.
 
 ## Benchmarks pipeline
 

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -770,6 +770,34 @@ public sealed partial class QueryViewModel : ObservableObject
             : null;
     }
 
+    /// <summary>
+    /// Points the grid at a result set that was never run — the headless
+    /// screenshot harness's entry point (tools/Screenshot), which has no server
+    /// behind it. Sets exactly what the run path's <see cref="ResultSet"/> case
+    /// sets: the columns (so the grid can build its per-column type icons), the
+    /// rows, and the status-bar segments. Never called in production.
+    /// </summary>
+    public void SeedResult(
+        IReadOnlyList<ColumnInfo> columns,
+        IReadOnlyList<object?[]> rows,
+        string status = "Done",
+        string? rowCountText = null,
+        string? timingText = null)
+    {
+        _columns = columns;
+        ColumnNames.Clear();
+        foreach (var column in columns)
+        {
+            ColumnNames.Add(column.Name);
+        }
+
+        Rows = new AvaloniaList<object?[]>(rows);
+        Status = status;
+        HasError = false;
+        RowCountText = rowCountText ?? RowLabel(rows.Count);
+        TimingText = timingText;
+    }
+
     private void NotifyScriptResultChanged()
     {
         OnPropertyChanged(nameof(IsScriptResult));

--- a/PgNimbus.App/ViewModels/SchemaTreeNode.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeNode.cs
@@ -31,6 +31,23 @@ public abstract partial class SchemaTreeNode : ObservableObject
     /// <summary>Re-fetches this node's children immediately, bypassing the lazy-load-once gate (used after schema-changing operations like ALTER TABLE).</summary>
     public Task RefreshAsync() => LoadChildrenAsync();
 
+    /// <summary>
+    /// Fills this node's children in up front and marks it loaded, so expanding
+    /// it never reaches for the catalog. The headless screenshot harness
+    /// (tools/Screenshot) builds its fixture trees this way; production always
+    /// loads lazily through <see cref="FetchChildrenAsync"/>.
+    /// </summary>
+    public void SeedChildren(IEnumerable<SchemaTreeNode> children)
+    {
+        Children.Clear();
+        foreach (var child in children)
+        {
+            Children.Add(child);
+        }
+
+        _loaded = true;
+    }
+
     partial void OnIsExpandedChanged(bool value)
     {
         if (!value || _loaded)

--- a/PgNimbus.slnx
+++ b/PgNimbus.slnx
@@ -69,4 +69,5 @@
   <Project Path="PgNimbus.Benchmarks/PgNimbus.Benchmarks.csproj" />
   <Project Path="PgNimbus.Core.Tests/PgNimbus.Core.Tests.csproj" />
   <Project Path="PgNimbus.Core/PgNimbus.Core.csproj" />
+  <Project Path="tools/Screenshot/Screenshot.csproj" />
 </Solution>

--- a/tools/Screenshot/Fixtures.cs
+++ b/tools/Screenshot/Fixtures.cs
@@ -1,0 +1,253 @@
+using Npgsql;
+using PgNimbus.App.Completion;
+using PgNimbus.App.ViewModels;
+using PgNimbus.Core.Import;
+using PgNimbus.Core.Monitoring;
+using PgNimbus.Core.Notifications;
+using PgNimbus.Core.Query;
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.Screenshot;
+
+/// <summary>
+/// Builds fully-populated ViewModels with no live Postgres behind them.
+///
+/// Every service in the app takes an <see cref="NpgsqlDataSource"/>, and
+/// <see cref="NpgsqlDataSource.Create(string)"/> opens no socket, so the whole
+/// object graph constructs offline. The address it points at is deliberately
+/// <em>unroutable</em> (TEST-NET-3, RFC 5737) rather than a closed local port:
+/// windows that kick off a refresh when they open (activity, database overview,
+/// schema tree) would otherwise get a fast connection-refused back and overwrite
+/// the seeded fixture status line with an error a fraction of a second after the
+/// window shows. Against an address that simply never answers, those refreshes
+/// stay in flight for the life of the (very short) process and never touch the
+/// seeded state.
+/// </summary>
+internal static class Fixtures
+{
+    private const string OfflineConnectionString =
+        "Host=203.0.113.1;Port=5432;Database=shop;Username=pgnimbus;Timeout=300;Command Timeout=0";
+
+    public static NpgsqlDataSource DataSource { get; } = NpgsqlDataSource.Create(OfflineConnectionString);
+
+    /// <summary>
+    /// A main-window view model wired exactly as <c>App.BuildMainWindow</c> wires
+    /// one, minus the settings/workspace persistence (a screenshot run must not
+    /// read or write the developer's real app data) and minus the catalog refresh
+    /// it kicks off — the schema tree is seeded here instead.
+    /// </summary>
+    public static MainViewModel MainWindowViewModel()
+    {
+        var dataSource = DataSource;
+        var schemaService = new SchemaService(dataSource);
+        var schemaTree = new SchemaTreeViewModel(schemaService, showSizes: true);
+
+        var viewModel = new MainViewModel(
+            new QueryEngine(dataSource),
+            new ExplainService(dataSource),
+            schemaTree,
+            schemaService,
+            new SchemaEditor(dataSource),
+            new DdlService(dataSource),
+            new SqlCompletionProvider(schemaService),
+            new NotifyMonitorViewModel(new NotificationListener(dataSource)),
+            new ActivityService(dataSource),
+            new DatabaseStatsService(dataSource),
+            new ImportService(dataSource),
+            connectionHost: "localhost",
+            connectionDatabase: "shop");
+
+        // SavedQueriesViewModel loads the real on-disk saved queries and history
+        // in its constructor (MainViewModel news up the stores itself, so there
+        // is nothing to inject). Drop whatever that pulled in before it can reach
+        // a screenshot, and seed the fixture lists instead.
+        viewModel.SavedQueries.SavedQueries.Clear();
+        viewModel.SavedQueries.History.Clear();
+        SeedSavedQueries(viewModel.SavedQueries);
+
+        SeedSchemaTree(schemaTree, schemaService);
+        return viewModel;
+    }
+
+    // --- Schema tree ------------------------------------------------------
+
+    /// <summary>
+    /// A small but realistic catalog: two schemas, a mix of relation kinds, and
+    /// columns on the tables the scenarios expand. Nodes are seeded rather than
+    /// loaded, so expanding one never reaches for the catalog.
+    /// </summary>
+    private static void SeedSchemaTree(SchemaTreeViewModel tree, SchemaService schemaService)
+    {
+        var publicSchema = Schema(schemaService, tree, "public",
+            Table(schemaService, "public", "orders", RelationKind.Table, 268_435_456, Columns(
+                ("id", "bigint", true, true),
+                ("customer_id", "bigint", true, false),
+                ("status", "order_status", true, false),
+                ("total", "numeric(12,2)", true, false),
+                ("metadata", "jsonb", false, false),
+                ("placed_at", "timestamp with time zone", true, false))),
+            Table(schemaService, "public", "order_items", RelationKind.Table, 92_274_688, Columns(
+                ("id", "bigint", true, true),
+                ("order_id", "bigint", true, false),
+                ("product_id", "bigint", true, false),
+                ("quantity", "integer", true, false),
+                ("unit_price", "numeric(12,2)", true, false))),
+            Table(schemaService, "public", "customers", RelationKind.Table, 41_943_040, Columns(
+                ("id", "bigint", true, true),
+                ("email", "citext", true, false),
+                ("full_name", "text", true, false),
+                ("created_at", "timestamp with time zone", true, false))),
+            Table(schemaService, "public", "products", RelationKind.Table, 12_582_912, Columns(
+                ("id", "bigint", true, true),
+                ("sku", "text", true, false),
+                ("name", "text", true, false),
+                ("price", "numeric(12,2)", true, false),
+                ("tags", "text[]", false, false))),
+            Table(schemaService, "public", "active_customers", RelationKind.View, null, Columns(
+                ("id", "bigint", false, false),
+                ("email", "citext", false, false))),
+            Table(schemaService, "public", "daily_revenue", RelationKind.MaterializedView, 6_291_456, Columns(
+                ("day", "date", false, false),
+                ("revenue", "numeric", false, false))));
+
+        var analyticsSchema = Schema(schemaService, tree, "analytics",
+            Table(schemaService, "analytics", "events", RelationKind.PartitionedTable, null, Columns(
+                ("id", "bigint", true, true),
+                ("occurred_at", "timestamp with time zone", true, false),
+                ("payload", "jsonb", false, false))),
+            Table(schemaService, "analytics", "sessions", RelationKind.Table, 734_003_200, Columns(
+                ("id", "uuid", true, true),
+                ("customer_id", "bigint", false, false),
+                ("started_at", "timestamp with time zone", true, false))));
+
+        tree.Schemas.Add(publicSchema);
+        tree.Schemas.Add(analyticsSchema);
+        tree.Schemas.Add(new RolesGroupNode(schemaService));
+
+        publicSchema.IsExpanded = true;
+    }
+
+    private static SchemaNode Schema(SchemaService schemaService, SchemaTreeViewModel tree, string name, params TableNode[] tables)
+    {
+        var node = new SchemaNode(schemaService, name, () => tree.ShowAdvancedObjects, () => tree.ShowSizes);
+        node.SeedChildren(tables);
+        return node;
+    }
+
+    private static TableNode Table(
+        SchemaService schemaService, string schema, string name, RelationKind kind, long? totalBytes,
+        IEnumerable<ColumnDetail> columns)
+    {
+        var node = new TableNode(schemaService, schema, name, kind, totalBytes, static () => true, static () => false);
+        node.SeedChildren(columns.Select(c => new ColumnNode(c)));
+        return node;
+    }
+
+    private static IEnumerable<ColumnDetail> Columns(params (string Name, string Type, bool NotNull, bool PrimaryKey)[] columns) =>
+        columns.Select(c => new ColumnDetail(c.Name, c.Type, c.NotNull, c.PrimaryKey));
+
+    // --- Saved queries + history ------------------------------------------
+
+    private static void SeedSavedQueries(SavedQueriesViewModel saved)
+    {
+        saved.SavedQueries.Add(new SavedQuery(Guid.Parse("11111111-1111-1111-1111-111111111111"), "Revenue by day", "SELECT day, revenue\n  FROM daily_revenue\n ORDER BY day DESC;"));
+        saved.SavedQueries.Add(new SavedQuery(Guid.Parse("22222222-2222-2222-2222-222222222222"), "Slow orders", "SELECT *\n  FROM orders\n WHERE placed_at > now() - interval '1 day';"));
+        saved.SavedQueries.Add(new SavedQuery(Guid.Parse("33333333-3333-3333-3333-333333333333"), "Unshipped items", "SELECT o.id, count(*)\n  FROM orders o\n  JOIN order_items i ON i.order_id = o.id\n WHERE o.status = 'pending'\n GROUP BY o.id;"));
+
+        var now = new DateTimeOffset(2026, 7, 30, 9, 41, 0, TimeSpan.Zero);
+        saved.History.Add(new QueryHistoryEntry("SELECT * FROM orders ORDER BY placed_at DESC LIMIT 50;", now, 18.4, "50 rows") { Connection = "localhost/shop" });
+        saved.History.Add(new QueryHistoryEntry("UPDATE orders SET status = 'shipped' WHERE id = 4821;", now.AddMinutes(-6), 4.1, "1 row affected") { Connection = "localhost/shop" });
+        saved.History.Add(new QueryHistoryEntry("SELECT count(*) FROM analytics.events;", now.AddMinutes(-22), 942.0, "1 row") { Connection = "localhost/shop" });
+    }
+
+    // --- Result sets ------------------------------------------------------
+
+    /// <summary>The orders result set the grid scenarios show.</summary>
+    public static (IReadOnlyList<ColumnInfo> Columns, IReadOnlyList<object?[]> Rows) OrdersResult()
+    {
+        IReadOnlyList<ColumnInfo> columns =
+        [
+            new("id", "bigint", typeof(long), TableOid, 1),
+            new("customer", "text", typeof(string), TableOid, 2),
+            new("status", "order_status", typeof(string), TableOid, 3),
+            new("total", "numeric", typeof(decimal), TableOid, 4),
+            new("metadata", "jsonb", typeof(string), TableOid, 5),
+            new("placed_at", "timestamp with time zone", typeof(DateTime), TableOid, 6),
+        ];
+
+        var statuses = new[] { "shipped", "pending", "cancelled", "shipped", "paid" };
+        var names = new[]
+        {
+            "Ada Lovelace", "Grace Hopper", "Alan Turing", "Karen Spärck Jones", "Barbara Liskov",
+            "Edsger Dijkstra", "Frances Allen", "Ken Thompson", "Radia Perlman", "Leslie Lamport",
+            "Margaret Hamilton", "Donald Knuth", "Jean Bartik", "Tony Hoare", "Adele Goldberg",
+            "Vint Cerf", "Shafi Goldwasser", "Bjarne Stroustrup", "Anita Borg", "Dennis Ritchie",
+        };
+
+        var placed = new DateTime(2026, 7, 30, 9, 12, 0, DateTimeKind.Utc);
+        var rows = new List<object?[]>();
+        for (var i = 0; i < names.Length; i++)
+        {
+            rows.Add(
+            [
+                4801L + i,
+                names[i],
+                statuses[i % statuses.Length],
+                decimal.Round(18.5m + i * 37.25m, 2),
+                $$"""{"channel": "web", "coupon": {{(i % 3 == 0 ? "\"SUMMER26\"" : "null")}}}""",
+                placed.AddMinutes(-7 * i),
+            ]);
+        }
+
+        return (columns, rows);
+    }
+
+    // Any non-zero oid: it only has to be consistent across the columns for the
+    // result to look like it reads straight through from one table.
+    private const uint TableOid = 16_421;
+
+    // --- Monitoring -------------------------------------------------------
+
+    public static IReadOnlyList<BackendActivity> Backends() =>
+    [
+        new(4821, "app", "shop", "pgNimbus", "10.0.0.14", "active", null, null, 0.4, "SELECT * FROM orders WHERE placed_at > now() - interval '1 day'"),
+        new(4822, "app", "shop", "shop-api", "10.0.0.21", "active", "Lock", "transactionid", 31.7, "UPDATE orders SET status = 'shipped' WHERE id = 4821"),
+        new(4823, "app", "shop", "shop-api", "10.0.0.22", "active", "Lock", "transactionid", 12.9, "UPDATE orders SET status = 'paid' WHERE id = 4821"),
+        new(4830, "reporting", "shop", "metabase", "10.0.0.44", "active", "IO", "DataFileRead", 184.2, "SELECT day, sum(revenue) FROM daily_revenue GROUP BY day"),
+        new(4844, "app", "shop", "shop-worker", "10.0.0.31", "idle in transaction", null, null, 96.0, "BEGIN"),
+        new(4851, "postgres", "shop", "psql", null, "idle", null, null, 0.0, "SELECT 1"),
+    ];
+
+    public static IReadOnlyList<BlockingBackend> BlockingBackends() =>
+    [
+        new(4844, "app", "shop", "shop-worker", "idle in transaction", null, null, 96.0, "UPDATE orders SET status = 'paid' WHERE id = 4821", [], null, null),
+        new(4822, "app", "shop", "shop-api", "active", "Lock", "transactionid", 31.7, "UPDATE orders SET status = 'shipped' WHERE id = 4821", [4844], "orders", "RowExclusiveLock"),
+        new(4823, "app", "shop", "shop-api", "active", "Lock", "transactionid", 12.9, "UPDATE order_items SET quantity = 2 WHERE order_id = 4821", [4822], "order_items", "RowExclusiveLock"),
+    ];
+
+    public static IReadOnlyList<RelationSize> LargestRelations() =>
+    [
+        new("analytics", "sessions", RelationKind.Table, 734_003_200, 612_368_384, 121_634_816, 4_182_004),
+        new("public", "orders", RelationKind.Table, 268_435_456, 201_326_592, 67_108_864, 1_204_881),
+        new("public", "order_items", RelationKind.Table, 92_274_688, 71_303_168, 20_971_520, 3_901_223),
+        new("public", "customers", RelationKind.Table, 41_943_040, 33_554_432, 8_388_608, 184_002),
+        new("public", "products", RelationKind.Table, 12_582_912, 10_485_760, 2_097_152, 24_119),
+        new("public", "daily_revenue", RelationKind.MaterializedView, 6_291_456, 6_291_456, 0, 1_460),
+    ];
+
+    public static IReadOnlyList<TableScanUsage> TableScans() =>
+    [
+        new("public", "orders", 412, 498_120_004, 1_284_902, 4_012_884, 1_204_881, 18_402),
+        new("analytics", "sessions", 88_401, 3_910_442_881, 12_004, 41_002, 4_182_004, 902_144),
+        new("public", "order_items", 92, 8_120_004, 4_012_884, 12_884_112, 3_901_223, 4_012),
+        new("public", "customers", 1_204, 218_120_004, 902_884, 1_884_112, 184_002, 1_204),
+        new("public", "products", 8_402, 202_884, 12_884, 88_112, 24_119, 88),
+    ];
+
+    public static IReadOnlyList<UnusedIndex> UnusedIndexes() =>
+    [
+        new("public", "orders", "orders_metadata_gin_idx", 41_943_040),
+        new("analytics", "sessions", "sessions_started_at_idx", 20_971_520),
+        new("public", "customers", "customers_full_name_idx", 8_388_608),
+    ];
+}

--- a/tools/Screenshot/Fixtures/plan-analyze.json
+++ b/tools/Screenshot/Fixtures/plan-analyze.json
@@ -1,0 +1,111 @@
+[
+  {
+    "Plan": {
+      "Node Type": "Sort",
+      "Parallel Aware": false,
+      "Startup Cost": 84210.44,
+      "Total Cost": 84960.44,
+      "Plan Rows": 300000,
+      "Plan Width": 64,
+      "Actual Startup Time": 1804.221,
+      "Actual Total Time": 1912.884,
+      "Actual Rows": 412884,
+      "Actual Loops": 1,
+      "Sort Key": ["o.placed_at DESC"],
+      "Sort Method": "external merge",
+      "Sort Space Used": 41208,
+      "Sort Space Type": "Disk",
+      "Shared Hit Blocks": 18422,
+      "Shared Read Blocks": 90114,
+      "Temp Read Blocks": 5142,
+      "Temp Written Blocks": 5164,
+      "Plans": [
+        {
+          "Node Type": "Hash Join",
+          "Parent Relationship": "Outer",
+          "Parallel Aware": false,
+          "Join Type": "Inner",
+          "Startup Cost": 4210.00,
+          "Total Cost": 61204.18,
+          "Plan Rows": 300000,
+          "Plan Width": 64,
+          "Actual Startup Time": 61.402,
+          "Actual Total Time": 1502.118,
+          "Actual Rows": 412884,
+          "Actual Loops": 1,
+          "Hash Cond": "(i.order_id = o.id)",
+          "Shared Hit Blocks": 18422,
+          "Shared Read Blocks": 90114,
+          "Plans": [
+            {
+              "Node Type": "Seq Scan",
+              "Parent Relationship": "Outer",
+              "Parallel Aware": false,
+              "Relation Name": "order_items",
+              "Alias": "i",
+              "Startup Cost": 0.00,
+              "Total Cost": 42104.22,
+              "Plan Rows": 1900000,
+              "Plan Width": 32,
+              "Actual Startup Time": 0.018,
+              "Actual Total Time": 902.441,
+              "Actual Rows": 412884,
+              "Actual Loops": 1,
+              "Filter": "(quantity > 1)",
+              "Rows Removed by Filter": 3488339,
+              "Shared Hit Blocks": 4120,
+              "Shared Read Blocks": 84882
+            },
+            {
+              "Node Type": "Hash",
+              "Parent Relationship": "Inner",
+              "Parallel Aware": false,
+              "Startup Cost": 3210.00,
+              "Total Cost": 3210.00,
+              "Plan Rows": 80000,
+              "Plan Width": 40,
+              "Actual Startup Time": 58.914,
+              "Actual Total Time": 58.914,
+              "Actual Rows": 120488,
+              "Actual Loops": 1,
+              "Hash Buckets": 131072,
+              "Hash Batches": 4,
+              "Original Hash Batches": 1,
+              "Peak Memory Usage": 4128,
+              "Shared Hit Blocks": 14302,
+              "Shared Read Blocks": 5232,
+              "Plans": [
+                {
+                  "Node Type": "Index Scan",
+                  "Parent Relationship": "Outer",
+                  "Parallel Aware": false,
+                  "Scan Direction": "Forward",
+                  "Index Name": "orders_placed_at_idx",
+                  "Relation Name": "orders",
+                  "Alias": "o",
+                  "Startup Cost": 0.42,
+                  "Total Cost": 3120.44,
+                  "Plan Rows": 80000,
+                  "Plan Width": 40,
+                  "Actual Startup Time": 0.041,
+                  "Actual Total Time": 41.208,
+                  "Actual Rows": 120488,
+                  "Actual Loops": 1,
+                  "Index Cond": "(placed_at > (now() - '30 days'::interval))",
+                  "Shared Hit Blocks": 14302,
+                  "Shared Read Blocks": 5232
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Settings": {
+      "work_mem": "4MB",
+      "random_page_cost": "1.1"
+    },
+    "Planning Time": 0.884,
+    "Execution Time": 1948.402
+  }
+]

--- a/tools/Screenshot/Program.cs
+++ b/tools/Screenshot/Program.cs
@@ -1,0 +1,88 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Media.Imaging;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using PgNimbus.App;
+using PgNimbus.Screenshot;
+
+// Usage: dotnet run --project tools/Screenshot -- <outputDir> [scenario-substring]
+//
+// Renders every scenario in light and dark and writes one PNG per (scenario,
+// theme). No display, no xdotool, no Postgres — see CLAUDE.md, "Headless
+// screenshot harness".
+
+var outDir = args.Length > 0 ? args[0] : "screenshots";
+var filter = args.Length > 1 ? args[1] : null;
+Directory.CreateDirectory(outDir);
+
+BuildAvaloniaApp().SetupWithoutStarting();
+
+var scenarios = new (string Name, Func<Window> Build)[]
+{
+    ("main-window", Scenarios.Results),
+    ("main-window-empty", Scenarios.EmptyResults),
+    ("main-window-error", Scenarios.QueryError),
+    ("main-window-script", Scenarios.ScriptResult),
+    ("main-window-plan", Scenarios.QueryPlan),
+    ("main-window-plan-tree", Scenarios.QueryPlanTree),
+    ("main-window-palette", Scenarios.CommandPalette),
+    ("main-window-sidebar-filter", Scenarios.SidebarFilter),
+    ("main-window-cell-inspector", Scenarios.CellInspector),
+    ("activity-window", Scenarios.Activity),
+    ("activity-window-blocking", Scenarios.ActivityBlocking),
+    ("database-overview-window", Scenarios.DatabaseOverview),
+    ("shortcuts-window", Scenarios.Shortcuts),
+    ("preferences-window", Scenarios.Preferences),
+    ("crash-window", Scenarios.Crash),
+};
+
+var failures = 0;
+foreach (var (name, build) in scenarios)
+{
+    if (filter is not null && !name.Contains(filter, StringComparison.OrdinalIgnoreCase))
+    {
+        continue;
+    }
+
+    foreach (var theme in new[] { ThemeVariant.Light, ThemeVariant.Dark })
+    {
+        failures += Capture(name, theme, build) ? 0 : 1;
+    }
+}
+
+Console.WriteLine($"Wrote screenshots to {Path.GetFullPath(outDir)}");
+return failures == 0 ? 0 : 1;
+
+bool Capture(string name, ThemeVariant theme, Func<Window> build)
+{
+    // Set before the window is built: ActualThemeVariant resolves as the visual
+    // tree attaches, and several panels resolve theme-dependent resources then
+    // (see CLAUDE.md, UI design rule 7 — "a panel's constructor can't see
+    // app-level resources").
+    Application.Current!.RequestedThemeVariant = theme;
+
+    var window = build();
+    window.Show();
+
+    // Pump the dispatcher, force one render tick, then pump again: layout jobs
+    // posted during the first pass (measure/arrange, ItemsSource swaps) have to
+    // run before the frame is worth capturing.
+    Dispatcher.UIThread.RunJobs();
+    AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+    Dispatcher.UIThread.RunJobs();
+
+    using var frame = window.CaptureRenderedFrame();
+    var path = Path.Combine(outDir, $"{name}.{(theme == ThemeVariant.Dark ? "dark" : "light")}.png");
+    frame?.Save(path, new PngBitmapEncoderOptions());
+    window.Close();
+
+    Console.WriteLine(frame is null ? $"FAILED (no frame): {path}" : $"Wrote {path}");
+    return frame is not null;
+}
+
+static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>()
+    .UseSkia()
+    .UseHeadless(new AvaloniaHeadlessPlatformOptions { UseHeadlessDrawing = false })
+    .WithInterFont();

--- a/tools/Screenshot/Scenarios.cs
+++ b/tools/Screenshot/Scenarios.cs
@@ -1,0 +1,233 @@
+using Avalonia.Controls;
+using PgNimbus.App.ViewModels;
+using PgNimbus.App.Views;
+using PgNimbus.Core.Monitoring;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Screenshot;
+
+/// <summary>
+/// One scenario per interesting UI state. Each returns a ready-to-show
+/// <see cref="Window"/>; <c>Program</c> renders it in both themes.
+///
+/// Scenarios drive the ViewModels through the same public surface production
+/// uses (set the property, run the command) rather than poking at views, so a
+/// screenshot shows what the app would actually render — the one concession is
+/// that data arrives from <see cref="Fixtures"/> instead of a server.
+/// </summary>
+internal static class Scenarios
+{
+    private const string SampleSql = """
+        SELECT o.id,
+               c.full_name AS customer,
+               o.status,
+               o.total,
+               o.metadata,
+               o.placed_at
+          FROM orders AS o
+          JOIN customers AS c
+            ON c.id = o.customer_id
+         WHERE o.placed_at > now() - interval '30 days'
+         ORDER BY o.placed_at DESC;
+        """;
+
+    // --- Main window ------------------------------------------------------
+
+    /// <summary>The default view: schema tree, a query, and its result grid.</summary>
+    public static Window Results()
+    {
+        var vm = Fixtures.MainWindowViewModel();
+        SeedOrdersResult(vm.ActiveTab);
+        return HostMainWindow(vm);
+    }
+
+    /// <summary>A tab that has never run — the results pane's empty state.</summary>
+    public static Window EmptyResults()
+    {
+        var vm = Fixtures.MainWindowViewModel();
+        vm.ActiveTab.Sql = SampleSql;
+        return HostMainWindow(vm);
+    }
+
+    /// <summary>A failed run: the error status line and the identifier-fix offer.</summary>
+    public static Window QueryError()
+    {
+        var vm = Fixtures.MainWindowViewModel();
+        var tab = vm.ActiveTab;
+        tab.Sql = "SELECT * FROM Orders WHERE placed_at > now() - interval '30 days';";
+        tab.Status = "Error: relation \"orders\" does not exist";
+        tab.HasError = true;
+        return HostMainWindow(vm);
+    }
+
+    /// <summary>A multi-statement script: the per-statement section strip above the grid.</summary>
+    public static Window ScriptResult()
+    {
+        var vm = Fixtures.MainWindowViewModel();
+        var tab = vm.ActiveTab;
+        tab.Sql = "SET work_mem = '64MB';\n\n" + SampleSql + "\n\nUPDATE orders SET status = 'shipped' WHERE id = 4801;";
+
+        var (columns, rows) = Fixtures.OrdersResult();
+        tab.ResultSections.Add(ScriptResultViewModel.From(1, "SET work_mem = '64MB'", new CommandResult
+        {
+            Elapsed = TimeSpan.FromMilliseconds(1.2),
+            RowsAffected = 0,
+            CommandTag = "SET",
+        }));
+        tab.ResultSections.Add(ScriptResultViewModel.From(2, SampleSql, new MaterializedResultSet
+        {
+            Elapsed = TimeSpan.FromMilliseconds(18.4),
+            Columns = columns,
+            Rows = rows,
+        }));
+        tab.ResultSections.Add(ScriptResultViewModel.From(3, "UPDATE orders SET status = 'shipped' WHERE id = 4801", new CommandResult
+        {
+            Elapsed = TimeSpan.FromMilliseconds(4.1),
+            RowsAffected = 1,
+            CommandTag = "UPDATE",
+        }));
+        tab.SelectedSection = tab.ResultSections[1];
+        return HostMainWindow(vm);
+    }
+
+    /// <summary>The plan's text layout plus the warnings strip.</summary>
+    public static Window QueryPlan() => PlanWindow(asTree: false);
+
+    /// <summary>The graphical plan tree: time-heat bars, bottleneck node, metric toggle.</summary>
+    public static Window QueryPlanTree() => PlanWindow(asTree: true);
+
+    private static Window PlanWindow(bool asTree)
+    {
+        var vm = Fixtures.MainWindowViewModel();
+        var tab = vm.ActiveTab;
+        tab.Sql = SampleSql;
+
+        var plan = ExplainService.Import(File.ReadAllText(FixturePath("plan-analyze.json")));
+        tab.ShowImportedPlan(plan.Result, plan.DisplayText, plan.RawJson);
+        tab.IsPlanTextView = !asTree;
+        return HostMainWindow(vm);
+    }
+
+    /// <summary>The command palette over a populated window.</summary>
+    public static Window CommandPalette()
+    {
+        var vm = Fixtures.MainWindowViewModel();
+        SeedOrdersResult(vm.ActiveTab);
+
+        // Fire-and-forget on purpose: the palette opens synchronously with its
+        // action/saved-query entries, and the catalog fetch it then starts never
+        // completes against the offline data source (see Fixtures).
+        _ = vm.OpenCommandPaletteAsync();
+        return HostMainWindow(vm);
+    }
+
+    /// <summary>The sidebar filter narrowing the tree to matching relations.</summary>
+    public static Window SidebarFilter()
+    {
+        var vm = Fixtures.MainWindowViewModel();
+        SeedOrdersResult(vm.ActiveTab);
+        vm.SchemaTree.FilterText = "order";
+        return HostMainWindow(vm);
+    }
+
+    /// <summary>The cell inspector over a jsonb value, in read mode.</summary>
+    public static Window CellInspector()
+    {
+        var vm = Fixtures.MainWindowViewModel();
+        SeedOrdersResult(vm.ActiveTab);
+        vm.CellInspector.Open("metadata", """{"channel":"web","coupon":"SUMMER26","items":[{"sku":"NIM-1","qty":2}]}""");
+        return HostMainWindow(vm);
+    }
+
+    // --- Secondary windows ------------------------------------------------
+
+    /// <summary>Server Activity, backends tab.</summary>
+    public static Window Activity() => BuildActivityWindow(tab: 0);
+
+    /// <summary>Server Activity, who-blocks-whom tree.</summary>
+    public static Window ActivityBlocking() => BuildActivityWindow(tab: 1);
+
+    private static Window BuildActivityWindow(int tab)
+    {
+        var vm = Fixtures.MainWindowViewModel().Activity;
+        foreach (var backend in Fixtures.Backends())
+        {
+            vm.Rows.Add(new ActivityRow(backend));
+        }
+
+        foreach (var root in BlockingTree.Build(Fixtures.BlockingBackends()))
+        {
+            vm.BlockingRoots.Add(new BlockingNode(root));
+        }
+
+        vm.HasLockWaits = true;
+        vm.Status = $"{vm.Rows.Count} backends · 09:41:02";
+        vm.BlockingStatus = "2 backends waiting on locks · 09:41:02";
+        vm.AutoRefresh = false;
+        vm.SelectedTab = tab;
+        vm.SelectedRow = vm.Rows[1];
+        vm.SelectedBlockingNode = vm.BlockingRoots[0];
+
+        return new ActivityWindow { DataContext = vm, Width = 1100, Height = 700 };
+    }
+
+    /// <summary>Database Overview: sizes, cache-hit ratios, scan usage, unused indexes.</summary>
+    public static Window DatabaseOverview()
+    {
+        var vm = Fixtures.MainWindowViewModel().DatabaseOverview;
+        vm.DatabaseName = "shop";
+        vm.DatabaseSizeText = "1.2 GB";
+        vm.TableCacheHitText = "99.1 %";
+        vm.IndexCacheHitText = "99.8 %";
+
+        foreach (var relation in Fixtures.LargestRelations())
+        {
+            vm.LargestRelations.Add(new RelationSizeRow(relation));
+        }
+
+        foreach (var scan in Fixtures.TableScans())
+        {
+            vm.TableScans.Add(new TableScanRow(scan));
+        }
+
+        foreach (var index in Fixtures.UnusedIndexes())
+        {
+            vm.UnusedIndexes.Add(new UnusedIndexRow(index));
+        }
+
+        vm.Status = "6 relations · 3 unused indexes wasting 68 MB · 09:41:02";
+        return new DatabaseOverviewWindow { DataContext = vm, Width = 1100, Height = 760 };
+    }
+
+    /// <summary>The F1 keyboard cheat sheet (projected from the command catalog).</summary>
+    public static Window Shortcuts() => new ShortcutsWindow { Width = 900, Height = 760 };
+
+    /// <summary>The preferences page.</summary>
+    public static Window Preferences() =>
+        new PreferencesWindow { DataContext = new PreferencesViewModel(Fixtures.MainWindowViewModel()), Width = 720, Height = 640 };
+
+    /// <summary>The crash reporter, with a representative failure.</summary>
+    public static Window Crash() =>
+        new CrashWindow(
+            new InvalidOperationException("The connection pool has been shut down."),
+            Path.Combine("C:", "Users", "you", "AppData", "Roaming", "pgNimbus", "logs", "pgnimbus.log"))
+        {
+            Width = 720,
+            Height = 480,
+        };
+
+    // --- Helpers ----------------------------------------------------------
+
+    private static void SeedOrdersResult(QueryViewModel tab)
+    {
+        var (columns, rows) = Fixtures.OrdersResult();
+        tab.Sql = SampleSql;
+        tab.SeedResult(columns, rows, rowCountText: $"{rows.Count} rows", timingText: "18 ms · first byte 6 ms");
+    }
+
+    private static Window HostMainWindow(MainViewModel viewModel) =>
+        new MainWindow { DataContext = viewModel, Width = 1440, Height = 900 };
+
+    private static string FixturePath(string name) =>
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", name);
+}

--- a/tools/Screenshot/Screenshot.csproj
+++ b/tools/Screenshot/Screenshot.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Headless visual-verification harness (CLAUDE.md "Headless screenshot
+    harness"). Dev-only: it is not referenced by the app, ships in no package,
+    and is excluded from the NativeAOT publish. It renders the real Views bound
+    to fixture ViewModels through Avalonia.Headless + Skia and writes PNGs, so a
+    UI change can be reviewed without a display, without xdotool, and without a
+    live Postgres.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>PgNimbus.Screenshot</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <!-- The app enables the trim/AOT analyzers; this tool is never published
+         AOT, and Avalonia.Headless itself isn't annotated for it. -->
+    <IsAotCompatible>false</IsAotCompatible>
+    <NoWarn>$(NoWarn);IL2026;IL2104;IL3053</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Headless" Version="12.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../PgNimbus.App/PgNimbus.App.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Fixtures/**" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Ported from kubeNimbus. Until now the only way to actually *see* a UI change was the Xvfb + xdotool + live-Postgres path in `CLAUDE.md`: Linux only, needs a server behind it, and it depends on clicks landing where a screenshot said they would.

`tools/Screenshot` renders the real Views bound to fixture ViewModels through `Avalonia.Headless` (Skia, `UseHeadlessDrawing = false`) and writes one PNG per scenario per theme. No display, no input tool, no database.

```bash
dotnet run --project tools/Screenshot -- <outputDir> [scenario-substring]
```

15 scenarios: main window with results, its empty and error states, a script's section strip, a plan as text and as the heat tree, the command palette, the sidebar filter, the cell inspector, both activity tabs, database overview, the F1 sheet, preferences, the crash window.

### Three fixture decisions worth reviewing

- **The offline data source points at TEST-NET-3 (`203.0.113.1`), not a closed local port.** Every service takes an `NpgsqlDataSource` and `Create()` opens no socket, so the graph builds offline either way. But windows that refresh when they open (activity, overview, schema tree) get connection-refused straight back from a closed port and overwrite the seeded status line a fraction of a second after the window shows. An address that never answers leaves the seeded state alone.
- **Scenarios drive the same public ViewModel surface production drives.** Two seams exist for it: `SchemaTreeNode.SeedChildren` and `QueryViewModel.SeedResult`, both documented as harness-only. Everything else is ordinary property/command use.
- **Nothing touches the developer's real app data.** No workspace restore, no settings written; and since `MainViewModel` news up its own `SavedQueryStore`/`QueryHistoryStore`, the fixtures clear what those loaded before seeding. Without that a screenshot ships whatever is in the running developer's saved queries and history.

### CI

`ci.yml` renders the whole set on every PR and uploads it as the `screenshots` artifact. That makes the harness a smoke test too (a view that throws while loading, or renders no frame, fails the run) and gives a reviewer images instead of a diff.

### Verification

All 30 images rendered locally on Windows and read back. Full solution builds Debug + Release with no new warnings; 636 Core tests pass.

### Noticed while doing this, not fixed here

The plan **tree** renders collapsed to its root node — unlike the blocking tree, which auto-expands so the whole chain reads at a glance. Worth the same treatment, but it is a behavior change and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)