### PR TITLE
Sidebar: filter by column name, pin a Recent section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,6 +361,25 @@ and wrong project memory is worse than none.
    accent after the extraction, twice). Resolve app resources from
    `OnAttachedToVisualTree` (`ApplyTextSelectionBrush` in both panels), where
    `ActualThemeVariant` is final too.
+8. **The schema sidebar filters and pins, it doesn't just scroll.** A real
+   database runs to hundreds of relations, so the filter box and the pinned
+   Recent section are load-bearing navigation, not polish — any new sidebar
+   content has to stay filterable. The filter matches **schema names, table
+   names, and the columns of already-expanded tables** (`ApplyFilter` /
+   `TableMatches` in `SchemaTreeViewModel`), because "customer_id" is how you
+   find the tables that reference a customer, not just the one called
+   `customers`; a row that survives on a deep match expands to show why — a
+   match you can't see reads as a bug. Columns only participate once their
+   table is expanded, same lazy-load rule the rest of the tree follows.
+   The pinned **Recent** section (`RecentGroupNode`, top of the tree, max 5,
+   most recent first) is fed by `SchemaTreeViewModel.RecordRecentRelation` from
+   every route that opens a relation — tree double-click, palette jump,
+   follow-FK, Source (DDL) — so it reflects what was worked on rather than how
+   it was reached. Its children are *fresh* `TableNode` instances, not the ones
+   already in the tree: sharing instances would mean expanding a recent entry
+   also expands (and shares filter state with) the same relation's row under its
+   schema. Session-scoped and deliberately not persisted, but it does survive a
+   schema refresh — the relations are still there.
 
 ## Platform window chrome
 

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -182,6 +182,7 @@
         <StreamGeometry x:Key="TableIconGeometry">M5,4H19A2,2 0 0,1 21,6V17A2,2 0 0,1 19,19H5A2,2 0 0,1 3,17V6A2,2 0 0,1 5,4M5,8V12H11V8H5M13,8V12H19V8H13M5,14V17H11V14H5M13,14V17H19V14H13Z</StreamGeometry>
         <StreamGeometry x:Key="MagnifyIconGeometry">M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z</StreamGeometry>
         <StreamGeometry x:Key="CloseIconGeometry">M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z</StreamGeometry>
+        <StreamGeometry x:Key="HistoryIconGeometry">M13.5,8H12V13L16.28,15.54L17,14.33L13.5,12.25V8M13,3A9,9 0 0,0 4,12H1L4.96,16.03L9,12H6A7,7 0 0,1 13,5A7,7 0 0,1 20,12A7,7 0 0,1 13,19C11.07,19 9.32,18.21 8.06,16.94L6.64,18.36C8.27,20 10.5,21 13,21A9,9 0 0,0 22,12A9,9 0 0,0 13,3Z</StreamGeometry>
         <StreamGeometry x:Key="RefreshIconGeometry">M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0 0,1 6,12A6,6 0 0,1 12,6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z</StreamGeometry>
         <!-- Transaction control (Begin/Commit/Rollback) + paging, as vectors so they
              align on the same 12px box as the other command-bar PathIcons instead

--- a/PgNimbus.App/ViewModels/CatalogNodes.cs
+++ b/PgNimbus.App/ViewModels/CatalogNodes.cs
@@ -2,6 +2,44 @@ using PgNimbus.Core.Schema;
 
 namespace PgNimbus.App.ViewModels;
 
