### PR TITLE
Bump SSH.NET to 2026.0.0 for CVE-2026-48798

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,10 +61,12 @@ Three rules about it:
 
 ## Hard architectural rules
 
-1. **`PgNimbus.Core` has zero Avalonia/UI dependencies.** It references only
-   `Npgsql`. Anything UI-related belongs in `PgNimbus.App`. This keeps the
-   engine reusable for a future CLI or test harness — don't leak
-   `Avalonia.*` or `CommunityToolkit.Mvvm` types into `Core`.
+1. **`PgNimbus.Core` has zero Avalonia/UI dependencies.** Its only packages are
+   `Npgsql`, `System.Security.Cryptography.ProtectedData` (the DPAPI credential
+   store) and `SSH.NET` (the tunnel) — all headless. Anything UI-related belongs
+   in `PgNimbus.App`. This keeps the engine reusable for a future CLI or test
+   harness — don't leak `Avalonia.*` or `CommunityToolkit.Mvvm` types into
+   `Core`.
 2. **Streaming + cancellation are non-negotiable.** `QueryEngine.ExecuteAsync`
    returns result rows via `IAsyncEnumerable<RowBatch>` in ~200-row batches so
    the UI can render before the full result set arrives. Every execution
@@ -597,7 +599,7 @@ csproj / WiX / MSIX manifest reference them unchanged:
 ## Tech stack
 
 - `net10.0` for all projects.
-- Core: `Npgsql`.
+- Core: `Npgsql`, `System.Security.Cryptography.ProtectedData`, `SSH.NET`.
 - App: `Avalonia`, `Avalonia.Desktop`, `Avalonia.Themes.Fluent`,
   `Avalonia.Fonts.Inter`, `Avalonia.Controls.DataGrid`, `Avalonia.AvaloniaEdit`,
   `CommunityToolkit.Mvvm`, `AvaloniaUI.DiagnosticsSupport` (DevTools/MCP —

--- a/PgNimbus.Core/PgNimbus.Core.csproj
+++ b/PgNimbus.Core/PgNimbus.Core.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="10.0.3" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.10" />
-    <PackageReference Include="SSH.NET" Version="2025.1.0" />
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
GitHub's Dependabot alert flags SSH.NET <= 2025.1.0 as high severity
(CVSS 7.1, GHSA-q939-rpr3-3284): ScpClient.Download writes files using
names the remote SCP server supplies during a recursive download, with
no check that the resulting path stays inside the requested directory.
A malicious or MITM'd server can send "../" or absolute paths and
overwrite anything the client process can reach.

pgNimbus never touches ScpClient — Connections/SshTunnel.cs uses only
SshClient plus ForwardedPortLocal for the database port forward — so
the vulnerable code path was unreachable here. The upgrade still has to
happen: Directory.Build.props promotes NU1902-NU1904 to errors with
NuGetAuditMode=all, so the advisory fails `dotnet restore` outright
(verified: "error NU1903: Package 'SSH.NET' 2025.1.0 has a known high
severity vulnerability"), which would break every build and the release
pipeline, not just the audit.

2026.0.0 is the patched release and declares no breaking changes; it
also carries three other security fixes and a large allocation
reduction in SFTP. The one API tightening it does make — ScpClient now
requiring an explicit IRemotePathTransformation — does not reach us.
Full solution builds with 0 errors and all 647 Core tests pass.

Also corrects CLAUDE.md, which still claimed Core references Npgsql
alone; SSH.NET and ProtectedData have been there too, and a stale
dependency list is what let this one read as out of scope.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TxaDQM8oyZCyqxGL47swNZ