### PR TITLE
Add a right-click tab-management menu to the query tab strip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,19 @@ and wrong project memory is worse than none.
 4. **Tabs drag-reorder; the ☰ app menu is the file-command home.** The query
    tab strip reorders by dragging (live, browser-style — pointer handlers in
    `MainWindow.axaml.cs`; the order persists via the workspace snapshot, which
-   serializes `Tabs` in collection order). The ☰ button (top-left, 2026-07)
+   serializes `Tabs` in collection order). Right-clicking a tab opens a
+   three-item flyout — Close / Close others / Close to the right — built and
+   shown from `MainWindow.OnTabStripContextRequested` (code, not XAML: the
+   handler has to resolve the clicked `ListBoxItem` and re-target the menu
+   before it opens, and a `ContextFlyout` on the strip would also fire on its
+   empty space). Deliberately just the close family, and only the two verbs a
+   tab bar can't express by pointing at one tab — the strip's own ✕, its ▾
+   finder and drag-reorder cover the rest. Right-click also makes the clicked
+   tab active (VS / Notepad++ do the same) so the verbs read against what the
+   user is looking at, and the bulk pair is in the catalog as `CloseOtherTabs`
+   / `CloseTabsToTheRight` (palette-only, no chord — three tab commands
+   already own one), so the palette reaches them too, acting on the active
+   tab. The ☰ button (top-left, 2026-07)
    opens the one discoverable menu for file/tab-level commands: New tab,
    Open .sql / Open recent, Save / Save as, Close tab, Switch connection,
    New window, Preferences. The command bar's centered "Search" pill

--- a/PgNimbus.App/Commands/CommandBindings.cs
+++ b/PgNimbus.App/Commands/CommandBindings.cs
@@ -145,6 +145,8 @@ public static class CommandBindings
 
         [CommandId.NewTab] = vm => vm.AddTabCommand,
         [CommandId.CloseTab] = vm => vm.CloseTabCommand,
+        [CommandId.CloseOtherTabs] = vm => vm.CloseOtherTabsCommand,
+        [CommandId.CloseTabsToTheRight] = vm => vm.CloseTabsToTheRightCommand,
         [CommandId.NextTab] = vm => vm.NextTabCommand,
         [CommandId.PreviousTab] = vm => vm.PreviousTabCommand,
         [CommandId.OpenFile] = vm => vm.OpenFileCommand,

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -506,7 +506,7 @@ public sealed partial class MainViewModel : ObservableObject
         tab.Executed += SavedQueries.RecordExecution;
         Tabs.Add(tab);
         ActiveTab = tab;
-        CloseTabCommand.NotifyCanExecuteChanged();
+        NotifyTabCommands();
         return tab;
     }
 
@@ -528,6 +528,9 @@ public sealed partial class MainViewModel : ObservableObject
         Tabs.Move(oldIndex, newIndex);
         // Re-assert: a collection Move can churn the ListBox's selection.
         ActiveTab = tab;
+        // "Close tabs to the right" is position-dependent — a reorder can flip
+        // it either way for the tab that just moved.
+        NotifyTabCommands();
     }
 
     /// <summary>
@@ -664,7 +667,59 @@ public sealed partial class MainViewModel : ObservableObject
             ActiveTab = Tabs[Math.Min(index, Tabs.Count - 1)];
         }
 
