### PR TITLE
Stop the binding-error bursts from ActiveTab and Browse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -629,6 +629,21 @@ csproj / WiX / MSIX manifest reference them unchanged:
   (via `TextChanged` + `PropertyChanged`, with a re-entrancy guard), not via
   XAML `Binding`. Both the main SQL editor (`_suppressEditorSync`) and the
   cell inspector's JSON editor (`_suppressInspectorSync`) follow this pattern.
+- **A nullable view model never sits *inside* a binding path.** Avalonia logs
+  `[Binding] … 'Value is null.'` on every re-evaluation where an *intermediate*
+  link of a path is null — a real binding bug then hides in the noise. Two
+  shapes produced ~65 of those messages per closed tab (fixed 2026-08): the
+  status bar's browse paging reached through `ActiveTab.Browse.PageLabel`, and
+  `Browse` is null on every tab that isn't browsing a table — it now hangs off
+  `DataContext="{Binding ActiveTab.Browse}"` (+ `x:DataType`, the same shape the
+  command-palette overlay uses), so the null lands at the *end* of the path
+  where it is merely an unset binding; and `MainViewModel.CloseTab` removed the
+  tab strip's selected item, which makes the two-way `SelectedItem` binding push
+  `ActiveTab = null` synchronously and every `ActiveTab.*` binding in the window
+  log against that transient null — it now moves the selection to the neighbour
+  (right, or left when the last tab closes) *before* `Tabs.RemoveAt`, so the
+  removal never touches the selection.
+
 - **json/jsonb are a first-class editable type.** `ColumnValueEditorClassifier`
   maps them to `ColumnValueEditor.Json` (jsonpath isn't JSON-shaped so it takes
   the plain-cast `CastText` path below; hstore stays `Text` — its display needs

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -785,10 +785,19 @@ public sealed partial class MainViewModel : ObservableObject
             return;
         }
 
-        // Decide before the removal: when the removed item is the ListBox's
-        // selection, RemoveAt makes the two-way SelectedItem binding push
-        // ActiveTab = null synchronously, so comparing afterwards misses.
-        var wasActive = ReferenceEquals(ActiveTab, tab);
+        // Move the selection off the doomed tab *before* removing it. Removing
+        // the ListBox's selected item makes its two-way SelectedItem binding
+        // push ActiveTab = null synchronously, and every binding under
+        // ActiveTab logs a path error against that transient null (a screenful
+        // of [Binding] noise per closed tab) before a post-removal reassignment
+        // could put it right. Reselecting first means the removal never touches
+        // the selection at all. Successor: the tab to the right, or the one to
+        // the left when the last tab is closing — the count guard above
+        // guarantees a neighbour exists.
+        if (ActiveTab is null || ReferenceEquals(ActiveTab, tab))
+        {
+            ActiveTab = Tabs[index < Tabs.Count - 1 ? index + 1 : index - 1];
+        }
 
         // A query still running in the closed tab would otherwise keep streaming
         // in the background, holding a pool connection and server-side work for a
@@ -797,11 +806,6 @@ public sealed partial class MainViewModel : ObservableObject
 
         tab.Executed -= SavedQueries.RecordExecution;
         Tabs.RemoveAt(index);
-
-        if (wasActive || ActiveTab is null)
-        {
-            ActiveTab = Tabs[Math.Min(index, Tabs.Count - 1)];
-        }
 
         NotifyTabCommands();
     }

--- a/PgNimbus.App/Views/MainWindow.axaml
+++ b/PgNimbus.App/Views/MainWindow.axaml
@@ -563,15 +563,25 @@
                                 IsVisible="{Binding ActiveTab.IsBrowsing}"
                                 IsEnabled="{Binding !ActiveTab.IsRunning}">
                         <Rectangle Classes="statusSeparator" />
-                        <TextBlock Classes="statusText dim" Text="{Binding ActiveTab.Browse.PageLabel}" VerticalAlignment="Center" />
-                        <Button Classes="chip" Padding="4" VerticalAlignment="Center"
-                                Command="{Binding ActiveTab.Browse.PreviousPageCommand}" ToolTip.Tip="Previous page">
-                            <PathIcon Data="{StaticResource ChevronLeftIconGeometry}" Width="11" Height="11" />
-                        </Button>
-                        <Button Classes="chip" Padding="4" VerticalAlignment="Center"
-                                Command="{Binding ActiveTab.Browse.NextPageCommand}" ToolTip.Tip="Next page">
-                            <PathIcon Data="{StaticResource ChevronRightIconGeometry}" Width="11" Height="11" />
-                        </Button>
+                        <!-- The paging controls hang off the browse view model itself
+                             rather than reaching through ActiveTab.Browse.*: Browse is
+                             null on every tab that isn't browsing a table (the common
+                             case), and a null *inside* a binding path is logged as a
+                             [Binding] error on every re-evaluation, while a null
+                             DataContext is just an unset binding. Same shape as the
+                             command palette's Border below. -->
+                        <StackPanel Orientation="Horizontal" Spacing="8" VerticalAlignment="Center"
+                                    x:DataType="vm:TableBrowseViewModel" DataContext="{Binding ActiveTab.Browse}">
+                            <TextBlock Classes="statusText dim" Text="{Binding PageLabel}" VerticalAlignment="Center" />
+                            <Button Classes="chip" Padding="4" VerticalAlignment="Center"
+                                    Command="{Binding PreviousPageCommand}" ToolTip.Tip="Previous page">
+                                <PathIcon Data="{StaticResource ChevronLeftIconGeometry}" Width="11" Height="11" />
+                            </Button>
+                            <Button Classes="chip" Padding="4" VerticalAlignment="Center"
+                                    Command="{Binding NextPageCommand}" ToolTip.Tip="Next page">
+                                <PathIcon Data="{StaticResource ChevronRightIconGeometry}" Width="11" Height="11" />
+                            </Button>
+                        </StackPanel>
                     </StackPanel>
                 </Grid>
             </Border>

