### PR TITLE
Stop the CI artifacts from eating the 0.5 GB storage budget

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -100,6 +100,9 @@ jobs:
         with:
           name: bench-results
           path: bench-results/
+          # A few hundred bytes of JSON + summary; the trend that matters is
+          # appended to gh-pages below and outlives the artifact.
+          retention-days: 14
 
       # Real tag-triggered releases append to the benchmark history on
       # gh-pages (./dev/bench), which renders per-metric trend charts.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,15 @@ on:
 permissions:
   contents: read
 
+# A newer push supersedes whatever was still running for the same branch, so a
+# force-push burst leaves one run instead of five — and one screenshots
+# artifact instead of five. The head ref (not github.ref) is the key on
+# purpose: a branch push and the pull_request run of that same branch would
+# otherwise land in different groups and never cancel each other.
+concurrency:
+  group: ci-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   DOTNET_NOLOGO: "1"
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
@@ -98,10 +107,17 @@ jobs:
           "${{ runner.temp }}/screenshots"
           --baseline tools/Screenshot/baselines
 
-      # if: always() — the run above fails on a mismatch, and the diff images it
-      # just wrote are the whole point of looking at the artifact.
+      # if: failure() — on a mismatch the diff images the run just wrote are the
+      # whole point of looking at the artifact. On a green run they are, by
+      # definition, the committed baselines again, and nobody has ever
+      # downloaded them: uploading ~3 MB per push kept ~50 identical copies
+      # alive against a 0.5 GB Actions storage allowance. Kept short for the
+      # same reason — a visual diff is looked at while the PR is open or not
+      # at all.
       - uses: actions/upload-artifact@v7
-        if: always()
+        if: failure()
         with:
           name: screenshots
           path: ${{ runner.temp }}/screenshots
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,13 @@ jobs:
         with:
           name: windows-msi
           path: pgNimbus-${{ env.VERSION }}-win-x64.msi
+          # Handed straight to the "release" job below, which publishes it as a
+          # GitHub Release asset — and Release assets do not count against the
+          # Actions storage allowance. So this copy is a same-run hand-off, not
+          # a keepsake; the 90-day default kept a second copy of every package
+          # ever built. A workflow_dispatch test run (no "release" job) still
+          # leaves it downloadable for the rest of the day.
+          retention-days: 1
 
       - name: Build MSIX (for Microsoft Store submission)
         # Self-signed for upload only — Store re-signs with its own trusted
@@ -143,6 +150,12 @@ jobs:
         with:
           name: windows-msix
           path: pgNimbus-${{ env.VERSION }}-win-x64.msix
+          # The one build artifact with no Release asset behind it: Partner Center
+          # submission is a manual download-and-upload step (see CLAUDE.md,
+          # "Microsoft Store (MSIX)"), so it has to outlive the run. Two weeks is
+          # long enough for that and short enough that a ~25 MB package is not
+          # held 90 days per release.
+          retention-days: 14
 
       # winget manifests are rendered right here rather than in a separate
       # job: the MSI and its SHA256 are already at hand, so this saves a
@@ -166,6 +179,8 @@ jobs:
         with:
           name: winget-manifests
           path: winget-manifests.zip
+          # Same-run hand-off to "release" (see windows-msi above).
+          retention-days: 1
 
   build-macos:
     # Apple Silicon only: GitHub retired the last Intel macOS runner image
