### PR TITLE
Draw boolean cells as icons so the check and cross sit on one baseline

### DIFF
--- a/PgNimbus.App/Converters/RowIndexConverter.cs
+++ b/PgNimbus.App/Converters/RowIndexConverter.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
+using Avalonia;
 using Avalonia.Data.Converters;
+using Avalonia.Media;
 using PgNimbus.Core.Schema;
 
 namespace PgNimbus.App.Converters;
@@ -77,27 +79,68 @@ public sealed class RowIndexConverter : IValueConverter
 }
 
 /// <summary>
-/// Renders a boolean cell as a ✓/✗ glyph instead of the literal "true"/"false"
-/// text, so a boolean column reads at a glance. SQL NULL keeps the same "NULL"
-/// placeholder every other column uses (dimmed via <see cref="NullCellOpacityConverter"/>).
+/// Renders a boolean cell as the app's own check/close icon geometry instead of
+/// the literal "true"/"false" text, so a boolean column reads at a glance.
+/// Drawn rather than typed: the ✓/✗ dingbats (U+2713/U+2717) are not carried by
+/// one font on every platform — Inter has the check and not the cross — so the
+/// pair fell back to different fonts and sat at visibly different heights in the
+/// row. Two geometries from the same icon set share one box and one baseline.
+/// Returns null for anything that is not a bool (SQL NULL, or a surprise value);
+/// <see cref="BoolCellTextConverter"/> covers those cases with text.
 /// </summary>
-public sealed class BoolCellGlyphConverter : IValueConverter
+public sealed class BoolCellIconConverter : IValueConverter
 {
-    public const string True = "✓";  // ✓
-    public const string False = "✗";  // ✗
+    // UI-thread only (cells are generated and rendered there), so a plain
+    // lazily-filled cache is fine.
+    private static Geometry? _check;
+    private static Geometry? _cross;
+    private static bool _resolved;
 
     private readonly int _index;
 
-    public BoolCellGlyphConverter(int index) => _index = index;
+    public BoolCellIconConverter(int index) => _index = index;
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is object?[] row && _index < row.Length && row[_index] is bool b ? Icon(b) : null;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+
+    private static Geometry? Icon(bool value)
+    {
+        if (!_resolved)
+        {
+            _resolved = true;
+            _check = Find("CheckIconGeometry");
+            _cross = Find("CloseIconGeometry");
+        }
+
+        return value ? _check : _cross;
+    }
+
+    private static Geometry? Find(string key) =>
+        Application.Current is { } app && app.TryGetResource(key, null, out var resource)
+            ? resource as Geometry
+            : null;
+}
+
+/// <summary>
+/// The text half of a boolean cell: the shared "NULL" placeholder for SQL NULL
+/// and, defensively, the text form of a value a boolean column should never
+/// hold. Empty for a real bool — <see cref="BoolCellIconConverter"/> draws that.
+/// </summary>
+public sealed class BoolCellTextConverter : IValueConverter
+{
+    private readonly int _index;
+
+    public BoolCellTextConverter(int index) => _index = index;
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         value is object?[] row && _index < row.Length
             ? row[_index] switch
             {
                 null => RowIndexConverter.NullPlaceholder,
-                bool b => b ? True : False,
-                // A boolean column should only ever hold bool/null, but never
-                // throw on a surprise value — show its text form.
+                bool => string.Empty,
                 var other => other.ToString(),
             }
             : null;

--- a/PgNimbus.App/ResultTextColumn.cs
+++ b/PgNimbus.App/ResultTextColumn.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using Avalonia.Data;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
@@ -18,8 +19,9 @@ namespace PgNimbus.App;
 /// binding has to be attached per generated element.
 /// The column also renders type-aware: given its resolved
 /// <see cref="PgTypeCategory"/> it right-aligns and mono-fonts numeric cells
-/// (so digits line up) and shows a ✓/✗ glyph for booleans instead of the
-/// literal "true"/"false" — for every result set, not just editable ones.
+/// (so digits line up) and draws a centered check/cross icon for booleans
+/// instead of the literal "true"/"false" — for every result set, not just
+/// editable ones.
 /// When the result maps to an editable table, the column also knows its
 /// Postgres type (via <paramref name="editorMeta"/>) and generates a
 /// type-appropriate cell editor: a dropdown of pg_enum labels for enum
@@ -33,6 +35,10 @@ public sealed class ResultTextColumn : DataGridTextColumn
     // Shared numeric font — the same mono stack the SQL editor/inspector use, so
     // digits line up column-to-column under the right-aligned numeric cells.
     private static readonly FontFamily MonoFont = new("Cascadia Code,Consolas,Menlo,monospace");
+
+    // Drawn at roughly cap height so the icon reads as one line of text rather
+    // than as a control sitting inside the row.
+    private const double BoolIconSize = 13;
 
     private readonly int _index;
     private readonly ColumnDetail? _editorMeta;
@@ -65,18 +71,10 @@ public sealed class ResultTextColumn : DataGridTextColumn
         Justification = "Pathless binding uses a converter only; no dynamic code.")]
     protected override Control GenerateElement(DataGridCell cell, object dataItem)
     {
-        // Boolean cells read as a ✓/✗ glyph rather than "true"/"false" — its own
-        // TextBlock (bound through the glyph converter), centered.
+        // Boolean cells read as a check/cross icon rather than "true"/"false".
         if (_category == PgTypeCategory.Boolean)
         {
-            var glyph = new TextBlock
-            {
-                TextAlignment = TextAlignment.Center,
-                HorizontalAlignment = HorizontalAlignment.Stretch,
-            };
-            glyph.Bind(TextBlock.TextProperty, new Binding { Converter = new BoolCellGlyphConverter(_index) });
-            glyph.Bind(Visual.OpacityProperty, new Binding { Converter = new NullCellOpacityConverter(_index) });
-            return glyph;
+            return GenerateBooleanElement();
         }
 
         var element = base.GenerateElement(cell, dataItem);
@@ -94,6 +92,50 @@ public sealed class ResultTextColumn : DataGridTextColumn
         }
 
         return element;
