### PR TITLE
Activity: chart the trend behind the counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,24 @@ and wrong project memory is worse than none.
    recursion). The tree's nodes auto-expand so the whole wait chain shows at a
    glance and survives the 2s auto-refresh rebuild; cancel/terminate on the
    Blocking tab target the *selected* node's pid (aim at the root holder to
-   release everyone beneath it).
+   release everyone beneath it). The window's status bar carries a **trend**
+   (2026-07): a single count can't tell a spike from the steady state, and
+   `pg_stat_activity` keeps no history to ask. `Monitoring/ActivityHistory` (Core,
+   unit-tested, a read-only sibling of `BlockingTree`) is a fixed-capacity ring of
+   `ActivitySample`s — 150 samples, 5 minutes at the 2s cadence — **bounded and
+   never persisted** by design; long-range server metrics are Prometheus's job, so
+   don't grow it into a store. Three rules it exists to enforce: a *failed* poll
+   records a **gap, not a zero** (a server that stopped answering must not draw
+   like a server that went quiet, and `Sparkline` breaks its line across nulls);
+   `Series` hands back a **fresh array** per poll, since a ring mutated in place
+   raises no change notification; and both overlaid series share one scale
+   (`ActivityViewModel.TrendPeak` → `Sparkline.MinimumScale`), or two lock waiters
+   would draw as tall as forty active backends. `Controls/Sparkline.cs` is a
+   hand-rolled `Control` (area + polyline straight into a `DrawingContext`) for the
+   same reason kubeNimbus's is: the Avalonia charting packages bring
+   reflection-based binding and theming, which the NativeAOT shipping build can't
+   accept. The trend stays hidden until the second sample — a one-point chart says
+   nothing a number doesn't (UI rule 1).
 4. **No passwords on `ConnectionProfile`.** Passwords come from
    `ICredentialStore` (DPAPI on Windows via `WindowsDpapiCredentialStore`, a
    permission-restricted file fallback elsewhere via

--- a/PgNimbus.App/Controls/Sparkline.cs
+++ b/PgNimbus.App/Controls/Sparkline.cs
@@ -1,0 +1,164 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+
+namespace PgNimbus.App.Controls;
+
+/// <summary>
+/// A tiny line-plus-area chart for a bounded series of samples — enough to tell
+/// a spike from a steady state, which a single number never can.
+///
+/// Hand-rolled on purpose: the Avalonia charting packages bring reflection-based
+/// binding and theming with them, which the NativeAOT publish (the shipping
+/// build) can't accept. This draws straight into a <see cref="DrawingContext"/>,
+/// so there is no reflection and no template to resolve.
+///
+/// <see cref="Values"/> is nullable per point and a <c>null</c> is a <b>gap, not
+/// a zero</b>: the line breaks across it. A server that stopped answering must
+/// not draw the same shape as a server that went quiet.
+/// </summary>
+public sealed class Sparkline : Control
+{
+    /// <summary>Headroom above the series peak, so the tallest point isn't flush against the top edge.</summary>
+    private const double Headroom = 0.12;
+
+    public static readonly StyledProperty<IReadOnlyList<double?>?> ValuesProperty =
+        AvaloniaProperty.Register<Sparkline, IReadOnlyList<double?>?>(nameof(Values));
+
+    public static readonly StyledProperty<IBrush?> StrokeProperty =
+        AvaloniaProperty.Register<Sparkline, IBrush?>(nameof(Stroke));
+
+    public static readonly StyledProperty<double> StrokeThicknessProperty =
+        AvaloniaProperty.Register<Sparkline, double>(nameof(StrokeThickness), 1.25);
+
+    /// <summary>
+    /// The floor the vertical scale is measured against, so a series that never
+    /// exceeds it stays visually flat instead of amplifying noise into a
+    /// mountain range (1 backend vs 2 is not a spike).
+    /// </summary>
+    public static readonly StyledProperty<double> MinimumScaleProperty =
+        AvaloniaProperty.Register<Sparkline, double>(nameof(MinimumScale), 1);
+
+    static Sparkline()
+    {
+        AffectsRender<Sparkline>(ValuesProperty, StrokeProperty, StrokeThicknessProperty, MinimumScaleProperty);
+    }
+
+    public IReadOnlyList<double?>? Values
+    {
+        get => GetValue(ValuesProperty);
+        set => SetValue(ValuesProperty, value);
+    }
+
+    public IBrush? Stroke
+    {
+        get => GetValue(StrokeProperty);
+        set => SetValue(StrokeProperty, value);
+    }
+
+    public double StrokeThickness
+    {
+        get => GetValue(StrokeThicknessProperty);
+        set => SetValue(StrokeThicknessProperty, value);
+    }
+
+    public double MinimumScale
+    {
+        get => GetValue(MinimumScaleProperty);
+        set => SetValue(MinimumScaleProperty, value);
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        var values = Values;
+        if (values is null || values.Count == 0 || Stroke is not { } stroke)
+        {
+            return;
+        }
+
+        var width = Bounds.Width;
+        var height = Bounds.Height;
+        if (width <= 0 || height <= 0)
+        {
+            return;
+        }
+
+        var peak = Math.Max(MinimumScale, values.Max(v => v ?? 0)) * (1 + Headroom);
+        var pen = new Pen(stroke, StrokeThickness, lineCap: PenLineCap.Round, lineJoin: PenLineJoin.Round);
+
+        // The area under the line reads as volume without competing with the
+        // line itself, so it's the same brush at a low opacity rather than a
+        // second themed resource to keep in step.
+        var fill = new ImmutableSolidColorBrush(
+            (stroke as ISolidColorBrush)?.Color ?? Colors.Gray,
+            opacity: 0.18);
+
+        // A single point has no width to span, so treat the series as if it
+        // started one step to the left rather than dividing by zero.
+        var step = values.Count > 1 ? width / (values.Count - 1) : width;
+
+        // One geometry per run of consecutive readings: a gap ends the current
+        // run and the next reading starts a new one, so the line never bridges
+        // a period nothing was measured.
+        var run = new List<Point>();
+        for (var i = 0; i <= values.Count; i++)
+        {
+            var value = i < values.Count ? values[i] : null;
+            if (value is { } v)
+            {
+                var y = height - Math.Clamp(v / peak, 0, 1) * height;
+                run.Add(new Point(i * step, y));
+                continue;
+            }
+
+            DrawRun(context, run, pen, fill, height);
+            run.Clear();
+        }
+    }
+
+    private static void DrawRun(DrawingContext context, List<Point> run, Pen pen, IBrush fill, double height)
+    {
+        if (run.Count == 0)
+        {
+            return;
+        }
+
+        // A lone reading between two gaps has no line to draw — a dot keeps it
+        // visible rather than silently dropping the only thing measured.
+        if (run.Count == 1)
+        {
+            context.DrawEllipse(pen.Brush, null, run[0], pen.Thickness, pen.Thickness);
+            return;
+        }
+
+        var area = new StreamGeometry();
+        using (var ctx = area.Open())
+        {
+            ctx.BeginFigure(new Point(run[0].X, height), isFilled: true);
+            foreach (var point in run)
+            {
+                ctx.LineTo(point);
+            }
+
+            ctx.LineTo(new Point(run[^1].X, height));
+            ctx.EndFigure(isClosed: true);
+        }
+
+        context.DrawGeometry(fill, null, area);
+
+        var line = new StreamGeometry();
+        using (var ctx = line.Open())
+        {
+            ctx.BeginFigure(run[0], isFilled: false);
+            for (var i = 1; i < run.Count; i++)
+            {
+                ctx.LineTo(run[i]);
+            }
+
+            ctx.EndFigure(isClosed: false);
+        }
+
+        context.DrawGeometry(null, pen, line);
+    }
+}

--- a/PgNimbus.App/ViewModels/ActivityViewModel.cs
+++ b/PgNimbus.App/ViewModels/ActivityViewModel.cs
@@ -180,9 +180,88 @@ public sealed partial class ActivityViewModel : ObservableObject
     /// <summary>Roots of the blocking forest — the lock holders to cancel to unstick everyone below.</summary>
     public ObservableCollection<BlockingNode> BlockingRoots { get; } = [];
 
-    public ActivityViewModel(ActivityService service)
+    // --- Trend ------------------------------------------------------------
+
+    private readonly ActivityHistory _history;
+
+    /// <summary>
+    /// Busy backends per poll, oldest first — the sparkline's main series.
+    /// Active rather than total, because a pool full of idle connections is the
+    /// steady state everywhere and its line would never move. Replaced with a
+    /// fresh array each refresh (see <see cref="ActivityHistory.Series"/>).
+    /// </summary>
+    [ObservableProperty]
+    private IReadOnlyList<double?> _activeSeries = [];
+
+    /// <summary>Backends waiting on a lock per poll, drawn over the active line — the shape you open this window to find.</summary>
+    [ObservableProperty]
+    private IReadOnlyList<double?> _lockWaitSeries = [];
+
+    /// <summary>
+    /// The peak across both series, which both sparklines are scaled to. Without
+    /// a shared denominator each would auto-scale to its own maximum and two
+    /// lock waiters would draw as tall as forty active backends — the overlay
+    /// would be a lie.
+    /// </summary>
+    [ObservableProperty]
+    private double _trendPeak = 1;
+
+    /// <summary>
+    /// True once there is more than one sample to draw. A one-point chart says
+    /// nothing a number doesn't, so the trend stays hidden until the second poll
+    /// rather than showing an empty frame (UI rule 1 — nothing always-visible
+    /// that isn't earning its space).
+    /// </summary>
+    public bool HasTrend => _history.Count > 1;
+
+    /// <summary>The window the sparkline covers, e.g. "last 2 min" — a chart with no time span is unreadable.</summary>
+    public string TrendLabel
+    {
+        get
+        {
+            var samples = _history.Samples();
+            if (samples.Count < 2)
+            {
+                return "";
+            }
+
+            var span = samples[^1].At - samples[0].At;
+            return span.TotalMinutes >= 1
+                ? $"last {span.TotalMinutes:F0} min"
+                : $"last {span.TotalSeconds:F0}s";
+        }
+    }
+
+    /// <summary>
+    /// <paramref name="history"/> is the trend window this view fills as it
+    /// polls; it is a parameter rather than a field initializer so a caller can
+    /// hand in a pre-filled one (the screenshot harness does).
+    /// </summary>
+    public ActivityViewModel(ActivityService service, ActivityHistory? history = null)
     {
         _service = service;
+        _history = history ?? new ActivityHistory();
+        PublishTrend();
+    }
+
+    /// <summary>
+    /// Folds this poll into the trend window. A failed poll records a gap rather
+    /// than zeros — see <see cref="ActivitySample"/> — so a server that stopped
+    /// answering doesn't draw like a server that went quiet.
+    /// </summary>
+    private void RecordTrend(int? backends, int? active, int? waiting)
+    {
+        _history.Record(new ActivitySample(DateTimeOffset.Now, backends, active, waiting));
+        PublishTrend();
+    }
+
+    private void PublishTrend()
+    {
+        ActiveSeries = _history.Series(s => s.Active);
+        LockWaitSeries = _history.Series(s => s.WaitingOnLock);
+        TrendPeak = Math.Max(1, ActiveSeries.Concat(LockWaitSeries).Select(v => v ?? 0).DefaultIfEmpty(0).Max());
+        OnPropertyChanged(nameof(HasTrend));
+        OnPropertyChanged(nameof(TrendLabel));
     }
 
     [RelayCommand]
@@ -213,12 +292,15 @@ public sealed partial class ActivityViewModel : ObservableObject
             SelectedRow = selectedPid is { } pid ? Rows.FirstOrDefault(r => r.Pid == pid) : null;
 
             var locks = Rows.Count(r => r.IsWaitingOnLock);
+            RecordTrend(Rows.Count, Rows.Count(r => r.State == "active"), locks);
             Status = $"{Rows.Count} backend{(Rows.Count == 1 ? "" : "s")}"
                 + (locks > 0 ? $" · {locks} waiting on locks" : "")
                 + $" · {DateTime.Now:HH:mm:ss}";
         }
         catch (Exception ex)
         {
+            // A poll that failed is a hole in the trend, not a quiet server.
+            RecordTrend(null, null, null);
             Status = ex.Message;
         }
     }