+        NotifyTabCommands();
+    }
+
+    private bool CanCloseOtherTabs(QueryViewModel? tab) => Tabs.Count > 1 && Tabs.Contains(tab ?? ActiveTab);
+
+    /// <summary>
+    /// Closes every tab except <paramref name="tab"/> (the active one when the
+    /// palette invokes this with no parameter). Goes through <see cref="CloseTab"/>
+    /// per tab so each one still cancels its running query and unhooks its
+    /// history handler; the snapshot is taken first because that mutates
+    /// <see cref="Tabs"/> underneath the enumeration.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanCloseOtherTabs))]
+    private void CloseOtherTabs(QueryViewModel? tab)
+    {
+        tab ??= ActiveTab;
+        foreach (var other in Tabs.Where(t => !ReferenceEquals(t, tab)).ToList())
+        {
+            CloseTab(other);
+        }
+    }
+
+    private bool CanCloseTabsToTheRight(QueryViewModel? tab)
+    {
+        var index = Tabs.IndexOf(tab ?? ActiveTab);
+        return index >= 0 && index < Tabs.Count - 1;
+    }
+
+    /// <summary>Closes everything after <paramref name="tab"/> in strip order.</summary>
+    [RelayCommand(CanExecute = nameof(CanCloseTabsToTheRight))]
+    private void CloseTabsToTheRight(QueryViewModel? tab)
+    {
+        tab ??= ActiveTab;
+        var index = Tabs.IndexOf(tab);
+        if (index < 0)
+        {
+            return;
+        }
+
+        foreach (var right in Tabs.Skip(index + 1).ToList())
+        {
+            CloseTab(right);
+        }
+    }
+
+    // Every close command's CanExecute reads the tab count or a tab's position,
+    // so all three re-evaluate together whenever the strip's contents or order
+    // change — one call site instead of three easy-to-forget ones.
+    private void NotifyTabCommands()
+    {
         CloseTabCommand.NotifyCanExecuteChanged();
+        CloseOtherTabsCommand.NotifyCanExecuteChanged();
+        CloseTabsToTheRightCommand.NotifyCanExecuteChanged();
     }
 
     [RelayCommand]

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -72,6 +72,7 @@ public partial class MainWindow : Window
         TabsList.PointerMoved += OnTabStripPointerMoved;
         TabsList.PointerReleased += (_, _) => EndTabDrag();
         TabsList.PointerCaptureLost += (_, _) => EndTabDrag();
+        TabsList.ContextRequested += OnTabStripContextRequested;
 
         // The ☰ app menu's "Open recent" submenu reflects the list as of the
         // moment the menu opens, not app start.
@@ -621,6 +622,65 @@ public partial class MainWindow : Window
         {
             container.Opacity = opacity;
         }
+    }
+
+    // --- Tab-strip context menu -------------------------------------------
+
+    // Built lazily and re-shown, so the strip carries no extra always-visible
+    // chrome: bulk tab management is a right-click (and a palette entry), never
+    // a toolbar button. Deliberately just the close family — the strip's own ✕,
+    // its ▾ finder and drag-reorder already cover the rest, and every item here
+    // is one the tab bar can't express by pointing at a single tab.
+    private MenuFlyout? _tabMenu;
+    private MenuItem? _tabMenuClose;
+    private MenuItem? _tabMenuCloseOthers;
+    private MenuItem? _tabMenuCloseRight;
+
+    private void OnTabStripContextRequested(object? sender, ContextRequestedEventArgs e)
+    {
+        if (_viewModel is null
+            || (e.Source as Visual)?.FindAncestorOfType<ListBoxItem>(includeSelf: true) is not { } container
+            || container.DataContext is not QueryViewModel tab)
+        {
+            return; // right-click on the strip's empty space: nothing to act on
+        }
+
+        // Right-click targets what it points at, the way VS and Notepad++ do,
+        // so the menu's verbs read against the tab the user is looking at.
+        _viewModel.ActiveTab = tab;
+
+        _tabMenu ??= BuildTabMenu(_viewModel);
+
+        // Each item's enabled state comes from its command's CanExecute against
+        // this tab; assigning the parameter is what re-evaluates it.
+        _tabMenuClose!.CommandParameter = tab;
+        _tabMenuCloseOthers!.CommandParameter = tab;
+        _tabMenuCloseRight!.CommandParameter = tab;
+
+        _tabMenu.ShowAt(container, showAtPointer: true);
+        e.Handled = true;
+    }
+
+    private MenuFlyout BuildTabMenu(MainViewModel viewModel)
+    {
+        _tabMenuClose = new MenuItem
+        {
+            Header = "Close",
+            Command = viewModel.CloseTabCommand,
+            InputGesture = CommandBindings.GestureFor(CommandId.CloseTab),
+        };
+        _tabMenuCloseOthers = new MenuItem
+        {
+            Header = "Close others",
+            Command = viewModel.CloseOtherTabsCommand,
+        };
+        _tabMenuCloseRight = new MenuItem
+        {
+            Header = "Close to the right",
+            Command = viewModel.CloseTabsToTheRightCommand,
+        };
+
+        return new MenuFlyout { Items = { _tabMenuClose, _tabMenuCloseOthers, _tabMenuCloseRight } };
     }
 
     // --- Tab-strip navigation extras -------------------------------------

