### PR TITLE
Move the Fluent control layer into the shared design system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,17 @@ of [nimbusUi](https://github.com/Shman4ik/nimbusUi), referenced as an ordinary
 - `Theme/Icons.axaml` — the MDI glyphs both apps draw.
 - `Theme/Theme.axaml` — the shared style classes (`card`, `layer`, `chip`,
   `toolbar`, `searchpill`, `statusBar`, …).
+- `Theme/Controls.axaml` — the Fluent **control** retheming: `TextBox`/`ComboBox`/
+  `NumericUpDown` radius and brand text selection, `SelectableTextBlock`,
+  `ListBox`/`ListBoxItem`/`TreeView`/`TreeViewItem` rounded rows, `DataGrid` soft
+  rules, the `.soft` and `.soft.danger` button families, `ToggleButton.soft`, the
+  chip checked/active washes, `TabControl`. **These moved out of
+  `Styles/Theme.axaml`**, where they had been defined for pgNimbus alone: kubeNimbus
+  had none of them and was drawing stock Fluent inputs, lists and grids next to
+  these, which is what made the two apps stop looking like one family. Change them
+  there, not here. What is left in this app's own `Styles/Theme.axaml` is `TabItem`,
+  `TabControl.segmented` and the AvaloniaEdit completion/search themes — all
+  genuinely pgNimbus's (see DESIGN.md's not-shared table).
 - `Chrome/` — the one-bar window chrome and its drawn caption buttons.
 - `Hotkeys.cs` — Ctrl/Cmd resolution; `PgNimbus.App.Hotkeys` forwards to it.
 - **[`DESIGN.md`](shared/nimbusUi/DESIGN.md) — the UI rules, single source.**

--- a/PgNimbus.App/Styles/Theme.axaml
+++ b/PgNimbus.App/Styles/Theme.axaml
@@ -213,55 +213,15 @@
         </ResourceDictionary>
     </Styles.Resources>
 
-    <!-- Filled destructive primary button — the affirmative of a destructive
-         confirm (Terminate / Drop / Delete / Discard). Mirrors .accent, in red. -->
-    <Style Selector="Button.danger">
-        <Setter Property="Background" Value="{StaticResource AppDangerBrush}" />
-        <Setter Property="Foreground" Value="White" />
-        <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="BorderThickness" Value="0" />
-    </Style>
-    <Style Selector="Button.danger:pointerover">
-        <Setter Property="Background" Value="{StaticResource AppDangerHoverBrush}" />
-    </Style>
-    <Style Selector="Button.danger:pressed">
-        <Setter Property="Background" Value="{StaticResource AppDangerPressedBrush}" />
-    </Style>
-    <Style Selector="Button.danger:disabled">
-        <Setter Property="Background" Value="{DynamicResource SystemControlDisabledBaseLowBrush}" />
-        <Setter Property="Foreground" Value="{DynamicResource SystemControlDisabledBaseMediumLowBrush}" />
-    </Style>
+    <!-- Button.danger, the chip checked/active washes, and the .soft button family
+         moved to the shared design system (shared/nimbusUi, Theme/Controls.axaml):
+         kubeNimbus needs exactly the same vocabulary and was rendering stock Fluent
+         without it. Nothing about them was Postgres-specific. -->
 
-    <!-- Checked state for chip-styled ToggleButtons (e.g. cell inspector's Wrap
-         toggle): the app's brand-blue selection wash, same as the toolbar toggle.
-         Fluent paints the checked fill on PART_ContentPresenter via its ControlTheme,
-         which outranks a plain Background setter, so the wash overrides that template
-         part; idle/hover/pressed are all pinned so the "on" chip stays blue rather
-         than flipping to Fluent's grey on hover. -->
-    <Style Selector="ToggleButton.chip:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-    </Style>
-    <Style Selector="ToggleButton.chip:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-    </Style>
-    <!-- Same wash for plain chip Buttons acting as a segmented pair (plan Text/Tree
-         switch), where a bound "active" class marks the selected segment instead of
-         :checked. A plain Button has no Fluent checked-state /template/ override, so
-         the rest state renders via TemplateBinding Background; :pointerover is pinned
-         at the template part so the active segment keeps the wash while hovered. -->
-    <Style Selector="Button.chip.active">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-        <Setter Property="Opacity" Value="1" />
-    </Style>
-    <Style Selector="Button.chip.active:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-    </Style>
-
-    <!-- Left-nav style TabItem: pill highlight instead of the classic underline tab strip -->
-    <Style Selector="TabControl">
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="Padding" Value="0" />
-    </Style>
+    <!-- Left-nav style TabItem: pill highlight instead of the classic underline tab
+         strip. TabControl's own transparent background is shared; TabItem is NOT —
+         DESIGN.md keeps it per-app, because kubeNimbus styles the same selector for
+         its compact inspector strip. -->
     <Style Selector="TabItem">
         <Setter Property="Padding" Value="12,9" />
         <Setter Property="Margin" Value="3,2" />