@@ -260,6 +275,8 @@ jobs:
         with:
           name: macos-dmg-arm64
           path: dist/*.dmg
+          # Same-run hand-off to "release" (see windows-msi above).
+          retention-days: 1
 
   build-linux:
     strategy:
@@ -350,11 +367,15 @@ jobs:
         with:
           name: sbom
           path: sbom/*.cdx.json
+          # Same-run hand-off to "release" (see windows-msi above).
+          retention-days: 1
 
       - uses: actions/upload-artifact@v7
         with:
           name: linux-packages-${{ matrix.rid }}
           path: dist/*
+          # Same-run hand-off to "release" (see windows-msi above).
+          retention-days: 1
 
       # The raw x64 publish output feeds the benchmark job so it doesn't
       # repeat the slow NativeAOT publish. Tarred because upload-artifact
@@ -369,6 +390,8 @@ jobs:
         with:
           name: publish-linux-x64
           path: publish-linux-x64.tar.gz
+          # Consumed by the benchmark job in this same run and by nothing else.
+          retention-days: 1
 
   # The publish gate. Each build job smoke-launches its own artifacts before
   # uploading them, so "needs" already means "every package started and drew a

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -112,3 +112,7 @@ jobs:
         with:
           name: screenshots
           path: ${{ runner.temp }}/shots
+          # The PR this workflow opens is where these images actually get
+          # reviewed — the artifact is a fallback for the run where the push or
+          # the PR create failed. Days, not months.
+          retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1185,6 +1185,44 @@ automatically discoverable via winget's built-in `msstore` source with no
 separate winget submission. It's an *additional* channel, not a replacement
 for the direct MSI + `winget-pkgs` path above — the two coexist.
 
+### Actions storage is a 0.5 GB budget (2026-08)
+
+The account's included GitHub Actions storage is **0.5 GB**, and it is a
+*standing* budget, not a per-run one: an artifact counts for every day it
+stays alive. So **every `upload-artifact` must set `retention-days`** — the
+default is 90, and at 90 days this pipeline held ~6.8 GB (13x the allowance)
+in copies of things that were already stored for free somewhere else. Two
+rules keep it there:
+
+1. **An artifact that ships in the GitHub Release gets `retention-days: 1`.**
+   Release assets don't count against the Actions allowance, and the `release`
+   job consumes these in the same run — the artifact is a job-to-job hand-off,
+   not storage. That covers `windows-msi`, `macos-dmg-arm64`,
+   `linux-packages-*`, `sbom`, `winget-manifests`, and `publish-linux-x64`
+   (benchmark input). A day is still long enough for a human to grab a
+   `workflow_dispatch` test build, where the `release` job never runs.
+   `windows-msix` is the one exception at 14 days: Partner Center submission is
+   a manual download-and-upload, so it has to outlive the run.
+2. **Diagnostic artifacts upload on `failure()` only, for days not months.**
+   The CI `screenshots` artifact is worth looking at exactly when the visual
+   regression went red; on a green run it is a byte-for-byte re-render of
+   `tools/Screenshot/baselines/`, which is already in git. Pair the condition
+   with `if-no-files-found: ignore` — the usual failure is the render step
+   throwing, which leaves the directory empty, and a missing diagnostic must
+   not turn one red step into two.
+
+Retention is **not retroactive**: lowering it leaves already-uploaded artifacts
+on their original 90-day clock, so a change like this needs a one-time purge of
+the backlog (`gh api repos/OWNER/REPO/actions/artifacts` → `DELETE`) to actually
+free anything. The repo's default retention is set to 7 days as a backstop for
+uploads that forget rule 1.
+
+Runner *minutes* ride the same fix from the other side: every workflow that
+triggers on both `push` and `pull_request` keys its `concurrency` group on
+`github.event.pull_request.head.ref || github.ref`. Keyed on `github.ref` the
+two triggers land in different groups (`refs/heads/x` vs `refs/pull/N/merge`)
+and run the whole job twice for one commit — which is also two artifacts.
+
 ### Supply-chain proofs (2026-07)
 
 Unsigned binaries still get verifiable provenance, three layers:


### PR DESCRIPTION
## What and why

GitHub warned that the account is at 90% of its 0.5 GB included Actions storage. Measuring the live artifacts across both repos found 6.8 GB, roughly 13x the allowance, and almost all of it a second copy of something already stored for free.

Nothing in this repo set `retention-days`, so every upload sat for the default 90 days:

| artifact | live | already stored where |
|---|---|---|
| `macos-dmg-arm64` | 1.13 GB | GitHub Release asset |
| `windows-msix` | 1.12 GB | manual Partner Center upload |
| `windows-msi` | 0.89 GB | GitHub Release asset |
| `linux-packages-*` | 1.37 GB | GitHub Release asset |
| `publish-linux-x64` | 0.46 GB | consumed by one benchmark job |
| `screenshots` | 0.16 GB | re-render of the committed baselines |

Release assets do not count against the Actions allowance and the `release` job consumes its inputs in the same run, so everything it downloads drops to `retention-days: 1`. A day is still long enough to grab a `workflow_dispatch` test build, where `release` never runs. `windows-msix` keeps 14 days: it is the one build output with no Release asset behind it, and Partner Center submission is a manual download-and-upload.

The CI `screenshots` artifact now uploads on `failure()` only. On a red run the diff images are the whole point of the artifact; on a green run it is a byte-for-byte re-render of `tools/Screenshot/baselines`, which is already in git. `if-no-files-found: ignore` goes with the condition, because the usual failure is the render step itself throwing, which leaves the directory empty, and a missing diagnostic must not turn one red step into two.

Also adds the `concurrency` group this workflow never had. It is keyed on the head branch rather than `github.ref` so that a push run and the `pull_request` run of the same branch cancel each other instead of landing in separate groups and building the same commit twice.

Projected steady state: about 0.03 GB for this repo, down from 5.1 GB.

## Verified

- [x] All five workflow files parse (`yaml.safe_load`)
- [x] Artifact inventory and the per-artifact GB-day arithmetic taken from the live `repos/.../actions/artifacts` API, not estimated
- [ ] `dotnet build PgNimbus.slnx` - not run, no code changed
- [ ] Screenshot baselines - untouched

Anything left unverified: the `failure()` path on the screenshots upload has not been exercised by a real red run yet; the next visual-regression failure is what proves the artifact still appears. Nothing else in the pipeline can be observed until the next `v*` tag.

Retention is **not retroactive**: the artifacts already uploaded keep their original 90-day expiry, so this PR on its own frees nothing. The existing backlog is being purged separately via the API.

## Checklist

- [x] [CLAUDE.md](../CLAUDE.md) updated - new "Actions storage is a 0.5 GB budget" section under Release pipeline
- [x] Touches `shared/nimbusUi`? No. But kubeNimbus has the same problem and gets the paired change: https://github.com/Shman4ik/kubeNimbus/pull/62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