+    }
+
+    /// <summary>
+    /// The check/cross icon and the "NULL" placeholder share one cell: exactly
+    /// one of them ever has content, so they overlap in a single-cell Panel and
+    /// both centre themselves in it. The icon is a drawn geometry rather than a
+    /// ✓/✗ text glyph because those two dingbats resolve to different fallback
+    /// fonts on most platforms, which left the cross riding high above the row's
+    /// centre while the check sat on the text baseline.
+    /// </summary>
+    // Pathless converter bindings, same as GenerateElement's — no reflection.
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Pathless binding uses a converter only; no reflection member access.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Pathless binding uses a converter only; no dynamic code.")]
+    private Control GenerateBooleanElement()
+    {
+        var icon = new Avalonia.Controls.Shapes.Path
+        {
+            Width = BoolIconSize,
+            Height = BoolIconSize,
+            Stretch = Stretch.Uniform,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        icon.Bind(Avalonia.Controls.Shapes.Path.DataProperty, new Binding
+        {
+            Converter = new BoolCellIconConverter(_index),
+        });
+        // Shape.Fill is not an inherited property, so take the cell's text
+        // colour (which the row's selected/unselected states retint) explicitly.
+        icon.Bind(Avalonia.Controls.Shapes.Shape.FillProperty, icon.GetObservable(TextElement.ForegroundProperty));
+
+        var text = new TextBlock
+        {
+            TextAlignment = TextAlignment.Center,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        text.Bind(TextBlock.TextProperty, new Binding { Converter = new BoolCellTextConverter(_index) });
+
+        var cell = new Panel { Children = { icon, text } };
+        cell.Bind(Visual.OpacityProperty, new Binding { Converter = new NullCellOpacityConverter(_index) });
+        return cell;
     }
 
     protected override Control GenerateEditingElementDirect(DataGridCell cell, object dataItem)

--- a/tools/Screenshot/Fixtures.cs
+++ b/tools/Screenshot/Fixtures.cs
@@ -181,8 +181,9 @@ internal static class Fixtures
             new("customer", "text", typeof(string), TableOid, 2),
             new("status", "order_status", typeof(string), TableOid, 3),
             new("total", "numeric", typeof(decimal), TableOid, 4),
-            new("metadata", "jsonb", typeof(string), TableOid, 5),
-            new("placed_at", "timestamp with time zone", typeof(DateTime), TableOid, 6),
+            new("paid", "boolean", typeof(bool), TableOid, 5),
+            new("metadata", "jsonb", typeof(string), TableOid, 6),
+            new("placed_at", "timestamp with time zone", typeof(DateTime), TableOid, 7),
         ];
 
         var statuses = new[] { "shipped", "pending", "cancelled", "shipped", "paid" };
@@ -204,6 +205,9 @@ internal static class Fixtures
                 names[i],
                 statuses[i % statuses.Length],
                 decimal.Round(18.5m + i * 37.25m, 2),
+                // true / false / NULL in turn, so the boolean column's check,
+                // cross and NULL placeholder all appear in the screenshots.
+                i % 3 == 2 ? null : (object)(i % 3 == 0),
                 $$"""{"channel": "web", "coupon": {{(i % 3 == 0 ? "\"SUMMER26\"" : "null")}}}""",
                 placed.AddMinutes(-7 * i),
             ]);