--- a/PgNimbus.App/Views/ActivityWindow.axaml
+++ b/PgNimbus.App/Views/ActivityWindow.axaml
@@ -1,6 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:PgNimbus.App.ViewModels"
+        xmlns:controls="using:PgNimbus.App.Controls"
         x:Class="PgNimbus.App.Views.ActivityWindow"
         x:DataType="vm:ActivityViewModel"
         Title="pgNimbus — Server Activity"
@@ -162,7 +163,25 @@
         <!-- One status strip flush along the window's bottom edge, showing the
              visible tab's line — not a floating caption per tab. -->
         <Border Grid.Row="1" Classes="statusBar" Margin="0,12,0,0">
-            <TextBlock Classes="statusText dim" Text="{Binding ActiveStatus}" />
+            <DockPanel>
+                <!-- The trend for the session so far: active backends, with lock
+                     waiters drawn over them in warning amber. A single count
+                     can't tell a spike from the steady state, and pg_stat_activity
+                     has no history of its own to ask. Hidden until there are two
+                     samples to join — a one-point chart says nothing. -->
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="8"
+                            VerticalAlignment="Center" IsVisible="{Binding HasTrend}"
+                            ToolTip.Tip="Active backends over this session, with lock waits in amber. Not persisted — pg_stat_activity keeps no history.">
+                    <TextBlock Classes="statusText dim" Text="{Binding TrendLabel}" VerticalAlignment="Center" />
+                    <Panel Width="110" Height="18" VerticalAlignment="Center">
+                        <controls:Sparkline Values="{Binding ActiveSeries}" MinimumScale="{Binding TrendPeak}"
+                                            Stroke="{DynamicResource AppAccentBrush}" />
+                        <controls:Sparkline Values="{Binding LockWaitSeries}" MinimumScale="{Binding TrendPeak}"
+                                            Stroke="{DynamicResource AppWarningBrush}" />
+                    </Panel>
+                </StackPanel>
+                <TextBlock Classes="statusText dim" Text="{Binding ActiveStatus}" VerticalAlignment="Center" />
+            </DockPanel>
         </Border>
 
     </Grid>