--- a/PgNimbus.Core/Commands/CommandCatalog.cs
+++ b/PgNimbus.Core/Commands/CommandCatalog.cs
@@ -166,6 +166,24 @@ public static class CommandCatalog
             Chord = new(CommandKey.W, Cmd),
             Surfaces = Everywhere,
         },
+        // The bulk-close pair: no chord (three tab commands already own one),
+        // reachable from the tab strip's right-click menu and the palette.
+        new()
+        {
+            Id = CommandId.CloseOtherTabs,
+            Title = "Close other tabs",
+            Category = CommandCategory.Tabs,
+            Glyph = "✕",
+            Surfaces = PaletteOnly,
+        },
+        new()
+        {
+            Id = CommandId.CloseTabsToTheRight,
+            Title = "Close tabs to the right",
+            Category = CommandCategory.Tabs,
+            Glyph = "✕",
+            Surfaces = PaletteOnly,
+        },
         new()
         {
             Id = CommandId.NextTab,

--- a/PgNimbus.Core/Commands/CommandDescriptor.cs
+++ b/PgNimbus.Core/Commands/CommandDescriptor.cs
@@ -24,6 +24,8 @@ public enum CommandId
     // --- Tabs & files ---
     NewTab,
     CloseTab,
+    CloseOtherTabs,
+    CloseTabsToTheRight,
     NextTab,
     PreviousTab,
     GoToTabByNumber,


### PR DESCRIPTION
Right-clicking a query tab now opens a small flyout with the bulk-close verbs a tab bar cannot express by pointing at a single tab.

## What changed

| Item | Enabled when |
| --- | --- |
| Close (Ctrl+W) | more than one tab is open |
| Close others | more than one tab is open |
| Close to the right | the clicked tab is not the last one |

Deliberately just the close family. Save / Save as / Open recent already live in the hamburger menu and the palette, "move to new window" is covered by Switch connection and New window, and pin/duplicate would be new mechanics rather than tab management. No new always-visible chrome, per UI rule 1.

## Why it is shaped this way

- `CloseOtherTabs` and `CloseTabsToTheRight` are declared once in `CommandCatalog` (palette-only, no chord, since three tab commands already own one), so they also show up in the Ctrl+K palette where they act on the active tab. UI rule 5, one catalog entry plus one resolver line in `CommandBindings`.
- Both go through the existing `CloseTab`, so every closed tab still cancels its in-flight query and unhooks its history handler.
- The menu is built and shown from `MainWindow.OnTabStripContextRequested` instead of being declared as a `ContextFlyout`. The handler needs to resolve the clicked `ListBoxItem` and re-target the items before the menu opens, and a flyout attached to the strip itself would also fire on its empty space.
- Right-click makes the clicked tab active first, the way Visual Studio and Notepad++ behave, so the verbs read against the tab the user is looking at.

## Reviewer notes

- Enabled state comes from each command's `CanExecute` against the clicked tab. Assigning `CommandParameter` on open is what re-evaluates it, so the menu is correct without any per-open plumbing.
- `NotifyTabCommands` replaces the scattered `CloseTabCommand.NotifyCanExecuteChanged()` calls and now also fires from `MoveTab`, since "close to the right" is position-dependent.
- `docs/reference/keyboard-shortcuts.md` is unchanged on purpose: the new commands carry no gesture, so they stay off the cheat sheet and the golden-file test still passes.

## Verification

`dotnet build` is clean and the Core suite passes (627 passed, 0 failed, 9 skipped for lack of a test Postgres).

Driven against a real build: all three items act on the clicked tab, Close and Close others gray out when a single tab is left, Close to the right grays out on the last tab, and right-clicking empty strip space opens nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)