--- a/tools/Screenshot/Scenarios.cs
+++ b/tools/Screenshot/Scenarios.cs
@@ -22,6 +22,7 @@ internal static class Scenarios
                c.full_name AS customer,
                o.status,
                o.total,
+               o.paid,
                o.metadata,
                o.placed_at
           FROM orders AS o


### PR DESCRIPTION
A boolean result cell rendered the ✓ (U+2713) and ✗ (U+2717) dingbats as text. Inter carries the check but not the cross, so the two resolved to different fonts with different metrics: the cross rode visibly high in the row while the check sat on the text baseline, and the pair also differed in weight. Nothing about the cell was centred vertically either — the TextBlock kept the default alignment.

Both halves are now one drawn geometry each, taken from the shared icon set (CheckIconGeometry / CloseIconGeometry), sized to roughly cap height and centred in both axes. Shape.Fill is not an inherited property, so the icon picks the cell's text colour up from TextElement.Foreground explicitly, which keeps it tracking the theme and the row's selected state.

BoolCellGlyphConverter splits accordingly: BoolCellIconConverter returns the geometry for a real bool, BoolCellTextConverter keeps the shared "NULL" placeholder (and the defensive text form of a value a boolean column should never hold). Exactly one of them ever has content, so they overlap in a single-cell Panel.

The screenshot harness had no boolean column at all, which is why this path was never in a rendered diff. The orders fixture grows a `paid` column cycling true / false / NULL so the check, the cross and the placeholder are all in the CI screenshots.

<!--
  Thanks for the PR. Keep this short — the goal is to tell a reviewer what
  changed, why, and how much to trust it. Delete sections that don't apply.
-->

## What and why

<!-- What this changes, and the problem it solves. Link the issue if there is one. -->

## Verified

<!--
  Tick what you actually ran, and say what you didn't. "Not verified against a
  live database" is a useful, welcome answer — an unverified claim of
  verification is not.
-->

- [ ] `dotnet build PgNimbus.slnx`
- [ ] `dotnet test --project PgNimbus.Core.Tests/PgNimbus.Core.Tests.csproj`
      — against a live Postgres? <!-- yes / no, tests skip cleanly without one -->
- [ ] NativeAOT publish, no new trim/AOT warnings — RID: <!-- win-x64 (shipping) / linux-x64 -->
- [ ] `dotnet run --project tools/Screenshot -- <dir>` (UI changes)

Anything left unverified:

## Screenshots

<!-- Before/after for any UI change, both themes if the change is visual. -->

## Checklist

- [ ] [CLAUDE.md](../CLAUDE.md) updated if this changes anything it describes
      — it's the contract, not a record of the past
- [ ] **Touches `shared/nimbusUi`?** Then the change is kubeNimbus's too: push
      the subtree up (`git subtree push --prefix shared/nimbusUi …`), open the
      matching kubeNimbus PR, and link it here. A shared change that lands in
      one app only is how the copies drifted in the first place — see
      [DESIGN.md](../shared/nimbusUi/DESIGN.md).
- [ ] Anything general enough for kubeNimbus (a token, a style class, a window
      behaviour) went into `shared/nimbusUi` rather than this app's
      `Styles/Theme.axaml`
- [ ] No new UI state that renders as a blank rectangle (loading / empty /
      disconnected / error each have an explicit visual)
- [ ] `PgNimbus.Core` still has zero UI dependencies
- [ ] No credentials persisted anywhere they weren't already