--- a/PgNimbus.Core.Tests/Monitoring/ActivityHistoryTests.cs
+++ b/PgNimbus.Core.Tests/Monitoring/ActivityHistoryTests.cs
@@ -1,0 +1,97 @@
+using PgNimbus.Core.Monitoring;
+
+namespace PgNimbus.Core.Tests.Monitoring;
+
+public class ActivityHistoryTests
+{
+    private static readonly DateTimeOffset T0 = new(2026, 7, 30, 9, 41, 0, TimeSpan.Zero);
+
+    private static ActivitySample Sample(int i) =>
+        new(T0.AddSeconds(2 * i), Backends: 10 + i, Active: i, WaitingOnLock: i % 3);
+
+    [Test]
+    public async Task EmptyHistoryHasNoSamples()
+    {
+        var history = new ActivityHistory();
+
+        await Assert.That(history.Count).IsEqualTo(0);
+        await Assert.That(history.Samples()).IsEmpty();
+        await Assert.That(history.Series(s => s.Active)).IsEmpty();
+    }
+
+    [Test]
+    public async Task SamplesComeBackOldestFirst()
+    {
+        var history = new ActivityHistory(capacity: 5);
+        for (var i = 0; i < 3; i++)
+        {
+            history.Record(Sample(i));
+        }
+
+        await Assert.That(history.Series(s => s.Active)).IsEquivalentTo(new double?[] { 0, 1, 2 });
+    }
+
+    [Test]
+    public async Task WrapAroundKeepsTheNewestWindowInOrder()
+    {
+        // The wrap is where a ring buffer usually starts drawing a plausible but
+        // wrong chart, so pin it: seven samples through a five-slot window must
+        // leave 2..6, in that order.
+        var history = new ActivityHistory(capacity: 5);
+        for (var i = 0; i < 7; i++)
+        {
+            history.Record(Sample(i));
+        }
+
+        await Assert.That(history.Count).IsEqualTo(5);
+        await Assert.That(history.Series(s => s.Active)).IsEquivalentTo(new double?[] { 2, 3, 4, 5, 6 });
+        await Assert.That(history.Samples()[0].At).IsEqualTo(T0.AddSeconds(4));
+        await Assert.That(history.Samples()[4].At).IsEqualTo(T0.AddSeconds(12));
+    }
+
+    [Test]
+    public async Task NeverGrowsPastCapacity()
+    {
+        var history = new ActivityHistory(capacity: 4);
+        for (var i = 0; i < 50; i++)
+        {
+            history.Record(Sample(i));
+        }
+
+        await Assert.That(history.Count).IsEqualTo(4);
+        await Assert.That(history.Samples()).HasCount(4);
+    }
+
+    [Test]
+    public async Task AFailedPollIsAGapNotAZero()
+    {
+        // A server that stopped answering must not draw the same shape as a
+        // server that went idle — the chart breaks its line across nulls.
+        var history = new ActivityHistory(capacity: 5);
+        history.Record(Sample(0));
+        history.RecordGap(T0.AddSeconds(2));
+        history.Record(Sample(2));
+
+        var series = history.Series(s => s.Active);
+        await Assert.That(series).IsEquivalentTo(new double?[] { 0, null, 2 });
+        await Assert.That(history.Samples()[1].Backends).IsNull();
+        await Assert.That(history.Samples()[1].At).IsEqualTo(T0.AddSeconds(2));
+    }
+
+    [Test]
+    public async Task SeriesReturnsAFreshArrayEachCall()
+    {
+        // The view rebinds to a new instance per poll; handing back the same
+        // buffer would mean a mutation nothing notices.
+        var history = new ActivityHistory(capacity: 3);
+        history.Record(Sample(0));
+
+        await Assert.That(history.Series(s => s.Active)).IsNotSameReferenceAs(history.Series(s => s.Active));
+    }
+
+    [Test]
+    public async Task CapacityMustBePositive()
+    {
+        await Assert.That(() => new ActivityHistory(capacity: 0)).Throws<ArgumentOutOfRangeException>();
+    }
+}