+/// <summary>
+/// The pinned "Recent" group at the top of the sidebar: the relations most
+/// recently opened, newest first. A database with hundreds of relations has the
+/// same navigation problem a long list of anything does — you work with three
+/// tables at a time and re-find them in the tree over and over.
+///
+/// Its children are <em>fresh</em> <see cref="TableNode"/> instances rather than
+/// the ones already in the tree, so expanding a recent entry doesn't also expand
+/// (or share filter state with) the relation's row under its schema. Cost is one
+/// column query per expanded entry, which is what a first expand costs anywhere
+/// else in the tree.
+/// </summary>
+public sealed class RecentGroupNode : SchemaTreeNode
+{
+    private readonly SchemaService _schemaService;
+    private readonly Func<IReadOnlyList<RelationInfo>> _recent;
+    private readonly Func<bool> _showAdvanced;
+
+    public RecentGroupNode(SchemaService schemaService, Func<IReadOnlyList<RelationInfo>> recent, Func<bool> showAdvanced)
+    {
+        _schemaService = schemaService;
+        _recent = recent;
+        _showAdvanced = showAdvanced;
+        Name = "Recent";
+        MarkExpandable();
+    }
+
+    // No size hint on a recent entry: sizes ride along with a schema's table
+    // list (GetTablesAsync), and a recent entry is rebuilt from just the
+    // relation's identity. TableNode renders no hint for a null size, which is
+    // the same thing it does for a view.
+    protected override Task<IReadOnlyList<SchemaTreeNode>> FetchChildrenAsync() =>
+        Task.FromResult<IReadOnlyList<SchemaTreeNode>>(_recent()
+            .Select(r => (SchemaTreeNode)new TableNode(
+                _schemaService, r.Schema, r.Name, r.Kind, totalBytes: null, showSizes: null, showAdvanced: _showAdvanced))
+            .ToList());
+}
+
 /// <summary>"Functions" group under each schema — lazily lists that schema's functions/procedures/aggregates.</summary>
 public sealed class FunctionsGroupNode : SchemaTreeNode
 {

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -579,6 +579,8 @@ public sealed partial class MainViewModel : ObservableObject
     /// </summary>
     public async Task ShowSourceAsync(TableNode table)
     {
+        SchemaTree.RecordRecentRelation(table.Schema, table.Name, table.Kind);
+
         var ddl = await _ddlService.GenerateAsync(table.Schema, table.Name, CancellationToken.None);
 
         var tab = NewTab();
@@ -697,10 +699,15 @@ public sealed partial class MainViewModel : ObservableObject
         }
     }
 
-    public Task PreviewTableAsync(TableNode table) => PreviewTableAsync(table.Schema, table.Name);
+    public Task PreviewTableAsync(TableNode table) => PreviewTableAsync(table.Schema, table.Name, kind: table.Kind);
 
