### PR TITLE
Fix low-contrast text on checked ToggleButton.soft

### DIFF
--- a/shared/nimbusUi/src/Nimbus.Ui/Theme/Controls.axaml
+++ b/shared/nimbusUi/src/Nimbus.Ui/Theme/Controls.axaml
@@ -207,19 +207,30 @@
         <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
 
+    <!-- Fluent's ControlTheme also paints checked-state Foreground on the inner
+         PART_ContentPresenter (ToggleButtonForegroundChecked, meant for its own
+         solid accent-filled background). That Template-priority setter outranks
+         the plain Foreground above, so without pinning it here the pill renders
+         Fluent's near-white checked text over our translucent AppSelectionBrush
+         wash instead of AppAccentBrush - low-contrast, barely-legible text
+         (see the "Auto" toggle in the Activity window). Same fix as the
+         Background/BorderBrush pins below. -->
     <Style Selector="ToggleButton.soft:checked /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
         <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+        <Setter Property="Foreground" Value="{StaticResource AppAccentBrush}" />
     </Style>
 
     <Style Selector="ToggleButton.soft:checked:pointerover /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
         <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+        <Setter Property="Foreground" Value="{StaticResource AppAccentBrush}" />
     </Style>
 
     <Style Selector="ToggleButton.soft:checked:pressed /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="{StaticResource AppSelectionBrush}" />
         <Setter Property="BorderBrush" Value="{StaticResource AppAccentBrush}" />
+        <Setter Property="Foreground" Value="{StaticResource AppAccentBrush}" />
     </Style>
 
     <Style Selector="ToggleButton.soft:disabled">


### PR DESCRIPTION
## What and why

The Activity window's "Auto" toggle (and any future `ToggleButton.soft` in
either app) rendered near-illegible text when checked. Fluent's ControlTheme
paints checked-state `Foreground` on the inner `PART_ContentPresenter` at
Template priority, which outranks the plain `Foreground` setter on
`ToggleButton.soft:checked`. That left Fluent's near-white checked text
sitting on our translucent `AppSelectionBrush` wash instead of
`AppAccentBrush` — the same trap already fixed for `Background`/`BorderBrush`
on this same style, just not for `Foreground`.

Fix: pin `Foreground` on the same template part for `:checked`,
`:checked:pointerover`, and `:checked:pressed`.

## Verified

- [x] `dotnet build` (PgNimbus.App, Debug)
- [x] Headless screenshot harness (`tools/Screenshot`) rendered the Activity
      window with `AutoRefresh = true` in both light and dark theme —
      "Auto" now shows accent-blue text instead of washed-out white.
      (Temporary scenario tweak used only for verification, reverted before
      commit — the checked-in scenario deliberately keeps `AutoRefresh =
      false` today.)
- [ ] `dotnet test` — not run
- [ ] NativeAOT publish — not run
- [ ] Baseline screenshots — not refreshed (no committed scenario currently
      renders the checked state, so no baseline changes)

## Screenshots

Light, checked "Auto":
before = white text on light-blue wash (low contrast, as reported)
after = accent-blue text (this PR)

Dark, checked "Auto": accent-blue text, verified correct in both themes.

## Checklist

- [x] CLAUDE.md — no contract-level statement needs updating for this
- [ ] **Touches `shared/nimbusUi`.** Same fix belongs in kubeNimbus — subtree
      push + matching kubeNimbus PR not yet done, pending confirmation.
- [x] Nothing new added to app-local `Styles/Theme.axaml` — fix stayed in
      the shared control theme where the original style lives
- [x] No new UI state
- [x] `PgNimbus.Core` untouched
- [x] No credential handling touched