--- a/PgNimbus.Core/Monitoring/ActivityHistory.cs
+++ b/PgNimbus.Core/Monitoring/ActivityHistory.cs
@@ -1,0 +1,84 @@
+namespace PgNimbus.Core.Monitoring;
+
+/// <summary>
+/// One polled snapshot of how busy the server is. Every count is nullable
+/// because a <em>failed</em> poll has to be recorded as a gap rather than as
+/// zero: a server that stopped answering must not draw the same shape as a
+/// server that went quiet.
+/// </summary>
+public sealed record ActivitySample(DateTimeOffset At, int? Backends, int? Active, int? WaitingOnLock)
+{
+    /// <summary>A poll that produced no reading (the query failed, the connection dropped).</summary>
+    public static ActivitySample Gap(DateTimeOffset at) => new(at, null, null, null);
+}
+
+/// <summary>
+/// A bounded, session-only window of <see cref="ActivitySample"/>s — what turns
+/// the activity view's point-in-time counts into a trend you can read a spike
+/// off. It lives in Core because it is engine state with no UI dependency (a CLI
+/// would want the same window), and it is <b>deliberately bounded and never
+/// persisted</b>: <c>pg_stat_activity</c> has no history, so anything shown over
+/// time is only what this session observed. Long-range server metrics are
+/// Prometheus's job — do not grow this into a store.
+/// </summary>
+public sealed class ActivityHistory
+{
+    /// <summary>150 samples — five minutes at the activity window's 2-second cadence.</summary>
+    public const int DefaultCapacity = 150;
+
+    private readonly ActivitySample[] _samples;
+    private int _next;
+    private int _count;
+
+    public ActivityHistory(int capacity = DefaultCapacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(capacity, 1);
+        _samples = new ActivitySample[capacity];
+    }
+
+    public int Capacity => _samples.Length;
+
+    public int Count => _count;
+
+    /// <summary>Appends a sample, dropping the oldest once the window is full.</summary>
+    public void Record(ActivitySample sample)
+    {
+        _samples[_next] = sample;
+        _next = (_next + 1) % _samples.Length;
+        _count = Math.Min(_count + 1, _samples.Length);
+    }
+
+    /// <summary>Records a poll that produced nothing — see <see cref="ActivitySample.Gap"/>.</summary>
+    public void RecordGap(DateTimeOffset at) => Record(ActivitySample.Gap(at));
+
+    /// <summary>The window, oldest first.</summary>
+    public IReadOnlyList<ActivitySample> Samples()
+    {
+        var result = new ActivitySample[_count];
+        var start = (_next - _count + _samples.Length) % _samples.Length;
+        for (var i = 0; i < _count; i++)
+        {
+            result[i] = _samples[(start + i) % _samples.Length];
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// One field of the window as a plain array, oldest first — a fresh instance
+    /// per call on purpose: a chart bound to a buffer mutated in place raises no
+    /// change notification, and a few hundred doubles is cheaper than any
+    /// observable-collection plumbing.
+    /// </summary>
+    public double?[] Series(Func<ActivitySample, int?> select)
+    {
+        var samples = Samples();
+        var result = new double?[samples.Count];
+        for (var i = 0; i < samples.Count; i++)
+        {
+            result[i] = select(samples[i]);
+        }
+
+        return result;
+    }
+}

--- a/tools/Screenshot/Fixtures.cs
+++ b/tools/Screenshot/Fixtures.cs
@@ -218,6 +218,28 @@ internal static class Fixtures
         new(4851, "postgres", "shop", "psql", null, "idle", null, null, 0.0, "SELECT 1"),
     ];
 
+    /// <summary>
+    /// A session's worth of polls behind the status bar's trend: a quiet stretch,
+    /// a burst of activity with lock waits behind it, and a hole where two polls
+    /// failed (which must draw as a gap, not as zero).
+    /// </summary>
+    public static IReadOnlyList<ActivitySample> ActivityTrend()
+    {
+        var start = new DateTimeOffset(2026, 7, 30, 9, 38, 22, TimeSpan.Zero);
+        var active = new int?[]
+        {
+            2, 3, 2, 2, 4, 3, 2, 3, 2, 2, 3, 5, 9, 14, 18, 21, 19, 22, 26, 24,
+            20, 17, 19, 23, 27, 25, 21, 16, 12, 9, null, null, 7, 5, 4, 3, 4, 6, 5, 4,
+        };
+        var waiting = new int?[]
+        {
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 4, 5, 6, 6,
+            5, 4, 4, 5, 6, 5, 4, 3, 2, 1, null, null, 1, 1, 0, 0, 0, 2, 2, 1,
+        };
+
+        return [.. active.Select((a, i) => new ActivitySample(start.AddSeconds(2 * i), a is null ? null : a + 6, a, waiting[i]))];
+    }
+
     public static IReadOnlyList<BlockingBackend> BlockingBackends() =>
     [
         new(4844, "app", "shop", "shop-worker", "idle in transaction", null, null, 96.0, "UPDATE orders SET status = 'paid' WHERE id = 4821", [], null, null),

--- a/tools/Screenshot/Scenarios.cs
+++ b/tools/Screenshot/Scenarios.cs
@@ -182,7 +182,15 @@ internal static class Scenarios
 
     private static Window BuildActivityWindow(int tab)
     {
-        var vm = Fixtures.MainWindowViewModel().Activity;
+        // A session's worth of polls behind the status bar's trend, seeded
+        // through the constructor rather than replayed one Record at a time.
+        var history = new ActivityHistory();
+        foreach (var sample in Fixtures.ActivityTrend())
+        {
+            history.Record(sample);
+        }
+
+        var vm = new ActivityViewModel(new ActivityService(Fixtures.DataSource), history);
         foreach (var backend in Fixtures.Backends())
         {
             vm.Rows.Add(new ActivityRow(backend));
@@ -207,7 +215,7 @@ internal static class Scenarios
     /// <summary>Database Overview: sizes, cache-hit ratios, scan usage, unused indexes.</summary>
     public static Window DatabaseOverview()
     {
-        var vm = Fixtures.MainWindowViewModel().DatabaseOverview;
+        var vm = new DatabaseOverviewViewModel(new DatabaseStatsService(Fixtures.DataSource));
         vm.DatabaseName = "shop";
         vm.DatabaseSizeText = "1.2 GB";
         vm.TableCacheHitText = "99.1 %";


### PR DESCRIPTION
Stacked on #175 → #174; retarget to `main` as those merge.

Ported from kubeNimbus's usage-graphs pass. The Server Activity window polls every 2 seconds and throws every reading away, so "12 backends, 3 waiting on locks" can't tell you whether that is a spike or Tuesday — and `pg_stat_activity` keeps no history to ask.

- **Core** gains `Monitoring/ActivityHistory`: a fixed-capacity ring of `ActivitySample`s, 150 of them (five minutes at the window's cadence). Bounded and never persisted on purpose — long-range server metrics are Prometheus's job, not a GUI client's. It sits alongside `BlockingTree` as pure, unit-tested engine state a future CLI would want unchanged.
- **App** gains `Controls/Sparkline`: a hand-rolled `Control` drawing an area and a polyline straight into a `DrawingContext`. Hand-rolled because the Avalonia charting packages bring reflection-based binding and theming with them, which the NativeAOT shipping build can't accept.

### Three things the code and tests exist to pin

- **A failed poll is a gap, not a zero.** A server that stopped answering must not draw the same shape as a server that went quiet, so the sample is all-null and the line breaks across it.
- **`Series()` hands back a fresh array per poll.** A ring mutated in place raises no change notification.
- **Both overlaid series share one scale** (`TrendPeak` → `Sparkline.MinimumScale`). Auto-scaling each to its own maximum would draw two lock waiters as tall as forty active backends.

### On UI rule 1

No new band of chrome: the chart sits in the status bar that was already there, right-docked opposite the status text, and stays hidden until there are two samples to join — a one-point chart says nothing a number doesn't.

### Verification

The harness's activity scenarios replay a session's worth of polls, including two failed ones; the rendered gap in the line was checked at 4x. `ActivityViewModel` takes the history as a constructor parameter so a caller can hand in a pre-filled one — that is what the scenarios do. 643 Core tests pass (7 new); Release build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)