--- a/PgNimbus.App/Views/QueryEditorPanel.axaml.cs
+++ b/PgNimbus.App/Views/QueryEditorPanel.axaml.cs
@@ -264,8 +264,10 @@ public partial class QueryEditorPanel : UserControl
 
     private void OnMainViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        // ActiveTab is transiently null while the tab ListBox reacts to the
-        // removal of its selected item (see MainViewModel.CloseTab).
+        // Guarded because the tab strip's two-way SelectedItem binding can write
+        // a null: CloseTab reselects before it removes, so it no longer does,
+        // but the property is non-nullable by convention (a null!-initialized
+        // backing field), not by the compiler.
         if (e.PropertyName == nameof(MainViewModel.ActiveTab) && _model is { ActiveTab: not null })
         {
             AttachQuery(_model.ActiveTab);

--- a/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
@@ -235,8 +235,10 @@ public partial class ResultsGridPanel : UserControl
 
     private void OnMainViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        // ActiveTab is transiently null while the tab ListBox reacts to the
-        // removal of its selected item (see MainViewModel.CloseTab).
+        // Guarded because the tab strip's two-way SelectedItem binding can write
+        // a null: CloseTab reselects before it removes, so it no longer does,
+        // but the property is non-nullable by convention (a null!-initialized
+        // backing field), not by the compiler.
         if (e.PropertyName == nameof(MainViewModel.ActiveTab) && _model is { ActiveTab: not null })
         {
             AttachQuery(_model.ActiveTab);


### PR DESCRIPTION
Avalonia logs a [Binding] error for every re-evaluation where an *intermediate* link of a binding path is null, and two paths in the main window hit that constantly: ~65 messages per closed tab, which is exactly the noise a real binding bug would hide in.

Both are transient/expected nulls, not functional bugs, so the fix is to keep the null out of the middle of the path:

- CloseTab moved the selection *after* Tabs.RemoveAt. Removing the tab strip's selected item makes its two-way SelectedItem binding push ActiveTab = null synchronously, so every ActiveTab.* binding in the window logged against that transient null before the reassignment put it right (59 of the 65). It now reselects the neighbour — right, or left when the last tab closes — before the removal, so the removal never touches the selection. Same successor as before, and closing a non-active tab still leaves the selection alone.
- The status bar's browse paging reached through ActiveTab.Browse.*, and Browse is null on every tab that isn't browsing a table (the common case). It now hangs off DataContext="{Binding ActiveTab.Browse}" with x:DataType, the same shape the command-palette overlay uses, so the null lands at the end of the path where it is merely an unset binding.

Verified with a temporary headless probe over tools/Screenshot (real MainWindow + MainViewModel, LogToTrace to console), baseline vs fix: 65 -> 0 binding errors across window start, new tab and close tab. Tab successor semantics unchanged in all three cases, and the browse status bar renders pixel-identically to baseline.

<!--
  Thanks for the PR. Keep this short — the goal is to tell a reviewer what
  changed, why, and how much to trust it. Delete sections that don't apply.
-->

## What and why

<!-- What this changes, and the problem it solves. Link the issue if there is one. -->

## Verified

<!--
  Tick what you actually ran, and say what you didn't. "Not verified against a
  live database" is a useful, welcome answer — an unverified claim of
  verification is not.
-->

- [ ] `dotnet build PgNimbus.slnx`
- [ ] `dotnet test --project PgNimbus.Core.Tests/PgNimbus.Core.Tests.csproj`
      — against a live Postgres? <!-- yes / no, tests skip cleanly without one -->
- [ ] `dotnet test --project PgNimbus.App.Tests/PgNimbus.App.Tests.csproj`
      <!-- headless UI tests: real windows, no display, no database -->
- [ ] NativeAOT publish, no new trim/AOT warnings — RID: <!-- win-x64 (shipping) / linux-x64 -->
- [ ] UI changes: baselines refreshed via `scripts/screenshots/update-baselines.sh`
      (or the Screenshots workflow) and the image diff reviewed
      <!-- CI compares against tools/Screenshot/baselines and goes red on any change -->
- [ ] Release-facing change: `scripts/screenshots/update-published.sh` for the
      README / docs / Store shots

Anything left unverified:

## Screenshots

<!-- Before/after for any UI change, both themes if the change is visual. -->

## Checklist

- [ ] [CLAUDE.md](../CLAUDE.md) updated if this changes anything it describes
      — it's the contract, not a record of the past
- [ ] **Touches `shared/nimbusUi`?** Then the change is kubeNimbus's too: push
      the subtree up (`git subtree push --prefix shared/nimbusUi …`), open the
      matching kubeNimbus PR, and link it here. A shared change that lands in
      one app only is how the copies drifted in the first place — see
      [DESIGN.md](../shared/nimbusUi/DESIGN.md).
- [ ] Anything general enough for kubeNimbus (a token, a style class, a window
      behaviour) went into `shared/nimbusUi` rather than this app's
      `Styles/Theme.axaml`
- [ ] No new UI state that renders as a blank rectangle (loading / empty /
      disconnected / error each have an explicit visual)
- [ ] `PgNimbus.Core` still has zero UI dependencies
- [ ] No credentials persisted anywhere they weren't already
