### PR TITLE
docs(demo): use wslc instead of Docker for local Postgres

### DIFF
--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -23,17 +23,24 @@ be allowed to `CREATE EXTENSION`.
 
 ## Running it
 
-Point it at any PostgreSQL 14+ database (a throwaway local DB, a Docker
-`postgres`, or a hosted one like Neon). **It drops and recreates the demo
+Point it at any PostgreSQL 14+ database (a throwaway local DB, a `postgres`
+container, or a hosted one like Neon). **It drops and recreates the demo
 schemas and the `public.*` demo tables**, so use a database you don't mind
 overwriting.
+
+A throwaway local Postgres, via WSL's built-in `wslc.exe` (no Docker Desktop
+needed — ships with WSL 2.9.3+):
+
+```powershell
+wslc run -d --rm --name pgnimbus-demo -e POSTGRES_PASSWORD=postgres -p 55432:5432 postgres:17
+```
 
 ```bash
 # macOS / Linux
 ./seed.sh "postgres://user:pass@host:5432/dbname?sslmode=require"
 
 # Windows / PowerShell
-./seed.ps1 "postgres://user:pass@host:5432/dbname?sslmode=require"
+./seed.ps1 "postgres://postgres:postgres@localhost:55432/postgres"
 ```
 
 Omit the argument to fall back to libpq's `PG*` environment variables


### PR DESCRIPTION
## Summary
- The demo-seeding README pointed contributors at Docker Desktop for a throwaway local Postgres. Swapped the example to `wslc run` — WSL's built-in container CLI (ships with WSL 2.9.3+), which covers this single-container use case with no separate Docker install.
- Verified `wslc` works end-to-end on Windows/WSL: pulled `postgres:17`, port-mapped it, and connected via `wslc exec ... psql`.

## Test plan
- [x] Manually ran the new `wslc run -d --rm --name pgnimbus-demo -e POSTGRES_PASSWORD=postgres -p 55432:5432 postgres:17` command and confirmed the container comes up and is reachable via `wslc exec`.
- [x] Reviewed the rest of the repo for other Docker references tied to local dev — none found (no Dockerfile/docker-compose; CI and the release benchmark pipeline use GitHub Actions' `postgres:17` service container, unrelated to Docker Desktop).