### PR TITLE
Fix two Mac-reported bugs: paste box splicing, close quitting the app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,19 @@ Three rules about it:
    round-trips: the window inherits a warm pool. The one deliberate exception is
    `BuildMainWindow`'s string overload behind `PGNIMBUS_CONN`, which stays lazy
    because no connect form is standing behind it.
+   The dialog's **paste-a-connection-string box behaves like a browser address
+   bar** (2026-08): focusing it selects everything, so a paste replaces the
+   whole string. It has to, because the box is two things at once — the paste
+   target *and* a mirror of the form below, rewritten as a `postgres://` URI on
+   every field edit. So it is almost never empty, its content reads as a hint
+   rather than as text anyone typed, and splicing a pasted string into the
+   middle of it produced a hybrid of the two that then *parsed*, filling the
+   form with nonsense (the reported bug). Select-all-on-focus is in
+   `ConnectionDialog.axaml.cs`: a tunneled `PointerPressed` that only fires on
+   the click bringing focus in (left button only — marking a right-click handled
+   would swallow the box's own cut/copy/paste menu), plus a `GotFocus` handler
+   for Tab/arrow entry. Clicks after that place the caret normally, so the
+   string stays editable by hand.
 3. **Loading a query never overwrites the active tab.** Saved queries,
    history entries, and generated DDL all open in a *new* tab.
 4. **Tabs drag-reorder; the ☰ app menu is the file-command home.** The query
@@ -501,6 +514,22 @@ Three rules about it:
   bar (`BuildMacNativeMenu`) is the file-command home there, so it would be a
   second copy of the same commands. The sidebar toggle icon is platform-picked
   via `{OnPlatform}` (SF-style geometry on macOS).
+- **macOS: closing the last window does not quit the app (2026-08).** Closing a
+  window and quitting are two separate actions there, and the app that exits
+  when its last window closes is the one Mac users report as a bug. So
+  `App.KeepRunningWithNoWindowsOnMac` sets `ShutdownMode.OnExplicitShutdown` on
+  macOS only — Windows and Linux keep Avalonia's default `OnLastWindowClose`,
+  where a windowless background app would read as "close did nothing" — and
+  subscribes to `IActivatableLifetime.Activated` (via
+  `Application.TryGetFeature`) for `ActivationKind.Reopen`, the Dock-icon click.
+  Reopen raises an existing window if there is one, and otherwise builds a fresh
+  connection dialog: the closed `MainWindow`'s `Closed` handler already disposed
+  its data source and SSH tunnel, so there is nothing to resurrect. What still
+  quits, and why `OnExplicitShutdown` is safe: Cmd+Q and the app menu's Quit
+  arrive as a platform shutdown request, which
+  `ClassicDesktopStyleApplicationLifetime` routes straight to `DoShutdown`
+  without consulting `ShutdownMode`, as does the `Shutdown()` that
+  `CrashReporter` and `StartupProbe` call directly.
 - **Windows** — every remaining window still calls `ThemedWindowChrome.Attach(this)`
   for the **icon** (details in the icon section below). Its caption-colour half is
   moot on `MainWindow`, whose caption is ours, and still applies to the dialogs and

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -190,6 +190,8 @@ public partial class App : Application
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            KeepRunningWithNoWindowsOnMac(desktop);
+
             var envConnectionString = Environment.GetEnvironmentVariable("PGNIMBUS_CONN");
             if (!string.IsNullOrWhiteSpace(envConnectionString))
             {
@@ -210,6 +212,71 @@ public partial class App : Application
     }
 
     /// <summary>
+    /// macOS only: closing the last window leaves the app running instead of
+    /// quitting it. Closing a window and quitting an app are two different
+    /// actions on macOS — the menu bar stays, the Dock icon stays, and clicking
+    /// that icon brings a window back (<see cref="ActivationKind.Reopen"/>).
+    /// Quitting is Cmd+Q / the app menu's Quit, which still works: the
+    /// platform's quit request reaches
+    /// <c>ClassicDesktopStyleApplicationLifetime</c> through its
+    /// <c>ShutdownRequested</c> hook, which doesn't consult
+    /// <see cref="ShutdownMode"/> — so does <c>Shutdown()</c>, which the crash
+    /// reporter and the startup probe call directly.
+    ///
+    /// Windows and Linux keep Avalonia's default <c>OnLastWindowClose</c>: a
+    /// windowless app in the background is a macOS idea, and elsewhere it would
+    /// read as "close did nothing".
+    /// </summary>
+    private void KeepRunningWithNoWindowsOnMac(IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
+        if (TryGetFeature(typeof(IActivatableLifetime)) is IActivatableLifetime activatable)
+        {
+            activatable.Activated += (_, e) =>
+            {
+                if (e.Kind == ActivationKind.Reopen)
+                {
+                    ReopenWindow(desktop);
+                }
+            };
+        }
+    }
+
+    /// <summary>
+    /// The Dock icon was clicked. A window that merely sat behind something else
+    /// (or minimized) is what the user is asking for, so raise that; only when
+    /// every window is gone does the app need a fresh entry point, and that's
+    /// the connection dialog — the closed window's data source and SSH tunnel
+    /// went with it (see <see cref="BuildMainWindow(NpgsqlDataSource, string?, SshTunnel?)"/>),
+    /// so there is nothing to resurrect.
+    /// </summary>
+    private static void ReopenWindow(IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        if (desktop.Windows.Count > 0)
+        {
+            var existing = desktop.Windows.FirstOrDefault(w => w.IsActive) ?? desktop.Windows[0];
+            if (existing.WindowState == WindowState.Minimized)
+            {
+                existing.WindowState = WindowState.Normal;
+            }
+
+            existing.Show();
+            existing.Activate();
+            return;
+        }
+
+        var dialog = BuildConnectionDialog(desktop);
+        desktop.MainWindow = dialog;
+        dialog.Show();
+    }
+
+    /// <summary>
     /// Builds the connection-profile picker. Used for three flows:
     /// startup (as <see cref="IClassicDesktopStyleApplicationLifetime.MainWindow"/>,
     /// no <paramref name="previousWindow"/>, default <paramref name="replaceMainWindow"/>),
@@ -223,11 +290,14 @@ public partial class App : Application
     /// and <see cref="IClassicDesktopStyleApplicationLifetime.MainWindow"/> itself
     /// — untouched; the new window simply joins them. Only the startup flow
     /// passes <paramref name="autoConnect"/>, and even then the dialog only
-    /// connects on its own if the user turned the preference on.
-    /// There is no explicit
-    /// <c>ShutdownMode</c> set, so Avalonia's default <c>OnLastWindowClose</c>
-    /// applies: the app keeps running until every window (whichever one that is)
-    /// has closed.
+    /// connects on its own if the user turned the preference on. A fourth caller
+    /// is <see cref="ReopenWindow"/>, the macOS Dock-icon route back in.
+    ///
+    /// <c>ShutdownMode</c> is Avalonia's default <c>OnLastWindowClose</c> on
+    /// Windows and Linux — the app keeps running until every window (whichever
+    /// one that is) has closed — and <c>OnExplicitShutdown</c> on macOS, where
+    /// closing the last window is not quitting (see
+    /// <see cref="KeepRunningWithNoWindowsOnMac"/>).
     ///
     /// Note: two windows connected to the same host/database each own a
     /// separate in-memory workspace snapshot but save under the same

--- a/PgNimbus.App/Views/ConnectionDialog.axaml
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml
@@ -67,9 +67,12 @@
 
         <!-- Paste-anything import: URI / JDBC / Key=Value / libpq / psql command line.
              Parses automatically as you paste/type, and mirrors the fields below
-             as a postgres:// URI whenever you edit them by hand. -->
+             as a postgres:// URI whenever you edit them by hand. Because of that
+             mirroring the box is usually already full, so it behaves like a
+             browser address bar - focusing it selects everything (see
+             ConnectionDialog.axaml.cs). -->
         <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,14,12">
-            <TextBox Grid.Column="0" Text="{Binding ImportText}" Margin="0,0,6,0"
+            <TextBox Name="ImportBox" Grid.Column="0" Text="{Binding ImportText}" Margin="0,0,6,0"
                      PlaceholderText="Paste a connection string (postgres://…, jdbc:…, Key=Value;…, psql …)"
                      ToolTip.Tip="Paste a postgres:// URI, JDBC URL, Npgsql Key=Value string, libpq keyword string or psql command line and the fields fill in by themselves">
                 <TextBox.KeyBindings>

--- a/PgNimbus.App/Views/ConnectionDialog.axaml.cs
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml.cs
@@ -33,6 +33,47 @@ public partial class ConnectionDialog : Window
         ProfilesList.AddHandler(PointerPressedEvent, OnProfilesPointerPressed, Avalonia.Interactivity.RoutingStrategies.Tunnel);
         ProfilesList.PointerMoved += OnProfilesPointerMoved;
         ProfilesList.PointerReleased += OnProfilesPointerReleased;
+
+        // Address-bar behaviour for the paste box. Its content is written by the
+        // app, not by the user: the form mirrors itself back into it as a
+        // postgres:// URI, so by the time anyone reaches for it it already holds
+        // a string that reads as a hint. Splicing a pasted connection string into
+        // the middle of that produced a hybrid of the two - which then parsed,
+        // and filled the form with nonsense. Selecting everything as focus
+        // arrives makes a paste (or a keystroke) replace the whole string, the
+        // way an address bar does.
+        ImportBox.AddHandler(PointerPressedEvent, OnImportBoxPointerPressed, Avalonia.Interactivity.RoutingStrategies.Tunnel);
+        ImportBox.GotFocus += OnImportBoxGotFocus;
+    }
+
+    /// <summary>
+    /// The click that brings focus to the paste box selects its whole content;
+    /// clicks after that place the caret as usual, so the string is still
+    /// editable by hand. Left button only - marking a right-click handled would
+    /// swallow the box's own cut/copy/paste menu.
+    /// </summary>
+    private void OnImportBoxPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (ImportBox.IsFocused || !e.GetCurrentPoint(ImportBox).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        ImportBox.Focus();
+        ImportBox.SelectAll();
+
+        // The TextBox's own press handler runs next and would collapse the
+        // selection back to a caret, so this click ends here.
+        e.Handled = true;
+    }
+
+    /// <summary>Keyboard focus never goes through the pointer handler above, so Tab into the box selects all too.</summary>
+    private void OnImportBoxGotFocus(object? sender, FocusChangedEventArgs e)
+    {
+        if (e.NavigationMethod is NavigationMethod.Tab or NavigationMethod.Directional)
+        {
+            ImportBox.SelectAll();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Both came in from a macOS user.

Pasting a connection string into the connect dialog's paste box spliced it
into whatever was already there instead of replacing it. That box is two
things at once: the paste target, and a mirror of the form below rewritten
as a postgres:// URI on every field edit. So it is almost never empty, and
its content reads as a hint rather than as text anyone typed. Pasting a
second connection string produced a hybrid of the two, which then parsed,
and filled the form with nonsense (host "db.postgres", database
"/bob@other.host:5432/shopexample.com:6543/analytics").

It now behaves like a browser address bar: the click that brings focus in
selects everything, so a paste replaces the whole string. Clicks after that
place the caret normally, so the string is still editable by hand. Left
button only, or marking the press handled would swallow the box's own
cut/copy/paste menu; a GotFocus handler covers Tab and arrow entry, which
never reach the pointer handler.

Closing the window quit the whole app on macOS, where closing a window and
quitting are separate actions. ShutdownMode is now OnExplicitShutdown there
(Windows and Linux keep OnLastWindowClose, where a windowless background app
would read as "close did nothing"), and IActivatableLifetime's Reopen - the
Dock icon click - raises an existing window or, when every window is gone,
builds a fresh connection dialog. The closed MainWindow already disposed its
data source and SSH tunnel, so there is nothing to resurrect.

Cmd+Q still quits: a platform shutdown request goes straight to DoShutdown
without consulting ShutdownMode, as does the Shutdown() that CrashReporter
and StartupProbe call.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0134kyK3z6vDC2YMsn67CQAL