-    public async Task PreviewTableAsync(string schema, string name, string? initialFilter = null)
+    public async Task PreviewTableAsync(string schema, string name, string? initialFilter = null, RelationKind kind = RelationKind.Table)
     {
+        // Every route to browsing a relation funnels through here (tree
+        // double-click, palette jump, follow-FK), which makes it the one place
+        // the sidebar's Recent section needs to hear about.
+        SchemaTree.RecordRecentRelation(schema, name, kind);
+
         // Opens in a new tab rather than the active one - see the "loading a
         // query never overwrites the active tab" rule (CLAUDE.md).
         var tab = NewTab();
@@ -805,7 +812,7 @@ public sealed partial class MainViewModel : ObservableObject
             $"{r.Schema}.{r.Name}",
             "Table",
             GlyphFor(r.Kind),
-            () => PreviewTableAsync(r.Schema, r.Name)));
+            () => PreviewTableAsync(r.Schema, r.Name, kind: r.Kind)));
 
     private static string GlyphFor(RelationKind kind) => kind switch
     {

--- a/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
@@ -67,6 +67,76 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
 
     public ObservableCollection<SchemaTreeNode> Schemas { get; } = [];
 
+    // --- Recent relations -------------------------------------------------
+
+    /// <summary>How many entries the pinned Recent section holds — enough for the handful of relations a task actually involves, short enough to stay scannable above the tree.</summary>
+    private const int MaxRecent = 5;
+
+    private readonly List<RelationInfo> _recent = [];
+
+    private RecentGroupNode? _recentGroup;
+
+    /// <summary>
+    /// Records a relation as recently opened, floating it to the top of the
+    /// pinned Recent section (see <see cref="RecentGroupNode"/>). Called from the
+    /// host for every route that opens one — the tree's double-click, the palette's
+    /// table jump, follow-FK, "Source (DDL)" — so Recent reflects what was worked
+    /// on rather than how it was reached.
+    ///
+    /// Session-scoped by design: it is not persisted, and a schema refresh keeps it
+    /// (the relations are still there). Re-recording an entry already at the top is
+    /// a no-op, so re-opening the same table doesn't churn the list.
+    /// </summary>
+    public void RecordRecentRelation(string schema, string name, RelationKind kind)
+    {
+        var entry = new RelationInfo(schema, name, kind);
+        if (_recent.Count > 0 && _recent[0] == entry)
+        {
+            return;
+        }
+
+        _recent.RemoveAll(r => r.Schema == schema && r.Name == name);
+        _recent.Insert(0, entry);
+        if (_recent.Count > MaxRecent)
+        {
+            _recent.RemoveRange(MaxRecent, _recent.Count - MaxRecent);
+        }
+
+        SyncRecentSection();
+    }
+
+    /// <summary>
+    /// Keeps the pinned Recent node in step with <see cref="_recent"/>: present and
+    /// expanded at the top of the tree once anything has been opened, absent before
+    /// that (an empty section is pure noise). The node rebuilds its own children,
+    /// so the same instance survives a refresh with its expansion state intact.
+    /// </summary>
+    private void SyncRecentSection()
+    {
+        if (_recent.Count == 0)
+        {
+            return;
+        }
+
+        if (_recentGroup is null)
+        {
+            _recentGroup = new RecentGroupNode(_schemaService, () => _recent, () => ShowAdvancedObjects);
+            _recentGroup.IsExpanded = true;
+        }
+
+        if (Schemas.Count == 0 || Schemas[0] != _recentGroup)
+        {
+            Schemas.Remove(_recentGroup);
+            Schemas.Insert(0, _recentGroup);
+        }
+
+        // Fire-and-forget like every other node refresh in this tree: the group
+        // builds its children from the in-memory list, so there is nothing to
+        // await and nothing that can fail.
+        _ = _recentGroup.RefreshAsync();
+        ApplyFilter();
+    }
+
     // --- Host-supplied actions --------------------------------------------
     // The schema tree's context-menu / double-click / refresh actions are
     // window-level orchestration — opening query and browse tabs, refreshing
@@ -167,8 +237,12 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
     /// <summary>
     /// Walks the loaded tree and toggles <see cref="SchemaTreeNode.IsFilteredIn"/> so a schema shows when its
     /// own name matches (all its tables stay visible) or when any loaded table matches (only the matches show,
-    /// and the schema auto-expands to reveal them). An empty filter reveals everything. Only schema and table
-    /// names participate; unloaded (lazily-expandable) tables can't be matched until their schema is expanded.
+    /// and the schema auto-expands to reveal them). An empty filter reveals everything.
+    ///
+    /// A table matches on its own name <em>or</em> on any of its loaded column names, so "customer_id" finds
+    /// the tables that reference a customer rather than only the table called customers — a table that
+    /// survives on a column match expands to show why. Unloaded (lazily-expandable) nodes can't be matched
+    /// until they're expanded, which applies to schemas and to a table's columns alike.
     /// </summary>
     private void ApplyFilter()
     {
@@ -190,6 +264,23 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
 
         foreach (var node in Schemas)
         {
+            // The pinned Recent group holds tables, so it filters like a schema
+            // does - except its own name ("Recent") is chrome, not something to
+            // match on, and an empty Recent section under a filter is noise.
+            if (node is RecentGroupNode recent)
+            {
+                var anyRecentMatches = false;
+                foreach (var child in recent.Children)
+                {
+                    var matches = child is TableNode table && TableMatches(table, query);
+                    child.IsFilteredIn = matches || child is not TableNode;
+                    anyRecentMatches |= matches;
+                }
+
+                recent.IsFilteredIn = anyRecentMatches;
+                continue;
+            }
+
             // The root-level Extensions/Roles groups aren't schemas and their
             // children aren't tables, so a schema/table-name filter has nothing
             // to say about them - keep them in rather than hiding them outright.
@@ -209,11 +300,11 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
 
             foreach (var child in schema.Children)
             {
-                // Only real tables are matched by name. Sub-groups (Functions)
-                // and placeholder/error rows aren't tables and have no name to
+                // Only real tables are matched. Sub-groups (Functions) and
+                // placeholder/error rows aren't tables and have no name to
                 // match, so they ride the schema's own visibility instead of
                 // being filtered out.
-                var tableMatches = child is TableNode && Contains(child.Name, query);
+                var tableMatches = child is TableNode table && TableMatches(table, query);
                 child.IsFilteredIn = schemaMatches || tableMatches || child is not TableNode;
                 anyTableMatches |= tableMatches;
             }
@@ -226,6 +317,28 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
                 schema.IsExpanded = true;
             }
         }
+    }
+
+    /// <summary>
+    /// A table matches on its own name, or on one of its already-loaded column
+    /// names — expanding it in that case, since a row that matched on something
+    /// invisible reads as a bug. Columns load on first expand, so an unexpanded
+    /// table can only ever match by name.
+    /// </summary>
+    private static bool TableMatches(TableNode table, string query)
+    {
+        if (Contains(table.Name, query))
+        {
+            return true;
+        }
+
+        if (!table.Children.Any(c => c is ColumnNode column && Contains(column.Name, query)))
+        {
+            return false;
+        }
+
+        table.IsExpanded = true;
+        return true;
     }
 
     private static bool Contains(string haystack, string needle) =>