@@ -365,172 +325,12 @@
         <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
     </Style>
 
-    <!-- Soft action button: a refined, tactile pill (card-toned fill + hairline
-         border) that reads as a real button, unlike the flat transparent
-         .toolbar variant. Hover lifts to the accent tint. Fluent repaints
-         PART_ContentPresenter on hover, so the states are pinned at the template
-         part (same trick as .searchpill). Add .danger for destructive actions. -->
-    <Style Selector="Button.soft">
-        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
-        <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
-        <Setter Property="Padding" Value="11,6" />
-        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-    </Style>
-    <Style Selector="Button.soft /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.12" />
-                <BrushTransition Property="BorderBrush" Duration="0:0:0.12" />
-            </Transitions>
-        </Setter>
-    </Style>
-    <Style Selector="Button.soft:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
-    </Style>
-    <Style Selector="Button.soft:pressed /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
-    </Style>
-    <!-- Disabled soft button: quiet, no border glow -->
-    <Style Selector="Button.soft:disabled">
-        <Setter Property="Opacity" Value="0.4" />
-    </Style>
-    <!-- Destructive variant (terminate a session): red glyph/text, red hover wash. -->
-    <Style Selector="Button.soft.danger">
-        <Setter Property="Foreground" Value="{StaticResource AppDangerBrush}" />
-    </Style>
-    <Style Selector="Button.soft.danger PathIcon">
-        <Setter Property="Foreground" Value="{StaticResource AppDangerBrush}" />
-    </Style>
-    <Style Selector="Button.soft.danger:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppDangerWashBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource AppDangerBorderBrush}" />
-    </Style>
-    <Style Selector="Button.soft.danger:pressed /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppDangerWashBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource AppDangerBorderBrush}" />
-    </Style>
-    <!-- A disabled destructive button must not still shout red: .soft:disabled's
-         0.4 opacity over AppDangerBrush lands on a washed-out pink that reads as
-         "broken", not "unavailable". Drop back to the ordinary foreground so it
-         dims like every other disabled button. -->
-    <Style Selector="Button.soft.danger:disabled">
-        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-    </Style>
-    <Style Selector="Button.soft.danger:disabled PathIcon">
-        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-    </Style>
-
-    <!-- Toggle variant of .soft, for an on/off action that belongs in the same
-         button group as its neighbours (the activity window's "Auto" refresh
-         next to "Refresh"). A .chip there would sit at a different height and
-         radius, and its checked blue wash reads as a *selected tab* - which is
-         exactly what the segmented strip beside it already means. This keeps
-         the .soft pill geometry and marks "on" with the accent border + wash.
-         Fluent repaints PART_ContentPresenter for every ToggleButton state, so
-         each state is pinned at the template part (same trick as .searchpill),
-         and selectors match by style key so ToggleButton needs its own rules
-         rather than inheriting the Button.soft ones. -->
-    <Style Selector="ToggleButton.soft">
-        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
-        <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
-        <Setter Property="Padding" Value="11,6" />
-        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-    </Style>
-    <Style Selector="ToggleButton.soft /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
-        <Setter Property="Transitions">
-            <Transitions>
-                <BrushTransition Property="Background" Duration="0:0:0.12" />
-                <BrushTransition Property="BorderBrush" Duration="0:0:0.12" />
-            </Transitions>
-        </Setter>
-    </Style>
-    <Style Selector="ToggleButton.soft:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
-    </Style>
-    <Style Selector="ToggleButton.soft:pressed /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
-    </Style>
-    <Style Selector="ToggleButton.soft:checked">
-        <Setter Property="Foreground" Value="{StaticResource AppAccentBrush}" />
-        <Setter Property="FontWeight" Value="SemiBold" />
-    </Style>
-    <Style Selector="ToggleButton.soft:checked /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
-    </Style>
-    <Style Selector="ToggleButton.soft:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
-    </Style>
-    <Style Selector="ToggleButton.soft:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
-    </Style>
-    <Style Selector="ToggleButton.soft:disabled">
-        <Setter Property="Opacity" Value="0.4" />
-    </Style>
-
-    <!-- Lists / trees: rounded row selection instead of edge-to-edge highlight bars -->
-    <Style Selector="ListBox, TreeView">
-        <Setter Property="Background" Value="Transparent" />
-        <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="Padding" Value="4" />
-    </Style>
-    <Style Selector="ListBoxItem">
-        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
-        <Setter Property="Padding" Value="8,6" />
-        <Setter Property="Margin" Value="0,1" />
-    </Style>
-    <Style Selector="ListBoxItem:selected">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-    </Style>
-    <Style Selector="TreeViewItem">
-        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
-        <Setter Property="Padding" Value="4,3" />
-        <!-- Tighter rows than Fluent's ~30px default -->
-        <Setter Property="MinHeight" Value="26" />
-    </Style>
-    <Style Selector="TreeViewItem:selected /template/ Border#PART_LayoutRoot">
-        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
-    </Style>
-
-    <!-- Inputs: rounded to match the rest of the surface -->
-    <Style Selector="TextBox, ComboBox, NumericUpDown">
-        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
-    </Style>
-    <!-- Selected text in every plain TextBox (connection dialog fields, search
-         boxes, etc.) uses the same brand-blue wash as the SQL editor instead of
-         FluentTheme's OS-accent-derived default - SelectionBrush is a TextBox-only
-         property (not exposed on ComboBox/NumericUpDown), hence its own selector;
-         it still reaches the editable TextBox inside a NumericUpDown's template. -->
-    <Style Selector="TextBox">
-        <Setter Property="SelectionBrush" Value="{StaticResource AppTextSelectionBrush}" />
-    </Style>
-    <!-- Read-only selectable text (cell-inspector Wrap view, EXPLAIN output, the
-         pending-changes SQL preview) shares the same brand-blue wash - otherwise
-         it falls back to FluentTheme's grey OS-accent default and selection reads
-         differently there than in the SQL editor / TextBoxes. -->
-    <Style Selector="SelectableTextBlock">
-        <Setter Property="SelectionBrush" Value="{StaticResource AppTextSelectionBrush}" />
-    </Style>
-
-    <!-- Results grid: soft horizontal rules instead of a full grid -->
-    <Style Selector="DataGrid">
-        <Setter Property="GridLinesVisibility" Value="Horizontal" />
-        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}" />
-        <Setter Property="RowBackground" Value="Transparent" />
-        <Setter Property="BorderThickness" Value="0" />
-    </Style>
+    <!-- The .soft / .soft.danger button family, the list-and-tree row styling, the
+         input corner radius and brand text selection, and the DataGrid's soft
+         horizontal rules all moved to shared/nimbusUi (Theme/Controls.axaml). They
+         were the reason the two apps stopped looking alike: kubeNimbus had none of
+         them and rendered every input, list and grid as raw Fluent. Change them
+         there, not here — and rebuild both apps (nimbusUi/CLAUDE.md rule 5). -->
 
     <!--
         SQL completion popup rows (the card shell is the CompletionList

--- a/shared/nimbusUi/CLAUDE.md
+++ b/shared/nimbusUi/CLAUDE.md
@@ -33,7 +33,16 @@ future move.
    upgraded yet. Today: 12.1.0 (pgNimbus), while kubeNimbus is on 12.1.1.
 5. **A change here is not done until both apps have been built against it.**
    There is no test suite that can catch a broken style — the apps' screenshot
-   harnesses are the only check, and they live in the apps.
+   harnesses are the only check, and they live in the apps. Building is not
+   enough on its own: a XAML file that fails to *load* compiles perfectly, so
+   render the scenarios too.
+6. **A style both apps need but only one has is a bug, not a gap.** The first
+   extraction pulled up the shell vocabulary and left the whole Fluent control
+   layer in pgNimbus, so kubeNimbus drew stock inputs, lists and grids next to
+   pgNimbus's toned ones. Nobody noticed from inside either app — you only see
+   it with the two windows side by side, which is exactly the comparison this
+   library exists to survive. When adding a style, ask what the *other* app
+   renders for the same control today.
 
 ## Working on this from inside an app repo
 
@@ -55,8 +64,11 @@ so this is one session's work, not a follow-up ticket.
 src/Nimbus.Ui/
   Theme/Tokens.axaml      Colour, radii, scrollbars, Fluent resource overrides.
   Theme/Icons.axaml       MDI geometries used by both apps (Apache-2.0).
-  Theme/Controls.axaml    Primitive style classes + Fluent control retheming.
-  Theme/Theme.axaml       The single include point; merges the three above.
+  Theme/Controls.axaml    Fluent control retheming: inputs, lists, trees, grids,
+                          the .soft/.danger button families, TabControl.
+  Theme/Theme.axaml       The include point. Merges the dictionaries, pulls in
+                          Controls.axaml, and holds the shell vocabulary itself
+                          (card, layer, chip, searchpill, toolbar, statusBar, …).
   Chrome/                 One-bar window chrome + drawn caption buttons.
   Hotkeys.cs              Ctrl/Cmd resolution, gesture labels.
 ```

--- a/shared/nimbusUi/DESIGN.md
+++ b/shared/nimbusUi/DESIGN.md
@@ -151,8 +151,9 @@ reasons:
 | Thing | Why it stays per-app |
 |---|---|
 | `TabItem` styling | pgNimbus styles it for the query tab strip (12,9 padding, a margin, a corner radius), kubeNimbus for the compact inspector strip (12,6, `MinHeight` 0). Same selector, genuinely different jobs. |
+| `TabControl.segmented` | pgNimbus's segmented strip. kubeNimbus does the same job with `ListBox.segmented` + `TabControl.headerless` on purpose — a `TabControl` cannot host a panel's own tools on its header row, and its inspector dock needs exactly that (its rule 10). Sharing a mechanism the sibling has explicitly rejected buys nothing. |
 | Domain icons | A Kubernetes cube and a Postgres elephant are not shared vocabulary. `Theme/Icons.axaml` holds only glyphs both apps actually use. |
-| Everything in `*.Core` | Both engines are UI-free by their own hard rule and share nothing but coincidence. |
+| Everything in `*.Core` | Both engines are UI-free by their own hard rule and share nothing but coincidence. This is why each app has its own copy of the command catalog and chord types: they are UI-free by design, so they cannot live in a library that references Avalonia. |
 
 ## Cross-port list
 
@@ -165,3 +166,25 @@ mechanism — a rule nobody tracks is a rule that decays.
 - [x] One-bar window chrome on Windows → pgNimbus (rule 9). It previously extended
       the client area on macOS only, with a hand-rolled `BeginMoveDrag`.
 - [ ] `AppSuccessBrush` → pgNimbus. The status trio was two-thirds defined there.
+- [x] **The Fluent control layer → `Theme/Controls.axaml`.** Inputs, lists, trees,
+      grids and the `.soft`/`.danger` button families were defined in pgNimbus only,
+      so kubeNimbus rendered every `TextBox`, `ComboBox`, `ListBox`, `TreeView` and
+      `DataGrid` as stock Fluent beside pgNimbus's toned versions — two apps sharing a
+      design system and visibly not looking like it. This was the single biggest cause
+      of the family drifting apart, and it was invisible from inside either app.
+- [ ] **`ThemedWindowChrome`'s caption-colour half → shared.** Both apps have a copy
+      that pins a secondary window's Windows 11 caption to the shell tone (without it,
+      a dialog gets a black title bar while the app is in Light). pgNimbus's copy also
+      carries a native-icon half that is genuinely its own; only the DWM colour part
+      should move.
+- [ ] **Preferences page shape → keep them converging.** Both apps now use the same
+      page: section header, one card per setting, label and explanation left, control
+      right, immediate apply, no OK/Cancel. It is duplicated markup rather than a
+      shared control today, and that is fine — but a change to one is a change both
+      should get.
+- [ ] **Load the window icon through `AssetLoader`, not `Icon="/Assets/…"`** — see the
+      note under kubeNimbus's release section. The XAML attribute goes through
+      `IconTypeConverter`, which cannot resolve a relative asset path under NativeAOT
+      and killed kubeNimbus's published binary on *every* RID. pgNimbus already loads
+      its icons in code and is unaffected; worth confirming no window there still uses
+      the attribute form.

--- a/shared/nimbusUi/src/Nimbus.Ui/Theme/Controls.axaml
+++ b/shared/nimbusUi/src/Nimbus.Ui/Theme/Controls.axaml
@@ -1,0 +1,316 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--
+        Fluent control retheming: the stock controls both apps use, toned to the
+        Nimbus surface. Everything here restyles a control BOTH apps put on screen
+        constantly — inputs, lists, grids, secondary buttons — which is why it is
+        shared rather than duplicated.
+
+        This file exists because the first extraction only pulled up the *shell*
+        vocabulary (card / layer / chip / searchpill / toolbar / accent, tokens,
+        scrollbars) and left the control layer behind in pgNimbus. The result was
+        that kubeNimbus rendered every TextBox, ComboBox, ListBox, TreeView and
+        DataGrid as raw Fluent next to pgNimbus's toned versions — two apps sharing
+        a design system and visibly not looking like it. If a style below is
+        changed, it changes both apps: that is the point of it being here.
+
+        What deliberately stayed per-app, and why:
+          - `TabItem` / `TabItem:selected` — pgNimbus styles it for the query tab
+            strip, kubeNimbus for the compact inspector strip. Same selector,
+            genuinely different jobs (see DESIGN.md).
+          - `TabControl.segmented` — pgNimbus's segmented strip. kubeNimbus does
+            the same job with `ListBox.segmented` + `TabControl.headerless` on
+            purpose, because a TabControl cannot host a panel's own tools on its
+            header row and its inspector dock needs exactly that. Sharing a
+            mechanism the sibling has explicitly rejected buys nothing.
+    -->
+
+    <Styles.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <!--
+                    Merged again here, exactly as Theme.axaml does and for the same
+                    reason: a StaticResource in a styles file resolves against that
+                    file's own resource chain. Without this every token below fails
+                    at XAML load rather than at build.
+                -->
+                <ResourceInclude Source="avares://Nimbus.Ui/Theme/Tokens.axaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Styles.Resources>
+
+    <!-- ==================================================================
+         Buttons
+         ================================================================== -->
+
+    <!-- Filled destructive primary button — the affirmative of a destructive
+         confirm (Delete / Drop / Terminate / Discard). Mirrors .accent, in red. -->
+    <Style Selector="Button.danger">
+        <Setter Property="Background" Value="{StaticResource AppDangerBrush}" />
+        <Setter Property="Foreground" Value="White" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="BorderThickness" Value="0" />
+    </Style>
+
+    <Style Selector="Button.danger:pointerover">
+        <Setter Property="Background" Value="{StaticResource AppDangerHoverBrush}" />
+    </Style>
+
+    <Style Selector="Button.danger:pressed">
+        <Setter Property="Background" Value="{StaticResource AppDangerPressedBrush}" />
+    </Style>
+
+    <Style Selector="Button.danger:disabled">
+        <Setter Property="Background" Value="{DynamicResource SystemControlDisabledBaseLowBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlDisabledBaseMediumLowBrush}" />
+    </Style>
+
+    <!-- Checked state for chip-styled ToggleButtons. Fluent paints the checked fill
+         on PART_ContentPresenter via its ControlTheme, which outranks a plain
+         Background setter, so the wash has to override that template part; hover and
+         pressed are both pinned so an "on" chip stays blue rather than flipping to
+         Fluent's grey under the pointer. (The rest state lives in Theme.axaml
+         alongside the other chip rules.) -->
+    <Style Selector="ToggleButton.chip:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+    </Style>
+
+    <Style Selector="ToggleButton.chip:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+    </Style>
+
+    <!-- The same wash for plain chip Buttons acting as a segmented pair, where a
+         bound "active" class marks the selected segment instead of :checked. A plain
+         Button has no Fluent checked-state /template/ override, so the rest state
+         renders through the TemplateBinding; :pointerover is pinned at the template
+         part so the active segment keeps the wash while hovered. -->
+    <Style Selector="Button.chip.active">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="Opacity" Value="1" />
+    </Style>
+
+    <Style Selector="Button.chip.active:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+    </Style>
+
+    <!-- Soft action button: a refined, tactile pill (card-toned fill + hairline
+         border) that reads as a real button, unlike the flat transparent .toolbar
+         variant. Hover lifts to the accent tint. Fluent repaints
+         PART_ContentPresenter on hover, so the states are pinned at the template
+         part (same trick as .searchpill). Add .danger for destructive actions. -->
+    <Style Selector="Button.soft">
+        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="11,6" />
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
+
+    <Style Selector="Button.soft /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Transitions">
+            <Transitions>
+                <BrushTransition Property="Background" Duration="0:0:0.12" />
+                <BrushTransition Property="BorderBrush" Duration="0:0:0.12" />
+            </Transitions>
+        </Setter>
+    </Style>
+
+    <Style Selector="Button.soft:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+
+    <Style Selector="Button.soft:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+
+    <!-- Disabled soft button: quiet, no border glow -->
+    <Style Selector="Button.soft:disabled">
+        <Setter Property="Opacity" Value="0.4" />
+    </Style>
+
+    <!-- Destructive variant: red glyph/text, red hover wash. -->
+    <Style Selector="Button.soft.danger">
+        <Setter Property="Foreground" Value="{StaticResource AppDangerBrush}" />
+    </Style>
+
+    <Style Selector="Button.soft.danger PathIcon">
+        <Setter Property="Foreground" Value="{StaticResource AppDangerBrush}" />
+    </Style>
+
+    <Style Selector="Button.soft.danger:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppDangerWashBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppDangerBorderBrush}" />
+    </Style>
+
+    <Style Selector="Button.soft.danger:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppDangerWashBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppDangerBorderBrush}" />
+    </Style>
+
+    <!-- A disabled destructive button must not still shout red: .soft:disabled's
+         0.4 opacity over AppDangerBrush lands on a washed-out pink that reads as
+         "broken", not "unavailable". Drop back to the ordinary foreground so it
+         dims like every other disabled button. -->
+    <Style Selector="Button.soft.danger:disabled">
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
+
+    <Style Selector="Button.soft.danger:disabled PathIcon">
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
+
+    <!-- Toggle variant of .soft, for an on/off action that belongs in the same
+         button group as its neighbours. A .chip there would sit at a different
+         height and radius, and its checked blue wash reads as a *selected tab* —
+         which is what a segmented strip beside it already means. This keeps the
+         .soft pill geometry and marks "on" with the accent border + wash. Fluent
+         repaints PART_ContentPresenter for every ToggleButton state, so each state
+         is pinned at the template part, and selectors match by style key — so
+         ToggleButton needs its own rules rather than inheriting the Button.soft
+         ones. -->
+    <Style Selector="ToggleButton.soft">
+        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="11,6" />
+        <Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+    </Style>
+
+    <Style Selector="ToggleButton.soft /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource CardBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource CardBorderBrush}" />
+        <Setter Property="Transitions">
+            <Transitions>
+                <BrushTransition Property="Background" Duration="0:0:0.12" />
+                <BrushTransition Property="BorderBrush" Duration="0:0:0.12" />
+            </Transitions>
+        </Setter>
+    </Style>
+
+    <Style Selector="ToggleButton.soft:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+
+    <Style Selector="ToggleButton.soft:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+
+    <Style Selector="ToggleButton.soft:checked">
+        <Setter Property="Foreground" Value="{StaticResource AppAccentBrush}" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+
+    <Style Selector="ToggleButton.soft:checked /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+
+    <Style Selector="ToggleButton.soft:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+
+    <Style Selector="ToggleButton.soft:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+        <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+    </Style>
+
+    <Style Selector="ToggleButton.soft:disabled">
+        <Setter Property="Opacity" Value="0.4" />
+    </Style>
+
+    <!-- ==================================================================
+         Tabs
+         ================================================================== -->
+
+    <!-- The container only: transparent, and no padding of its own, so a tab's
+         content sits flush against whatever surface hosts it. `TabItem` itself is
+         deliberately NOT here — pgNimbus styles it for the query tab strip and
+         kubeNimbus for the compact inspector strip, which is the one documented
+         same-selector-different-job exception (DESIGN.md). -->
+    <Style Selector="TabControl">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Padding" Value="0" />
+    </Style>
+
+    <!-- ==================================================================
+         Lists and trees
+         ================================================================== -->
+
+    <!-- Rounded row selection instead of Fluent's edge-to-edge highlight bars.
+         An app that wants a different row shape overrides on its own class
+         (kubeNimbus does exactly that for its switcher and segmented strips). -->
+    <Style Selector="ListBox, TreeView">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="4" />
+    </Style>
+
+    <Style Selector="ListBoxItem">
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="8,6" />
+        <Setter Property="Margin" Value="0,1" />
+    </Style>
+
+    <Style Selector="ListBoxItem:selected">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+    </Style>
+
+    <Style Selector="TreeViewItem">
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="4,3" />
+        <!-- Tighter rows than Fluent's ~30px default -->
+        <Setter Property="MinHeight" Value="26" />
+    </Style>
+
+    <Style Selector="TreeViewItem:selected /template/ Border#PART_LayoutRoot">
+        <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
+    </Style>
+
+    <!-- ==================================================================
+         Inputs and text
+         ================================================================== -->
+
+    <!-- Rounded to match the rest of the surface. -->
+    <Style Selector="TextBox, ComboBox, NumericUpDown">
+        <Setter Property="CornerRadius" Value="{StaticResource ControlCornerRadius}" />
+    </Style>
+
+    <!-- Selected text in every plain TextBox uses the brand-blue wash instead of
+         FluentTheme's OS-accent-derived default (rule 11: the accent is ours, never
+         the OS's). SelectionBrush is a TextBox-only property — not exposed on
+         ComboBox/NumericUpDown — hence its own selector; it still reaches the
+         editable TextBox inside a NumericUpDown's template. -->
+    <Style Selector="TextBox">
+        <Setter Property="SelectionBrush" Value="{StaticResource AppTextSelectionBrush}" />
+    </Style>
+
+    <!-- Read-only selectable text shares the same wash. Otherwise it falls back to
+         Fluent's grey OS-accent default and selection reads differently there than
+         in an editable box two inches away. -->
+    <Style Selector="SelectableTextBlock">
+        <Setter Property="SelectionBrush" Value="{StaticResource AppTextSelectionBrush}" />
+    </Style>
+
+    <!-- ==================================================================
+         Data grid
+         ================================================================== -->
+
+    <!-- Soft horizontal rules instead of a full grid. The per-cell gutter that goes
+         with this is DESIGN.md rule 12 and lives in each app, since the column
+         widths it has to be balanced against are the app's own. -->
+    <Style Selector="DataGrid">
+        <Setter Property="GridLinesVisibility" Value="Horizontal" />
+        <Setter Property="HorizontalGridLinesBrush" Value="{DynamicResource SystemControlForegroundBaseLowBrush}" />
+        <Setter Property="RowBackground" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+    </Style>
+
+</Styles>

--- a/shared/nimbusUi/src/Nimbus.Ui/Theme/Theme.axaml
+++ b/shared/nimbusUi/src/Nimbus.Ui/Theme/Theme.axaml
@@ -16,6 +16,12 @@
 
         24 of the 28 blocks below were byte-identical in the two apps at extraction. The
         other four are noted where they sit.
+
+        The Fluent *control* retheming — inputs, lists, trees, grids, the soft and
+        danger button variants — lives in the sibling `Controls.axaml`, included
+        below. It is a separate file only for length: this one is the shell
+        vocabulary the apps compose their chrome from, that one is the stock
+        controls underneath it, and the two are read for different reasons.
     -->
 
     <Styles.Resources>
@@ -37,6 +43,11 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Styles.Resources>
+
+    <!-- Loaded FIRST, so a shell class below can override a control rule it sets.
+         Both are still ahead of the consuming app's own Theme.axaml (see either
+         App.axaml), which is what lets an app override anything shared. -->
+    <StyleInclude Source="avares://Nimbus.Ui/Theme/Controls.axaml" />
 
     <Style Selector="ScrollBar /template/ Thumb">
         <Setter Property="CornerRadius" Value="5" />


### PR DESCRIPTION
## What and why

The first extraction pulled up the **shell** vocabulary — tokens, `card`, `layer`, `chip`, `searchpill`, `toolbar`, `accent`, scrollbars, `statusBar`, `sectionHeader` — and left the Fluent **control** retheming here:

- `TextBox`/`ComboBox`/`NumericUpDown` corner radius, and the brand text-selection wash
- `SelectableTextBlock` selection brush
- `ListBox`/`ListBoxItem`/`TreeView`/`TreeViewItem` rounded rows
- `DataGrid` soft horizontal rules
- `Button.soft`, `Button.soft.danger`, `Button.danger`, `ToggleButton.soft`
- the chip checked/active washes
- `TabControl`

kubeNimbus had **none** of it, so it drew stock Fluent inputs, lists and grids next to these — two apps sharing a design system and visibly not looking like it. Nobody notices that from inside either app; it only shows with the two windows side by side, which is exactly the comparison the shared library exists to survive.

All of it passes the membership test — none of it can only be described by naming Postgres — so it moves to `shared/nimbusUi/Theme/Controls.axaml`, a new file the shared CLAUDE.md already described in its layout section but which did not exist yet.

**What stays here** is genuinely this app's, and is now stated in DESIGN.md's not-shared table:

- `TabItem` — kubeNimbus styles the same selector for its compact inspector strip (already documented)
- `TabControl.segmented` — kubeNimbus does that job with `ListBox.segmented` + `TabControl.headerless` on purpose, because a `TabControl` cannot host a panel's own tools on its header row and its inspector dock needs exactly that
- the AvaloniaEdit completion and search panel themes

**Nothing about pgNimbus should look different.** The shared file loads before this app's own `Theme.axaml` (see `App.axaml`), so an override here still wins; the styles themselves are unchanged rules in a new home.

## Verified

- [x] `dotnet build PgNimbus.slnx` — 0 warnings
- [ ] `dotnet test --project PgNimbus.Core.Tests/PgNimbus.Core.Tests.csproj` — **not run**; this PR touches no C#, only style files and docs
- [ ] NativeAOT publish — **not run**, same reason
- [x] `dotnet run --project tools/Screenshot -- <dir>` — all 30 scenarios rendered and compared against the pre-move output

**Anything left unverified:** the app has not been driven by hand this session. The screenshot harness covers every view it renders, but hover, pressed and disabled states are not in a static render — `Button.soft`'s hover/pressed template-part pinning and `ToggleButton.soft`'s checked states are the ones worth clicking, since they are the styles most dependent on load order.

## Screenshots

All 30 scenarios, both themes — identical to before the move. The preferences window, the main window's schema tree, the results grid and the segmented monitoring strips are the ones that exercise the moved styles most.

## Checklist

- [x] [CLAUDE.md](../CLAUDE.md) updated — the shared-layout list now names `Theme/Controls.axaml` and says what is left in this app's own `Styles/Theme.axaml`, and why
- [x] **Touches `shared/nimbusUi`** — paired kubeNimbus PR: https://github.com/Shman4ik/kubeNimbus/pull/28
- [x] Anything general enough for kubeNimbus went into `shared/nimbusUi` — that is the entire content of this PR

> **Subtree pushed.** `shared/nimbusUi` is up at [nimbusUi@c991f41](https://github.com/Shman4ik/nimbusUi/commit/c991f41), a fast-forward from the extraction commit. All three copies of the nine shared files now match byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