@@ -254,6 +367,11 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
             }
 
             Schemas.Add(new RolesGroupNode(_schemaService));
+
+            // Recent survives a refresh — the relations are still there, and
+            // losing the section on every catalog reload would defeat it. The
+            // node is re-inserted at the top and rebuilds its own children.
+            SyncRecentSection();
 
             // A fresh catalog invalidates any prior filter pass; re-apply so a lingering query still holds.
             ApplyFilter();

--- a/PgNimbus.App/Views/SchemaTreePanel.axaml
+++ b/PgNimbus.App/Views/SchemaTreePanel.axaml
@@ -12,6 +12,12 @@
          and context-menu Click handlers live in the code-behind and resolve their
          actions through this sub-ViewModel's host-supplied callbacks. -->
     <UserControl.DataTemplates>
+        <DataTemplate DataType="vm:RecentGroupNode">
+            <StackPanel Orientation="Horizontal" Spacing="6">
+                <PathIcon Data="{StaticResource HistoryIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" Opacity="0.8" />
+                <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
+            </StackPanel>
+        </DataTemplate>
         <DataTemplate DataType="vm:SchemaNode">
             <StackPanel Orientation="Horizontal" Spacing="6">
                 <PathIcon Data="{StaticResource DatabaseIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
@@ -193,9 +199,10 @@
                           ToolTip.Tip="Also show functions, sequences, types, indexes, triggers and extensions">
                 <PathIcon Data="{StaticResource TuneIconGeometry}" Width="14" Height="14" />
             </ToggleButton>
-            <!-- Type-to-filter box: matches schema and loaded-table names, case-insensitive substring -->
+            <!-- Type-to-filter box: case-insensitive substring over schema names,
+                 table names, and the columns of already-expanded tables -->
             <TextBox FontSize="12"
-                     PlaceholderText="Filter schemas &amp; tables…"
+                     PlaceholderText="Filter schemas, tables &amp; columns…"
                      Text="{Binding FilterText, Mode=TwoWay}">
                 <TextBox.InnerLeftContent>
                     <PathIcon Data="{StaticResource MagnifyIconGeometry}" Width="13" Height="13"

--- a/tools/Screenshot/Program.cs
+++ b/tools/Screenshot/Program.cs
@@ -29,6 +29,8 @@ var scenarios = new (string Name, Func<Window> Build)[]
     ("main-window-plan-tree", Scenarios.QueryPlanTree),
     ("main-window-palette", Scenarios.CommandPalette),
     ("main-window-sidebar-filter", Scenarios.SidebarFilter),
+    ("main-window-sidebar-column-filter", Scenarios.SidebarColumnFilter),
+    ("main-window-sidebar-recent", Scenarios.SidebarRecent),
     ("main-window-cell-inspector", Scenarios.CellInspector),
     ("activity-window", Scenarios.Activity),
     ("activity-window-blocking", Scenarios.ActivityBlocking),

--- a/tools/Screenshot/Scenarios.cs
+++ b/tools/Screenshot/Scenarios.cs
@@ -3,6 +3,7 @@ using PgNimbus.App.ViewModels;
 using PgNimbus.App.Views;
 using PgNimbus.Core.Monitoring;
 using PgNimbus.Core.Query;
+using PgNimbus.Core.Schema;
 
 namespace PgNimbus.Screenshot;
 
@@ -127,6 +128,38 @@ internal static class Scenarios
         var vm = Fixtures.MainWindowViewModel();
         SeedOrdersResult(vm.ActiveTab);
         vm.SchemaTree.FilterText = "order";
+        return HostMainWindow(vm);
+    }
+
+    /// <summary>The pinned Recent section, after a few relations have been opened.</summary>
+    public static Window SidebarRecent()
+    {
+        var vm = Fixtures.MainWindowViewModel();
+        SeedOrdersResult(vm.ActiveTab);
+
+        // Oldest first — the section floats the most recent to the top.
+        vm.SchemaTree.RecordRecentRelation("public", "products", RelationKind.Table);
+        vm.SchemaTree.RecordRecentRelation("analytics", "sessions", RelationKind.Table);
+        vm.SchemaTree.RecordRecentRelation("public", "customers", RelationKind.Table);
+        vm.SchemaTree.RecordRecentRelation("public", "orders", RelationKind.Table);
+        return HostMainWindow(vm);
+    }
+
+    /// <summary>The filter matching a column name rather than a table name.</summary>
+    public static Window SidebarColumnFilter()
+    {
+        var vm = Fixtures.MainWindowViewModel();
+        SeedOrdersResult(vm.ActiveTab);
+
+        // Columns only participate once a table has been expanded, so expand the
+        // ones this filter is meant to find — the same state a user reaches by
+        // opening a table in the tree.
+        foreach (var table in vm.SchemaTree.Schemas.SelectMany(s => s.Children).OfType<TableNode>())
+        {
+            table.IsExpanded = true;
+        }
+
+        vm.SchemaTree.FilterText = "customer_id";
         return HostMainWindow(vm);
     }
 


### PR DESCRIPTION
Stacked on #174 (the screenshot harness) so the change could be verified visually — retarget to `main` once that merges.

Both halves are ported from kubeNimbus's sidebar navigation pass, where a catalog of 100+ kinds made the gaps obvious. A database with hundreds of relations has them just as badly.

### Filter matches column names

`ApplyFilter`/`TableMatches` now match the columns of already-expanded tables, not just schema and table names, so `customer_id` finds the tables that *reference* a customer rather than only the one called `customers`. A table that survives on a column match expands itself — a row that matched on something invisible reads as a bug. Columns only participate once their table is expanded, which is the same lazy rule the rest of the tree follows; the placeholder text now says so ("Filter schemas, tables & columns…").

### Pinned Recent section

`RecentGroupNode` sits at the top of the tree and holds the five most recently opened relations, newest first. It is fed by `SchemaTreeViewModel.RecordRecentRelation` from the one place every browse route funnels through (`PreviewTableAsync` — tree double-click, palette jump, follow-FK) plus Source (DDL), so it reflects what was worked on rather than how it was reached.

Two decisions worth a look:

- **Fresh `TableNode` instances, not the ones already in the tree.** Sharing instances would mean expanding a recent entry also expands the same relation's row under its schema, and shares its `IsFilteredIn` state. The cost is one column query on first expand, which is what a first expand costs anywhere else.
- **Session-scoped, not persisted — but it survives a schema refresh.** The relations are still there after a reload, and losing the section on every refresh would defeat it. Persisting across restarts would need a settings schema change and is deliberately not done.

Under an active filter the section filters like a schema does, and hides entirely when nothing in it matches (an empty Recent group is pure noise).

### Verification

Two new harness scenarios, `main-window-sidebar-recent` and `main-window-sidebar-column-filter`, rendered and read back in both themes. Solution builds clean; 636 Core tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)