### PR TITLE
Roles and permissions: the engine, the generated SQL, and the window shell

### DIFF
--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -13,6 +13,7 @@ using PgNimbus.Core.Monitoring;
 using PgNimbus.Core.Notifications;
 using PgNimbus.Core.Query;
 using PgNimbus.Core.Schema;
+using PgNimbus.Core.Security;
 using PgNimbus.Core.Settings;
 
 namespace PgNimbus.App;
@@ -401,6 +402,9 @@ public partial class App : Application
         var ddlService = new DdlService(dataSource);
         var activityService = new ActivityService(dataSource);
         var databaseStatsService = new DatabaseStatsService(dataSource);
+        var roleService = new RoleService(dataSource);
+        var privilegeService = new PrivilegeService(dataSource);
+        var securityEditor = new SecurityEditor(dataSource);
         var importService = new ImportService(dataSource);
         var schemaTree = new SchemaTreeViewModel(
             schemaService,
@@ -422,7 +426,7 @@ public partial class App : Application
         var workspaceKey = string.IsNullOrEmpty(connectionHost) ? null : $"{connectionHost}/{connectionDatabase}";
 
         var viewModel = new MainViewModel(
-            engine, explainService, schemaTree, schemaService, schemaEditor, ddlService, completionProvider, notifyMonitor, activityService, databaseStatsService, importService,
+            engine, explainService, schemaTree, schemaService, schemaEditor, ddlService, completionProvider, notifyMonitor, activityService, databaseStatsService, roleService, privilegeService, securityEditor, importService,
             accentColor,
             connectionHost: connectionHost,
             connectionDatabase: connectionDatabase,

--- a/PgNimbus.App/Commands/CommandBindings.cs
+++ b/PgNimbus.App/Commands/CommandBindings.cs
@@ -164,6 +164,7 @@ public static class CommandBindings
         [CommandId.ToggleSidebar] = vm => vm.ToggleSidebarCommand,
         [CommandId.ServerActivity] = vm => vm.ShowActivityCommand,
         [CommandId.DatabaseOverview] = vm => vm.ShowDatabaseOverviewCommand,
+        [CommandId.SecurityManager] = vm => vm.ShowSecurityCommand,
         [CommandId.SwitchConnection] = vm => vm.SwitchConnectionCommand,
         [CommandId.NewWindow] = vm => vm.OpenNewWindowCommand,
         [CommandId.ToggleTheme] = vm => vm.ToggleThemeCommand,

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -3,11 +3,13 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using PgNimbus.App.Completion;
+using PgNimbus.App.ViewModels.Security;
 using PgNimbus.Core.Commands;
 using PgNimbus.Core.Import;
 using PgNimbus.Core.Monitoring;
 using PgNimbus.Core.Query;
 using PgNimbus.Core.Schema;
+using PgNimbus.Core.Security;
 using PgNimbus.Core.Settings;
 
 namespace PgNimbus.App.ViewModels;
@@ -33,6 +35,9 @@ public sealed partial class MainViewModel : ObservableObject
 
     /// <summary>Backs the Database Overview window (sizes, cache-hit, scan usage, unused indexes).</summary>
     public DatabaseOverviewViewModel DatabaseOverview { get; }
+
+    /// <summary>Backs the Roles &amp; Permissions window (roles, grants, default privileges, RLS).</summary>
+    public SecurityViewModel Security { get; }
 
     /// <summary>COPY-based CSV/JSON loader behind the Import dialog (the view constructs the dialog's ViewModel from it).</summary>
     public ImportService Importer { get; }
@@ -66,6 +71,9 @@ public sealed partial class MainViewModel : ObservableObject
     public event Action? ActivityRequested;
     // Raised to open (or focus) the Database Overview window, which the view owns.
     public event Action? DatabaseOverviewRequested;
+
+    // Raised to open (or focus) the Roles & Permissions window.
+    public event Action? SecurityRequested;
     // Raised to collapse/restore the sidebar (the view owns the grid column).
     public event Action? SidebarToggleRequested;
     // Raised to open the "Open SQL file" picker; MainWindow owns the
@@ -216,6 +224,9 @@ public sealed partial class MainViewModel : ObservableObject
     [RelayCommand]
     private void ShowDatabaseOverview() => DatabaseOverviewRequested?.Invoke();
 
+    [RelayCommand]
+    private void ShowSecurity() => SecurityRequested?.Invoke();
+
     // Relations rarely change mid-session, so the palette's "jump to a table"
     // list is fetched once and reused across opens.
     private IReadOnlyList<RelationInfo>? _relationCache;
@@ -344,6 +355,9 @@ public sealed partial class MainViewModel : ObservableObject
         NotifyMonitorViewModel notifyMonitor,
         ActivityService activityService,
         DatabaseStatsService databaseStatsService,
+        RoleService roleService,
+        PrivilegeService privilegeService,
+        SecurityEditor securityEditor,
         ImportService importService,
         string? accentColor = null,
         string connectionHost = "",
@@ -411,6 +425,10 @@ public sealed partial class MainViewModel : ObservableObject
         NotifyMonitor = notifyMonitor;
         Activity = new ActivityViewModel(activityService);
         DatabaseOverview = new DatabaseOverviewViewModel(databaseStatsService);
+        Security = new SecurityViewModel(roleService, privilegeService, securityEditor, connectionDatabase);
+        // Every privilege change leaves the security window as a script in a new
+        // editor tab rather than being applied from there - see OpenGeneratedSql.
+        Security.OpenSqlInNewTab = (title, sql) => OpenGeneratedSql(title, sql);
         Importer = importService;
         AccentColor = accentColor;
 
@@ -690,6 +708,22 @@ public sealed partial class MainViewModel : ObservableObject
         var tab = NewTab();
         tab.DefaultTitle = "Imported plan";
         tab.ShowImportedPlan(plan.Result, plan.DisplayText, plan.RawJson);
+    }
+
+    /// <summary>
+    /// Drops a generated script into a new tab, where it can be read, edited and
+    /// run. This is how every privilege change leaves the Roles &amp; Permissions
+    /// window: the window composes the GRANT/REVOKE text, the user reviews it in
+    /// the editor they already trust, and nothing is applied behind their back.
+    /// The one deliberate exception is a statement carrying a password, which
+    /// never comes through here — see <c>SecurityEditor</c>.
+    /// </summary>
+    public QueryViewModel OpenGeneratedSql(string title, string sql)
+    {
+        var tab = NewTab();
+        tab.DefaultTitle = title;
+        tab.Sql = sql;
+        return tab;
     }
 
     /// <summary>

--- a/PgNimbus.App/ViewModels/SavedQueriesViewModel.cs
+++ b/PgNimbus.App/ViewModels/SavedQueriesViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using PgNimbus.Core.Query;
+using PgNimbus.Core.Security;
 
 namespace PgNimbus.App.ViewModels;
 
@@ -75,9 +76,18 @@ public sealed partial class SavedQueriesViewModel : ObservableObject
         ApplyHistoryFilter();
     }
 
+    /// <summary>
+    /// Files an executed statement in the history — the single choke point for
+    /// it, which is why the password redaction lives here rather than at a call
+    /// site. Nothing in the Roles &amp; Permissions window routes a PASSWORD
+    /// literal through a query tab (see <c>SecurityEditor</c>), but a user can
+    /// always type <c>ALTER ROLE … PASSWORD 'x'</c> into the editor themselves,
+    /// and <see cref="QueryHistoryStore"/> writes what it is given to disk in
+    /// the clear.
+    /// </summary>
     public void RecordExecution(QueryHistoryEntry entry)
     {
-        entry = entry with { Connection = _getConnectionLabel() };
+        entry = entry with { Sql = SecretRedactor.Redact(entry.Sql), Connection = _getConnectionLabel() };
         History.Insert(0, entry);
         _historyStore.Append(entry);
     }

--- a/PgNimbus.App/ViewModels/Security/DefaultPrivilegesTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/DefaultPrivilegesTabViewModel.cs
@@ -1,0 +1,19 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.App.ViewModels.Security;
+
+/// <summary>pg_default_acl: what a future object created by a given role will already be granted.</summary>
+public sealed partial class DefaultPrivilegesTabViewModel : ObservableObject, ISecuritySection
+{
+    private readonly PrivilegeService _privileges;
+    private readonly SecurityViewModel _host;
+
+    public DefaultPrivilegesTabViewModel(PrivilegeService privileges, SecurityViewModel host)
+    {
+        _privileges = privileges;
+        _host = host;
+    }
+
+    public Task RefreshAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/PgNimbus.App/ViewModels/Security/PermissionsTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/PermissionsTabViewModel.cs
@@ -1,0 +1,19 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.App.ViewModels.Security;
+
+/// <summary>Pick an object, see which role can do what to it -- and which grant explains that.</summary>
+public sealed partial class PermissionsTabViewModel : ObservableObject, ISecuritySection
+{
+    private readonly PrivilegeService _privileges;
+    private readonly SecurityViewModel _host;
+
+    public PermissionsTabViewModel(PrivilegeService privileges, SecurityViewModel host)
+    {
+        _privileges = privileges;
+        _host = host;
+    }
+
+    public Task RefreshAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/PgNimbus.App/ViewModels/Security/RlsTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/RlsTabViewModel.cs
@@ -1,0 +1,19 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.App.ViewModels.Security;
+
+/// <summary>Row-level security: which tables have it, which policies apply, and who bypasses it.</summary>
+public sealed partial class RlsTabViewModel : ObservableObject, ISecuritySection
+{
+    private readonly PrivilegeService _privileges;
+    private readonly SecurityViewModel _host;
+
+    public RlsTabViewModel(PrivilegeService privileges, SecurityViewModel host)
+    {
+        _privileges = privileges;
+        _host = host;
+    }
+
+    public Task RefreshAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
@@ -1,0 +1,21 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.App.ViewModels.Security;
+
+/// <summary>The roles list, one role's attributes, and its membership tree in both directions.</summary>
+public sealed partial class RolesTabViewModel : ObservableObject, ISecuritySection
+{
+    private readonly RoleService _roleService;
+    private readonly SecurityEditor _editor;
+    private readonly SecurityViewModel _host;
+
+    public RolesTabViewModel(RoleService roleService, SecurityEditor editor, SecurityViewModel host)
+    {
+        _roleService = roleService;
+        _editor = editor;
+        _host = host;
+    }
+
+    public Task RefreshAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/PgNimbus.App/ViewModels/Security/SecurityViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/SecurityViewModel.cs
@@ -1,0 +1,149 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.App.ViewModels.Security;
+
+/// <summary>
+/// One tab of the Roles &amp; Permissions window. The root view model owns the
+/// shared snapshot (roles, the membership graph, the server version) and calls
+/// each section to re-read whatever it shows; a section never opens the window's
+/// connection on its own schedule.
+/// </summary>
+public interface ISecuritySection
+{
+    /// <summary>Re-read this section from the catalog. Never throws — failures land in <see cref="SecurityViewModel.Status"/>.</summary>
+    Task RefreshAsync(CancellationToken ct);
+}
+
+/// <summary>
+/// Drives the Roles &amp; Permissions window — the 0.11 headline feature, and the
+/// answer to a question the incumbent clients do not answer: not "what does the
+/// catalog store for this object" but "what can this role actually do, and which
+/// grant explains that".
+///
+/// Shaped like <see cref="DatabaseOverviewViewModel"/>: a snapshot taken on open
+/// and re-taken on Refresh, no timer, everything read-only against pg_catalog.
+/// What it does *not* do is apply changes behind the user's back — every
+/// privilege change leaves through <see cref="OpenSqlInNewTab"/> as a script in
+/// the editor, following the <c>DdlTemplates</c> precedent. The single exception
+/// is a statement carrying a password, which runs through
+/// <see cref="SecurityEditor"/> and is never shown or persisted.
+/// </summary>
+public sealed partial class SecurityViewModel : ObservableObject
+{
+    private readonly RoleService _roleService;
+
+    [ObservableProperty]
+    private string _status = "";
+
+    /// <summary>The connected database, for the window's context line.</summary>
+    [ObservableProperty]
+    private string _databaseName = "";
+
+    /// <summary>
+    /// <c>current_user</c>. Shown because half of "why can't I see this?" is
+    /// that the *reader* lacks the privilege, not the role being inspected.
+    /// </summary>
+    [ObservableProperty]
+    private string _currentRole = "";
+
+    [ObservableProperty]
+    private string _serverVersionText = "";
+
+    /// <summary>
+    /// The server's version, or null before the first refresh. Gates the
+    /// privileges and catalog columns that don't exist everywhere — see
+    /// <see cref="PgFeatures"/>.
+    /// </summary>
+    [ObservableProperty]
+    private Version? _serverVersion;
+
+    /// <summary>
+    /// The shared role snapshot every section reads, rebuilt on each refresh.
+    /// Null before the first one completes.
+    /// </summary>
+    [ObservableProperty]
+    private RoleGraph? _graph;
+
+    public SecurityViewModel(
+        RoleService roleService,
+        PrivilegeService privilegeService,
+        SecurityEditor editor,
+        string databaseName)
+    {
+        _roleService = roleService;
+        DatabaseName = databaseName;
+
+        Roles = new RolesTabViewModel(roleService, editor, this);
+        Permissions = new PermissionsTabViewModel(privilegeService, this);
+        DefaultPrivileges = new DefaultPrivilegesTabViewModel(privilegeService, this);
+        Rls = new RlsTabViewModel(privilegeService, this);
+    }
+
+    public RolesTabViewModel Roles { get; }
+
+    public PermissionsTabViewModel Permissions { get; }
+
+    public DefaultPrivilegesTabViewModel DefaultPrivileges { get; }
+
+    public RlsTabViewModel Rls { get; }
+
+    /// <summary>
+    /// Hands a generated script to the main window's editor, in a new tab. Set by
+    /// the view when it opens the window; null in the screenshot harness, where
+    /// there is no main window to open a tab in — so every caller must null-check
+    /// rather than assume.
+    /// </summary>
+    public Action<string, string>? OpenSqlInNewTab { get; set; }
+
+    /// <summary>
+    /// Re-reads the shared role snapshot, then fans out to the four sections.
+    /// Sections run in parallel because their reads are independent — one round
+    /// trip's worth of latency instead of four, which is what makes this bearable
+    /// over an SSH tunnel.
+    /// </summary>
+    [RelayCommand(AllowConcurrentExecutions = false)]
+    public async Task RefreshAsync(CancellationToken ct)
+    {
+        try
+        {
+            Status = "Reading roles…";
+
+            var rolesTask = _roleService.GetRolesAsync(includePredefined: true, ct);
+            var membershipsTask = _roleService.GetMembershipsAsync(ct);
+            var currentRoleTask = _roleService.GetCurrentRoleAsync(ct);
+            var versionTask = _roleService.GetServerVersionAsync(ct);
+            await Task.WhenAll(rolesTask, membershipsTask, currentRoleTask, versionTask);
+
+            Graph = RoleGraph.Build(await rolesTask, await membershipsTask);
+            CurrentRole = await currentRoleTask;
+            ServerVersion = await versionTask;
+            ServerVersionText = $"PostgreSQL {ServerVersion.Major}.{ServerVersion.Minor}";
+
+            await Task.WhenAll(
+                Roles.RefreshAsync(ct),
+                Permissions.RefreshAsync(ct),
+                DefaultPrivileges.RefreshAsync(ct),
+                Rls.RefreshAsync(ct));
+
+            var visible = Graph.Roles.Count(r => !r.IsPredefined);
+            Status = $"{visible} role{(visible == 1 ? "" : "s")} · {DateTime.Now:HH:mm:ss}";
+        }
+        catch (OperationCanceledException)
+        {
+            // A superseded snapshot — not an error worth surfacing.
+        }
+        catch (Exception ex)
+        {
+            Status = ex.Message;
+        }
+    }
+
+    /// <summary>
+    /// The one place a section reports a failure, so a single read going wrong
+    /// (an extension type the server will not expand, a permission the reader
+    /// lacks) costs a status line rather than the whole window.
+    /// </summary>
+    public void ReportError(string what, Exception ex) => Status = $"{what}: {ex.Message}";
+}

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -207,6 +207,7 @@ public partial class MainWindow : Window
                 CommandItem("Refresh Schema", CommandId.RefreshSchema),
                 CommandItem("Server Activity…", CommandId.ServerActivity),
                 CommandItem("Database Overview…", CommandId.DatabaseOverview),
+                CommandItem("Roles and Permissions…", CommandId.SecurityManager),
             },
         };
 
@@ -459,6 +460,7 @@ public partial class MainWindow : Window
             _viewModel.ImportPlanRequested -= ShowImportPlanDialog;
         _viewModel.ActivityRequested -= ShowActivityWindow;
             _viewModel.DatabaseOverviewRequested -= ShowDatabaseOverviewWindow;
+            _viewModel.SecurityRequested -= ShowSecurityWindow;
             _viewModel.SidebarToggleRequested -= ToggleSidebar;
             _viewModel.OpenFileRequested -= OnOpenFileRequested;
             _viewModel.SaveFileRequested -= OnSaveFileRequested;
@@ -475,6 +477,7 @@ public partial class MainWindow : Window
         _viewModel.ImportPlanRequested += ShowImportPlanDialog;
         _viewModel.ActivityRequested += ShowActivityWindow;
         _viewModel.DatabaseOverviewRequested += ShowDatabaseOverviewWindow;
+        _viewModel.SecurityRequested += ShowSecurityWindow;
         _viewModel.SidebarToggleRequested += ToggleSidebar;
         _viewModel.OpenFileRequested += OnOpenFileRequested;
         _viewModel.SaveFileRequested += OnSaveFileRequested;
@@ -1049,6 +1052,24 @@ public partial class MainWindow : Window
         _databaseOverviewWindow = new DatabaseOverviewWindow { DataContext = _viewModel?.DatabaseOverview };
         _databaseOverviewWindow.Closed += (_, _) => _databaseOverviewWindow = null;
         _databaseOverviewWindow.Show(this);
+    }
+
+    private Security.SecurityWindow? _securityWindow;
+
+    // One live instance, like the other two reference windows. Deliberately a
+    // window and not an overlay: it is read beside the editor while a grant is
+    // being fixed, and the scripts it generates land in that editor's tabs.
+    private void ShowSecurityWindow()
+    {
+        if (_securityWindow is not null)
+        {
+            _securityWindow.Activate();
+            return;
+        }
+
+        _securityWindow = new Security.SecurityWindow { DataContext = _viewModel?.Security };
+        _securityWindow.Closed += (_, _) => _securityWindow = null;
+        _securityWindow.Show(this);
     }
 
     // The Explain toolbar button is a single slot with a flyout (minimalist rule);

--- a/PgNimbus.App/Views/Security/DefaultPrivilegesTabView.axaml
+++ b/PgNimbus.App/Views/Security/DefaultPrivilegesTabView.axaml
@@ -1,0 +1,7 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:PgNimbus.App.ViewModels.Security"
+             x:Class="PgNimbus.App.Views.Security.DefaultPrivilegesTabView"
+             x:DataType="vm:DefaultPrivilegesTabViewModel">
+    <Panel />
+</UserControl>

--- a/PgNimbus.App/Views/Security/DefaultPrivilegesTabView.axaml.cs
+++ b/PgNimbus.App/Views/Security/DefaultPrivilegesTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PgNimbus.App.Views.Security;
+
+public partial class DefaultPrivilegesTabView : UserControl
+{
+    public DefaultPrivilegesTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/PgNimbus.App/Views/Security/PermissionsTabView.axaml
+++ b/PgNimbus.App/Views/Security/PermissionsTabView.axaml
@@ -1,0 +1,7 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:PgNimbus.App.ViewModels.Security"
+             x:Class="PgNimbus.App.Views.Security.PermissionsTabView"
+             x:DataType="vm:PermissionsTabViewModel">
+    <Panel />
+</UserControl>

--- a/PgNimbus.App/Views/Security/PermissionsTabView.axaml.cs
+++ b/PgNimbus.App/Views/Security/PermissionsTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PgNimbus.App.Views.Security;
+
+public partial class PermissionsTabView : UserControl
+{
+    public PermissionsTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/PgNimbus.App/Views/Security/RlsTabView.axaml
+++ b/PgNimbus.App/Views/Security/RlsTabView.axaml
@@ -1,0 +1,7 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:PgNimbus.App.ViewModels.Security"
+             x:Class="PgNimbus.App.Views.Security.RlsTabView"
+             x:DataType="vm:RlsTabViewModel">
+    <Panel />
+</UserControl>

--- a/PgNimbus.App/Views/Security/RlsTabView.axaml.cs
+++ b/PgNimbus.App/Views/Security/RlsTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PgNimbus.App.Views.Security;
+
+public partial class RlsTabView : UserControl
+{
+    public RlsTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/PgNimbus.App/Views/Security/RolesTabView.axaml
+++ b/PgNimbus.App/Views/Security/RolesTabView.axaml
@@ -1,0 +1,7 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:PgNimbus.App.ViewModels.Security"
+             x:Class="PgNimbus.App.Views.Security.RolesTabView"
+             x:DataType="vm:RolesTabViewModel">
+    <Panel />
+</UserControl>

--- a/PgNimbus.App/Views/Security/RolesTabView.axaml.cs
+++ b/PgNimbus.App/Views/Security/RolesTabView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace PgNimbus.App.Views.Security;
+
+public partial class RolesTabView : UserControl
+{
+    public RolesTabView()
+    {
+        InitializeComponent();
+    }
+}

--- a/PgNimbus.App/Views/Security/SecurityWindow.axaml
+++ b/PgNimbus.App/Views/Security/SecurityWindow.axaml
@@ -1,0 +1,64 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:PgNimbus.App.ViewModels.Security"
+        xmlns:views="using:PgNimbus.App.Views.Security"
+        x:Class="PgNimbus.App.Views.Security.SecurityWindow"
+        x:DataType="vm:SecurityViewModel"
+        Title="pgNimbus — Roles and Permissions"
+        Width="1100" Height="720"
+        MinWidth="820" MinHeight="440"
+        WindowStartupLocation="CenterOwner"
+        FontFamily="{StaticResource InterFont}">
+
+    <Grid RowDefinitions="Auto,*,Auto" Margin="12">
+
+        <!-- Context line. Who you are connected as is half of "why can't I see
+             this?": the reader's own privileges decide what the catalog shows. -->
+        <Border Grid.Row="0" Background="{StaticResource CardBackgroundBrush}"
+                BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                CornerRadius="{StaticResource CardCornerRadius}" Padding="16,12" Margin="0,0,0,10">
+            <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto">
+                <StackPanel Grid.Column="0" Spacing="2" Margin="0,0,36,0">
+                    <TextBlock Text="DATABASE" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <TextBlock Text="{Binding DatabaseName}" FontSize="16" FontWeight="SemiBold" />
+                </StackPanel>
+                <StackPanel Grid.Column="1" Spacing="2" Margin="0,0,36,0"
+                            ToolTip.Tip="The role this window reads the catalog as — it only ever sees what this role is allowed to see">
+                    <TextBlock Text="CONNECTED AS" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <TextBlock Text="{Binding CurrentRole}" FontSize="16" FontWeight="SemiBold" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Spacing="2">
+                    <TextBlock Text="SERVER" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <TextBlock Text="{Binding ServerVersionText}" FontSize="16" FontWeight="SemiBold" />
+                </StackPanel>
+                <Button Grid.Column="4" Classes="soft" VerticalAlignment="Center"
+                        Command="{Binding RefreshCommand}"
+                        ToolTip.Tip="Re-read roles, privileges and policies from the catalog">
+                    <StackPanel Orientation="Horizontal" Spacing="7">
+                        <PathIcon Data="{StaticResource RefreshIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
+                        <TextBlock Text="Refresh" VerticalAlignment="Center" />
+                    </StackPanel>
+                </Button>
+            </Grid>
+        </Border>
+
+        <TabControl Grid.Row="1" Classes="segmented">
+            <TabItem Header="Roles">
+                <views:RolesTabView DataContext="{Binding Roles}" />
+            </TabItem>
+            <TabItem Header="Permissions">
+                <views:PermissionsTabView DataContext="{Binding Permissions}" />
+            </TabItem>
+            <TabItem Header="Default privileges">
+                <views:DefaultPrivilegesTabView DataContext="{Binding DefaultPrivileges}" />
+            </TabItem>
+            <TabItem Header="Row-level security">
+                <views:RlsTabView DataContext="{Binding Rls}" />
+            </TabItem>
+        </TabControl>
+
+        <TextBlock Grid.Row="2" Text="{Binding Status}" FontSize="11" Opacity="0.7" Margin="2,8,2,0" />
+
+    </Grid>
+
+</Window>

--- a/PgNimbus.App/Views/Security/SecurityWindow.axaml.cs
+++ b/PgNimbus.App/Views/Security/SecurityWindow.axaml.cs
@@ -1,0 +1,25 @@
+using Avalonia.Controls;
+using PgNimbus.App.ViewModels.Security;
+
+namespace PgNimbus.App.Views.Security;
+
+/// <summary>
+/// The Roles &amp; Permissions window: who exists, what they can do, and which
+/// grant explains it. A reference view you keep open beside the editor while you
+/// fix something, which is why it is a window rather than an overlay panel (see
+/// the OverlayPanel rule in CLAUDE.md) — and why the scripts it generates land
+/// in the main window's editor rather than being applied from here.
+///
+/// One live instance, opened from the command palette, no toolbar button. Same
+/// shape as <c>DatabaseOverviewWindow</c>, including the snapshot-on-open.
+/// </summary>
+public partial class SecurityWindow : Window
+{
+    public SecurityWindow()
+    {
+        InitializeComponent();
+        ThemedWindowChrome.Attach(this);
+
+        Opened += (_, _) => (DataContext as SecurityViewModel)?.RefreshCommand.Execute(null);
+    }
+}

--- a/PgNimbus.Core.Tests/Security/EffectivePrivilegeResolverTests.cs
+++ b/PgNimbus.Core.Tests/Security/EffectivePrivilegeResolverTests.cs
@@ -1,0 +1,412 @@
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.Core.Tests.Security;
+
+public class EffectivePrivilegeResolverTests
+{
+    // ------------------------------------------------------------- fixtures
+
+    /// <summary>
+    /// A hand-fed <see cref="IRoleMembershipLookup"/> so the resolver can be
+    /// exercised without a server (and without RoleGraph, which is the thing
+    /// under test's collaborator, not its dependency).
+    /// </summary>
+    private sealed class FakeLookup : IRoleMembershipLookup
+    {
+        private readonly Dictionary<string, IReadOnlyList<string>> _groups;
+        private readonly HashSet<string> _superusers;
+
+        public FakeLookup(
+            Dictionary<string, IReadOnlyList<string>>? groups = null,
+            params string[] superusers)
+        {
+            _groups = groups ?? [];
+            _superusers = new HashSet<string>(superusers, StringComparer.Ordinal);
+        }
+
+        /// <summary>Nearest first, as the interface documents.</summary>
+        public IReadOnlyList<string> InheritedGroups(string role) =>
+            _groups.TryGetValue(role, out var g) ? g : [];
+
+        public bool IsSuperuser(string role) => _superusers.Contains(role);
+    }
+
+    private static SecurableRef Table(string schema = "sales", string name = "orders") =>
+        new(SecurableKind.Table, 16384, schema, name);
+
+    private static SecurableRef Function() =>
+        new(SecurableKind.Function, 16500, "public", "f", "integer");
+
+    private static SecurableRef Database() =>
+        new(SecurableKind.Database, 16600, null, "demo");
+
+    private static ObjectAcl Acl(SecurableRef obj, string owner, params AclEntry[] entries) =>
+        new(obj, owner, false, entries);
+
+    /// <summary>The catalog ACL column was NULL: no entries, but the defaults apply.</summary>
+    private static ObjectAcl DefaultAcl(SecurableRef obj, string owner) =>
+        new(obj, owner, true, []);
+
+    private static AclEntry Grant(
+        string? grantee,
+        PrivilegeKind privilege,
+        string? grantor = "postgres",
+        bool withGrantOption = false) =>
+        new(grantee, grantor, privilege, withGrantOption);
+
+    private static readonly IReadOnlyList<PrivilegeKind> Crud =
+    [
+        PrivilegeKind.Select, PrivilegeKind.Insert, PrivilegeKind.Update, PrivilegeKind.Delete,
+    ];
+
+    private static EffectivePrivilege One(IReadOnlyList<EffectivePrivilege> all, PrivilegeKind privilege) =>
+        all.Single(e => e.Privilege == privilege);
+
+    // ------------------------------------------------------------ resolution
+
+    [Test]
+    public async Task DirectGrantIsAttributedToItsGrantor()
+    {
+        var acl = Acl(Table(), "postgres", Grant("app_ro", PrivilegeKind.Select));
+
+        var result = EffectivePrivilegeResolver.Resolve(
+            acl, ["app_ro"], Crud, new FakeLookup());
+
+        var select = One(result, PrivilegeKind.Select);
+        await Assert.That(select.Granted).IsTrue();
+        await Assert.That(select.Source).IsEqualTo(PrivilegeSource.Direct);
+        await Assert.That(select.GrantedBy).IsEqualTo("postgres");
+        await Assert.That(select.Via).IsNull();
+
+        // And the ones nobody granted stay honestly empty.
+        await Assert.That(One(result, PrivilegeKind.Insert).Granted).IsFalse();
+        await Assert.That(One(result, PrivilegeKind.Insert).Source).IsEqualTo(PrivilegeSource.None);
+    }
+
+    [Test]
+    public async Task ResolveCoversEveryRoleTimesPrivilege()
+    {
+        var result = EffectivePrivilegeResolver.Resolve(
+            Acl(Table(), "postgres"), ["a", "b", "c"], Crud, new FakeLookup());
+
+        await Assert.That(result).Count().IsEqualTo(12);
+    }
+
+    [Test]
+    public async Task GrantToAGroupIsInheritedByItsMember()
+    {
+        // The case every other tool renders as "app_ro has nothing".
+        var acl = Acl(Table(), "postgres", Grant("readers", PrivilegeKind.Select));
+        var lookup = new FakeLookup(new() { ["app_ro"] = new[] { "readers" } });
+
+        var select = One(
+            EffectivePrivilegeResolver.Resolve(acl, ["app_ro"], [PrivilegeKind.Select], lookup),
+            PrivilegeKind.Select);
+
+        await Assert.That(select.Granted).IsTrue();
+        await Assert.That(select.Source).IsEqualTo(PrivilegeSource.Inherited);
+        await Assert.That(select.Via).IsEqualTo("readers");
+        await Assert.That(select.GrantedBy).IsEqualTo("postgres");
+    }
+
+    [Test]
+    public async Task NearestGroupWinsWhenTwoInTheChainHaveTheGrant()
+    {
+        // app_ro -> readers -> everyone, and both hold SELECT. The attribution
+        // must name readers: it is the edge the user would actually edit.
+        // Deliberately ordered so the *far* group's ACL entry comes first, which
+        // is what a naive scan of acl.Entries would pick up.
+        var acl = Acl(
+            Table(), "postgres",
+            Grant("everyone", PrivilegeKind.Select),
+            Grant("readers", PrivilegeKind.Select));
+        var lookup = new FakeLookup(new() { ["app_ro"] = new[] { "readers", "everyone" } });
+
+        var select = One(
+            EffectivePrivilegeResolver.Resolve(acl, ["app_ro"], [PrivilegeKind.Select], lookup),
+            PrivilegeKind.Select);
+
+        await Assert.That(select.Source).IsEqualTo(PrivilegeSource.Inherited);
+        await Assert.That(select.Via).IsEqualTo("readers");
+    }
+
+    [Test]
+    public async Task PublicGrantReachesARoleWithNoGrantsOfItsOwn()
+    {
+        var acl = Acl(Table(), "postgres", Grant(null, PrivilegeKind.Select));
+
+        var select = One(
+            EffectivePrivilegeResolver.Resolve(acl, ["nobody"], [PrivilegeKind.Select], new FakeLookup()),
+            PrivilegeKind.Select);
+
+        await Assert.That(select.Granted).IsTrue();
+        await Assert.That(select.Source).IsEqualTo(PrivilegeSource.Public);
+    }
+
+    [Test]
+    public async Task OwnerHoldsEverythingWithNoAclEntryAtAll()
+    {
+        var result = EffectivePrivilegeResolver.Resolve(
+            Acl(Table(), "alice"), ["alice"], Crud, new FakeLookup());
+
+        await Assert.That(result.All(e => e.Granted)).IsTrue();
+        await Assert.That(result.All(e => e.Source == PrivilegeSource.Owner)).IsTrue();
+    }
+
+    [Test]
+    public async Task OwnershipOutranksAnExplicitDirectGrant()
+    {
+        // A GRANT naming the owner is redundant; reporting it as "granted
+        // directly" would send someone off to revoke a grant that changes nothing.
+        var acl = Acl(Table(), "alice", Grant("alice", PrivilegeKind.Select));
+
+        var select = One(
+            EffectivePrivilegeResolver.Resolve(acl, ["alice"], [PrivilegeKind.Select], new FakeLookup()),
+            PrivilegeKind.Select);
+
+        await Assert.That(select.Source).IsEqualTo(PrivilegeSource.Owner);
+    }
+
+    [Test]
+    public async Task SuperuserOutranksOwnershipAndEveryGrant()
+    {
+        var acl = Acl(Table(), "postgres", Grant("postgres", PrivilegeKind.Select));
+        var lookup = new FakeLookup(superusers: "postgres");
+
+        var result = EffectivePrivilegeResolver.Resolve(acl, ["postgres"], Crud, lookup);
+
+        await Assert.That(result.All(e => e.Granted)).IsTrue();
+        await Assert.That(result.All(e => e.Source == PrivilegeSource.Superuser)).IsTrue();
+    }
+
+    [Test]
+    public async Task WithGrantOptionIsCarriedThrough()
+    {
+        var acl = Acl(
+            Table(), "postgres",
+            Grant("app_rw", PrivilegeKind.Select, withGrantOption: true),
+            Grant("app_rw", PrivilegeKind.Insert));
+
+        var result = EffectivePrivilegeResolver.Resolve(
+            acl, ["app_rw"], [PrivilegeKind.Select, PrivilegeKind.Insert], new FakeLookup());
+
+        await Assert.That(One(result, PrivilegeKind.Select).WithGrantOption).IsTrue();
+        await Assert.That(One(result, PrivilegeKind.Insert).WithGrantOption).IsFalse();
+    }
+
+    // -------------------------------------------------------- NULL ACL column
+
+    [Test]
+    public async Task DefaultAclOnATableGrantsPublicNothing()
+    {
+        // relacl IS NULL means "the owner has everything and the defaults
+        // apply" — and for a table the default for PUBLIC is nothing at all.
+        var acl = DefaultAcl(Table(), "alice");
+
+        var result = EffectivePrivilegeResolver.Resolve(acl, ["bob"], Crud, new FakeLookup());
+
+        await Assert.That(result.All(e => !e.Granted)).IsTrue();
+        await Assert.That(result.All(e => e.Source == PrivilegeSource.None)).IsTrue();
+    }
+
+    [Test]
+    public async Task DefaultAclOnATableStillGivesTheOwnerEverything()
+    {
+        var result = EffectivePrivilegeResolver.Resolve(
+            DefaultAcl(Table(), "alice"), ["alice"], Crud, new FakeLookup());
+
+        await Assert.That(result.All(e => e.Source == PrivilegeSource.Owner)).IsTrue();
+    }
+
+    [Test]
+    public async Task DefaultAclOnAFunctionGrantsPublicExecute()
+    {
+        // proacl IS NULL: Postgres executes this for anybody. A grid that
+        // rendered the empty ACL literally would claim the opposite.
+        var result = EffectivePrivilegeResolver.Resolve(
+            DefaultAcl(Function(), "alice"), ["bob"], [PrivilegeKind.Execute], new FakeLookup());
+
+        await Assert.That(result[0].Granted).IsTrue();
+        await Assert.That(result[0].Source).IsEqualTo(PrivilegeSource.Public);
+    }
+
+    [Test]
+    public async Task DefaultAclOnADatabaseGrantsPublicConnectAndTemporary()
+    {
+        var result = EffectivePrivilegeResolver.Resolve(
+            DefaultAcl(Database(), "alice"),
+            ["bob"],
+            [PrivilegeKind.Connect, PrivilegeKind.Temporary, PrivilegeKind.Create],
+            new FakeLookup());
+
+        await Assert.That(One(result, PrivilegeKind.Connect).Source).IsEqualTo(PrivilegeSource.Public);
+        await Assert.That(One(result, PrivilegeKind.Temporary).Source).IsEqualTo(PrivilegeSource.Public);
+
+        // CREATE is not a default — only the owner gets it.
+        await Assert.That(One(result, PrivilegeKind.Create).Granted).IsFalse();
+    }
+
+    [Test]
+    public async Task AnExplicitlyEmptyAclIsNotADefaultOne()
+    {
+        // relacl = '{}' (everything revoked, even from the owner's own default
+        // entry) is a different state from relacl IS NULL, and PUBLIC gets
+        // nothing on a function whose ACL was explicitly emptied.
+        var acl = Acl(Function(), "alice");
+
+        var result = EffectivePrivilegeResolver.Resolve(
+            acl, ["bob"], [PrivilegeKind.Execute], new FakeLookup());
+
+        await Assert.That(result[0].Granted).IsFalse();
+    }
+
+    // ------------------------------------------------------- reconciliation
+
+    [Test]
+    public async Task ServerAgreementKeepsTheResolvedSource()
+    {
+        var acl = Acl(Table(), "postgres", Grant("app_ro", PrivilegeKind.Select));
+
+        var result = EffectivePrivilegeResolver.Resolve(
+            acl, ["app_ro"], [PrivilegeKind.Select], new FakeLookup(),
+            new Dictionary<(string, PrivilegeKind), bool> { [("app_ro", PrivilegeKind.Select)] = true });
+
+        await Assert.That(result[0].Granted).IsTrue();
+        await Assert.That(result[0].Source).IsEqualTo(PrivilegeSource.Direct);
+    }
+
+    [Test]
+    public async Task ServerSaysGrantedButNothingWeReadExplainsIt()
+    {
+        // A grant through a role we could not see. Say so, don't guess.
+        var result = EffectivePrivilegeResolver.Resolve(
+            Acl(Table(), "postgres"), ["app_ro"], [PrivilegeKind.Select], new FakeLookup(),
+            new Dictionary<(string, PrivilegeKind), bool> { [("app_ro", PrivilegeKind.Select)] = true });
+
+        await Assert.That(result[0].Granted).IsTrue();
+        await Assert.That(result[0].Source).IsEqualTo(PrivilegeSource.Unknown);
+        await Assert.That(result[0].Explanation).IsEqualTo("granted, source not visible from here");
+    }
+
+    [Test]
+    public async Task ServerSaysDeniedSoTheResolvedGrantIsDropped()
+    {
+        // The NOINHERIT case: the ACL names a group the role belongs to, but the
+        // privilege only arrives after SET ROLE, so the server says no.
+        var acl = Acl(Table(), "postgres", Grant("readers", PrivilegeKind.Select));
+        var lookup = new FakeLookup(new() { ["app_ro"] = new[] { "readers" } });
+
+        var result = EffectivePrivilegeResolver.Resolve(
+            acl, ["app_ro"], [PrivilegeKind.Select], lookup,
+            new Dictionary<(string, PrivilegeKind), bool> { [("app_ro", PrivilegeKind.Select)] = false });
+
+        await Assert.That(result[0].Granted).IsFalse();
+        await Assert.That(result[0].Source).IsEqualTo(PrivilegeSource.None);
+        await Assert.That(result[0].Via).IsNull();
+    }
+
+    [Test]
+    public async Task PairsTheServerDidNotAnswerFallBackToTheResolver()
+    {
+        var acl = Acl(Table(), "postgres", Grant("app_ro", PrivilegeKind.Select));
+
+        var result = EffectivePrivilegeResolver.Resolve(
+            acl, ["app_ro"], [PrivilegeKind.Select, PrivilegeKind.Insert], new FakeLookup(),
+            new Dictionary<(string, PrivilegeKind), bool> { [("app_ro", PrivilegeKind.Insert)] = false });
+
+        await Assert.That(One(result, PrivilegeKind.Select).Source).IsEqualTo(PrivilegeSource.Direct);
+        await Assert.That(One(result, PrivilegeKind.Insert).Granted).IsFalse();
+    }
+
+    // ------------------------------------------------------------- sentence
+
+    [Test]
+    public async Task ExplainSentenceNamesTheSourceThenWhatIsMissing()
+    {
+        var acl = Acl(Table(), "postgres", Grant("readers", PrivilegeKind.Select));
+        var lookup = new FakeLookup(new() { ["app_ro"] = new[] { "readers" } });
+        var effective = EffectivePrivilegeResolver.Resolve(acl, ["app_ro"], Crud, lookup);
+
+        var sentence = EffectivePrivilegeResolver.ExplainSentence(
+            "app_ro", Table(), effective, hasSchemaUsage: true);
+
+        await Assert.That(sentence).IsEqualTo(
+            "app_ro can SELECT sales.orders — inherited from readers. It cannot INSERT, UPDATE or DELETE.");
+    }
+
+    [Test]
+    public async Task ExplainSentenceListsSeveralGrantedPrivileges()
+    {
+        var acl = Acl(
+            Table(), "postgres",
+            Grant("app_rw", PrivilegeKind.Select),
+            Grant("app_rw", PrivilegeKind.Insert));
+        var effective = EffectivePrivilegeResolver.Resolve(acl, ["app_rw"], Crud, new FakeLookup());
+
+        var sentence = EffectivePrivilegeResolver.ExplainSentence(
+            "app_rw", Table(), effective, hasSchemaUsage: true);
+
+        await Assert.That(sentence).IsEqualTo(
+            "app_rw can SELECT and INSERT sales.orders — granted directly by postgres. "
+            + "It cannot UPDATE or DELETE.");
+    }
+
+    [Test]
+    public async Task ExplainSentenceSaysSoWhenNothingIsGranted()
+    {
+        var effective = EffectivePrivilegeResolver.Resolve(
+            Acl(Table(), "postgres"), ["app_ro"], Crud, new FakeLookup());
+
+        var sentence = EffectivePrivilegeResolver.ExplainSentence(
+            "app_ro", Table(), effective, hasSchemaUsage: true);
+
+        await Assert.That(sentence).IsEqualTo("app_ro has no privileges on sales.orders.");
+    }
+
+    [Test]
+    public async Task ExplainSentenceCallsOutTheMissingSchemaUsage()
+    {
+        // Every table privilege granted, and it still fails. This is the trap.
+        var acl = Acl(
+            Table(), "postgres",
+            Grant("app_ro", PrivilegeKind.Select),
+            Grant("app_ro", PrivilegeKind.Insert),
+            Grant("app_ro", PrivilegeKind.Update),
+            Grant("app_ro", PrivilegeKind.Delete));
+        var effective = EffectivePrivilegeResolver.Resolve(acl, ["app_ro"], Crud, new FakeLookup());
+
+        var sentence = EffectivePrivilegeResolver.ExplainSentence(
+            "app_ro", Table(), effective, hasSchemaUsage: false);
+
+        await Assert.That(sentence).IsEqualTo(
+            "app_ro can SELECT, INSERT, UPDATE and DELETE sales.orders — granted directly by postgres. "
+            + "app_ro also lacks USAGE on schema sales, which blocks access to everything in it.");
+    }
+
+    [Test]
+    public async Task ExplainSentenceIgnoresOtherRolesRows()
+    {
+        var acl = Acl(Table(), "postgres", Grant("someone_else", PrivilegeKind.Select));
+        var effective = EffectivePrivilegeResolver.Resolve(
+            acl, ["someone_else", "app_ro"], [PrivilegeKind.Select], new FakeLookup());
+
+        var sentence = EffectivePrivilegeResolver.ExplainSentence(
+            "app_ro", Table(), effective, hasSchemaUsage: true);
+
+        await Assert.That(sentence).IsEqualTo("app_ro has no privileges on sales.orders.");
+    }
+
+    [Test]
+    public async Task ExplainSentenceOnASchemalessObjectSkipsTheUsageClause()
+    {
+        // A database has no schema to need USAGE on, so the clause must not appear
+        // even when the flag is false.
+        var effective = EffectivePrivilegeResolver.Resolve(
+            DefaultAcl(Database(), "alice"), ["bob"], [PrivilegeKind.Connect], new FakeLookup());
+
+        var sentence = EffectivePrivilegeResolver.ExplainSentence(
+            "bob", Database(), effective, hasSchemaUsage: false);
+
+        await Assert.That(sentence).IsEqualTo("bob can CONNECT demo — granted to PUBLIC.");
+    }
+}

--- a/PgNimbus.Core.Tests/Security/GrantScriptBuilderTests.cs
+++ b/PgNimbus.Core.Tests/Security/GrantScriptBuilderTests.cs
@@ -1,0 +1,318 @@
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.Core.Tests.Security;
+
+/// <summary>
+/// The generated script is the product here — it is what the user reads,
+/// edits and runs — so these assert exact text rather than "contains GRANT".
+/// A layout change has to be deliberate enough to update a test.
+/// </summary>
+public class GrantScriptBuilderTests
+{
+    private static SecurableRef Table(string schema, string name) =>
+        new(SecurableKind.Table, 16384, schema, name);
+
+    private static SecurableRef SchemaRef(string name) =>
+        new(SecurableKind.Schema, 2200, null, name);
+
+    /// <summary>Source files are CRLF; the builder emits "\n". Compare on one convention.</summary>
+    private static string N(string text) => text.ReplaceLineEndings("\n");
+
+    [Test]
+    public async Task EmptyChangeSetProducesNoScript()
+    {
+        await Assert.That(GrantScriptBuilder.Build([])).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task PrivilegesForOneCellCollapseIntoOneStatement()
+    {
+        // Two clicks in the grid, one statement — and in Privileges.For order
+        // (SELECT before INSERT), not the order they were clicked.
+        var sql = GrantScriptBuilder.Build(
+        [
+            new PrivilegeChange(Table("sales", "orders"), "app_rw", PrivilegeKind.Insert, Grant: true),
+            new PrivilegeChange(Table("sales", "orders"), "app_rw", PrivilegeKind.Select, Grant: true),
+        ]);
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            GRANT SELECT, INSERT ON TABLE sales.orders TO app_rw;
+            """));
+    }
+
+    [Test]
+    public async Task RevokesAreEmittedBeforeGrants()
+    {
+        // Grant-then-revoke and revoke-then-grant are different scripts. The
+        // order is fixed by the builder, not by the click order.
+        var sql = GrantScriptBuilder.Build(
+        [
+            new PrivilegeChange(Table("sales", "orders"), "app_rw", PrivilegeKind.Select, Grant: true),
+            new PrivilegeChange(Table("sales", "orders"), "app_rw", PrivilegeKind.Delete, Grant: false),
+        ]);
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            REVOKE DELETE ON TABLE sales.orders FROM app_rw;
+            GRANT SELECT ON TABLE sales.orders TO app_rw;
+            """));
+    }
+
+    [Test]
+    public async Task AFullPrivilegeSetCollapsesToAllPrivileges()
+    {
+        var everything = Privileges.For(SecurableKind.Table)
+            .Select(p => new PrivilegeChange(Table("sales", "orders"), "app_rw", p, Grant: true))
+            .ToList();
+
+        await Assert.That(N(GrantScriptBuilder.Build(everything))).IsEqualTo(N("""
+            GRANT ALL PRIVILEGES ON TABLE sales.orders TO app_rw;
+            """));
+    }
+
+    [Test]
+    public async Task APartialPrivilegeSetIsSpelledOut()
+    {
+        // One short of the full set must not become ALL PRIVILEGES — that would
+        // widen the grant on any server whose "all" is bigger than ours.
+        var almost = Privileges.For(SecurableKind.Table)
+            .Where(p => p != PrivilegeKind.Truncate)
+            .Select(p => new PrivilegeChange(Table("sales", "orders"), "app_rw", p, Grant: true))
+            .ToList();
+
+        await Assert.That(N(GrantScriptBuilder.Build(almost))).IsEqualTo(N("""
+            GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES, TRIGGER, MAINTAIN ON TABLE sales.orders TO app_rw;
+            """));
+    }
+
+    [Test]
+    public async Task GrantOptionIsASuffixOnGrantAndAPrefixOnRevoke()
+    {
+        var sql = GrantScriptBuilder.Build(
+        [
+            new PrivilegeChange(Table("sales", "orders"), "app_rw", PrivilegeKind.Select, Grant: true, WithGrantOption: true),
+            new PrivilegeChange(Table("sales", "orders"), "app_ro", PrivilegeKind.Select, Grant: false, WithGrantOption: true),
+        ]);
+
+        // REVOKE has no "WITH GRANT OPTION" tail; taking back only the right to
+        // re-grant is GRANT OPTION FOR, a different statement.
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            REVOKE GRANT OPTION FOR SELECT ON TABLE sales.orders FROM app_ro;
+            GRANT SELECT ON TABLE sales.orders TO app_rw WITH GRANT OPTION;
+            """));
+    }
+
+    [Test]
+    public async Task PublicIsAKeywordOnBothSides()
+    {
+        var sql = GrantScriptBuilder.Build(
+        [
+            new PrivilegeChange(SchemaRef("sales"), null, PrivilegeKind.Usage, Grant: true),
+            new PrivilegeChange(SchemaRef("archive"), null, PrivilegeKind.Usage, Grant: false),
+            new PrivilegeChange(SchemaRef("archive"), null, PrivilegeKind.Create, Grant: false),
+        ]);
+
+        // PUBLIC is never quoted — "PUBLIC" would name a role instead.
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            REVOKE ALL PRIVILEGES ON SCHEMA archive FROM PUBLIC;
+            GRANT USAGE ON SCHEMA sales TO PUBLIC;
+            """));
+    }
+
+    [Test]
+    public async Task ColumnGrantsShareOneColumnList()
+    {
+        var sql = GrantScriptBuilder.Build(
+        [
+            new PrivilegeChange(Table("public", "users"), "app_ro", PrivilegeKind.Select, Grant: true, Column: "id"),
+            new PrivilegeChange(Table("public", "users"), "app_ro", PrivilegeKind.Select, Grant: true, Column: "email"),
+        ]);
+
+        // Columns sorted ordinally, not by click order — the script has to be
+        // byte-identical for the same change set.
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            GRANT SELECT (email, id) ON TABLE public.users TO app_ro;
+            """));
+    }
+
+    [Test]
+    public async Task ColumnAndObjectGrantsCoexist()
+    {
+        var sql = GrantScriptBuilder.Build(
+        [
+            new PrivilegeChange(Table("public", "users"), "app_ro", PrivilegeKind.Update, Grant: true, Column: "email"),
+            new PrivilegeChange(Table("public", "users"), "app_ro", PrivilegeKind.Select, Grant: true),
+        ]);
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            GRANT SELECT ON TABLE public.users TO app_ro;
+            GRANT UPDATE (email) ON TABLE public.users TO app_ro;
+            """));
+    }
+
+    [Test]
+    public async Task IdentifiersAreQuotedOnlyWhenBeingBareWouldChangeThem()
+    {
+        var sql = GrantScriptBuilder.Build(
+        [
+            new PrivilegeChange(Table("sales", "Order Items"), "App RO", PrivilegeKind.Select, Grant: true),
+            new PrivilegeChange(Table("sales", "orders"), "app_ro", PrivilegeKind.Select, Grant: true),
+        ]);
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            GRANT SELECT ON TABLE sales."Order Items" TO "App RO";
+            GRANT SELECT ON TABLE sales.orders TO app_ro;
+            """));
+    }
+
+    [Test]
+    public async Task ShuffledInputProducesTheSameScript()
+    {
+        List<PrivilegeChange> changes =
+        [
+            new(Table("sales", "orders"), "app_rw", PrivilegeKind.Select, Grant: true),
+            new(Table("sales", "orders"), "app_rw", PrivilegeKind.Insert, Grant: true),
+            new(Table("archive", "orders"), null, PrivilegeKind.Select, Grant: false),
+            new(SchemaRef("sales"), "app_rw", PrivilegeKind.Usage, Grant: true),
+            new(Table("public", "users"), "app_ro", PrivilegeKind.Select, Grant: true, Column: "id"),
+        ];
+
+        var forwards = GrantScriptBuilder.Build(changes);
+        var backwards = GrantScriptBuilder.Build([.. Enumerable.Reverse(changes)]);
+
+        await Assert.That(backwards).IsEqualTo(forwards);
+        await Assert.That(N(forwards)).IsEqualTo(N("""
+            REVOKE SELECT ON TABLE archive.orders FROM PUBLIC;
+            GRANT SELECT (id) ON TABLE public.users TO app_ro;
+            GRANT USAGE ON SCHEMA sales TO app_rw;
+            GRANT SELECT, INSERT ON TABLE sales.orders TO app_rw;
+            """));
+    }
+
+    [Test]
+    public async Task DuplicateChangesDoNotDuplicateAPrivilege()
+    {
+        var sql = GrantScriptBuilder.Build(
+        [
+            new PrivilegeChange(Table("sales", "orders"), "app_rw", PrivilegeKind.Select, Grant: true),
+            new PrivilegeChange(Table("sales", "orders"), "app_rw", PrivilegeKind.Select, Grant: true),
+        ]);
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            GRANT SELECT ON TABLE sales.orders TO app_rw;
+            """));
+    }
+
+    // ---- Bulk ----------------------------------------------------------
+
+    [Test]
+    public async Task ReadOnlyGrantsUsageFirstAndMentionsThePredefinedRole()
+    {
+        var sql = GrantScriptBuilder.BuildBulk(new BulkGrantRequest(
+            "sales", "app_ro", BulkGrantPreset.ReadOnly, IncludeFutureObjects: false, FutureObjectsOwner: null));
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            -- GRANT ... ON ALL TABLES IN SCHEMA reaches only the objects that exist
+            -- right now. Anything created afterwards is not covered by these statements.
+            -- On PostgreSQL 14+ a cluster-wide read-only role is one membership instead
+            -- of this whole script: GRANT pg_read_all_data TO app_ro; the role editor
+            -- offers it.
+            GRANT USAGE ON SCHEMA sales TO app_ro;
+            GRANT SELECT ON ALL TABLES IN SCHEMA sales TO app_ro;
+            GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA sales TO app_ro;
+            """));
+    }
+
+    [Test]
+    public async Task ReadWriteWithFutureObjectsNamesTheCreatingRole()
+    {
+        var sql = GrantScriptBuilder.BuildBulk(new BulkGrantRequest(
+            "sales", "app_rw", BulkGrantPreset.ReadWrite, IncludeFutureObjects: true, FutureObjectsOwner: "app_owner"));
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            -- GRANT ... ON ALL TABLES IN SCHEMA reaches only the objects that exist
+            -- right now. Anything created afterwards is not covered by these statements.
+            -- ALTER DEFAULT PRIVILEGES is keyed to the role that CREATES an object, not
+            -- to the schema the object lands in. Set for the wrong creator it silently
+            -- does nothing, which is why the owner has to be named.
+            GRANT USAGE ON SCHEMA sales TO app_rw;
+            GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA sales TO app_rw;
+            GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA sales TO app_rw;
+            ALTER DEFAULT PRIVILEGES FOR ROLE app_owner IN SCHEMA sales GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_rw;
+            ALTER DEFAULT PRIVILEGES FOR ROLE app_owner IN SCHEMA sales GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO app_rw;
+            """));
+    }
+
+    [Test]
+    public async Task FullAddsCreateOnTheSchemaAndCoversFunctions()
+    {
+        var sql = GrantScriptBuilder.BuildBulk(new BulkGrantRequest(
+            "sales", "app_full", BulkGrantPreset.Full, IncludeFutureObjects: false, FutureObjectsOwner: null));
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            -- GRANT ... ON ALL TABLES IN SCHEMA reaches only the objects that exist
+            -- right now. Anything created afterwards is not covered by these statements.
+            GRANT USAGE ON SCHEMA sales TO app_full;
+            GRANT CREATE ON SCHEMA sales TO app_full;
+            GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA sales TO app_full;
+            GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA sales TO app_full;
+            GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA sales TO app_full;
+            """));
+    }
+
+    [Test]
+    public async Task RevokeAllReversesTheGrantScriptAndUndoesDefaultPrivileges()
+    {
+        var sql = GrantScriptBuilder.BuildBulk(new BulkGrantRequest(
+            "sales", "app_ro", BulkGrantPreset.RevokeAll, IncludeFutureObjects: true, FutureObjectsOwner: "app_owner"));
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            -- REVOKE ... ON ALL TABLES IN SCHEMA reaches only the objects that exist
+            -- right now. Anything created afterwards is not covered by these statements.
+            -- ALTER DEFAULT PRIVILEGES is keyed to the role that CREATES an object, not
+            -- to the schema the object lands in. Set for the wrong creator it silently
+            -- does nothing, which is why the owner has to be named.
+            ALTER DEFAULT PRIVILEGES FOR ROLE app_owner IN SCHEMA sales REVOKE ALL PRIVILEGES ON FUNCTIONS FROM app_ro;
+            ALTER DEFAULT PRIVILEGES FOR ROLE app_owner IN SCHEMA sales REVOKE ALL PRIVILEGES ON SEQUENCES FROM app_ro;
+            ALTER DEFAULT PRIVILEGES FOR ROLE app_owner IN SCHEMA sales REVOKE ALL PRIVILEGES ON TABLES FROM app_ro;
+            REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA sales FROM app_ro;
+            REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA sales FROM app_ro;
+            REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA sales FROM app_ro;
+            REVOKE ALL PRIVILEGES ON SCHEMA sales FROM app_ro;
+            """));
+    }
+
+    [Test]
+    [Arguments(BulkGrantPreset.ReadOnly)]
+    [Arguments(BulkGrantPreset.ReadWrite)]
+    [Arguments(BulkGrantPreset.Full)]
+    public async Task UsageOnTheSchemaIsAlwaysTheFirstStatement(BulkGrantPreset preset)
+    {
+        // pgadmin4#8954: granting every table privilege without the schema's own
+        // USAGE leaves the user with permission denied. It goes first, always.
+        var sql = GrantScriptBuilder.BuildBulk(new BulkGrantRequest(
+            "sales", "app", preset, IncludeFutureObjects: true, FutureObjectsOwner: "app_owner"));
+
+        var firstStatement = N(sql).Split('\n').First(l => !l.StartsWith("--", StringComparison.Ordinal));
+
+        await Assert.That(firstStatement).IsEqualTo("GRANT USAGE ON SCHEMA sales TO app;");
+    }
+
+    [Test]
+    public async Task FutureObjectsWithoutAnOwnerSaysSoInsteadOfGuessing()
+    {
+        var sql = GrantScriptBuilder.BuildBulk(new BulkGrantRequest(
+            "sales", "app_ro", BulkGrantPreset.ReadOnly, IncludeFutureObjects: true, FutureObjectsOwner: null));
+
+        await Assert.That(sql).Contains("-- No creating role was named, so the ALTER DEFAULT PRIVILEGES statements are");
+        await Assert.That(sql).DoesNotContain("ALTER DEFAULT PRIVILEGES FOR ROLE");
+    }
+
+    [Test]
+    public async Task BulkQuotesTheSchemaAndGranteeWhenTheyNeedIt()
+    {
+        var sql = GrantScriptBuilder.BuildBulk(new BulkGrantRequest(
+            "Sales Archive", null, BulkGrantPreset.ReadOnly, IncludeFutureObjects: false, FutureObjectsOwner: null));
+
+        await Assert.That(sql).Contains("""GRANT USAGE ON SCHEMA "Sales Archive" TO PUBLIC;""");
+    }
+}

--- a/PgNimbus.Core.Tests/Security/RoleGraphTests.cs
+++ b/PgNimbus.Core.Tests/Security/RoleGraphTests.cs
@@ -32,13 +32,13 @@ public class RoleGraphTests
             [Edge("app", "readers")]);
 
         var memberOf = graph.MemberOf("app");
-        await Assert.That(memberOf).HasCount(1);
+        await Assert.That(memberOf).Count().IsEqualTo(1);
         await Assert.That(memberOf[0].Role).IsEqualTo("readers");
         await Assert.That(memberOf[0].Inherits).IsTrue();
         await Assert.That(memberOf[0].Children).IsEmpty();
 
         var members = graph.Members("readers");
-        await Assert.That(members).HasCount(1);
+        await Assert.That(members).Count().IsEqualTo(1);
         await Assert.That(members[0].Role).IsEqualTo("app");
 
         await Assert.That(string.Join('|', graph.InheritedGroups("app"))).IsEqualTo("readers");
@@ -85,7 +85,7 @@ public class RoleGraphTests
 
         // The relationship still exists and the tree has to show it.
         var memberOf = graph.MemberOf("app");
-        await Assert.That(memberOf).HasCount(1);
+        await Assert.That(memberOf).Count().IsEqualTo(1);
         await Assert.That(memberOf[0].Role).IsEqualTo("ops");
         await Assert.That(memberOf[0].Inherits).IsFalse();
     }
@@ -202,7 +202,7 @@ public class RoleGraphTests
             [Role("app"), Role("readers")],
             [Edge("app", "readers"), Edge("app", "readers")]);
 
-        await Assert.That(graph.MemberOf("app")).HasCount(1);
-        await Assert.That(graph.InheritedGroups("app")).HasCount(1);
+        await Assert.That(graph.MemberOf("app")).Count().IsEqualTo(1);
+        await Assert.That(graph.InheritedGroups("app")).Count().IsEqualTo(1);
     }
 }

--- a/PgNimbus.Core.Tests/Security/RoleGraphTests.cs
+++ b/PgNimbus.Core.Tests/Security/RoleGraphTests.cs
@@ -1,0 +1,208 @@
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.Core.Tests.Security;
+
+public class RoleGraphTests
+{
+    private static RoleAttributes Role(string name, bool superuser = false) =>
+        new(0, name, CanLogin: true, IsSuperuser: superuser, Inherit: true, CanCreateRole: false,
+            CanCreateDb: false, CanReplicate: false, BypassRls: false, ConnectionLimit: -1,
+            ValidUntil: null, Settings: [], Comment: null);
+
+    /// <summary><paramref name="member"/> is a member of <paramref name="group"/>.</summary>
+    private static RoleMembership Edge(string member, string group, bool inherit = true) =>
+        new(member, group, AdminOption: false, InheritOption: inherit, SetOption: true, Grantor: "postgres");
+
+    [Test]
+    public async Task EmptyInputHasNothingInIt()
+    {
+        var graph = RoleGraph.Build([], []);
+
+        await Assert.That(graph.Roles).IsEmpty();
+        await Assert.That(graph.MemberOf("anyone")).IsEmpty();
+        await Assert.That(graph.Members("anyone")).IsEmpty();
+        await Assert.That(graph.InheritedGroups("anyone")).IsEmpty();
+    }
+
+    [Test]
+    public async Task SingleMembershipIsVisibleFromBothEnds()
+    {
+        var graph = RoleGraph.Build(
+            [Role("app"), Role("readers")],
+            [Edge("app", "readers")]);
+
+        var memberOf = graph.MemberOf("app");
+        await Assert.That(memberOf).HasCount(1);
+        await Assert.That(memberOf[0].Role).IsEqualTo("readers");
+        await Assert.That(memberOf[0].Inherits).IsTrue();
+        await Assert.That(memberOf[0].Children).IsEmpty();
+
+        var members = graph.Members("readers");
+        await Assert.That(members).HasCount(1);
+        await Assert.That(members[0].Role).IsEqualTo("app");
+
+        await Assert.That(string.Join('|', graph.InheritedGroups("app"))).IsEqualTo("readers");
+    }
+
+    [Test]
+    public async Task ChainIsReportedNearestFirst()
+    {
+        // app -> readers -> analysts: app holds everything granted to either group.
+        var graph = RoleGraph.Build(
+            [Role("app"), Role("readers"), Role("analysts")],
+            [Edge("app", "readers"), Edge("readers", "analysts")]);
+
+        await Assert.That(string.Join('|', graph.InheritedGroups("app"))).IsEqualTo("readers|analysts");
+
+        var memberOf = graph.MemberOf("app");
+        await Assert.That(memberOf.Single().Role).IsEqualTo("readers");
+        await Assert.That(memberOf.Single().Children.Single().Role).IsEqualTo("analysts");
+    }
+
+    [Test]
+    public async Task DiamondReportsTheSharedGroupOnce()
+    {
+        // app is in readers and writers; both are in staff. staff must not be listed twice.
+        var graph = RoleGraph.Build(
+            [Role("app"), Role("readers"), Role("writers"), Role("staff")],
+            [Edge("app", "readers"), Edge("app", "writers"), Edge("readers", "staff"), Edge("writers", "staff")]);
+
+        // Nearest level first, alphabetical within a level.
+        await Assert.That(string.Join('|', graph.InheritedGroups("app")))
+            .IsEqualTo("readers|writers|staff");
+    }
+
+    [Test]
+    public async Task NoInheritGroupIsShownButNotClaimed()
+    {
+        // Postgres gives app the privileges of ops only after SET ROLE ops, so
+        // reporting ops as inherited would promise access the server refuses.
+        var graph = RoleGraph.Build(
+            [Role("app"), Role("ops")],
+            [Edge("app", "ops", inherit: false)]);
+
+        await Assert.That(graph.InheritedGroups("app")).IsEmpty();
+
+        // The relationship still exists and the tree has to show it.
+        var memberOf = graph.MemberOf("app");
+        await Assert.That(memberOf).HasCount(1);
+        await Assert.That(memberOf[0].Role).IsEqualTo("ops");
+        await Assert.That(memberOf[0].Inherits).IsFalse();
+    }
+
+    [Test]
+    public async Task NoInheritInTheMiddleCutsOffEverythingAbove()
+    {
+        // app -> readers (inherit) -> ops (NOINHERIT) -> admins.
+        // Nothing above the NOINHERIT edge reaches app, not even transitively.
+        var graph = RoleGraph.Build(
+            [Role("app"), Role("readers"), Role("ops"), Role("admins")],
+            [Edge("app", "readers"), Edge("readers", "ops", inherit: false), Edge("ops", "admins")]);
+
+        await Assert.That(string.Join('|', graph.InheritedGroups("app"))).IsEqualTo("readers");
+
+        // readers itself is a member of ops, so ops still walks the tree with admins under it.
+        var readersGroups = graph.MemberOf("readers");
+        await Assert.That(readersGroups.Single().Role).IsEqualTo("ops");
+        await Assert.That(readersGroups.Single().Inherits).IsFalse();
+        await Assert.That(readersGroups.Single().Children.Single().Role).IsEqualTo("admins");
+    }
+
+    [Test]
+    public async Task MembershipCycleTerminates()
+    {
+        // Postgres refuses to create this, but the snapshot is read across
+        // statements and a malformed input must not hang the UI.
+        var graph = RoleGraph.Build(
+            [Role("a"), Role("b"), Role("c")],
+            [Edge("a", "b"), Edge("b", "c"), Edge("c", "a")]);
+
+        await Assert.That(string.Join('|', graph.InheritedGroups("a"))).IsEqualTo("b|c");
+
+        var memberOf = graph.MemberOf("a");
+        await Assert.That(memberOf.Single().Role).IsEqualTo("b");
+        await Assert.That(memberOf.Single().Children.Single().Role).IsEqualTo("c");
+
+        // c's only group is a, which is the root of this walk — the edge that
+        // closes the loop is dropped rather than followed.
+        await Assert.That(memberOf.Single().Children.Single().Children).IsEmpty();
+
+        var members = graph.Members("a");
+        await Assert.That(members.Single().Role).IsEqualTo("c");
+        await Assert.That(members.Single().Children.Single().Role).IsEqualTo("b");
+        await Assert.That(members.Single().Children.Single().Children).IsEmpty();
+    }
+
+    [Test]
+    public async Task SelfMembershipIsIgnored()
+    {
+        var graph = RoleGraph.Build([Role("a")], [Edge("a", "a")]);
+
+        await Assert.That(graph.MemberOf("a")).IsEmpty();
+        await Assert.That(graph.Members("a")).IsEmpty();
+        await Assert.That(graph.InheritedGroups("a")).IsEmpty();
+    }
+
+    [Test]
+    public async Task UnknownRolesAnswerEmptyRatherThanThrowing()
+    {
+        var graph = RoleGraph.Build([Role("app")], [Edge("app", "readers")]);
+
+        await Assert.That(graph.InheritedGroups("nobody")).IsEmpty();
+        await Assert.That(graph.MemberOf("nobody")).IsEmpty();
+        await Assert.That(graph.Members("nobody")).IsEmpty();
+        await Assert.That(graph.Find("nobody")).IsNull();
+        await Assert.That(graph.IsSuperuser("nobody")).IsFalse();
+    }
+
+    [Test]
+    public async Task GroupNamedOnlyByAnEdgeStillWalks()
+    {
+        // The membership names readers, but the role list never did (a filtered
+        // snapshot). The edge is still real, so the tree shows it and Find says so.
+        var graph = RoleGraph.Build([Role("app")], [Edge("app", "readers")]);
+
+        await Assert.That(graph.MemberOf("app").Single().Role).IsEqualTo("readers");
+        await Assert.That(string.Join('|', graph.InheritedGroups("app"))).IsEqualTo("readers");
+        await Assert.That(graph.Find("readers")).IsNull();
+    }
+
+    [Test]
+    public async Task SuperuserIsLookedUpByName()
+    {
+        var graph = RoleGraph.Build([Role("postgres", superuser: true), Role("app")], []);
+
+        await Assert.That(graph.IsSuperuser("postgres")).IsTrue();
+        await Assert.That(graph.IsSuperuser("app")).IsFalse();
+        await Assert.That(graph.Find("app")!.Name).IsEqualTo("app");
+    }
+
+    [Test]
+    public async Task SiblingsAndRolesAreAlphabetical()
+    {
+        var graph = RoleGraph.Build(
+            [Role("zulu"), Role("alpha"), Role("mike"), Role("staff")],
+            [Edge("staff", "zulu"), Edge("staff", "alpha"), Edge("staff", "mike"),
+             Edge("zulu", "staff"), Edge("alpha", "staff"), Edge("mike", "staff")]);
+
+        await Assert.That(string.Join('|', graph.Roles.Select(r => r.Name)))
+            .IsEqualTo("alpha|mike|staff|zulu");
+
+        // Upward siblings sort by group name, downward siblings by member name.
+        await Assert.That(string.Join('|', graph.MemberOf("staff").Select(n => n.Role)))
+            .IsEqualTo("alpha|mike|zulu");
+        await Assert.That(string.Join('|', graph.Members("staff").Select(n => n.Role)))
+            .IsEqualTo("alpha|mike|zulu");
+    }
+
+    [Test]
+    public async Task DuplicateEdgesCollapse()
+    {
+        var graph = RoleGraph.Build(
+            [Role("app"), Role("readers")],
+            [Edge("app", "readers"), Edge("app", "readers")]);
+
+        await Assert.That(graph.MemberOf("app")).HasCount(1);
+        await Assert.That(graph.InheritedGroups("app")).HasCount(1);
+    }
+}

--- a/PgNimbus.Core.Tests/Security/RoleScriptBuilderTests.cs
+++ b/PgNimbus.Core.Tests/Security/RoleScriptBuilderTests.cs
@@ -1,0 +1,254 @@
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.Core.Tests.Security;
+
+public class RoleScriptBuilderTests
+{
+    private static readonly DateTimeOffset Expiry = new(2027, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    /// <summary>Source files are CRLF; the builder emits "\n". Compare on one convention.</summary>
+    private static string N(string text) => text.ReplaceLineEndings("\n");
+
+    private static RoleDefinition Definition(
+        string name = "app_rw",
+        bool canLogin = true,
+        bool isSuperuser = false,
+        bool inherit = true,
+        bool canCreateDb = false,
+        bool canCreateRole = false,
+        bool canReplicate = false,
+        bool bypassRls = false,
+        int? connectionLimit = null,
+        DateTimeOffset? validUntil = null,
+        IReadOnlyList<string>? memberOf = null,
+        string? comment = null) =>
+        new(name, canLogin, isSuperuser, inherit, canCreateDb, canCreateRole, canReplicate, bypassRls,
+            connectionLimit, validUntil, memberOf ?? [], comment);
+
+    private static RoleAttributes Attributes(
+        string name = "app_rw",
+        bool canLogin = true,
+        bool isSuperuser = false,
+        bool inherit = true,
+        bool canCreateRole = false,
+        bool canCreateDb = false,
+        bool canReplicate = false,
+        bool bypassRls = false,
+        int connectionLimit = -1,
+        DateTimeOffset? validUntil = null,
+        string? comment = null) =>
+        new(16385, name, canLogin, isSuperuser, inherit, canCreateRole, canCreateDb, canReplicate, bypassRls,
+            connectionLimit, validUntil, [], comment);
+
+    [Test]
+    public async Task CreateSpellsOutEveryNegativeKeyword()
+    {
+        // No attribute is left to the server's default: the script has to say
+        // the same thing wherever it is pasted.
+        var sql = RoleScriptBuilder.Create(Definition(), password: null);
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            CREATE ROLE app_rw WITH LOGIN NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS;
+            """));
+    }
+
+    [Test]
+    public async Task CreateWithEverythingSet()
+    {
+        var sql = RoleScriptBuilder.Create(
+            Definition(
+                connectionLimit: 10,
+                validUntil: Expiry,
+                memberOf: ["readers", "Report Writers"],
+                comment: "the application role"),
+            password: "hunter2");
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            CREATE ROLE app_rw WITH LOGIN NOSUPERUSER INHERIT NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS CONNECTION LIMIT 10 VALID UNTIL '2027-01-01 00:00:00+00:00' PASSWORD 'hunter2';
+            GRANT readers TO app_rw;
+            GRANT "Report Writers" TO app_rw;
+            COMMENT ON ROLE app_rw IS 'the application role';
+            """));
+    }
+
+    [Test]
+    public async Task MaskedCreateNeverEmitsTheRealPassword()
+    {
+        // The same call renders the preview and the executed statement; only
+        // this flag differs. A leaked literal here is a leaked credential.
+        var sql = RoleScriptBuilder.Create(Definition(), password: "hunter2", maskPassword: true);
+
+        await Assert.That(sql).DoesNotContain("hunter2");
+        await Assert.That(sql).Contains("PASSWORD '••••';");
+    }
+
+    [Test]
+    public async Task CreateQuotesANameThatNeedsIt()
+    {
+        var sql = RoleScriptBuilder.Create(Definition(name: "App Reader"), password: null);
+
+        await Assert.That(sql).StartsWith("""CREATE ROLE "App Reader" WITH """);
+    }
+
+    [Test]
+    public async Task CreateEscapesAQuoteInTheComment()
+    {
+        var sql = RoleScriptBuilder.Create(Definition(comment: "the app's role"), password: null);
+
+        await Assert.That(sql).Contains("COMMENT ON ROLE app_rw IS 'the app''s role';");
+    }
+
+    [Test]
+    public async Task AlterEmitsNothingWhenNothingChanged()
+    {
+        await Assert.That(RoleScriptBuilder.Alter(Attributes(), Definition())).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task AlterEmitsOnlyTheChangedAttributes()
+    {
+        var sql = RoleScriptBuilder.Alter(
+            Attributes(canLogin: true, canCreateDb: false),
+            Definition(canLogin: false, canCreateDb: true));
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            ALTER ROLE app_rw WITH NOLOGIN CREATEDB;
+            """));
+    }
+
+    [Test]
+    public async Task AlterTreatsANullConnectionLimitAsRemovingTheLimit()
+    {
+        // Postgres stores "no limit" as -1, so clearing a limit is a real change.
+        var sql = RoleScriptBuilder.Alter(Attributes(connectionLimit: 5), Definition(connectionLimit: null));
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            ALTER ROLE app_rw WITH CONNECTION LIMIT -1;
+            """));
+    }
+
+    [Test]
+    public async Task AlterClearsAnExpiryWithInfinity()
+    {
+        // There is no NO VALID UNTIL; 'infinity' is how the expiry is removed.
+        var sql = RoleScriptBuilder.Alter(Attributes(validUntil: Expiry), Definition(validUntil: null));
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            ALTER ROLE app_rw WITH VALID UNTIL 'infinity';
+            """));
+    }
+
+    [Test]
+    public async Task AlterDiffsMembershipsWhenTheCurrentOnesAreKnown()
+    {
+        var sql = RoleScriptBuilder.Alter(
+            Attributes(),
+            Definition(memberOf: ["readers", "auditors"]),
+            currentMemberOf: ["readers", "writers"]);
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            GRANT auditors TO app_rw;
+            REVOKE writers FROM app_rw;
+            """));
+    }
+
+    [Test]
+    public async Task AlterLeavesMembershipAloneWhenTheCurrentOnesAreUnknown()
+    {
+        // RoleAttributes carries no memberships (they live in pg_auth_members,
+        // not pg_roles). Unknown means untouched, not "assume none".
+        var sql = RoleScriptBuilder.Alter(Attributes(), Definition(memberOf: ["readers"]));
+
+        await Assert.That(sql).IsEqualTo("");
+    }
+
+    [Test]
+    public async Task AlterEmitsACommentChangeAndClearsItWithNull()
+    {
+        await Assert.That(RoleScriptBuilder.Alter(Attributes(comment: "old"), Definition(comment: "new")))
+            .IsEqualTo("COMMENT ON ROLE app_rw IS 'new';");
+
+        await Assert.That(RoleScriptBuilder.Alter(Attributes(comment: "old"), Definition(comment: null)))
+            .IsEqualTo("COMMENT ON ROLE app_rw IS NULL;");
+    }
+
+    [Test]
+    public async Task SetPasswordMasksOnRequest()
+    {
+        await Assert.That(RoleScriptBuilder.SetPassword("app_rw", "hunter2"))
+            .IsEqualTo("ALTER ROLE app_rw WITH PASSWORD 'hunter2';");
+
+        await Assert.That(RoleScriptBuilder.SetPassword("app_rw", "hunter2", maskPassword: true))
+            .IsEqualTo("ALTER ROLE app_rw WITH PASSWORD '••••';");
+    }
+
+    [Test]
+    public async Task RenameAndMembershipHelpers()
+    {
+        await Assert.That(RoleScriptBuilder.Rename("app", "App Reader"))
+            .IsEqualTo("""ALTER ROLE app RENAME TO "App Reader";""");
+        await Assert.That(RoleScriptBuilder.AddMember("readers", "app")).IsEqualTo("GRANT readers TO app;");
+        await Assert.That(RoleScriptBuilder.RemoveMember("readers", "app")).IsEqualTo("REVOKE readers FROM app;");
+    }
+
+    [Test]
+    public async Task DropReassignsBeforeDroppingOwnedAndThenTheRole()
+    {
+        // The order is the whole point: REASSIGN OWNED moves the objects,
+        // DROP OWNED clears what is left, DROP ROLE then succeeds.
+        var sql = RoleScriptBuilder.Drop("app", "postgres");
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            -- "app" may own objects or hold grants, and DROP ROLE alone
+            -- then fails with 2BP01 without naming either the objects or the fix.
+            -- REASSIGN OWNED hands the objects to another role; DROP OWNED then removes
+            -- the privileges REASSIGN OWNED leaves behind. Both act on the current
+            -- database only -- repeat them while connected to every other database that
+            -- contains objects owned by this role, then drop it.
+            REASSIGN OWNED BY app TO postgres;
+            DROP OWNED BY app;
+            DROP ROLE app;
+            """));
+    }
+
+    [Test]
+    public async Task DropWithoutAReassignTargetWarnsThatObjectsAreDeleted()
+    {
+        var sql = RoleScriptBuilder.Drop("app", reassignTo: null);
+
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            -- "app" may own objects or hold grants, and DROP ROLE alone
+            -- then fails with 2BP01 without naming either the objects or the fix.
+            -- No role was named to take the objects over, so DROP OWNED will DELETE
+            -- everything "app" owns -- tables, schemas, data -- rather than hand
+            -- it over. Name a role to reassign to first if the objects should be kept.
+            -- DROP OWNED acts on the current database only -- repeat it while connected
+            -- to every other database that contains objects owned by this role, then
+            -- drop it.
+            DROP OWNED BY app;
+            DROP ROLE app;
+            """));
+    }
+
+    [Test]
+    public async Task DropQuotesTheRoleInEveryStatement()
+    {
+        var sql = RoleScriptBuilder.Drop("App Reader", "postgres");
+
+        await Assert.That(sql).Contains("""REASSIGN OWNED BY "App Reader" TO postgres;""");
+        await Assert.That(sql).Contains("""DROP OWNED BY "App Reader";""");
+        await Assert.That(sql).Contains("""DROP ROLE "App Reader";""");
+    }
+
+    [Test]
+    public async Task DropCannotBeBrokenOutOfByANewlineInTheRoleName()
+    {
+        // A role name can legally contain a newline, and the recipe comment is
+        // the one place a name is not inside a quoted identifier.
+        var sql = RoleScriptBuilder.Drop("ap\np", "postgres");
+
+        var commentLines = N(sql).Split('\n').TakeWhile(l => l.StartsWith("--", StringComparison.Ordinal));
+
+        await Assert.That(commentLines.Count()).IsEqualTo(6);
+    }
+}

--- a/PgNimbus.Core.Tests/Security/SecretRedactorTests.cs
+++ b/PgNimbus.Core.Tests/Security/SecretRedactorTests.cs
@@ -1,0 +1,151 @@
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.Core.Tests.Security;
+
+/// <summary>
+/// The failure mode this class exists to prevent is a password sitting in
+/// <c>query-history.json</c> or <c>pgnimbus.log</c> in plain text, so the tests
+/// lean on inputs that a naive matcher gets wrong: escaped quotes, dollar
+/// quoting, the word PASSWORD inside a string, and more than one statement.
+/// </summary>
+public class SecretRedactorTests
+{
+    [Test]
+    public async Task PlainPasswordIsRedacted()
+    {
+        await Assert.That(SecretRedactor.Redact("CREATE ROLE app WITH LOGIN PASSWORD 'hunter2';"))
+            .IsEqualTo("CREATE ROLE app WITH LOGIN PASSWORD '<redacted>';");
+    }
+
+    [Test]
+    [Arguments("ALTER ROLE app PASSWORD 'p';")]
+    [Arguments("ALTER ROLE app ENCRYPTED PASSWORD 'p';")]
+    [Arguments("ALTER ROLE app UNENCRYPTED PASSWORD 'p';")]
+    [Arguments("ALTER ROLE app PaSsWoRd 'p';")]
+    [Arguments("ALTER ROLE app password 'p';")]
+    [Arguments("ALTER ROLE app PASSWORD  \n  'p';")]
+    public async Task EveryKeywordSpellingIsCaught(string sql)
+    {
+        await Assert.That(SecretRedactor.ContainsSecret(sql)).IsTrue();
+        await Assert.That(SecretRedactor.Redact(sql)).DoesNotContain("'p'");
+        await Assert.That(SecretRedactor.Redact(sql)).Contains("'<redacted>'");
+    }
+
+    [Test]
+    public async Task DoubledQuotesInsideTheLiteralDoNotEndItEarly()
+    {
+        // 'hun''ter2' is one literal. A matcher that stops at the first inner
+        // quote leaves "ter2'" behind — half a password, still on disk.
+        await Assert.That(SecretRedactor.Redact("ALTER ROLE app PASSWORD 'hun''ter2';"))
+            .IsEqualTo("ALTER ROLE app PASSWORD '<redacted>';");
+    }
+
+    [Test]
+    public async Task EscapeStringLiteralsAreRedactedIncludingTheirPrefix()
+    {
+        await Assert.That(SecretRedactor.Redact(@"ALTER ROLE app PASSWORD E'hun\'ter2';"))
+            .IsEqualTo("ALTER ROLE app PASSWORD '<redacted>';");
+    }
+
+    [Test]
+    [Arguments("ALTER ROLE app PASSWORD $$hunter2$$;")]
+    [Arguments("ALTER ROLE app PASSWORD $pw$hunter2$pw$;")]
+    public async Task DollarQuotedPasswordsAreRedacted(string sql)
+    {
+        await Assert.That(SecretRedactor.Redact(sql)).IsEqualTo("ALTER ROLE app PASSWORD '<redacted>';");
+    }
+
+    [Test]
+    public async Task PasswordNullIsLeftAlone()
+    {
+        // Not a secret — the removal of one. Rewriting it would change what the
+        // history says happened.
+        const string sql = "ALTER ROLE app PASSWORD NULL;";
+
+        await Assert.That(SecretRedactor.ContainsSecret(sql)).IsFalse();
+        await Assert.That(SecretRedactor.Redact(sql)).IsEqualTo(sql);
+    }
+
+    [Test]
+    public async Task EveryOccurrenceInAScriptIsRedacted()
+    {
+        var sql = string.Join('\n',
+            "CREATE ROLE a WITH PASSWORD 'one';",
+            "CREATE ROLE b WITH PASSWORD 'two';");
+
+        var redacted = SecretRedactor.Redact(sql);
+
+        await Assert.That(redacted).DoesNotContain("one");
+        await Assert.That(redacted).DoesNotContain("two");
+        await Assert.That(redacted.Split("'<redacted>'").Length).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task SqlWithNoPasswordComesBackUnchanged()
+    {
+        const string sql = "SELECT * FROM users WHERE name = 'PASSWORD';";
+
+        await Assert.That(SecretRedactor.ContainsSecret(sql)).IsFalse();
+        await Assert.That(SecretRedactor.Redact(sql)).IsEqualTo(sql);
+    }
+
+    [Test]
+    public async Task TheWordInsideALiteralIsNotAKeyword()
+    {
+        // The scanner has to know it is inside a string. A regex here is where
+        // this class of bug lives.
+        const string sql = "SELECT 'set PASSWORD ''x''' AS hint;";
+
+        await Assert.That(SecretRedactor.Redact(sql)).IsEqualTo(sql);
+    }
+
+    [Test]
+    public async Task AQuotedIdentifierNamedPasswordIsNotAKeyword()
+    {
+        const string sql = """SELECT "password" FROM accounts;""";
+
+        await Assert.That(SecretRedactor.Redact(sql)).IsEqualTo(sql);
+    }
+
+    [Test]
+    public async Task AColumnNamedPasswordIsNotAKeyword()
+    {
+        const string sql = "SELECT password FROM accounts WHERE id = 1;";
+
+        await Assert.That(SecretRedactor.Redact(sql)).IsEqualTo(sql);
+    }
+
+    [Test]
+    public async Task AParameterPlaceholderIsNotALiteral()
+    {
+        const string sql = "ALTER ROLE app PASSWORD $1;";
+
+        // $1 is a positional parameter, not the start of a dollar quote — and
+        // there is no secret in the text to strip.
+        await Assert.That(SecretRedactor.Redact(sql)).IsEqualTo(sql);
+    }
+
+    [Test]
+    public async Task AnUnterminatedLiteralIsSwallowedRatherThanTrusted()
+    {
+        // Truncated statement text (a crash log capture). Err toward redacting.
+        await Assert.That(SecretRedactor.Redact("CREATE ROLE app PASSWORD 'hunter2"))
+            .IsEqualTo("CREATE ROLE app PASSWORD '<redacted>'");
+    }
+
+    [Test]
+    public async Task RedactionSurvivesACommentBetweenKeywordAndLiteral()
+    {
+        // Everything up to the literal is preserved verbatim — only the secret
+        // is replaced.
+        await Assert.That(SecretRedactor.Redact("ALTER ROLE app PASSWORD /* nested /* */ */ 'hunter2';"))
+            .IsEqualTo("ALTER ROLE app PASSWORD /* nested /* */ */ '<redacted>';");
+    }
+
+    [Test]
+    public async Task EmptyInputIsSafe()
+    {
+        await Assert.That(SecretRedactor.Redact("")).IsEqualTo("");
+        await Assert.That(SecretRedactor.ContainsSecret("")).IsFalse();
+    }
+}

--- a/PgNimbus.Core.Tests/Security/SecurityCatalogTests.cs
+++ b/PgNimbus.Core.Tests/Security/SecurityCatalogTests.cs
@@ -1,0 +1,345 @@
+using Npgsql;
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.Core.Tests.Security;
+
+/// <summary>
+/// Runs every catalog query in <see cref="RoleService"/> and
+/// <see cref="PrivilegeService"/> against a real server.
+///
+/// The pure halves — <c>RoleGraph</c>, <c>EffectivePrivilegeResolver</c> — are
+/// covered by their own tests with no server in sight. What those cannot catch
+/// is a query that does not parse, a column that moved between major versions,
+/// or an <c>aclexplode</c> shape that is not what the reader expects. Those fail
+/// at runtime in front of a user, so they are checked here instead.
+///
+/// Gated on <c>PGNIMBUS_TEST_CONN</c> like <c>QueryEngineCompositeTests</c>:
+/// unset (a plain local run) every test skips; CI's <c>postgres:17</c> service
+/// container sets it and they run for real. The connected role has to be able to
+/// create roles — on a managed server without that, these skip rather than fail.
+/// </summary>
+// Every test shares one scratch fixture of roles and objects, and roles are
+// cluster-wide, so these must not overlap with each other.
+[NotInParallel]
+public class SecurityCatalogTests
+{
+    private const string Prefix = "pgnimbus_sec_";
+    private const string Readers = Prefix + "readers";
+    private const string Writers = Prefix + "writers";
+    private const string AppRo = Prefix + "app_ro";
+    private const string Legacy = Prefix + "legacy";
+    private const string Schema = Prefix + "schema";
+
+    private static readonly string? ConnectionString = Environment.GetEnvironmentVariable("PGNIMBUS_TEST_CONN");
+
+    private static void SkipIfNoConnection()
+    {
+        if (string.IsNullOrEmpty(ConnectionString))
+        {
+            Skip.Test("PGNIMBUS_TEST_CONN not set — no Postgres available to test the security catalog reads against.");
+        }
+    }
+
+    private static NpgsqlDataSource CreateDataSource() => NpgsqlDataSource.Create(ConnectionString!);
+
+    /// <summary>
+    /// A small but deliberately awkward fixture: an inheritance chain
+    /// (app_ro → readers), a NOINHERIT membership (app_ro → legacy), a column
+    /// grant, a default privilege, an RLS table and a policy on a table where
+    /// RLS was never enabled. Torn down and rebuilt per test so a crashed run
+    /// cannot leave a stale shape behind.
+    /// </summary>
+    private static async Task ResetFixtureAsync(NpgsqlDataSource dataSource)
+    {
+        await ExecuteAsync(dataSource, $"""
+            DROP SCHEMA IF EXISTS {Schema} CASCADE;
+            DROP ROLE IF EXISTS {AppRo};
+            DROP ROLE IF EXISTS {Writers};
+            DROP ROLE IF EXISTS {Readers};
+            DROP ROLE IF EXISTS {Legacy};
+
+            CREATE ROLE {Readers} NOLOGIN;
+            CREATE ROLE {Writers} NOLOGIN;
+            CREATE ROLE {Legacy} NOLOGIN;
+            CREATE ROLE {AppRo} NOLOGIN CONNECTION LIMIT 5 VALID UNTIL '2030-01-01';
+            COMMENT ON ROLE {Readers} IS 'read-only group';
+            ALTER ROLE {AppRo} SET statement_timeout = '30s';
+
+            GRANT {Readers} TO {Writers};
+            GRANT {Writers} TO {AppRo};
+
+            CREATE SCHEMA {Schema};
+            CREATE TABLE {Schema}.orders (id bigint PRIMARY KEY, customer text);
+            CREATE TABLE {Schema}.secret (id bigint PRIMARY KEY, note text);
+            CREATE TABLE {Schema}.inert (id int);
+            CREATE SEQUENCE {Schema}.order_seq;
+
+            GRANT USAGE ON SCHEMA {Schema} TO {Readers};
+            GRANT SELECT ON {Schema}.orders TO {Readers};
+            GRANT SELECT (id) ON {Schema}.secret TO {Readers};
+            ALTER DEFAULT PRIVILEGES IN SCHEMA {Schema} GRANT SELECT ON TABLES TO {Readers};
+
+            ALTER TABLE {Schema}.orders ENABLE ROW LEVEL SECURITY;
+            CREATE POLICY orders_own ON {Schema}.orders FOR SELECT TO {Readers} USING (customer = current_user);
+            CREATE POLICY inert_policy ON {Schema}.inert USING (true);
+            """);
+
+        // NOINHERIT is set on the membership on PG16+ and on the member role
+        // before that, so the two servers reach the same state by different
+        // statements. RoleService reads whichever column exists; this makes sure
+        // there is something non-default for it to read either way.
+        await using var connection = await dataSource.OpenConnectionAsync(CancellationToken.None);
+        var sql = connection.PostgreSqlVersion.Major >= 16
+            ? $"GRANT {Legacy} TO {AppRo} WITH INHERIT FALSE"
+            : $"GRANT {Legacy} TO {AppRo}";
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync(CancellationToken.None);
+    }
+
+    private static async Task DropFixtureAsync(NpgsqlDataSource dataSource) =>
+        await ExecuteAsync(dataSource, $"""
+            DROP SCHEMA IF EXISTS {Schema} CASCADE;
+            DROP ROLE IF EXISTS {AppRo};
+            DROP ROLE IF EXISTS {Writers};
+            DROP ROLE IF EXISTS {Readers};
+            DROP ROLE IF EXISTS {Legacy};
+            """);
+
+    private static async Task ExecuteAsync(NpgsqlDataSource dataSource, string sql)
+    {
+        var ct = CancellationToken.None;
+        await using var connection = await dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    [Test]
+    public async Task Roles_carry_their_attributes_settings_and_comment()
+    {
+        SkipIfNoConnection();
+        await using var dataSource = CreateDataSource();
+        var ct = CancellationToken.None;
+        await ResetFixtureAsync(dataSource);
+
+        try
+        {
+            var roles = await new RoleService(dataSource).GetRolesAsync(includePredefined: false, ct);
+
+            var appRo = roles.Single(r => r.Name == AppRo);
+            await Assert.That(appRo.ConnectionLimit).IsEqualTo(5);
+            await Assert.That(appRo.ValidUntil).IsNotNull();
+            await Assert.That(appRo.Settings).Contains("statement_timeout=30s");
+
+            var readers = roles.Single(r => r.Name == Readers);
+            await Assert.That(readers.Comment).IsEqualTo("read-only group");
+            await Assert.That(readers.CanLogin).IsFalse();
+
+            // includePredefined: false must drop the built-ins initdb created.
+            await Assert.That(roles.Any(r => r.IsPredefined)).IsFalse();
+        }
+        finally
+        {
+            await DropFixtureAsync(dataSource);
+        }
+    }
+
+    /// <summary>
+    /// The membership read and the graph over it, together — the version-guarded
+    /// half of <see cref="RoleService"/> and the NOINHERIT rule that decides
+    /// whether a privilege is reported at all.
+    /// </summary>
+    [Test]
+    public async Task Membership_reflects_inheritance_and_the_noinherit_edge()
+    {
+        SkipIfNoConnection();
+        await using var dataSource = CreateDataSource();
+        var ct = CancellationToken.None;
+        await ResetFixtureAsync(dataSource);
+
+        try
+        {
+            var service = new RoleService(dataSource);
+            var graph = RoleGraph.Build(
+                await service.GetRolesAsync(includePredefined: true, ct),
+                await service.GetMembershipsAsync(ct));
+
+            // app_ro -> writers -> readers, nearest first.
+            var inherited = graph.InheritedGroups(AppRo);
+            await Assert.That(string.Join("|", inherited)).IsEqualTo($"{Writers}|{Readers}");
+
+            // The NOINHERIT membership is real, so it shows in the tree...
+            var memberOf = graph.MemberOf(AppRo);
+            await Assert.That(memberOf.Any(n => n.Role == Legacy)).IsTrue();
+            await Assert.That(memberOf.Single(n => n.Role == Legacy).Inherits).IsFalse();
+
+            // ...but its privileges are dormant until SET ROLE, so it is not inherited.
+            await Assert.That(inherited).DoesNotContain(Legacy);
+        }
+        finally
+        {
+            await DropFixtureAsync(dataSource);
+        }
+    }
+
+    [Test]
+    public async Task Table_acl_expands_and_a_null_acl_is_reported_as_default()
+    {
+        SkipIfNoConnection();
+        await using var dataSource = CreateDataSource();
+        var ct = CancellationToken.None;
+        await ResetFixtureAsync(dataSource);
+
+        try
+        {
+            var service = new PrivilegeService(dataSource);
+            var tables = await service.GetSecurablesAsync(SecurableKind.Table, Schema, ct);
+
+            var orders = tables.Single(t => t.Name == "orders");
+            var acl = await service.GetAclAsync(orders, ct);
+            await Assert.That(acl.IsDefaultAcl).IsFalse();
+            await Assert.That(acl.Entries.Any(e => e.Grantee == Readers && e.Privilege == PrivilegeKind.Select)).IsTrue();
+
+            // "inert" was never granted to anyone, so its relacl is NULL — which
+            // means "owner has everything, defaults apply", not "no privileges".
+            // Rendering that as an empty grid is the bug this flag exists to stop.
+            var inert = tables.Single(t => t.Name == "inert");
+            var inertAcl = await service.GetAclAsync(inert, ct);
+            await Assert.That(inertAcl.IsDefaultAcl).IsTrue();
+            await Assert.That(inertAcl.Entries).IsEmpty();
+        }
+        finally
+        {
+            await DropFixtureAsync(dataSource);
+        }
+    }
+
+    [Test]
+    public async Task Column_grants_default_privileges_and_policies_are_read()
+    {
+        SkipIfNoConnection();
+        await using var dataSource = CreateDataSource();
+        var ct = CancellationToken.None;
+        await ResetFixtureAsync(dataSource);
+
+        try
+        {
+            var service = new PrivilegeService(dataSource);
+
+            var secret = (await service.GetSecurablesAsync(SecurableKind.Table, Schema, ct))
+                .Single(t => t.Name == "secret");
+            var columns = await service.GetColumnAclsAsync(secret, ct);
+
+            // Only the granted column comes back: a NULL attacl is the normal
+            // case and means the table's own ACL decides.
+            await Assert.That(string.Join(",", columns.Select(c => c.Column))).IsEqualTo("id");
+            await Assert.That(columns[0].Entries.Any(e => e.Grantee == Readers && e.Privilege == PrivilegeKind.Select)).IsTrue();
+
+            var defaults = await service.GetDefaultPrivilegesAsync(ct);
+            var ours = defaults.Single(d => d.Schema == Schema && d.AppliesTo == SecurableKind.Table);
+            await Assert.That(ours.Entries.Any(e => e.Grantee == Readers && e.Privilege == PrivilegeKind.Select)).IsTrue();
+
+            var rls = await service.GetRlsAsync(Schema, ct);
+
+            var orders = rls.Single(t => t.Table == "orders");
+            await Assert.That(orders.RowSecurityEnabled).IsTrue();
+            await Assert.That(orders.Policies).Count().IsEqualTo(1);
+            await Assert.That(orders.Policies[0].Command).IsEqualTo("SELECT");
+            await Assert.That(string.Join(",", orders.Policies[0].Roles)).IsEqualTo(Readers);
+            await Assert.That(orders.Policies[0].Using).IsNotNull();
+
+            // A policy on a table where RLS was never switched on does nothing —
+            // showing it is the point, since it looks like protection and is not.
+            var inert = rls.Single(t => t.Table == "inert");
+            await Assert.That(inert.HasInertPolicies).IsTrue();
+        }
+        finally
+        {
+            await DropFixtureAsync(dataSource);
+        }
+    }
+
+    /// <summary>
+    /// The end-to-end differentiator: the server's own answer, attributed to a
+    /// source. app_ro holds SELECT only through readers, two memberships up.
+    /// </summary>
+    [Test]
+    public async Task Effective_privileges_attribute_an_inherited_grant()
+    {
+        SkipIfNoConnection();
+        await using var dataSource = CreateDataSource();
+        var ct = CancellationToken.None;
+        await ResetFixtureAsync(dataSource);
+
+        try
+        {
+            var roleService = new RoleService(dataSource);
+            var privileges = new PrivilegeService(dataSource);
+            var version = await roleService.GetServerVersionAsync(ct);
+
+            var graph = RoleGraph.Build(
+                await roleService.GetRolesAsync(includePredefined: true, ct),
+                await roleService.GetMembershipsAsync(ct));
+
+            var orders = (await privileges.GetSecurablesAsync(SecurableKind.Table, Schema, ct))
+                .Single(t => t.Name == "orders");
+            var acl = await privileges.GetAclAsync(orders, ct);
+
+            // The privilege list must come from the real server version: asking a
+            // pre-17 server about MAINTAIN raises "unrecognized privilege type"
+            // and takes the whole matrix with it.
+            var kinds = Privileges.For(SecurableKind.Table, version);
+            string[] roles = [AppRo, Readers, Legacy];
+
+            var answers = await privileges.GetServerAnswersAsync(orders, roles, kinds, ct);
+            var effective = EffectivePrivilegeResolver.Resolve(acl, roles, kinds, graph, answers);
+
+            var select = effective.Single(e => e.Role == AppRo && e.Privilege == PrivilegeKind.Select);
+            await Assert.That(select.Granted).IsTrue();
+            await Assert.That(select.Source).IsEqualTo(PrivilegeSource.Inherited);
+            await Assert.That(select.Via).IsEqualTo(Readers);
+
+            var insert = effective.Single(e => e.Role == AppRo && e.Privilege == PrivilegeKind.Insert);
+            await Assert.That(insert.Granted).IsFalse();
+
+            // legacy is a member of nothing and was granted nothing.
+            var legacySelect = effective.Single(e => e.Role == Legacy && e.Privilege == PrivilegeKind.Select);
+            await Assert.That(legacySelect.Granted).IsFalse();
+
+            await Assert.That(await privileges.HasSchemaUsageAsync(AppRo, Schema, ct)).IsTrue();
+        }
+        finally
+        {
+            await DropFixtureAsync(dataSource);
+        }
+    }
+
+    /// <summary>
+    /// What a drop dialog shows before <c>DROP ROLE</c> fails with 2BP01 — the
+    /// objects the role owns and the grants it holds.
+    /// </summary>
+    [Test]
+    public async Task Role_dependencies_list_what_blocks_a_drop()
+    {
+        SkipIfNoConnection();
+        await using var dataSource = CreateDataSource();
+        var ct = CancellationToken.None;
+        await ResetFixtureAsync(dataSource);
+
+        try
+        {
+            await ExecuteAsync(dataSource, $"ALTER TABLE {Schema}.orders OWNER TO {Writers}");
+
+            var service = new RoleService(dataSource);
+
+            var owned = await service.GetOwnedObjectsAsync(Writers, ct);
+            await Assert.That(owned.Any(d => d.Identity.Contains("orders", StringComparison.Ordinal))).IsTrue();
+
+            var held = await service.GetGrantsHeldAsync(Readers, ct);
+            await Assert.That(held).IsNotEmpty();
+        }
+        finally
+        {
+            await DropFixtureAsync(dataSource);
+        }
+    }
+}

--- a/PgNimbus.Core/Commands/CommandCatalog.cs
+++ b/PgNimbus.Core/Commands/CommandCatalog.cs
@@ -521,6 +521,16 @@ public static class CommandCatalog
         },
         new()
         {
+            Id = CommandId.SecurityManager,
+            Title = "Roles and permissions…",
+            CheatTitle = "Roles and permissions",
+            Category = CommandCategory.Navigation,
+            Glyph = "⚿",
+            Chord = new(CommandKey.U, CmdShift),
+            Surfaces = Everywhere,
+        },
+        new()
+        {
             Id = CommandId.SwitchConnection,
             Title = "Switch connection…",
             Category = CommandCategory.Navigation,

--- a/PgNimbus.Core/Commands/CommandDescriptor.cs
+++ b/PgNimbus.Core/Commands/CommandDescriptor.cs
@@ -67,6 +67,7 @@ public enum CommandId
     PreviewTable,
     ServerActivity,
     DatabaseOverview,
+    SecurityManager,
     SwitchConnection,
     NewWindow,
     ToggleTheme,

--- a/PgNimbus.Core/Security/EffectivePrivilegeResolver.cs
+++ b/PgNimbus.Core/Security/EffectivePrivilegeResolver.cs
@@ -1,0 +1,265 @@
+namespace PgNimbus.Core.Security;
+
+/// <summary>
+/// Turns a stored ACL into the answer a person actually asked for: can this role
+/// do this to this object, and which grant explains it.
+///
+/// This is the differentiator. pgAdmin, DBeaver, DataGrip and TablePlus all
+/// render the ACL as it sits in the catalog, which silently omits every
+/// privilege reached through role membership, through ownership, through PUBLIC,
+/// or through a NULL ACL column. A permission that works is invisible; a
+/// permission that is missing looks present. This walks the same ground the
+/// server does and names the source.
+///
+/// Pure logic — a read-only sibling of <c>PlanAnalyzer</c>, <c>BlockingTree</c>
+/// and <c>JsonTree</c>. No Npgsql, no Avalonia, fully unit-tested: the role
+/// graph arrives through <see cref="IRoleMembershipLookup"/> and the server's
+/// own verdict through an optional answers dictionary, so there is nothing here
+/// that needs a database to exercise.
+/// </summary>
+public static class EffectivePrivilegeResolver
+{
+    /// <summary>
+    /// Resolves every <paramref name="roles"/> × <paramref name="privileges"/>
+    /// pair against <paramref name="acl"/>, in that nesting order.
+    ///
+    /// The resolution order below <em>is</em> the semantics, so it is spelled
+    /// out rather than left to the reader of the switch. First match wins:
+    ///
+    /// <list type="number">
+    /// <item>Superuser — bypasses permission checks entirely, so nothing else matters.</item>
+    /// <item>Owner — ownership carries every privilege implicitly, and outranks
+    /// any explicit grant that happens to name the owner as well.</item>
+    /// <item>Direct — an ACL entry naming the role itself.</item>
+    /// <item>Inherited — an ACL entry naming a group the role inherits from,
+    /// attributed to the <em>nearest</em> such group.</item>
+    /// <item>PUBLIC — an entry granted to everyone, including the built-in
+    /// defaults that apply when the ACL column is NULL.</item>
+    /// <item>Otherwise not granted.</item>
+    /// </list>
+    ///
+    /// When <paramref name="serverAnswers"/> is supplied the server wins every
+    /// disagreement; see the reconciliation block below.
+    /// </summary>
+    public static IReadOnlyList<EffectivePrivilege> Resolve(
+        ObjectAcl acl,
+        IReadOnlyList<string> roles,
+        IReadOnlyList<PrivilegeKind> privileges,
+        IRoleMembershipLookup lookup,
+        IReadOnlyDictionary<(string Role, PrivilegeKind Privilege), bool>? serverAnswers = null)
+    {
+        var results = new List<EffectivePrivilege>(roles.Count * privileges.Count);
+
+        foreach (var role in roles)
+        {
+            var isSuperuser = lookup.IsSuperuser(role);
+            var isOwner = string.Equals(role, acl.Owner, StringComparison.Ordinal);
+
+            // Nearest-first, per IRoleMembershipLookup's contract — the walk stops
+            // at a NOINHERIT edge, so anything reachable only through SET ROLE is
+            // already excluded and must not be reported as effective.
+            IReadOnlyList<string> groups = isSuperuser || isOwner ? [] : lookup.InheritedGroups(role);
+
+            foreach (var privilege in privileges)
+            {
+                var resolved = ResolveOne(acl, role, privilege, isSuperuser, isOwner, groups);
+
+                if (serverAnswers is not null
+                    && serverAnswers.TryGetValue((role, privilege), out var serverSaysGranted))
+                {
+                    resolved = Reconcile(resolved, serverSaysGranted);
+                }
+
+                results.Add(resolved);
+            }
+        }
+
+        return results;
+    }
+
+    private static EffectivePrivilege ResolveOne(
+        ObjectAcl acl,
+        string role,
+        PrivilegeKind privilege,
+        bool isSuperuser,
+        bool isOwner,
+        IReadOnlyList<string> groups)
+    {
+        if (isSuperuser)
+        {
+            return new EffectivePrivilege(role, privilege, true, PrivilegeSource.Superuser);
+        }
+
+        if (isOwner)
+        {
+            return new EffectivePrivilege(role, privilege, true, PrivilegeSource.Owner);
+        }
+
+        if (FindEntry(acl, privilege, role) is { } direct)
+        {
+            return new EffectivePrivilege(
+                role, privilege, true, PrivilegeSource.Direct,
+                GrantedBy: direct.Grantor,
+                WithGrantOption: direct.WithGrantOption);
+        }
+
+        // Nearest group first, so the attribution names the role the user is
+        // most likely to recognise as the one they should edit. Scanning the ACL
+        // first instead would attribute to whichever grant happens to sit
+        // earliest in the catalog, which is arbitrary.
+        foreach (var group in groups)
+        {
+            if (FindEntry(acl, privilege, group) is { } inherited)
+            {
+                return new EffectivePrivilege(
+                    role, privilege, true, PrivilegeSource.Inherited,
+                    Via: group,
+                    GrantedBy: inherited.Grantor,
+                    WithGrantOption: inherited.WithGrantOption);
+            }
+        }
+
+        if (FindEntry(acl, privilege, null) is { } @public)
+        {
+            return new EffectivePrivilege(
+                role, privilege, true, PrivilegeSource.Public,
+                GrantedBy: @public.Grantor,
+                WithGrantOption: @public.WithGrantOption);
+        }
+
+        // A NULL ACL column has no entries at all, but Postgres's built-in
+        // defaults still apply, and some of them are grants to PUBLIC. Reporting
+        // those as "not granted" is the mistake that makes a permissions grid
+        // teach the wrong thing (see ObjectAcl.IsDefaultAcl).
+        if (acl.IsDefaultAcl && GrantedToPublicByDefault(acl.Object.Kind, privilege))
+        {
+            return new EffectivePrivilege(role, privilege, true, PrivilegeSource.Public);
+        }
+
+        return new EffectivePrivilege(role, privilege, false, PrivilegeSource.None);
+    }
+
+    /// <summary>
+    /// The server's verdict always wins — it ran the same check the executor
+    /// will run, expanding inheritance, ownership and superuser server-side.
+    /// Where we agree, our source survives as the explanation. Where we do not,
+    /// the disagreement is reported honestly rather than papered over:
+    /// a grant we cannot see becomes <see cref="PrivilegeSource.Unknown"/>, and
+    /// a grant we imagined (a NOINHERIT edge, a revoke that landed after this
+    /// snapshot was taken) collapses back to <see cref="PrivilegeSource.None"/>.
+    /// </summary>
+    private static EffectivePrivilege Reconcile(EffectivePrivilege resolved, bool serverSaysGranted) =>
+        (serverSaysGranted, resolved.Granted) switch
+        {
+            (true, true) => resolved,
+            (true, false) => resolved with { Granted = true, Source = PrivilegeSource.Unknown },
+            (false, true) => new EffectivePrivilege(resolved.Role, resolved.Privilege, false, PrivilegeSource.None),
+            (false, false) => resolved,
+        };
+
+    /// <summary>
+    /// The one ACL entry granting <paramref name="privilege"/> to
+    /// <paramref name="grantee"/> (null meaning PUBLIC), or null. When several
+    /// grantors granted the same thing, one carrying WITH GRANT OPTION wins so
+    /// the reported capability is not understated; otherwise the first entry
+    /// wins, which keeps the result deterministic.
+    /// </summary>
+    private static AclEntry? FindEntry(ObjectAcl acl, PrivilegeKind privilege, string? grantee)
+    {
+        AclEntry? first = null;
+
+        foreach (var entry in acl.Entries)
+        {
+            if (entry.Privilege != privilege
+                || !string.Equals(entry.Grantee, grantee, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (entry.WithGrantOption)
+            {
+                return entry;
+            }
+
+            first ??= entry;
+        }
+
+        return first;
+    }
+
+    /// <summary>
+    /// What PUBLIC holds on an object nobody has ever run a GRANT or REVOKE on.
+    /// Postgres grants EXECUTE on functions, USAGE on types, and CONNECT plus
+    /// TEMPORARY on databases by default; tables, sequences and schemas start
+    /// with nothing for PUBLIC (the <c>public</c> schema's historical CREATE
+    /// grant is a real ACL entry, not a default, and stopped existing in PG15).
+    /// </summary>
+    private static bool GrantedToPublicByDefault(SecurableKind kind, PrivilegeKind privilege) =>
+        (kind, privilege) switch
+        {
+            (SecurableKind.Function, PrivilegeKind.Execute) => true,
+            (SecurableKind.Type, PrivilegeKind.Usage) => true,
+            (SecurableKind.Database, PrivilegeKind.Connect) => true,
+            (SecurableKind.Database, PrivilegeKind.Temporary) => true,
+            _ => false,
+        };
+
+    // ------------------------------------------------------------- the sentence
+
+    /// <summary>
+    /// The plain-English answer, for people who would rather not decode
+    /// <c>{readers=arwdDxt/postgres}</c>: what the role can do and what explains
+    /// it, then what it cannot do, then the schema-USAGE trap if it applies.
+    ///
+    /// Deterministic by construction — privileges are listed in the order
+    /// <paramref name="effective"/> gives them, and the source phrasing comes
+    /// from <see cref="EffectivePrivilege.Explanation"/> rather than being
+    /// re-derived here, so the sentence and the "why?" column can never drift
+    /// apart.
+    /// </summary>
+    /// <param name="hasSchemaUsage">
+    /// From <c>PrivilegeService.HasSchemaUsageAsync</c>. When false and the
+    /// object lives in a schema, every grant above is inert — the single most
+    /// common reason a role with all the right privileges still gets
+    /// <c>permission denied</c>, so it gets its own clause.
+    /// </param>
+    public static string ExplainSentence(
+        string role,
+        SecurableRef obj,
+        IReadOnlyList<EffectivePrivilege> effective,
+        bool hasSchemaUsage)
+    {
+        var mine = effective.Where(e => string.Equals(e.Role, role, StringComparison.Ordinal)).ToList();
+        var granted = mine.Where(e => e.Granted).ToList();
+        var denied = mine.Where(e => !e.Granted).ToList();
+
+        var sentence = granted.Count == 0
+            ? $"{role} has no privileges on {obj.Display}."
+            : $"{role} can {Join(granted, "and")} {obj.Display} — {granted[0].Explanation}.";
+
+        if (granted.Count > 0 && denied.Count > 0)
+        {
+            sentence += $" It cannot {Join(denied, "or")}.";
+        }
+
+        if (!hasSchemaUsage && obj.Schema is { Length: > 0 } schema)
+        {
+            sentence += $" {role} also lacks USAGE on schema {schema}, which blocks access to everything in it.";
+        }
+
+        return sentence;
+    }
+
+    /// <summary>"SELECT", "SELECT and INSERT", "SELECT, INSERT and UPDATE".</summary>
+    private static string Join(IReadOnlyList<EffectivePrivilege> items, string conjunction)
+    {
+        var names = items.Select(e => Privileges.Sql(e.Privilege)).ToList();
+
+        return names.Count switch
+        {
+            0 => "",
+            1 => names[0],
+            _ => $"{string.Join(", ", names.Take(names.Count - 1))} {conjunction} {names[^1]}",
+        };
+    }
+}

--- a/PgNimbus.Core/Security/GrantScriptBuilder.cs
+++ b/PgNimbus.Core/Security/GrantScriptBuilder.cs
@@ -1,0 +1,421 @@
+using System.Text;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Security;
+
+/// <summary>
+/// One cell of the permissions grid the user toggled: a single privilege on a
+/// single object for a single grantee, in one direction.
+/// </summary>
+/// <param name="Grantee">The role name, or null for <c>PUBLIC</c>.</param>
+/// <param name="Grant">True for <c>GRANT</c>, false for <c>REVOKE</c>.</param>
+/// <param name="WithGrantOption">
+/// On a grant, appends <c>WITH GRANT OPTION</c>. On a revoke it means the
+/// narrower <c>REVOKE GRANT OPTION FOR …</c> — take away the right to re-grant
+/// but leave the privilege itself, which is a different statement, not a
+/// suffix.
+/// </param>
+/// <param name="Column">A column name for a column-level grant; null for the whole object.</param>
+public sealed record PrivilegeChange(
+    SecurableRef Object,
+    string? Grantee,
+    PrivilegeKind Privilege,
+    bool Grant,
+    bool WithGrantOption = false,
+    string? Column = null);
+
+/// <summary>The shape of a whole-schema grant, in the words users ask for it.</summary>
+public enum BulkGrantPreset
+{
+    /// <summary>Read the data: SELECT on tables, USAGE+SELECT on sequences.</summary>
+    ReadOnly,
+
+    /// <summary>Read and change the data, but not the schema.</summary>
+    ReadWrite,
+
+    /// <summary>Everything the schema and its contents can grant, including CREATE on the schema.</summary>
+    Full,
+
+    /// <summary>Take it all back, including the default privileges a grant script set up.</summary>
+    RevokeAll,
+}
+
+/// <summary>
+/// "Give this role read access to this schema", expressed once.
+/// </summary>
+/// <param name="Grantee">The role name, or null for <c>PUBLIC</c>.</param>
+/// <param name="IncludeFutureObjects">
+/// Also emit the <c>ALTER DEFAULT PRIVILEGES</c> statements, without which the
+/// grant stops applying at the next migration.
+/// </param>
+/// <param name="FutureObjectsOwner">
+/// The role that will *create* the future objects. A default privilege is keyed
+/// to the creating role, not to the schema, so this cannot be inferred and
+/// naming the wrong one silently does nothing.
+/// </param>
+public sealed record BulkGrantRequest(
+    string Schema,
+    string? Grantee,
+    BulkGrantPreset Preset,
+    bool IncludeFutureObjects,
+    string? FutureObjectsOwner);
+
+/// <summary>
+/// Turns permission edits into the <c>GRANT</c>/<c>REVOKE</c> script the user
+/// reviews before it runs. Deliberately a script and not a hidden write, same
+/// precedent as <see cref="Schema.DdlTemplates"/>: the statement in the editor
+/// can be read, edited and kept, and a form that can only express what its
+/// checkboxes list is a worse tool than the SQL.
+///
+/// Pure — no catalog access, no Npgsql. Every identifier goes through
+/// <see cref="SqlIdentifier.QuoteIfNeeded"/> and every literal through
+/// <see cref="SqlLiteral.Quote"/>; nothing is concatenated raw. Output is
+/// deterministic for a given change set regardless of the order the UI
+/// collected the edits in, because the script is compared in tests and in
+/// screenshots.
+/// </summary>
+public static class GrantScriptBuilder
+{
+    /// <summary>The pseudo-role every role is a member of. A keyword — never quoted.</summary>
+    public const string PublicGrantee = "PUBLIC";
+
+    private const string Newline = "\n";
+
+    /// <summary>
+    /// Collapses <paramref name="changes"/> into the fewest statements that say
+    /// the same thing: one statement per (object, columns, grantee, direction,
+    /// grant-option), with the privileges comma-joined in
+    /// <see cref="Privileges.For"/> order.
+    ///
+    /// <para>REVOKEs are emitted before GRANTs. A script that grants and then
+    /// revokes the same privilege is a different script from one that revokes
+    /// and then grants, and these get edited by hand — so the order is fixed
+    /// rather than inherited from whatever order the grid was clicked in.</para>
+    ///
+    /// <para>Returns an empty string for an empty change set.</para>
+    /// </summary>
+    public static string Build(IReadOnlyList<PrivilegeChange> changes)
+    {
+        if (changes.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        // Step 1: one bucket of privileges per grid cell.
+        var cells = changes
+            .GroupBy(c => new CellKey(c.Object, c.Grantee, c.Grant, c.WithGrantOption, c.Column))
+            .Select(g => new Cell(g.Key, SortPrivileges(g.Select(c => c.Privilege), OrderFor(g.Key))))
+            .ToList();
+
+        // Step 2: column cells that carry the identical privilege set merge into
+        // one statement with a shared column list — GRANT SELECT (id, email) …
+        // rather than two single-column statements.
+        var emitted = new List<Statement>();
+        foreach (var group in cells.GroupBy(c => new MergeKey(
+                     c.Key.Object,
+                     c.Key.Grantee,
+                     c.Key.Grant,
+                     c.Key.WithGrantOption,
+                     c.Key.Column is null,
+                     Signature(c.Privileges))))
+        {
+            var key = group.First().Key;
+            var privileges = group.First().Privileges;
+            var columns = key.Column is null
+                ? null
+                : group.Select(c => c.Key.Column!)
+                    .Distinct(StringComparer.Ordinal)
+                    // Ordinal, not input order: a shuffled change list has to
+                    // produce a byte-identical script.
+                    .OrderBy(c => c, StringComparer.Ordinal)
+                    .ToList();
+
+            emitted.Add(new Statement(
+                key.Grant,
+                key.Object.Display,
+                columns is null ? string.Empty : string.Join(",", columns),
+                Label(key.Grantee),
+                key.WithGrantOption,
+                RenderStatement(key, privileges, columns)));
+        }
+
+        var ordered = emitted
+            .OrderBy(s => s.Grant)                                     // false (REVOKE) first
+            .ThenBy(s => s.ObjectDisplay, StringComparer.Ordinal)
+            .ThenBy(s => s.ColumnKey, StringComparer.Ordinal)          // object-level ("") before column-level
+            .ThenBy(s => s.GranteeLabel, StringComparer.Ordinal)
+            .ThenBy(s => s.WithGrantOption)
+            .Select(s => s.Text);
+
+        return string.Join(Newline, ordered);
+    }
+
+    /// <summary>
+    /// The whole-schema grant, and the reason this class exists: the three
+    /// things pgAdmin's Grant Wizard gets wrong are handled here rather than
+    /// left to the user to discover from a <c>permission denied</c>.
+    ///
+    /// <list type="number">
+    /// <item><c>GRANT USAGE ON SCHEMA</c> is the first statement of every
+    /// non-revoke preset. Granting every table privilege without it leaves the
+    /// role unable to reach any of them (pgadmin4#8954).</item>
+    /// <item><c>ON ALL TABLES IN SCHEMA</c> only covers what exists right now,
+    /// which the script says in a comment, and
+    /// <see cref="BulkGrantRequest.IncludeFutureObjects"/> follows the grants
+    /// with the matching <c>ALTER DEFAULT PRIVILEGES</c>.</item>
+    /// <item>Revoking is a preset, not an afterthought — pgAdmin's wizard
+    /// cannot revoke at all (pgadmin4#7891) — and it undoes the default
+    /// privileges too, in the reverse order of the grant script.</item>
+    /// </list>
+    /// </summary>
+    public static string BuildBulk(BulkGrantRequest request)
+    {
+        var schema = SqlIdentifier.QuoteIfNeeded(request.Schema);
+        var grantee = Label(request.Grantee);
+        var revoking = request.Preset == BulkGrantPreset.RevokeAll;
+        var owner = string.IsNullOrWhiteSpace(request.FutureObjectsOwner)
+            ? null
+            : SqlIdentifier.QuoteIfNeeded(request.FutureObjectsOwner!);
+        var withDefaults = request.IncludeFutureObjects && owner is not null;
+
+        var sb = new StringBuilder();
+
+        void Line(string text) => sb.Append(text).Append(Newline);
+
+        // -- Comments first: everything below is a statement the user may edit,
+        //    and the traps are why the script looks the way it does.
+        Line(revoking
+            ? "-- REVOKE ... ON ALL TABLES IN SCHEMA reaches only the objects that exist"
+            : "-- GRANT ... ON ALL TABLES IN SCHEMA reaches only the objects that exist");
+        Line("-- right now. Anything created afterwards is not covered by these statements.");
+
+        if (request.IncludeFutureObjects)
+        {
+            Line("-- ALTER DEFAULT PRIVILEGES is keyed to the role that CREATES an object, not");
+            Line("-- to the schema the object lands in. Set for the wrong creator it silently");
+            Line("-- does nothing, which is why the owner has to be named.");
+
+            if (owner is null)
+            {
+                Line("-- No creating role was named, so the ALTER DEFAULT PRIVILEGES statements are");
+                Line("-- omitted rather than guessed at.");
+            }
+        }
+
+        if (request.Preset == BulkGrantPreset.ReadOnly)
+        {
+            Line("-- On PostgreSQL 14+ a cluster-wide read-only role is one membership instead");
+            Line($"-- of this whole script: GRANT pg_read_all_data TO {grantee}; the role editor");
+            Line("-- offers it.");
+        }
+
+        var objectClasses = ObjectClassesFor(request.Preset);
+
+        if (revoking)
+        {
+            // Exactly the reverse of the grant script: stop the bleeding for
+            // future objects first, then existing ones, then the schema itself.
+            if (withDefaults)
+            {
+                foreach (var (objectClass, _) in objectClasses.AsEnumerable().Reverse())
+                {
+                    Line($"ALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA {schema} REVOKE ALL PRIVILEGES ON {objectClass} FROM {grantee};");
+                }
+            }
+
+            foreach (var (objectClass, _) in objectClasses.AsEnumerable().Reverse())
+            {
+                Line($"REVOKE ALL PRIVILEGES ON ALL {objectClass} IN SCHEMA {schema} FROM {grantee};");
+            }
+
+            Line($"REVOKE ALL PRIVILEGES ON SCHEMA {schema} FROM {grantee};");
+            return sb.ToString().TrimEnd('\n');
+        }
+
+        // Rule 1: USAGE on the schema, before anything else, always.
+        Line($"GRANT USAGE ON SCHEMA {schema} TO {grantee};");
+
+        if (request.Preset == BulkGrantPreset.Full)
+        {
+            // Deliberately a second statement rather than "USAGE, CREATE": the
+            // combined form collapses to ALL PRIVILEGES on a two-privilege
+            // schema ACL and hides the USAGE grant this whole method exists to
+            // keep visible.
+            Line($"GRANT CREATE ON SCHEMA {schema} TO {grantee};");
+        }
+
+        foreach (var (objectClass, privileges) in objectClasses)
+        {
+            Line($"GRANT {privileges} ON ALL {objectClass} IN SCHEMA {schema} TO {grantee};");
+        }
+
+        if (withDefaults)
+        {
+            foreach (var (objectClass, privileges) in objectClasses)
+            {
+                Line($"ALTER DEFAULT PRIVILEGES FOR ROLE {owner} IN SCHEMA {schema} GRANT {privileges} ON {objectClass} TO {grantee};");
+            }
+        }
+
+        return sb.ToString().TrimEnd('\n');
+    }
+
+    /// <summary>The grantee as it is written in SQL: a keyword for PUBLIC, a quoted identifier otherwise.</summary>
+    private static string Label(string? grantee) =>
+        grantee is null || grantee.Equals(PublicGrantee, StringComparison.OrdinalIgnoreCase)
+            ? PublicGrantee
+            : SqlIdentifier.QuoteIfNeeded(grantee);
+
+    private static string RenderStatement(CellKey key, IReadOnlyList<PrivilegeKind> privileges, IReadOnlyList<string>? columns)
+    {
+        var list = RenderPrivileges(privileges, OrderFor(key), columns);
+        var target = key.Object.GrantTarget;
+        var grantee = Label(key.Grantee);
+
+        if (key.Grant)
+        {
+            var suffix = key.WithGrantOption ? " WITH GRANT OPTION" : string.Empty;
+            return $"GRANT {list} ON {target} TO {grantee}{suffix};";
+        }
+
+        // REVOKE has no WITH GRANT OPTION suffix — the narrower "take back the
+        // right to re-grant, keep the privilege" is a prefix and a different
+        // statement.
+        var prefix = key.WithGrantOption ? "GRANT OPTION FOR " : string.Empty;
+        return $"REVOKE {prefix}{list} ON {target} FROM {grantee};";
+    }
+
+    /// <summary>
+    /// The privilege list, with an optional column list attached to each entry.
+    /// A set that covers every privilege in <paramref name="order"/> collapses
+    /// to <c>ALL PRIVILEGES</c>.
+    ///
+    /// <para>That collapse is cosmetic, not semantic: <c>ALL PRIVILEGES</c> is
+    /// resolved by the server at execution time, so on a newer server it can
+    /// mean strictly more than the list it replaced (MAINTAIN arrived in PG17
+    /// and joined "all" for tables). It is emitted only when the change set
+    /// already covers everything this build knows about, so it never *narrows*
+    /// what was asked for — but a script kept and re-run against a newer server
+    /// may grant more than it did the first time.</para>
+    /// </summary>
+    private static string RenderPrivileges(
+        IReadOnlyList<PrivilegeKind> privileges,
+        IReadOnlyList<PrivilegeKind> order,
+        IReadOnlyList<string>? columns)
+    {
+        var suffix = columns is null || columns.Count == 0
+            ? string.Empty
+            : $" ({string.Join(", ", columns.Select(SqlIdentifier.QuoteIfNeeded))})";
+
+        if (order.Count > 0 && privileges.Count == order.Count && order.All(privileges.Contains))
+        {
+            return AllPrivileges + suffix;
+        }
+
+        return string.Join(", ", privileges.Select(p => Privileges.Sql(p) + suffix));
+    }
+
+    private static IReadOnlyList<PrivilegeKind> OrderFor(CellKey key) =>
+        key.Column is null ? Privileges.For(key.Object.Kind) : Privileges.ForColumn();
+
+    /// <summary>Position of <paramref name="privilege"/> in <paramref name="order"/>, or -1.</summary>
+    private static int IndexOf(IReadOnlyList<PrivilegeKind> order, PrivilegeKind privilege)
+    {
+        for (var i = 0; i < order.Count; i++)
+        {
+            if (order[i] == privilege)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Privileges in <see cref="Privileges.For"/> order — the order the
+    /// permissions matrix shows its columns in — not the order the edits
+    /// arrived in. Anything outside that list (a privilege the caller asked for
+    /// that does not apply to this object class) is kept and sorted last rather
+    /// than dropped, so a wrong change surfaces as wrong SQL instead of
+    /// disappearing.
+    /// </summary>
+    private static IReadOnlyList<PrivilegeKind> SortPrivileges(
+        IEnumerable<PrivilegeKind> privileges,
+        IReadOnlyList<PrivilegeKind> order) =>
+        privileges
+            .Distinct()
+            .OrderBy(p => IndexOf(order, p) is var i && i >= 0 ? i : int.MaxValue)
+            .ThenBy(p => (int)p)
+            .ToList();
+
+    private static string Signature(IReadOnlyList<PrivilegeKind> privileges) =>
+        string.Join(",", privileges.Select(p => ((int)p).ToString()));
+
+    /// <summary>
+    /// The object classes a preset touches, in grant order, with the privilege
+    /// list already rendered. Privileges are listed in
+    /// <see cref="Privileges.For"/> order (so a sequence reads USAGE, SELECT,
+    /// UPDATE) — the same order the permissions grid shows its columns in and
+    /// the same order <see cref="Build"/> emits, rather than a second ordering
+    /// convention for the bulk path.
+    ///
+    /// <para>Full and RevokeAll deliberately say <c>ALL PRIVILEGES</c> rather
+    /// than spelling the list out: those presets mean "whatever this server
+    /// can grant here", which is exactly what the server resolves
+    /// <c>ALL PRIVILEGES</c> to — including privileges added after this build
+    /// (MAINTAIN in PG17). The narrower presets spell their lists out for the
+    /// opposite reason: a read-only role must not silently widen.</para>
+    /// </summary>
+    private static IReadOnlyList<(string ObjectClass, string Privileges)> ObjectClassesFor(
+        BulkGrantPreset preset) => preset switch
+    {
+        BulkGrantPreset.ReadOnly =>
+        [
+            ("TABLES", Join(PrivilegeKind.Select)),
+            ("SEQUENCES", Join(PrivilegeKind.Usage, PrivilegeKind.Select)),
+        ],
+        BulkGrantPreset.ReadWrite =>
+        [
+            ("TABLES", Join(PrivilegeKind.Select, PrivilegeKind.Insert, PrivilegeKind.Update, PrivilegeKind.Delete)),
+            ("SEQUENCES", Join(PrivilegeKind.Usage, PrivilegeKind.Select, PrivilegeKind.Update)),
+        ],
+        BulkGrantPreset.Full or BulkGrantPreset.RevokeAll =>
+        [
+            ("TABLES", AllPrivileges),
+            ("SEQUENCES", AllPrivileges),
+            ("FUNCTIONS", AllPrivileges),
+        ],
+        _ => [],
+    };
+
+    private const string AllPrivileges = "ALL PRIVILEGES";
+
+    private static string Join(params PrivilegeKind[] privileges) =>
+        string.Join(", ", privileges.Select(Privileges.Sql));
+
+    private sealed record CellKey(
+        SecurableRef Object,
+        string? Grantee,
+        bool Grant,
+        bool WithGrantOption,
+        string? Column);
+
+    private sealed record Cell(CellKey Key, IReadOnlyList<PrivilegeKind> Privileges);
+
+    private sealed record MergeKey(
+        SecurableRef Object,
+        string? Grantee,
+        bool Grant,
+        bool WithGrantOption,
+        bool ObjectLevel,
+        string PrivilegeSignature);
+
+    private sealed record Statement(
+        bool Grant,
+        string ObjectDisplay,
+        string ColumnKey,
+        string GranteeLabel,
+        bool WithGrantOption,
+        string Text);
+}

--- a/PgNimbus.Core/Security/PrivilegeService.cs
+++ b/PgNimbus.Core/Security/PrivilegeService.cs
@@ -1,0 +1,608 @@
+using Npgsql;
+using NpgsqlTypes;
+
+namespace PgNimbus.Core.Security;
+
+/// <summary>
+/// Reads privileges out of pg_catalog: object ACLs, column ACLs, default
+/// privileges, RLS state, and the authoritative <c>has_*_privilege()</c>
+/// answers the resolver reconciles against.
+///
+/// Nothing here needs superuser. <c>pg_class.relacl</c>, <c>pg_namespace.nspacl</c>,
+/// <c>pg_default_acl</c>, <c>pg_policy</c> and the <c>has_*_privilege()</c>
+/// family are all readable by an ordinary role, which is the whole point —
+/// on RDS, Neon and Supabase you never are superuser, and a permissions panel
+/// that assumes otherwise shows an error where the (perfectly readable) answer
+/// should be. Deliberately absent: anything that touches <c>pg_authid</c>.
+///
+/// Everything here is read-only, so it is always safe to run against production.
+/// </summary>
+public sealed class PrivilegeService
+{
+    private readonly NpgsqlDataSource _dataSource;
+
+    public PrivilegeService(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    /// <summary>
+    /// Catalog schemas are hidden from the object picker unless the caller asks
+    /// for one by name — a picker that opens on four thousand pg_catalog entries
+    /// is not a picker. Mirrors <c>SchemaService</c>'s exclusion.
+    /// </summary>
+    private const string HideSystemSchemas = """
+                  AND (@schema IS NOT NULL
+                       OR (n.nspname NOT LIKE 'pg\_%' AND n.nspname <> 'information_schema'))
+        """;
+
+    // ---------------------------------------------------------------- picker
+
+    /// <summary>
+    /// The objects of one class that a privilege can be held on, name order —
+    /// the object picker's list. <paramref name="schema"/> filters where it
+    /// applies and is ignored for <see cref="SecurableKind.Database"/> and
+    /// <see cref="SecurableKind.Schema"/>, neither of which lives in a schema.
+    /// </summary>
+    public async Task<IReadOnlyList<SecurableRef>> GetSecurablesAsync(
+        SecurableKind kind,
+        string? schema,
+        CancellationToken ct)
+    {
+        // Views, matviews, partitioned tables and foreign tables are all TABLE
+        // to GRANT, so they are all SecurableKind.Table (see SecurableKind's doc).
+        var sql = kind switch
+        {
+            SecurableKind.Table => $"""
+                SELECT c.oid, n.nspname, c.relname
+                FROM pg_catalog.pg_class c
+                JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.relkind IN ('r', 'p', 'v', 'm', 'f')
+                  AND (@schema IS NULL OR n.nspname = @schema)
+                {HideSystemSchemas}
+                ORDER BY n.nspname, c.relname
+                """,
+
+            SecurableKind.Sequence => $"""
+                SELECT c.oid, n.nspname, c.relname
+                FROM pg_catalog.pg_class c
+                JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.relkind = 'S'
+                  AND (@schema IS NULL OR n.nspname = @schema)
+                {HideSystemSchemas}
+                ORDER BY n.nspname, c.relname
+                """,
+
+            SecurableKind.Schema => """
+                SELECT n.oid, NULL::text, n.nspname
+                FROM pg_catalog.pg_namespace n
+                WHERE n.nspname NOT LIKE 'pg\_%'
+                  AND n.nspname <> 'information_schema'
+                ORDER BY n.nspname
+                """,
+
+            SecurableKind.Database => """
+                SELECT d.oid, NULL::text, d.datname
+                FROM pg_catalog.pg_database d
+                WHERE NOT d.datistemplate
+                ORDER BY d.datname
+                """,
+
+            SecurableKind.Function => $"""
+                SELECT p.oid, n.nspname, p.proname,
+                       pg_catalog.pg_get_function_arguments(p.oid)
+                FROM pg_catalog.pg_proc p
+                JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+                WHERE (@schema IS NULL OR n.nspname = @schema)
+                {HideSystemSchemas}
+                ORDER BY n.nspname, p.proname, pg_catalog.pg_get_function_arguments(p.oid)
+                """,
+
+            // psql's \dT shape: drop the auto-generated array type of every base
+            // type, and drop the row-type Postgres creates behind each table
+            // (typrelid <> 0 with a relkind other than 'c'). A standalone
+            // composite type keeps its row-type and stays in the list.
+            SecurableKind.Type => $"""
+                SELECT t.oid, n.nspname, t.typname
+                FROM pg_catalog.pg_type t
+                JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+                WHERE (t.typrelid = 0
+                       OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid))
+                  AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_type el
+                                  WHERE el.oid = t.typelem AND el.typarray = t.oid)
+                  AND (@schema IS NULL OR n.nspname = @schema)
+                {HideSystemSchemas}
+                ORDER BY n.nspname, t.typname
+                """,
+
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+        };
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        if (sql.Contains("@schema", StringComparison.Ordinal))
+        {
+            AddSchemaParameter(command, schema);
+        }
+
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<SecurableRef>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new SecurableRef(
+                kind,
+                reader.GetFieldValue<uint>(0),
+                reader.IsDBNull(1) ? null : reader.GetString(1),
+                reader.GetString(2),
+                kind == SecurableKind.Function && !reader.IsDBNull(3) ? reader.GetString(3) : null));
+        }
+
+        return results;
+    }
+
+    // ------------------------------------------------------------ object ACL
+
+    /// <summary>
+    /// The object's owner and its stored ACL, expanded through
+    /// <c>aclexplode()</c>.
+    ///
+    /// The flag that matters is <see cref="ObjectAcl.IsDefaultAcl"/>: a NULL ACL
+    /// column does not mean "nobody has any privileges", it means nobody has
+    /// ever run a GRANT or REVOKE here, so the owner holds everything and the
+    /// built-in defaults apply. Rendering that as an empty grid is how a
+    /// permissions UI teaches the wrong thing, so it is reported as a flag and
+    /// left for the caller to render honestly.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The object no longer exists — it was dropped between the picker listing
+    /// it and this read.
+    /// </exception>
+    public async Task<ObjectAcl> GetAclAsync(SecurableRef obj, CancellationToken ct)
+    {
+        var (aclColumn, ownerColumn) = AclColumns(obj.Kind);
+        var catalog = Privileges.CatalogTable(obj.Kind);
+
+        // The three interpolated fragments all come from a switch over the
+        // SecurableKind enum, never from user input.
+        //
+        // LEFT JOIN LATERAL, so an object whose ACL is NULL still yields one row
+        // carrying the owner and the is-default flag. The COALESCE to an empty
+        // aclitem[] keeps that from depending on aclexplode's strictness.
+        var sql = $"""
+            SELECT pg_catalog.pg_get_userbyid(t.{ownerColumn}),
+                   t.{aclColumn} IS NULL,
+                   CASE WHEN a.grantee = 0 THEN NULL
+                        ELSE pg_catalog.pg_get_userbyid(a.grantee) END,
+                   CASE WHEN a.grantor = 0 THEN NULL
+                        ELSE pg_catalog.pg_get_userbyid(a.grantor) END,
+                   a.privilege_type,
+                   a.is_grantable
+            FROM {catalog} t
+            LEFT JOIN LATERAL pg_catalog.aclexplode(
+                COALESCE(t.{aclColumn}, ARRAY[]::aclitem[])) a ON true
+            WHERE t.oid = @oid
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        AddOidParameter(command, obj.Oid);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        string? owner = null;
+        var isDefault = true;
+        var entries = new List<AclEntry>();
+
+        while (await reader.ReadAsync(ct))
+        {
+            owner ??= reader.GetString(0);
+            isDefault = reader.GetBoolean(1);
+
+            if (reader.IsDBNull(4))
+            {
+                continue; // The LEFT JOIN's placeholder row: no ACL entries at all.
+            }
+
+            // An unmodelled privilege from a future server costs its own row,
+            // not the whole grid.
+            if (Privileges.Parse(reader.GetString(4)) is not { } privilege)
+            {
+                continue;
+            }
+
+            entries.Add(new AclEntry(
+                reader.IsDBNull(2) ? null : reader.GetString(2), // grantee 0 == PUBLIC
+                reader.IsDBNull(3) ? null : reader.GetString(3),
+                privilege,
+                reader.GetBoolean(5)));
+        }
+
+        if (owner is null)
+        {
+            throw new InvalidOperationException(
+                $"{obj.Display} no longer exists — it was dropped since the object list was built.");
+        }
+
+        return new ObjectAcl(obj, owner, isDefault, entries);
+    }
+
+    /// <summary>
+    /// Per-column grants on one table, from <c>pg_attribute.attacl</c>.
+    ///
+    /// Only columns that actually carry grants are returned. A NULL
+    /// <c>attacl</c> is the normal case and is genuinely nothing: column
+    /// privileges are purely additive on top of the table's, so "no column ACL"
+    /// means "whatever the table says", not "the owner has everything and the
+    /// defaults apply". That is why <see cref="ColumnAcl.IsDefaultAcl"/> is not
+    /// the right way to report it and the column is simply omitted — the
+    /// opposite call from <see cref="GetAclAsync"/>, for the opposite reason.
+    /// </summary>
+    public async Task<IReadOnlyList<ColumnAcl>> GetColumnAclsAsync(SecurableRef table, CancellationToken ct)
+    {
+        // An inner LATERAL join drops the NULL-attacl columns for us.
+        const string sql = """
+            SELECT a.attname,
+                   CASE WHEN e.grantee = 0 THEN NULL
+                        ELSE pg_catalog.pg_get_userbyid(e.grantee) END,
+                   CASE WHEN e.grantor = 0 THEN NULL
+                        ELSE pg_catalog.pg_get_userbyid(e.grantor) END,
+                   e.privilege_type,
+                   e.is_grantable
+            FROM pg_catalog.pg_attribute a
+            JOIN LATERAL pg_catalog.aclexplode(a.attacl) e ON true
+            WHERE a.attrelid = @oid
+              AND a.attnum > 0
+              AND NOT a.attisdropped
+            ORDER BY a.attnum, e.privilege_type
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        AddOidParameter(command, table.Oid);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var order = new List<string>();
+        var byColumn = new Dictionary<string, List<AclEntry>>(StringComparer.Ordinal);
+
+        while (await reader.ReadAsync(ct))
+        {
+            if (Privileges.Parse(reader.GetString(3)) is not { } privilege)
+            {
+                continue;
+            }
+
+            var column = reader.GetString(0);
+            if (!byColumn.TryGetValue(column, out var entries))
+            {
+                entries = [];
+                byColumn[column] = entries;
+                order.Add(column);
+            }
+
+            entries.Add(new AclEntry(
+                reader.IsDBNull(1) ? null : reader.GetString(1),
+                reader.IsDBNull(2) ? null : reader.GetString(2),
+                privilege,
+                reader.GetBoolean(4)));
+        }
+
+        return order.Select(c => new ColumnAcl(c, false, byColumn[c])).ToList();
+    }
+
+    // --------------------------------------------------------- default ACLs
+
+    /// <summary>
+    /// Every <c>ALTER DEFAULT PRIVILEGES</c> in force: what a future object
+    /// created by each role, in each schema, will be granted.
+    /// <see cref="DefaultPrivilege.Schema"/> is null for the database-wide
+    /// default (<c>defaclnamespace = 0</c>).
+    /// </summary>
+    public async Task<IReadOnlyList<DefaultPrivilege>> GetDefaultPrivilegesAsync(CancellationToken ct)
+    {
+        const string sql = """
+            SELECT r.rolname,
+                   n.nspname,
+                   d.defaclobjtype::text,
+                   CASE WHEN e.grantee = 0 THEN NULL
+                        ELSE pg_catalog.pg_get_userbyid(e.grantee) END,
+                   CASE WHEN e.grantor = 0 THEN NULL
+                        ELSE pg_catalog.pg_get_userbyid(e.grantor) END,
+                   e.privilege_type,
+                   e.is_grantable
+            FROM pg_catalog.pg_default_acl d
+            JOIN pg_catalog.pg_roles r ON r.oid = d.defaclrole
+            LEFT JOIN pg_catalog.pg_namespace n ON n.oid = d.defaclnamespace
+            JOIN LATERAL pg_catalog.aclexplode(d.defaclacl) e ON true
+            ORDER BY r.rolname, n.nspname NULLS FIRST, d.defaclobjtype, e.privilege_type
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var order = new List<(string Role, string? Schema, SecurableKind Kind)>();
+        var grouped = new Dictionary<(string, string?, SecurableKind), List<AclEntry>>();
+
+        while (await reader.ReadAsync(ct))
+        {
+            if (DefaultAclObjectKind(reader.GetString(2)) is not { } kind)
+            {
+                continue;
+            }
+
+            if (Privileges.Parse(reader.GetString(5)) is not { } privilege)
+            {
+                continue;
+            }
+
+            var key = (reader.GetString(0), reader.IsDBNull(1) ? null : reader.GetString(1), kind);
+            if (!grouped.TryGetValue(key, out var entries))
+            {
+                entries = [];
+                grouped[key] = entries;
+                order.Add(key);
+            }
+
+            entries.Add(new AclEntry(
+                reader.IsDBNull(3) ? null : reader.GetString(3),
+                reader.IsDBNull(4) ? null : reader.GetString(4),
+                privilege,
+                reader.GetBoolean(6)));
+        }
+
+        return order
+            .Select(k => new DefaultPrivilege(k.Role, k.Schema, k.Kind, grouped[k]))
+            .ToList();
+    }
+
+    // ------------------------------------------------------------------ RLS
+
+    /// <summary>
+    /// Row-level security state and policies for every table that either has RLS
+    /// switched on or has policies at all — a table with policies and RLS off is
+    /// inert, which is worth showing rather than hiding
+    /// (<see cref="RlsTableState.HasInertPolicies"/>).
+    ///
+    /// Read from <c>pg_policy</c> rather than the <c>pg_policies</c> view: the
+    /// view has no relation OID, so joining it back to <c>pg_class</c> for
+    /// <c>relrowsecurity</c>, <c>relforcerowsecurity</c> and the bypass check
+    /// would mean matching on schema-plus-table text. <c>polrelid</c> gives that
+    /// join for free and keeps all of it in one round trip; the price is calling
+    /// <c>pg_get_expr</c> for the quals ourselves, which the view does anyway.
+    /// </summary>
+    public async Task<IReadOnlyList<RlsTableState>> GetRlsAsync(string? schema, CancellationToken ct)
+    {
+        // BypassedByCurrentRole is the "works for me, not for the app" footgun,
+        // and FORCE ROW LEVEL SECURITY only closes half of it. Postgres treats
+        // the two bypass routes differently: a superuser or a BYPASSRLS role
+        // skips row security *always*, while the table owner skips it only
+        // while the table is not FORCE -- so the FORCE gate wraps the ownership
+        // term alone. pg_has_role(..., 'USAGE') rather than a bare relowner
+        // comparison because Postgres's own ownership check is
+        // has_privs_of_role(), so membership in the owning role bypasses too;
+        // rolsuper rides with rolbypassrls because has_bypassrls_privilege() is
+        // literally "superuser OR rolbypassrls".
+        const string sql = """
+            SELECT n.nspname,
+                   c.relname,
+                   c.relrowsecurity,
+                   c.relforcerowsecurity,
+                   (COALESCE((SELECT r.rolsuper OR r.rolbypassrls
+                              FROM pg_catalog.pg_roles r
+                              WHERE r.rolname = CURRENT_USER), false)
+                    OR (NOT c.relforcerowsecurity
+                        AND pg_catalog.pg_has_role(CURRENT_USER, c.relowner, 'USAGE'))),
+                   p.polname,
+                   p.polpermissive,
+                   p.polcmd::text,
+                   ARRAY(SELECT CASE WHEN ro = 0 THEN 'public'
+                                     ELSE pg_catalog.pg_get_userbyid(ro) END
+                         FROM unnest(p.polroles) AS ro),
+                   pg_catalog.pg_get_expr(p.polqual, p.polrelid),
+                   pg_catalog.pg_get_expr(p.polwithcheck, p.polrelid)
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            LEFT JOIN pg_catalog.pg_policy p ON p.polrelid = c.oid
+            WHERE c.relkind IN ('r', 'p')
+              AND (c.relrowsecurity
+                   OR EXISTS (SELECT 1 FROM pg_catalog.pg_policy pp WHERE pp.polrelid = c.oid))
+              AND (@schema IS NULL OR n.nspname = @schema)
+              AND (@schema IS NOT NULL
+                   OR (n.nspname NOT LIKE 'pg\_%' AND n.nspname <> 'information_schema'))
+            ORDER BY n.nspname, c.relname, p.polname
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        AddSchemaParameter(command, schema);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var order = new List<(string Schema, string Table)>();
+        var states = new Dictionary<(string, string), (bool Enabled, bool Force, bool Bypassed, List<RlsPolicyInfo> Policies)>();
+
+        while (await reader.ReadAsync(ct))
+        {
+            var tableSchema = reader.GetString(0);
+            var table = reader.GetString(1);
+            var key = (tableSchema, table);
+
+            if (!states.TryGetValue(key, out var state))
+            {
+                state = (reader.GetBoolean(2), reader.GetBoolean(3), reader.GetBoolean(4), []);
+                states[key] = state;
+                order.Add(key);
+            }
+
+            if (reader.IsDBNull(5))
+            {
+                continue; // RLS is on but the table has no policies (denies everything).
+            }
+
+            state.Policies.Add(new RlsPolicyInfo(
+                tableSchema,
+                table,
+                reader.GetString(5),
+                reader.GetBoolean(6),
+                reader.GetFieldValue<string[]>(8),
+                PolicyCommand(reader.GetString(7)),
+                reader.IsDBNull(9) ? null : reader.GetString(9),
+                reader.IsDBNull(10) ? null : reader.GetString(10)));
+        }
+
+        return order
+            .Select(k =>
+            {
+                var s = states[k];
+                return new RlsTableState(k.Schema, k.Table, s.Enabled, s.Force, s.Bypassed, s.Policies);
+            })
+            .ToList();
+    }
+
+    // -------------------------------------------------------- server answers
+
+    /// <summary>
+    /// Asks the server, for every role × privilege pair, whether it is allowed —
+    /// in one round trip.
+    ///
+    /// This is what makes <see cref="EffectivePrivilegeResolver"/> honest.
+    /// Unlike a raw ACL read, <c>has_*_privilege()</c> expands role inheritance,
+    /// ownership and superuser server-side, using exactly the code path the
+    /// executor will use, so it is ground truth: where the resolver's reading of
+    /// the ACL disagrees with it, the resolver is wrong and says so.
+    ///
+    /// The function name is chosen from <see cref="SecurableKind"/> via
+    /// <see cref="Privileges.HasPrivilegeFunction"/> — never from user input.
+    /// The OID, the role list and the privilege list are all parameters.
+    ///
+    /// One defensive detail: <c>has_*_privilege()</c> raises
+    /// <c>role "x" does not exist</c> for an unknown role name, which would
+    /// throw away the whole matrix over one stale entry. The EXISTS filter
+    /// against <c>pg_roles</c> drops those pairs instead, and the resolver then
+    /// simply trusts its own reading for them. The caller is still responsible
+    /// for passing privileges from <see cref="Privileges.For"/> with the real
+    /// server version: MAINTAIN against a pre-17 server raises
+    /// <c>unrecognized privilege type</c>, which has no equivalent in-SQL guard.
+    /// </summary>
+    public async Task<IReadOnlyDictionary<(string Role, PrivilegeKind Privilege), bool>> GetServerAnswersAsync(
+        SecurableRef obj,
+        IReadOnlyList<string> roles,
+        IReadOnlyList<PrivilegeKind> privileges,
+        CancellationToken ct)
+    {
+        var answers = new Dictionary<(string Role, PrivilegeKind Privilege), bool>();
+        if (roles.Count == 0 || privileges.Count == 0)
+        {
+            return answers;
+        }
+
+        var sql = $"""
+            SELECT r.role, p.priv,
+                   pg_catalog.{Privileges.HasPrivilegeFunction(obj.Kind)}(r.role::name, @oid, p.priv)
+            FROM unnest(@roles::text[]) AS r(role)
+            CROSS JOIN unnest(@privs::text[]) AS p(priv)
+            WHERE EXISTS (SELECT 1 FROM pg_catalog.pg_roles ro WHERE ro.rolname = r.role)
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        AddOidParameter(command, obj.Oid);
+        command.Parameters.Add(new NpgsqlParameter("roles", NpgsqlDbType.Array | NpgsqlDbType.Text)
+        {
+            Value = roles.ToArray(),
+        });
+        command.Parameters.Add(new NpgsqlParameter("privs", NpgsqlDbType.Array | NpgsqlDbType.Text)
+        {
+            Value = privileges.Select(Privileges.Sql).ToArray(),
+        });
+
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            if (Privileges.Parse(reader.GetString(1)) is not { } privilege)
+            {
+                continue;
+            }
+
+            answers[(reader.GetString(0), privilege)] = reader.GetBoolean(2);
+        }
+
+        return answers;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="role"/> has USAGE on <paramref name="schema"/>.
+    ///
+    /// Its own method because a missing schema USAGE is the single most common
+    /// reason a role holding every table privilege still gets
+    /// <c>permission denied</c> — the grants are all there and every one of them
+    /// is inert. The UI calls it out as its own line rather than burying it in
+    /// the matrix.
+    ///
+    /// Driving the call off <c>pg_roles</c> and <c>pg_namespace</c> keeps
+    /// <c>has_schema_privilege</c> from raising "role does not exist" or "schema
+    /// does not exist": an unknown role or schema yields no rows, which is
+    /// reported as false rather than as an exception.
+    /// </summary>
+    public async Task<bool> HasSchemaUsageAsync(string role, string schema, CancellationToken ct)
+    {
+        const string sql = """
+            SELECT pg_catalog.has_schema_privilege(r.rolname, n.nspname, 'USAGE')
+            FROM pg_catalog.pg_roles r
+            CROSS JOIN pg_catalog.pg_namespace n
+            WHERE r.rolname = @role AND n.nspname = @schema
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("role", role);
+        command.Parameters.AddWithValue("schema", schema);
+
+        var result = await command.ExecuteScalarAsync(ct);
+        return result is bool granted && granted;
+    }
+
+    // -------------------------------------------------------------- plumbing
+
+    private static void AddOidParameter(NpgsqlCommand command, uint oid) =>
+        command.Parameters.Add(new NpgsqlParameter<uint>("oid", NpgsqlDbType.Oid) { TypedValue = oid });
+
+    private static void AddSchemaParameter(NpgsqlCommand command, string? schema) =>
+        command.Parameters.Add(new NpgsqlParameter("schema", NpgsqlDbType.Text)
+        {
+            Value = (object?)schema ?? DBNull.Value,
+        });
+
+    /// <summary>The ACL and owner columns of the catalog an object of this class lives in.</summary>
+    private static (string Acl, string Owner) AclColumns(SecurableKind kind) => kind switch
+    {
+        SecurableKind.Table or SecurableKind.Sequence => ("relacl", "relowner"),
+        SecurableKind.Schema => ("nspacl", "nspowner"),
+        // pg_database's owner column is datdba, not datowner.
+        SecurableKind.Database => ("datacl", "datdba"),
+        SecurableKind.Function => ("proacl", "proowner"),
+        SecurableKind.Type => ("typacl", "typowner"),
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+    };
+
+    /// <summary>pg_default_acl.defaclobjtype; null for an object class we don't model.</summary>
+    private static SecurableKind? DefaultAclObjectKind(string defaclobjtype) => defaclobjtype switch
+    {
+        "r" => SecurableKind.Table,
+        "S" => SecurableKind.Sequence,
+        "f" => SecurableKind.Function,
+        "T" => SecurableKind.Type,
+        "n" => SecurableKind.Schema,
+        _ => null,
+    };
+
+    /// <summary>pg_policy.polcmd, as GRANT-style keywords.</summary>
+    private static string PolicyCommand(string polcmd) => polcmd switch
+    {
+        "*" => "ALL",
+        "r" => "SELECT",
+        "a" => "INSERT",
+        "w" => "UPDATE",
+        "d" => "DELETE",
+        _ => polcmd,
+    };
+}

--- a/PgNimbus.Core/Security/PrivilegeService.cs
+++ b/PgNimbus.Core/Security/PrivilegeService.cs
@@ -167,8 +167,13 @@ public sealed class PrivilegeService
         // SecurableKind enum, never from user input.
         //
         // LEFT JOIN LATERAL, so an object whose ACL is NULL still yields one row
-        // carrying the owner and the is-default flag. The COALESCE to an empty
-        // aclitem[] keeps that from depending on aclexplode's strictness.
+        // carrying the owner and the is-default flag. The NULL is handed to
+        // aclexplode as-is: the function is strict, so it returns no rows and
+        // the outer join supplies the placeholder. Do not "defend" that with a
+        // COALESCE to an empty array -- an empty array literal is
+        // zero-dimensional and aclexplode rejects it outright with
+        // "ACL arrays must be one-dimensional", which turns every untouched
+        // object into an error.
         var sql = $"""
             SELECT pg_catalog.pg_get_userbyid(t.{ownerColumn}),
                    t.{aclColumn} IS NULL,
@@ -179,8 +184,7 @@ public sealed class PrivilegeService
                    a.privilege_type,
                    a.is_grantable
             FROM {catalog} t
-            LEFT JOIN LATERAL pg_catalog.aclexplode(
-                COALESCE(t.{aclColumn}, ARRAY[]::aclitem[])) a ON true
+            LEFT JOIN LATERAL pg_catalog.aclexplode(t.{aclColumn}) a ON true
             WHERE t.oid = @oid
             """;
 

--- a/PgNimbus.Core/Security/RoleGraph.cs
+++ b/PgNimbus.Core/Security/RoleGraph.cs
@@ -1,0 +1,207 @@
+namespace PgNimbus.Core.Security;
+
+/// <summary>
+/// The role membership graph, indexed both ways: the roles a role belongs to and
+/// the roles that belong to it. Pure logic (Core stays Avalonia- and Npgsql-free
+/// here), unit-tested — the App binds a <c>TreeView</c> to the nodes and the
+/// effective-privilege resolver asks it the two <see cref="IRoleMembershipLookup"/>
+/// questions. Same builder shape as <c>Monitoring.BlockingTree</c>, for the same
+/// reason: the interesting behaviour is graph walking, which deserves tests that
+/// need no server.
+///
+/// The behaviour that makes this more than a dictionary is <c>NOINHERIT</c>. A
+/// membership whose <see cref="RoleMembership.InheritOption"/> is false gives the
+/// member the group's privileges only after an explicit <c>SET ROLE</c>, so those
+/// groups are shown in the membership tree (the relationship is real and the user
+/// needs to see it) but never reported by <see cref="InheritedGroups"/> — claiming
+/// a privilege the server will refuse is worse than showing none.
+/// </summary>
+public sealed class RoleGraph : IRoleMembershipLookup
+{
+    private readonly Dictionary<string, RoleAttributes> _byName;
+
+    /// <summary>member name → the memberships that walk upward, sorted by group name.</summary>
+    private readonly Dictionary<string, List<RoleMembership>> _up;
+
+    /// <summary>group name → the memberships that walk downward, sorted by member name.</summary>
+    private readonly Dictionary<string, List<RoleMembership>> _down;
+
+    private RoleGraph(
+        Dictionary<string, RoleAttributes> byName,
+        Dictionary<string, List<RoleMembership>> up,
+        Dictionary<string, List<RoleMembership>> down,
+        IReadOnlyList<RoleAttributes> roles)
+    {
+        _byName = byName;
+        _up = up;
+        _down = down;
+        Roles = roles;
+    }
+
+    /// <summary>Every role the graph was built from, alphabetically.</summary>
+    public IReadOnlyList<RoleAttributes> Roles { get; }
+
+    /// <summary>
+    /// Indexes a role snapshot. Role names are compared ordinally: Postgres stores
+    /// them case-sensitively, and folding <c>Admin</c> into <c>admin</c> here would
+    /// merge two genuinely different roles.
+    /// </summary>
+    public static RoleGraph Build(IEnumerable<RoleAttributes> roles, IEnumerable<RoleMembership> memberships)
+    {
+        var byName = new Dictionary<string, RoleAttributes>(StringComparer.Ordinal);
+        foreach (var role in roles)
+        {
+            // Later duplicates (shouldn't happen from the catalog) just overwrite.
+            byName[role.Name] = role;
+        }
+
+        var up = new Dictionary<string, List<RoleMembership>>(StringComparer.Ordinal);
+        var down = new Dictionary<string, List<RoleMembership>>(StringComparer.Ordinal);
+        var seenEdges = new HashSet<(string Member, string Group)>();
+
+        foreach (var edge in memberships)
+        {
+            // A role that is its own member is not a thing Postgres will create, and
+            // it would only ever be filtered back out by the cycle guard below.
+            if (string.Equals(edge.Member, edge.Group, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!seenEdges.Add((edge.Member, edge.Group)))
+            {
+                continue;
+            }
+
+            Index(up, edge.Member, edge);
+            Index(down, edge.Group, edge);
+        }
+
+        // Siblings render alphabetically: the tree is drawn straight from these
+        // lists and a screenshot baseline compares the result, so dictionary
+        // enumeration order is not good enough.
+        foreach (var edges in up.Values)
+        {
+            edges.Sort(static (a, b) => string.CompareOrdinal(a.Group, b.Group));
+        }
+
+        foreach (var edges in down.Values)
+        {
+            edges.Sort(static (a, b) => string.CompareOrdinal(a.Member, b.Member));
+        }
+
+        var ordered = byName.Values.OrderBy(r => r.Name, StringComparer.Ordinal).ToList();
+        return new RoleGraph(byName, up, down, ordered);
+
+        static void Index(Dictionary<string, List<RoleMembership>> index, string key, RoleMembership edge)
+        {
+            if (!index.TryGetValue(key, out var edges))
+            {
+                edges = [];
+                index[key] = edges;
+            }
+
+            edges.Add(edge);
+        }
+    }
+
+    /// <summary>
+    /// The roles <paramref name="role"/> belongs to, walking upward — a group that
+    /// is itself a member of another group nests. Empty for an unknown role.
+    /// </summary>
+    public IReadOnlyList<RoleTreeNode> MemberOf(string role) =>
+        Walk(role, _up, static edge => edge.Group, Path(role));
+
+    /// <summary>
+    /// The roles that belong to <paramref name="role"/>, walking downward. Empty
+    /// for an unknown role.
+    /// </summary>
+    public IReadOnlyList<RoleTreeNode> Members(string role) =>
+        Walk(role, _down, static edge => edge.Member, Path(role));
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> InheritedGroups(string role)
+    {
+        // Breadth-first so the result is nearest-first: a privilege the role picks
+        // up from its own group is a better explanation than the same privilege
+        // three groups further up. A group reachable by two paths (the diamond)
+        // is reported once, at the shortest distance.
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal) { role };
+        var frontier = new List<string> { role };
+
+        while (frontier.Count > 0)
+        {
+            var next = new List<string>();
+            foreach (var current in frontier)
+            {
+                if (!_up.TryGetValue(current, out var edges))
+                {
+                    continue;
+                }
+
+                foreach (var edge in edges)
+                {
+                    // NOINHERIT: the membership exists but its privileges are dormant
+                    // until SET ROLE, so the walk stops here rather than reporting
+                    // access the server would refuse.
+                    if (!edge.InheritOption)
+                    {
+                        continue;
+                    }
+
+                    // Doubles as the cycle guard — a snapshot read across statements
+                    // can contain a loop no live catalog would allow.
+                    if (seen.Add(edge.Group))
+                    {
+                        next.Add(edge.Group);
+                    }
+                }
+            }
+
+            next.Sort(StringComparer.Ordinal);
+            result.AddRange(next);
+            frontier = next;
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public bool IsSuperuser(string role) => _byName.TryGetValue(role, out var attributes) && attributes.IsSuperuser;
+
+    /// <summary>The role's attributes, or null when the snapshot never mentioned it.</summary>
+    public RoleAttributes? Find(string role) => _byName.GetValueOrDefault(role);
+
+    private static HashSet<string> Path(string role) => new(StringComparer.Ordinal) { role };
+
+    private static IReadOnlyList<RoleTreeNode> Walk(
+        string role,
+        Dictionary<string, List<RoleMembership>> index,
+        Func<RoleMembership, string> other,
+        HashSet<string> path)
+    {
+        if (!index.TryGetValue(role, out var edges))
+        {
+            return [];
+        }
+
+        var nodes = new List<RoleTreeNode>();
+        foreach (var edge in edges)
+        {
+            var next = other(edge);
+
+            // An edge back onto the current path closes a cycle; following it would
+            // recurse forever and hang the UI.
+            if (path.Contains(next))
+            {
+                continue;
+            }
+
+            var childPath = new HashSet<string>(path, StringComparer.Ordinal) { next };
+            nodes.Add(new RoleTreeNode(next, edge.InheritOption, Walk(next, index, other, childPath)));
+        }
+
+        return nodes;
+    }
+}

--- a/PgNimbus.Core/Security/RoleScriptBuilder.cs
+++ b/PgNimbus.Core/Security/RoleScriptBuilder.cs
@@ -1,0 +1,300 @@
+using System.Text;
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Security;
+
+/// <summary>
+/// The role the user asked for, as the editor describes it. The desired state,
+/// not a diff — <see cref="RoleScriptBuilder.Alter"/> does the diffing against
+/// the <see cref="RoleAttributes"/> the catalog reported.
+/// </summary>
+/// <param name="ConnectionLimit">
+/// Null means "no limit", which Postgres writes as <c>-1</c> and which
+/// <see cref="RoleScriptBuilder.Create"/> expresses by omitting the clause
+/// entirely.
+/// </param>
+/// <param name="ValidUntil">Null means the role never expires.</param>
+/// <param name="MemberOf">The groups this role should belong to.</param>
+public sealed record RoleDefinition(
+    string Name,
+    bool CanLogin,
+    bool IsSuperuser,
+    bool Inherit,
+    bool CanCreateDb,
+    bool CanCreateRole,
+    bool CanReplicate,
+    bool BypassRls,
+    int? ConnectionLimit,
+    DateTimeOffset? ValidUntil,
+    IReadOnlyList<string> MemberOf,
+    string? Comment);
+
+/// <summary>
+/// Generates the role DDL the user reviews before it runs — create, alter,
+/// rename, membership, password, and the drop recipe Postgres's own error
+/// message refuses to give.
+///
+/// Pure: no catalog access, no Npgsql. Identifiers go through
+/// <see cref="SqlIdentifier.QuoteIfNeeded"/> and literals through
+/// <see cref="SqlLiteral"/>; nothing is concatenated raw.
+/// </summary>
+public static class RoleScriptBuilder
+{
+    private const string Newline = "\n";
+
+    /// <summary>
+    /// What a masked password renders as. Four bullets, not the real length —
+    /// the length of a password is itself worth not leaking into a screenshot.
+    /// </summary>
+    private const string Mask = "••••";
+
+    /// <summary>
+    /// The <c>CREATE ROLE</c> statement, plus a <c>GRANT</c> per
+    /// <see cref="RoleDefinition.MemberOf"/> entry and a <c>COMMENT ON ROLE</c>
+    /// when a comment is set.
+    ///
+    /// <para><paramref name="maskPassword"/> is a security property, not a
+    /// formatting option. The same call produces the script the UI *shows* and
+    /// the script it *runs*: the shown one passes true and renders
+    /// <c>PASSWORD '••••'</c>, the executed one passes false. That is what
+    /// keeps the real literal out of the preview pane, out of a screenshot, and
+    /// — via <see cref="SecretRedactor"/> on the executed text — out of the
+    /// query history file and the crash log.</para>
+    ///
+    /// <para>The negative keywords (<c>NOSUPERUSER</c>, <c>NOCREATEDB</c>, …)
+    /// are always written out rather than left to the server's defaults, so the
+    /// generated script is a complete statement of intent that says the same
+    /// thing wherever it is pasted.</para>
+    /// </summary>
+    public static string Create(RoleDefinition definition, string? password, bool maskPassword = false)
+    {
+        var name = SqlIdentifier.QuoteIfNeeded(definition.Name);
+        var sb = new StringBuilder();
+
+        sb.Append("CREATE ROLE ").Append(name).Append(" WITH ");
+        sb.Append(string.Join(' ', AttributeKeywords(definition)));
+
+        if (definition.ConnectionLimit is { } limit)
+        {
+            sb.Append(" CONNECTION LIMIT ").Append(limit);
+        }
+
+        if (definition.ValidUntil is { } until)
+        {
+            sb.Append(" VALID UNTIL ").Append(SqlLiteral.Format(until));
+        }
+
+        if (password is not null)
+        {
+            sb.Append(" PASSWORD ").Append(RenderPassword(password, maskPassword));
+        }
+
+        sb.Append(';');
+
+        foreach (var group in definition.MemberOf)
+        {
+            sb.Append(Newline).Append(AddMember(group, definition.Name));
+        }
+
+        if (definition.Comment is not null)
+        {
+            sb.Append(Newline).Append(CommentOn(definition.Name, definition.Comment));
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The statements that move <paramref name="current"/> to
+    /// <paramref name="desired"/>, and nothing else — an empty string when the
+    /// two already agree. Emitting the full <c>ALTER ROLE</c> every time would
+    /// re-assert attributes nobody touched, which reads as a bigger change than
+    /// it is and makes the review pane useless.
+    ///
+    /// <para>Attribute changes collapse into a single
+    /// <c>ALTER ROLE … WITH …</c>; a changed comment becomes
+    /// <c>COMMENT ON ROLE</c>; membership differences become
+    /// <c>GRANT</c>/<c>REVOKE</c>.</para>
+    ///
+    /// <para><paramref name="currentMemberOf"/> is separate because
+    /// <see cref="RoleAttributes"/> does not carry memberships — they come from
+    /// <c>pg_auth_members</c>, not <c>pg_roles</c>. Null means "not known
+    /// here", and membership is then left alone rather than guessed at: with an
+    /// empty list assumed, every desired group would be re-granted and nothing
+    /// would ever be revoked.</para>
+    ///
+    /// <para>A renamed role is out of scope — <see cref="Rename"/> is its own
+    /// statement, and <see cref="RoleAttributes.Name"/> is what every statement
+    /// here targets.</para>
+    /// </summary>
+    public static string Alter(
+        RoleAttributes current,
+        RoleDefinition desired,
+        IReadOnlyList<string>? currentMemberOf = null)
+    {
+        var name = SqlIdentifier.QuoteIfNeeded(current.Name);
+        var statements = new List<string>();
+        var changed = new List<string>();
+
+        void Flag(bool now, bool then, string yes, string no)
+        {
+            if (now != then)
+            {
+                changed.Add(then ? yes : no);
+            }
+        }
+
+        Flag(current.CanLogin, desired.CanLogin, "LOGIN", "NOLOGIN");
+        Flag(current.IsSuperuser, desired.IsSuperuser, "SUPERUSER", "NOSUPERUSER");
+        Flag(current.Inherit, desired.Inherit, "INHERIT", "NOINHERIT");
+        Flag(current.CanCreateDb, desired.CanCreateDb, "CREATEDB", "NOCREATEDB");
+        Flag(current.CanCreateRole, desired.CanCreateRole, "CREATEROLE", "NOCREATEROLE");
+        Flag(current.CanReplicate, desired.CanReplicate, "REPLICATION", "NOREPLICATION");
+        Flag(current.BypassRls, desired.BypassRls, "BYPASSRLS", "NOBYPASSRLS");
+
+        // Postgres stores "no limit" as -1, and that is what a null desired
+        // limit means — so clearing a limit is a real change, not a no-op.
+        var desiredLimit = desired.ConnectionLimit ?? -1;
+        if (desiredLimit != current.ConnectionLimit)
+        {
+            changed.Add($"CONNECTION LIMIT {desiredLimit}");
+        }
+
+        if (desired.ValidUntil != current.ValidUntil)
+        {
+            // 'infinity' is how an expiry is removed; there is no "NO VALID UNTIL".
+            changed.Add(desired.ValidUntil is { } until
+                ? $"VALID UNTIL {SqlLiteral.Format(until)}"
+                : "VALID UNTIL 'infinity'");
+        }
+
+        if (changed.Count > 0)
+        {
+            statements.Add($"ALTER ROLE {name} WITH {string.Join(' ', changed)};");
+        }
+
+        if (currentMemberOf is not null)
+        {
+            var have = new HashSet<string>(currentMemberOf, StringComparer.Ordinal);
+            var want = new HashSet<string>(desired.MemberOf, StringComparer.Ordinal);
+
+            foreach (var group in desired.MemberOf.Where(g => !have.Contains(g)).Distinct(StringComparer.Ordinal))
+            {
+                statements.Add(AddMember(group, current.Name));
+            }
+
+            foreach (var group in currentMemberOf.Where(g => !want.Contains(g)).Distinct(StringComparer.Ordinal))
+            {
+                statements.Add(RemoveMember(group, current.Name));
+            }
+        }
+
+        if (desired.Comment != current.Comment)
+        {
+            statements.Add(CommentOn(current.Name, desired.Comment));
+        }
+
+        return string.Join(Newline, statements);
+    }
+
+    /// <summary>
+    /// <c>ALTER ROLE … WITH PASSWORD '…'</c>. <paramref name="maskPassword"/>
+    /// carries the same meaning as on <see cref="Create"/>: the preview gets
+    /// the mask, the execution gets the literal.
+    /// </summary>
+    public static string SetPassword(string role, string password, bool maskPassword = false) =>
+        $"ALTER ROLE {SqlIdentifier.QuoteIfNeeded(role)} WITH PASSWORD {RenderPassword(password, maskPassword)};";
+
+    /// <summary>Renames a role. Grants and ownership follow the OID, so nothing else has to change.</summary>
+    public static string Rename(string from, string to) =>
+        $"ALTER ROLE {SqlIdentifier.QuoteIfNeeded(from)} RENAME TO {SqlIdentifier.QuoteIfNeeded(to)};";
+
+    /// <summary>Makes <paramref name="member"/> a member of <paramref name="group"/>.</summary>
+    public static string AddMember(string group, string member) =>
+        $"GRANT {SqlIdentifier.QuoteIfNeeded(group)} TO {SqlIdentifier.QuoteIfNeeded(member)};";
+
+    /// <summary>Removes <paramref name="member"/> from <paramref name="group"/>.</summary>
+    public static string RemoveMember(string group, string member) =>
+        $"REVOKE {SqlIdentifier.QuoteIfNeeded(group)} FROM {SqlIdentifier.QuoteIfNeeded(member)};";
+
+    /// <summary>
+    /// The drop recipe, commented, in the only order that works.
+    ///
+    /// <para><c>DROP ROLE</c> fails with <c>2BP01</c> the moment the role owns
+    /// anything or holds any grant, and the server's error names neither the
+    /// objects nor the fix. <c>REASSIGN OWNED BY</c> hands the objects over;
+    /// <c>DROP OWNED BY</c> then clears the privileges reassignment leaves
+    /// behind; only then does the drop succeed. Both act on the current
+    /// database only, which is the part users find out about one database at a
+    /// time — so the script says so.</para>
+    ///
+    /// <para>With <paramref name="reassignTo"/> null the <c>REASSIGN</c> line
+    /// is omitted and the comment says plainly that <c>DROP OWNED</c> then
+    /// <em>deletes</em> the owned objects instead of transferring them. That
+    /// difference is the entire reason the parameter exists, and it is not
+    /// recoverable.</para>
+    /// </summary>
+    public static string Drop(string role, string? reassignTo)
+    {
+        var name = SqlIdentifier.QuoteIfNeeded(role);
+        var display = CommentSafe(role);
+        var sb = new StringBuilder();
+
+        sb.Append("-- \"").Append(display).Append("\" may own objects or hold grants, and DROP ROLE alone").Append(Newline);
+        sb.Append("-- then fails with 2BP01 without naming either the objects or the fix.").Append(Newline);
+
+        if (reassignTo is not null)
+        {
+            sb.Append("-- REASSIGN OWNED hands the objects to another role; DROP OWNED then removes").Append(Newline);
+            sb.Append("-- the privileges REASSIGN OWNED leaves behind. Both act on the current").Append(Newline);
+            sb.Append("-- database only -- repeat them while connected to every other database that").Append(Newline);
+            sb.Append("-- contains objects owned by this role, then drop it.").Append(Newline);
+            sb.Append("REASSIGN OWNED BY ").Append(name).Append(" TO ")
+                .Append(SqlIdentifier.QuoteIfNeeded(reassignTo)).Append(';').Append(Newline);
+        }
+        else
+        {
+            sb.Append("-- No role was named to take the objects over, so DROP OWNED will DELETE").Append(Newline);
+            sb.Append("-- everything \"").Append(display).Append("\" owns -- tables, schemas, data -- rather than hand").Append(Newline);
+            sb.Append("-- it over. Name a role to reassign to first if the objects should be kept.").Append(Newline);
+            sb.Append("-- DROP OWNED acts on the current database only -- repeat it while connected").Append(Newline);
+            sb.Append("-- to every other database that contains objects owned by this role, then").Append(Newline);
+            sb.Append("-- drop it.").Append(Newline);
+        }
+
+        sb.Append("DROP OWNED BY ").Append(name).Append(';').Append(Newline);
+        sb.Append("DROP ROLE ").Append(name).Append(';');
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Every attribute keyword, positive or negative — no attribute is left to
+    /// the server default.
+    /// </summary>
+    private static IEnumerable<string> AttributeKeywords(RoleDefinition d)
+    {
+        yield return d.CanLogin ? "LOGIN" : "NOLOGIN";
+        yield return d.IsSuperuser ? "SUPERUSER" : "NOSUPERUSER";
+        yield return d.Inherit ? "INHERIT" : "NOINHERIT";
+        yield return d.CanCreateDb ? "CREATEDB" : "NOCREATEDB";
+        yield return d.CanCreateRole ? "CREATEROLE" : "NOCREATEROLE";
+        yield return d.CanReplicate ? "REPLICATION" : "NOREPLICATION";
+        yield return d.BypassRls ? "BYPASSRLS" : "NOBYPASSRLS";
+    }
+
+    private static string CommentOn(string role, string? comment) =>
+        $"COMMENT ON ROLE {SqlIdentifier.QuoteIfNeeded(role)} IS {(comment is null ? "NULL" : SqlLiteral.Quote(comment))};";
+
+    private static string RenderPassword(string password, bool mask) =>
+        SqlLiteral.Quote(mask ? Mask : password);
+
+    /// <summary>
+    /// Strips the characters that would let a name break out of a <c>--</c>
+    /// comment. A role name can legally contain a newline; the recipe comment
+    /// is the one place in this file where a name is not inside a quoted
+    /// identifier, so it is the one place that has to defend itself.
+    /// </summary>
+    private static string CommentSafe(string text) =>
+        text.Replace('\r', ' ').Replace('\n', ' ');
+}

--- a/PgNimbus.Core/Security/RoleService.cs
+++ b/PgNimbus.Core/Security/RoleService.cs
@@ -1,0 +1,324 @@
+using Npgsql;
+
+namespace PgNimbus.Core.Security;
+
+/// <summary>
+/// Read-only catalog access for roles: attributes, membership edges, and the
+/// objects that would make <c>DROP ROLE</c> fail. Every query here is deliberately
+/// runnable by an ordinary, non-superuser login — it reads <c>pg_roles</c>, which
+/// is world-readable, and never <c>pg_authid</c>, which needs superuser and whose
+/// only extra column is the password hash this app has no business reading. That
+/// matters because on RDS, Neon and Supabase nobody is superuser, and a roles
+/// panel that assumes otherwise shows an error where perfectly readable data was
+/// available.
+/// </summary>
+public sealed class RoleService
+{
+    /// <summary>
+    /// Cap on <see cref="GetGrantsHeldAsync"/>. A role granted on 50k tables must
+    /// not hang the drop dialog; the caller reports a full page as "at least this
+    /// many" rather than pretending it is the whole list.
+    /// </summary>
+    public const int GrantsHeldLimit = 200;
+
+    private readonly NpgsqlDataSource _dataSource;
+
+    public RoleService(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    /// <summary>
+    /// Every role on the server, alphabetically. <paramref name="includePredefined"/>
+    /// false drops the built-in <c>pg_*</c> roles, matching
+    /// <c>SchemaService.GetRolesAsync</c>'s filter — the schema tree lists roles a
+    /// person created, not the ones initdb did.
+    /// </summary>
+    public async Task<IReadOnlyList<RoleAttributes>> GetRolesAsync(bool includePredefined, CancellationToken ct)
+    {
+        // The predefined filter rides a parameter rather than two SQL texts so the
+        // thirteen columns are spelled out once. 'pg\_%' escapes the underscore —
+        // an unescaped one is LIKE's single-character wildcard.
+        const string sql = """
+            SELECT r.oid, r.rolname, r.rolcanlogin, r.rolsuper, r.rolinherit,
+                   r.rolcreaterole, r.rolcreatedb, r.rolreplication, r.rolbypassrls,
+                   r.rolconnlimit, r.rolvaliduntil, r.rolconfig,
+                   pg_catalog.shobj_description(r.oid, 'pg_authid')
+            FROM pg_catalog.pg_roles r
+            WHERE @includePredefined OR r.rolname NOT LIKE 'pg\_%'
+            ORDER BY r.rolname
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("includePredefined", includePredefined);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<RoleAttributes>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new RoleAttributes(
+                reader.GetFieldValue<uint>(0),
+                reader.GetString(1),
+                reader.GetBoolean(2),
+                reader.GetBoolean(3),
+                reader.GetBoolean(4),
+                reader.GetBoolean(5),
+                reader.GetBoolean(6),
+                reader.GetBoolean(7),
+                reader.GetBoolean(8),
+                reader.GetInt32(9),
+                ReadValidUntil(reader, 10),
+                reader.IsDBNull(11) ? [] : reader.GetFieldValue<string[]>(11),
+                reader.IsDBNull(12) ? null : reader.GetString(12)));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Every edge of the role membership graph — who is a member of what — with
+    /// the grant options that decide whether the membership actually carries
+    /// privileges.
+    /// </summary>
+    public async Task<IReadOnlyList<RoleMembership>> GetMembershipsAsync(CancellationToken ct)
+    {
+        // PG16 split the single admin_option column into admin/inherit/set options.
+        // On older servers those columns do not exist at all, and naming a missing
+        // column is a hard parse error rather than a NULL — so this is two SQL
+        // texts, not one with a COALESCE. The pre-16 fallbacks reproduce the old
+        // semantics exactly: inheritance was a property of the *member* role
+        // (rolinherit), and every membership could be assumed with SET ROLE.
+        const string modernSql = """
+            SELECT m.rolname, g.rolname, a.admin_option, a.inherit_option, a.set_option, gr.rolname
+            FROM pg_catalog.pg_auth_members a
+            JOIN pg_catalog.pg_roles m ON m.oid = a.member
+            JOIN pg_catalog.pg_roles g ON g.oid = a.roleid
+            LEFT JOIN pg_catalog.pg_roles gr ON gr.oid = a.grantor
+            ORDER BY m.rolname, g.rolname
+            """;
+
+        const string legacySql = """
+            SELECT m.rolname, g.rolname, a.admin_option, m.rolinherit, true, gr.rolname
+            FROM pg_catalog.pg_auth_members a
+            JOIN pg_catalog.pg_roles m ON m.oid = a.member
+            JOIN pg_catalog.pg_roles g ON g.oid = a.roleid
+            LEFT JOIN pg_catalog.pg_roles gr ON gr.oid = a.grantor
+            ORDER BY m.rolname, g.rolname
+            """;
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        var sql = PgFeatures.SupportsRoleMemberOptions(connection.PostgreSqlVersion) ? modernSql : legacySql;
+
+        await using var command = new NpgsqlCommand(sql, connection);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<RoleMembership>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new RoleMembership(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetBoolean(2),
+                reader.GetBoolean(3),
+                reader.GetBoolean(4),
+                reader.IsDBNull(5) ? null : reader.GetString(5)));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Everything in the <em>current database</em> that <paramref name="role"/>
+    /// owns — the objects Postgres refuses a <c>DROP ROLE</c> over with 2BP01.
+    /// Listing them before the user hits that error is what turns an opaque
+    /// message into an actionable dialog (the fix is <c>REASSIGN OWNED BY</c>,
+    /// per database). Ordered by kind, then name.
+    /// </summary>
+    public async Task<IReadOnlyList<RoleDependency>> GetOwnedObjectsAsync(string role, CancellationToken ct)
+    {
+        // pg_get_userbyid rather than a ::regrole cast on the parameter: it never
+        // raises for an oid whose role has since been dropped, and the comparison
+        // stays against the raw name the caller passed (regrole's text output
+        // quotes anything that is not a bare lowercase identifier).
+        //
+        // Indexes and TOAST tables are excluded by the relkind list — they are
+        // owned implicitly by their parent and dropping the parent takes them.
+        // Array types and the row types Postgres creates behind every table are
+        // excluded for the same reason: they are not independently droppable, so
+        // listing them would pad the dialog with noise the user cannot act on.
+        const string sql = """
+            SELECT kind, identity FROM (
+                SELECT CASE c.relkind
+                           WHEN 'r' THEN 'table'
+                           WHEN 'p' THEN 'partitioned table'
+                           WHEN 'v' THEN 'view'
+                           WHEN 'm' THEN 'materialized view'
+                           WHEN 'S' THEN 'sequence'
+                           WHEN 'f' THEN 'foreign table'
+                       END AS kind,
+                       n.nspname || '.' || c.relname AS identity
+                FROM pg_catalog.pg_class c
+                JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+                  AND n.nspname <> 'pg_catalog'
+                  AND n.nspname <> 'information_schema'
+                  AND pg_catalog.pg_get_userbyid(c.relowner) = @role
+                UNION ALL
+                SELECT 'schema', n.nspname
+                FROM pg_catalog.pg_namespace n
+                WHERE n.nspname NOT LIKE 'pg\_%'
+                  AND n.nspname <> 'information_schema'
+                  AND pg_catalog.pg_get_userbyid(n.nspowner) = @role
+                UNION ALL
+                SELECT CASE p.prokind WHEN 'p' THEN 'procedure' ELSE 'function' END,
+                       n.nspname || '.' || p.proname
+                           || '(' || pg_catalog.pg_get_function_arguments(p.oid) || ')'
+                FROM pg_catalog.pg_proc p
+                JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+                WHERE n.nspname <> 'pg_catalog'
+                  AND n.nspname <> 'information_schema'
+                  AND pg_catalog.pg_get_userbyid(p.proowner) = @role
+                UNION ALL
+                SELECT 'type', n.nspname || '.' || t.typname
+                FROM pg_catalog.pg_type t
+                JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+                WHERE n.nspname <> 'pg_catalog'
+                  AND n.nspname <> 'information_schema'
+                  AND (t.typrelid = 0
+                       OR (SELECT c.relkind FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid) = 'c')
+                  AND NOT EXISTS (SELECT 1 FROM pg_catalog.pg_type e
+                                  WHERE e.oid = t.typelem AND e.typarray = t.oid)
+                  AND pg_catalog.pg_get_userbyid(t.typowner) = @role
+                UNION ALL
+                SELECT 'database', d.datname
+                FROM pg_catalog.pg_database d
+                WHERE pg_catalog.pg_get_userbyid(d.datdba) = @role
+            ) owned
+            ORDER BY kind, identity
+            """;
+
+        return await ReadDependenciesAsync(sql, role, limit: null, ct);
+    }
+
+    /// <summary>
+    /// Objects <paramref name="role"/> has been <em>granted</em> privileges on, in
+    /// the current database. These are the other half of the drop recipe: an
+    /// owned object needs <c>REASSIGN OWNED BY</c>, a held grant needs
+    /// <c>DROP OWNED BY</c>, and a dialog that shows only the first leaves the
+    /// user staring at the same 2BP01 after following its advice. Capped at
+    /// <see cref="GrantsHeldLimit"/> rows.
+    /// </summary>
+    public async Task<IReadOnlyList<RoleDependency>> GetGrantsHeldAsync(string role, CancellationToken ct)
+    {
+        // aclexplode yields one row per privilege, so UNION (not UNION ALL) folds
+        // a role holding SELECT+INSERT+UPDATE on one table into a single line.
+        //
+        // The grantee is matched by oid through a scalar subquery rather than the
+        // more obvious grantee::regrole::text = @role: regrole's output function
+        // applies quote_ident, so a role named "App User" renders as '"App User"'
+        // and would silently match nothing. An unknown role name makes the
+        // subquery NULL, which returns no rows — the right answer, and no error.
+        const string sql = """
+            SELECT kind, identity FROM (
+                SELECT 'privilege on table' AS kind, n.nspname || '.' || c.relname AS identity
+                FROM pg_catalog.pg_class c
+                JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                CROSS JOIN LATERAL pg_catalog.aclexplode(c.relacl) AS a
+                WHERE c.relacl IS NOT NULL
+                  AND n.nspname <> 'pg_catalog'
+                  AND n.nspname <> 'information_schema'
+                  AND a.grantee = (SELECT r.oid FROM pg_catalog.pg_roles r WHERE r.rolname = @role)
+                UNION
+                SELECT 'privilege on schema', n.nspname
+                FROM pg_catalog.pg_namespace n
+                CROSS JOIN LATERAL pg_catalog.aclexplode(n.nspacl) AS a
+                WHERE n.nspacl IS NOT NULL
+                  AND a.grantee = (SELECT r.oid FROM pg_catalog.pg_roles r WHERE r.rolname = @role)
+            ) held
+            ORDER BY kind, identity
+            LIMIT @limit
+            """;
+
+        return await ReadDependenciesAsync(sql, role, GrantsHeldLimit, ct);
+    }
+
+    /// <summary>The role this connection is currently acting as — the "you are here" of every permission answer.</summary>
+    public async Task<string> GetCurrentRoleAsync(CancellationToken ct)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand("SELECT current_user", connection);
+        await using var reader = await command.ExecuteReaderAsync(ct);
+        await reader.ReadAsync(ct);
+
+        return reader.GetString(0);
+    }
+
+    /// <summary>
+    /// The server's version, for the <see cref="PgFeatures"/> gates — MAINTAIN is
+    /// PG17+, the per-grant membership options are PG16+. Read from the handshake
+    /// Npgsql already did, so this costs a pooled connection and no round trip.
+    /// </summary>
+    public async Task<Version> GetServerVersionAsync(CancellationToken ct)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        return connection.PostgreSqlVersion;
+    }
+
+    private async Task<IReadOnlyList<RoleDependency>> ReadDependenciesAsync(
+        string sql,
+        string role,
+        int? limit,
+        CancellationToken ct)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.Parameters.AddWithValue("role", role);
+        if (limit is { } cap)
+        {
+            command.Parameters.AddWithValue("limit", cap);
+        }
+
+        await using var reader = await command.ExecuteReaderAsync(ct);
+
+        var results = new List<RoleDependency>();
+        while (await reader.ReadAsync(ct))
+        {
+            results.Add(new RoleDependency(reader.GetString(0), reader.GetString(1)));
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// <c>rolvaliduntil</c> is a timestamptz that is very often <c>infinity</c> —
+    /// what <c>CREATE ROLE … VALID UNTIL 'infinity'</c> stores, and what some
+    /// managed providers set by default. Npgsql surfaces that as
+    /// <see cref="DateTime.MaxValue"/> (or throws, depending on the infinity
+    /// conversion setting), and neither is something a DateTimeOffset column in
+    /// the UI can show. "Valid forever" and "no expiry" mean the same thing to the
+    /// user, so both collapse to null.
+    /// </summary>
+    private static DateTimeOffset? ReadValidUntil(NpgsqlDataReader reader, int ordinal)
+    {
+        if (reader.IsDBNull(ordinal))
+        {
+            return null;
+        }
+
+        try
+        {
+            var value = reader.GetFieldValue<DateTime>(ordinal);
+            if (value == DateTime.MaxValue || value == DateTime.MinValue)
+            {
+                return null;
+            }
+
+            return new DateTimeOffset(DateTime.SpecifyKind(value, DateTimeKind.Utc));
+        }
+        catch (Exception ex) when (ex is InvalidCastException or OverflowException or ArgumentOutOfRangeException or FormatException)
+        {
+            return null;
+        }
+    }
+}

--- a/PgNimbus.Core/Security/SecretRedactor.cs
+++ b/PgNimbus.Core/Security/SecretRedactor.cs
@@ -1,0 +1,363 @@
+using System.Text;
+
+namespace PgNimbus.Core.Security;
+
+/// <summary>
+/// Strips password literals out of SQL before it can be persisted. A safety
+/// net, not a formatter: <c>PgNimbus.Core.Query.QueryHistoryStore</c> writes
+/// executed statements to disk in the clear and
+/// <c>PgNimbus.Core.Diagnostics.CrashLog</c> can capture statement text, so a
+/// <c>CREATE ROLE … PASSWORD 'hunter2'</c> that reaches either one has put a
+/// live credential in a plain file. This runs on the way to disk, independent
+/// of whichever call site produced the statement — the redaction belongs next
+/// to the statement inspector in Core, not bolted onto one App call site that
+/// the next feature will bypass.
+///
+/// <para>Hand-rolled scanner rather than a regular expression, deliberately.
+/// A regex over SQL string literals has to model doubled <c>''</c> escapes,
+/// <c>E''</c> backslash escapes and dollar quoting all at once, and it has to
+/// avoid matching the word PASSWORD when that word is itself inside a literal
+/// or a quoted identifier. That is precisely the class of expression that looks
+/// right, passes its examples, and silently fails to match the one input that
+/// mattered. A scanner that tracks what it is inside of cannot make that
+/// mistake.</para>
+///
+/// <para>The bias is toward over-redacting: a false positive costs a mangled
+/// history entry, a false negative writes a password to disk. An unterminated
+/// literal is therefore swallowed to end-of-input rather than given the benefit
+/// of the doubt.</para>
+///
+/// <para>Known limit: the word PASSWORD inside a comment is not treated as a
+/// keyword, so a commented-out statement keeps its literal. Comments are not
+/// executed, so nothing this app runs takes that path.</para>
+/// </summary>
+public static class SecretRedactor
+{
+    /// <summary>What a redacted literal is replaced with, quotes included.</summary>
+    public const string Replacement = "'<redacted>'";
+
+    /// <summary>
+    /// Returns <paramref name="sql"/> with every password literal replaced by
+    /// <see cref="Replacement"/>, or the input unchanged when there is nothing
+    /// to redact. <c>PASSWORD NULL</c> is left alone: it is not a secret, it is
+    /// the removal of one, and rewriting it would change what the history says
+    /// happened.
+    /// </summary>
+    public static string Redact(string sql) => Scan(sql, out var redacted) ? redacted : sql;
+
+    /// <summary>True when <see cref="Redact"/> would change something.</summary>
+    public static bool ContainsSecret(string sql) => Scan(sql, out _);
+
+    /// <summary>
+    /// The one pass both entry points share. Returns whether a secret was
+    /// found; <paramref name="redacted"/> is only meaningful when it was.
+    /// </summary>
+    private static bool Scan(string sql, out string redacted)
+    {
+        redacted = sql;
+        if (string.IsNullOrEmpty(sql))
+        {
+            return false;
+        }
+
+        StringBuilder? output = null;
+        var copied = 0;
+        var i = 0;
+
+        while (i < sql.Length)
+        {
+            var c = sql[i];
+
+            if (TrySkipComment(sql, i, out var afterComment))
+            {
+                i = afterComment;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                i = SkipQuotedIdentifier(sql, i);
+                continue;
+            }
+
+            if (TryReadStringLiteral(sql, i, out var afterLiteral))
+            {
+                i = afterLiteral;
+                continue;
+            }
+
+            if (TryReadDollarQuoted(sql, i, out var afterDollar))
+            {
+                i = afterDollar;
+                continue;
+            }
+
+            if (IsWordStart(c))
+            {
+                var wordEnd = ReadWord(sql, i);
+                var isPassword = string.Compare(sql, i, "PASSWORD", 0, 8, StringComparison.OrdinalIgnoreCase) == 0
+                                 && wordEnd - i == 8;
+
+                if (!isPassword)
+                {
+                    i = wordEnd;
+                    continue;
+                }
+
+                // The keyword is preceded by ENCRYPTED / UNENCRYPTED in some
+                // dialects and grammars; that changes nothing here, because the
+                // literal always follows PASSWORD itself.
+                var valueStart = SkipTrivia(sql, wordEnd);
+
+                if (valueStart < sql.Length && StartsWithWord(sql, valueStart, "NULL"))
+                {
+                    i = wordEnd;
+                    continue;
+                }
+
+                int valueEnd;
+                if (!TryReadStringLiteral(sql, valueStart, out valueEnd)
+                    && !TryReadDollarQuoted(sql, valueStart, out valueEnd))
+                {
+                    // Not a literal — a parameter placeholder, a variable, or a
+                    // truncated statement. Nothing to strip.
+                    i = wordEnd;
+                    continue;
+                }
+
+                output ??= new StringBuilder(sql.Length);
+                output.Append(sql, copied, valueStart - copied).Append(Replacement);
+                copied = valueEnd;
+                i = valueEnd;
+                continue;
+            }
+
+            i++;
+        }
+
+        if (output is null)
+        {
+            return false;
+        }
+
+        output.Append(sql, copied, sql.Length - copied);
+        redacted = output.ToString();
+        return true;
+    }
+
+    /// <summary>Whitespace and comments between the keyword and its value.</summary>
+    private static int SkipTrivia(string sql, int i)
+    {
+        while (i < sql.Length)
+        {
+            if (char.IsWhiteSpace(sql[i]))
+            {
+                i++;
+                continue;
+            }
+
+            if (TrySkipComment(sql, i, out var after))
+            {
+                i = after;
+                continue;
+            }
+
+            break;
+        }
+
+        return i;
+    }
+
+    private static bool TrySkipComment(string sql, int i, out int end)
+    {
+        end = i;
+
+        if (i + 1 >= sql.Length)
+        {
+            return false;
+        }
+
+        if (sql[i] == '-' && sql[i + 1] == '-')
+        {
+            var newline = sql.IndexOf('\n', i + 2);
+            end = newline < 0 ? sql.Length : newline + 1;
+            return true;
+        }
+
+        if (sql[i] == '/' && sql[i + 1] == '*')
+        {
+            // Postgres block comments nest, so a depth counter, not a search
+            // for the first "*/".
+            var depth = 1;
+            var p = i + 2;
+            while (p + 1 < sql.Length && depth > 0)
+            {
+                if (sql[p] == '/' && sql[p + 1] == '*')
+                {
+                    depth++;
+                    p += 2;
+                }
+                else if (sql[p] == '*' && sql[p + 1] == '/')
+                {
+                    depth--;
+                    p += 2;
+                }
+                else
+                {
+                    p++;
+                }
+            }
+
+            end = depth > 0 ? sql.Length : p;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static int SkipQuotedIdentifier(string sql, int i)
+    {
+        var p = i + 1;
+        while (p < sql.Length)
+        {
+            if (sql[p] == '"')
+            {
+                if (p + 1 < sql.Length && sql[p + 1] == '"')
+                {
+                    p += 2;
+                    continue;
+                }
+
+                return p + 1;
+            }
+
+            p++;
+        }
+
+        return sql.Length;
+    }
+
+    /// <summary>
+    /// A single-quoted literal starting at <paramref name="i"/>, including an
+    /// <c>E</c>/<c>e</c> or <c>U&amp;</c> prefix if one is there. Doubled
+    /// <c>''</c> stays inside the literal; inside an E-string a backslash
+    /// escapes the next character. An unterminated literal runs to the end of
+    /// the input.
+    /// </summary>
+    private static bool TryReadStringLiteral(string sql, int i, out int end)
+    {
+        end = i;
+        if (i >= sql.Length)
+        {
+            return false;
+        }
+
+        var quote = i;
+        var backslashEscapes = false;
+
+        if ((sql[i] == 'E' || sql[i] == 'e') && i + 1 < sql.Length && sql[i + 1] == '\'')
+        {
+            quote = i + 1;
+            backslashEscapes = true;
+        }
+        else if ((sql[i] == 'U' || sql[i] == 'u') && i + 2 < sql.Length && sql[i + 1] == '&' && sql[i + 2] == '\'')
+        {
+            quote = i + 2;
+        }
+        else if (sql[i] != '\'')
+        {
+            return false;
+        }
+
+        var p = quote + 1;
+        while (p < sql.Length)
+        {
+            var c = sql[p];
+
+            if (backslashEscapes && c == '\\')
+            {
+                p += 2;
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                if (p + 1 < sql.Length && sql[p + 1] == '\'')
+                {
+                    p += 2;
+                    continue;
+                }
+
+                end = p + 1;
+                return true;
+            }
+
+            p++;
+        }
+
+        end = sql.Length;
+        return true;
+    }
+
+    /// <summary>
+    /// A dollar-quoted literal — <c>$$…$$</c> or <c>$tag$…$tag$</c>. A tag has
+    /// to look like an unquoted identifier, which is what keeps <c>$1</c> a
+    /// positional parameter rather than the start of a quote.
+    /// </summary>
+    private static bool TryReadDollarQuoted(string sql, int i, out int end)
+    {
+        end = i;
+        if (i >= sql.Length || sql[i] != '$')
+        {
+            return false;
+        }
+
+        var p = i + 1;
+        while (p < sql.Length && (char.IsLetterOrDigit(sql[p]) || sql[p] == '_'))
+        {
+            p++;
+        }
+
+        if (p >= sql.Length || sql[p] != '$')
+        {
+            return false;
+        }
+
+        var tagLength = p - (i + 1);
+        if (tagLength > 0 && char.IsDigit(sql[i + 1]))
+        {
+            return false;
+        }
+
+        var delimiter = sql.Substring(i, tagLength + 2);
+        var close = sql.IndexOf(delimiter, p + 1, StringComparison.Ordinal);
+        end = close < 0 ? sql.Length : close + delimiter.Length;
+        return true;
+    }
+
+    private static bool StartsWithWord(string sql, int i, string word)
+    {
+        if (string.Compare(sql, i, word, 0, word.Length, StringComparison.OrdinalIgnoreCase) != 0)
+        {
+            return false;
+        }
+
+        var after = i + word.Length;
+        return after >= sql.Length || !IsWordChar(sql[after]);
+    }
+
+    private static int ReadWord(string sql, int i)
+    {
+        var p = i;
+        while (p < sql.Length && IsWordChar(sql[p]))
+        {
+            p++;
+        }
+
+        return p;
+    }
+
+    private static bool IsWordStart(char c) => char.IsLetter(c) || c == '_';
+
+    private static bool IsWordChar(char c) => char.IsLetterOrDigit(c) || c == '_' || c == '$';
+}

--- a/PgNimbus.Core/Security/SecurityEditor.cs
+++ b/PgNimbus.Core/Security/SecurityEditor.cs
@@ -1,0 +1,52 @@
+using Npgsql;
+
+namespace PgNimbus.Core.Security;
+
+/// <summary>
+/// Runs a generated role/privilege script.
+///
+/// Almost nothing in the Roles &amp; Permissions window needs this: privilege
+/// changes are handed to the SQL editor as a script, because a GRANT the user
+/// can read, edit and run beats one applied behind their back. The exception is
+/// any statement carrying a <c>PASSWORD</c> literal. Postgres has no parameter
+/// form for it, so the secret has to be interpolated into statement text — and
+/// routing that through a query tab would file it in the on-disk query history
+/// and put it on screen. Those statements run here instead: composed, executed,
+/// and dropped, never shown and never persisted.
+///
+/// Everything runs inside one transaction. DDL is transactional in Postgres, so
+/// a three-statement drop-role recipe that fails on its second statement leaves
+/// the role exactly as it was rather than half-dismantled.
+/// </summary>
+public sealed class SecurityEditor
+{
+    private readonly NpgsqlDataSource _dataSource;
+
+    public SecurityEditor(NpgsqlDataSource dataSource)
+    {
+        _dataSource = dataSource;
+    }
+
+    /// <summary>
+    /// Executes <paramref name="script"/> — one or more statements — atomically.
+    /// The server's own error is allowed to propagate: a pre-flight permission
+    /// check would only guess, and it would guess wrong on managed Postgres
+    /// where the connected role is not a superuser but can still create roles.
+    /// </summary>
+    public async Task ExecuteScriptAsync(string script, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(script))
+        {
+            return;
+        }
+
+        await using var connection = await _dataSource.OpenConnectionAsync(ct);
+        await using var transaction = await connection.BeginTransactionAsync(ct);
+        await using (var command = new NpgsqlCommand(script, connection, transaction))
+        {
+            await command.ExecuteNonQueryAsync(ct);
+        }
+
+        await transaction.CommitAsync(ct);
+    }
+}

--- a/PgNimbus.Core/Security/SecurityModel.cs
+++ b/PgNimbus.Core/Security/SecurityModel.cs
@@ -1,0 +1,457 @@
+using PgNimbus.Core.Query;
+
+namespace PgNimbus.Core.Security;
+
+/// <summary>
+/// Every privilege Postgres can grant, as the <c>aclexplode()</c>
+/// <c>privilege_type</c> text names them. Kept as one flat enum rather than one
+/// per object class because the permissions grid is a single matrix — which
+/// members actually apply to a given object is <see cref="Privileges.For"/>'s
+/// job, not the type system's.
+/// </summary>
+public enum PrivilegeKind
+{
+    Select,
+    Insert,
+    Update,
+    Delete,
+    Truncate,
+    References,
+    Trigger,
+
+    /// <summary>PG17+: VACUUM/ANALYZE/REINDEX/CLUSTER without ownership.</summary>
+    Maintain,
+
+    Usage,
+    Create,
+    Connect,
+    Temporary,
+    Execute,
+
+    /// <summary>PG15+: SET on a configuration parameter.</summary>
+    Set,
+
+    /// <summary>PG15+: ALTER SYSTEM on a configuration parameter.</summary>
+    AlterSystem,
+}
+
+/// <summary>
+/// The class of thing a privilege is granted on. Views, materialized views,
+/// partitioned tables and foreign tables are all <see cref="Table"/> — Postgres
+/// grants on them with the same <c>TABLE</c> keyword and the same privilege
+/// set, so splitting them here would buy nothing but a wider switch.
+/// </summary>
+public enum SecurableKind
+{
+    Table,
+    Sequence,
+    Schema,
+    Database,
+    Function,
+    Type,
+}
+
+/// <summary>
+/// How a role came to hold (or not hold) a privilege on an object. This is the
+/// column the incumbents don't have: pgAdmin, DBeaver and DataGrip all render
+/// the stored ACL, which silently omits everything reached through role
+/// membership, ownership or PUBLIC.
+/// </summary>
+public enum PrivilegeSource
+{
+    /// <summary>The role does not have the privilege.</summary>
+    None,
+
+    /// <summary>A GRANT names this role directly.</summary>
+    Direct,
+
+    /// <summary>A GRANT names a role this one inherits from; see <see cref="EffectivePrivilege.Via"/>.</summary>
+    Inherited,
+
+    /// <summary>Granted to PUBLIC, so every role has it.</summary>
+    Public,
+
+    /// <summary>The role owns the object, which carries all privileges implicitly.</summary>
+    Owner,
+
+    /// <summary>The role is a superuser and bypasses permission checks entirely.</summary>
+    Superuser,
+
+    /// <summary>
+    /// The server says yes but nothing in the catalog we read explains why —
+    /// e.g. a grant through a role we could not see, or a privilege reached via
+    /// a chain the resolver declined to walk. Rendered honestly rather than
+    /// guessed at.
+    /// </summary>
+    Unknown,
+}
+
+/// <summary>
+/// Which privileges apply to which object class, and the text names Postgres
+/// uses for them in <c>GRANT</c> and <c>has_*_privilege()</c>. Pure lookup —
+/// no catalog access.
+/// </summary>
+public static class Privileges
+{
+    /// <summary>The SQL keyword: <c>PrivilegeKind.AlterSystem</c> → <c>"ALTER SYSTEM"</c>.</summary>
+    public static string Sql(PrivilegeKind privilege) => privilege switch
+    {
+        PrivilegeKind.Select => "SELECT",
+        PrivilegeKind.Insert => "INSERT",
+        PrivilegeKind.Update => "UPDATE",
+        PrivilegeKind.Delete => "DELETE",
+        PrivilegeKind.Truncate => "TRUNCATE",
+        PrivilegeKind.References => "REFERENCES",
+        PrivilegeKind.Trigger => "TRIGGER",
+        PrivilegeKind.Maintain => "MAINTAIN",
+        PrivilegeKind.Usage => "USAGE",
+        PrivilegeKind.Create => "CREATE",
+        PrivilegeKind.Connect => "CONNECT",
+        PrivilegeKind.Temporary => "TEMPORARY",
+        PrivilegeKind.Execute => "EXECUTE",
+        PrivilegeKind.Set => "SET",
+        PrivilegeKind.AlterSystem => "ALTER SYSTEM",
+        _ => throw new ArgumentOutOfRangeException(nameof(privilege), privilege, null),
+    };
+
+    /// <summary>
+    /// Parses the <c>privilege_type</c> text <c>aclexplode()</c> and
+    /// <c>information_schema</c> emit. Returns null for anything we don't model
+    /// (a future server's new privilege) so an unknown row is skipped rather
+    /// than throwing the whole grid away.
+    /// </summary>
+    public static PrivilegeKind? Parse(string privilegeType) => privilegeType.ToUpperInvariant() switch
+    {
+        "SELECT" => PrivilegeKind.Select,
+        "INSERT" => PrivilegeKind.Insert,
+        "UPDATE" => PrivilegeKind.Update,
+        "DELETE" => PrivilegeKind.Delete,
+        "TRUNCATE" => PrivilegeKind.Truncate,
+        "REFERENCES" => PrivilegeKind.References,
+        "TRIGGER" => PrivilegeKind.Trigger,
+        "MAINTAIN" => PrivilegeKind.Maintain,
+        "USAGE" => PrivilegeKind.Usage,
+        "CREATE" => PrivilegeKind.Create,
+        "CONNECT" => PrivilegeKind.Connect,
+        "TEMPORARY" or "TEMP" => PrivilegeKind.Temporary,
+        "EXECUTE" => PrivilegeKind.Execute,
+        "SET" => PrivilegeKind.Set,
+        "ALTER SYSTEM" => PrivilegeKind.AlterSystem,
+        _ => null,
+    };
+
+    /// <summary>
+    /// The privileges that can be granted on <paramref name="kind"/>, in the
+    /// order the permissions matrix shows its columns.
+    /// <paramref name="serverVersion"/> gates the ones that don't exist on
+    /// older servers (MAINTAIN is PG17+); pass null to include everything.
+    /// </summary>
+    public static IReadOnlyList<PrivilegeKind> For(SecurableKind kind, Version? serverVersion = null) => kind switch
+    {
+        SecurableKind.Table => PgFeatures.SupportsMaintain(serverVersion)
+            ?
+            [
+                PrivilegeKind.Select, PrivilegeKind.Insert, PrivilegeKind.Update, PrivilegeKind.Delete,
+                PrivilegeKind.Truncate, PrivilegeKind.References, PrivilegeKind.Trigger, PrivilegeKind.Maintain,
+            ]
+            :
+            [
+                PrivilegeKind.Select, PrivilegeKind.Insert, PrivilegeKind.Update, PrivilegeKind.Delete,
+                PrivilegeKind.Truncate, PrivilegeKind.References, PrivilegeKind.Trigger,
+            ],
+        SecurableKind.Sequence => [PrivilegeKind.Usage, PrivilegeKind.Select, PrivilegeKind.Update],
+        SecurableKind.Schema => [PrivilegeKind.Usage, PrivilegeKind.Create],
+        SecurableKind.Database => [PrivilegeKind.Connect, PrivilegeKind.Create, PrivilegeKind.Temporary],
+        SecurableKind.Function => [PrivilegeKind.Execute],
+        SecurableKind.Type => [PrivilegeKind.Usage],
+        _ => [],
+    };
+
+    /// <summary>The privileges grantable on a single column (a strict subset of the table's).</summary>
+    public static IReadOnlyList<PrivilegeKind> ForColumn() =>
+        [PrivilegeKind.Select, PrivilegeKind.Insert, PrivilegeKind.Update, PrivilegeKind.References];
+
+    /// <summary>
+    /// The <c>has_*_privilege</c> function that answers "can this role do this
+    /// to this object?" — the authoritative check, because unlike a raw ACL read
+    /// it expands role inheritance, ownership and superuser for us.
+    /// </summary>
+    public static string HasPrivilegeFunction(SecurableKind kind) => kind switch
+    {
+        SecurableKind.Table => "has_table_privilege",
+        SecurableKind.Sequence => "has_sequence_privilege",
+        SecurableKind.Schema => "has_schema_privilege",
+        SecurableKind.Database => "has_database_privilege",
+        SecurableKind.Function => "has_function_privilege",
+        SecurableKind.Type => "has_type_privilege",
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+    };
+
+    /// <summary>The catalog table an object of this class lives in, for the ACL read.</summary>
+    public static string CatalogTable(SecurableKind kind) => kind switch
+    {
+        SecurableKind.Table or SecurableKind.Sequence => "pg_catalog.pg_class",
+        SecurableKind.Schema => "pg_catalog.pg_namespace",
+        SecurableKind.Database => "pg_catalog.pg_database",
+        SecurableKind.Function => "pg_catalog.pg_proc",
+        SecurableKind.Type => "pg_catalog.pg_type",
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+    };
+}
+
+/// <summary>
+/// Server-version gates for the catalog columns and privileges that don't exist
+/// everywhere. A null version means "assume modern" — the screenshot/test
+/// fixtures have no server to ask.
+/// </summary>
+public static class PgFeatures
+{
+    /// <summary>PG16 split <c>pg_auth_members.admin_option</c> into admin/inherit/set options.</summary>
+    public static bool SupportsRoleMemberOptions(Version? v) => v is null || v.Major >= 16;
+
+    /// <summary>The MAINTAIN privilege arrived in PG17.</summary>
+    public static bool SupportsMaintain(Version? v) => v is null || v.Major >= 17;
+
+    /// <summary>The <c>pg_read_all_data</c> / <c>pg_write_all_data</c> predefined roles arrived in PG14.</summary>
+    public static bool SupportsPredefinedDataRoles(Version? v) => v is null || v.Major >= 14;
+}
+
+/// <summary>
+/// One object a privilege can be held on, carrying the OID because every
+/// <c>has_*_privilege()</c> check takes one — resolving by name would re-do the
+/// search-path dance the catalog already did for us.
+/// </summary>
+/// <param name="Arguments">
+/// A function's argument list (<c>integer, text</c>) — part of its identity, so
+/// two overloads are two securables. Null for everything else.
+/// </param>
+public sealed record SecurableRef(
+    SecurableKind Kind,
+    uint Oid,
+    string? Schema,
+    string Name,
+    string? Arguments = null)
+{
+    /// <summary>How the object is named in the UI: <c>sales.orders</c>, <c>public.f(integer)</c>.</summary>
+    public string Display =>
+        (Schema is null ? Name : $"{Schema}.{Name}")
+        + (Arguments is null ? "" : $"({Arguments})");
+
+    /// <summary>The quoted, schema-qualified name — safe to interpolate into SQL.</summary>
+    public string QuotedName =>
+        Schema is null
+            ? SqlIdentifier.QuoteIfNeeded(Name)
+            : $"{SqlIdentifier.QuoteIfNeeded(Schema)}.{SqlIdentifier.QuoteIfNeeded(Name)}";
+
+    /// <summary>
+    /// The <c>ON …</c> clause of a GRANT/REVOKE for this object, keyword
+    /// included: <c>TABLE "sales"."orders"</c>, <c>SCHEMA sales</c>,
+    /// <c>FUNCTION public.f(integer)</c>.
+    /// </summary>
+    public string GrantTarget => Kind switch
+    {
+        SecurableKind.Table => $"TABLE {QuotedName}",
+        SecurableKind.Sequence => $"SEQUENCE {QuotedName}",
+        SecurableKind.Schema => $"SCHEMA {QuotedName}",
+        SecurableKind.Database => $"DATABASE {QuotedName}",
+        SecurableKind.Function => $"FUNCTION {QuotedName}({Arguments ?? ""})",
+        SecurableKind.Type => $"TYPE {QuotedName}",
+        _ => throw new ArgumentOutOfRangeException(nameof(Kind), Kind, null),
+    };
+}
+
+/// <summary>
+/// A role as <c>pg_roles</c> describes it. Deliberately not <c>pg_authid</c> —
+/// that needs superuser and the only thing it adds is the password hash, which
+/// this app has no business reading.
+/// </summary>
+/// <param name="Settings">
+/// The <c>rolconfig</c> entries (<c>ALTER ROLE … SET x = y</c>), verbatim.
+/// </param>
+public sealed record RoleAttributes(
+    uint Oid,
+    string Name,
+    bool CanLogin,
+    bool IsSuperuser,
+    bool Inherit,
+    bool CanCreateRole,
+    bool CanCreateDb,
+    bool CanReplicate,
+    bool BypassRls,
+    int ConnectionLimit,
+    DateTimeOffset? ValidUntil,
+    IReadOnlyList<string> Settings,
+    string? Comment)
+{
+    /// <summary>A built-in <c>pg_*</c> role — listed, never offered for edit or drop.</summary>
+    public bool IsPredefined => Name.StartsWith("pg_", StringComparison.Ordinal);
+
+    /// <summary>True when the role can be connected as; the "user vs group" distinction users actually mean.</summary>
+    public bool IsUser => CanLogin;
+
+    /// <summary>Already expired — a login role nobody can log in as any more.</summary>
+    public bool IsExpired => ValidUntil is { } until && until <= DateTimeOffset.UtcNow;
+}
+
+/// <summary>
+/// One edge of the role membership graph: <paramref name="Member"/> is a member
+/// of <paramref name="Group"/>.
+/// </summary>
+/// <param name="InheritOption">
+/// Whether the member automatically holds the group's privileges. PG16 made this
+/// per-grant; on older servers it is the member's own <c>rolinherit</c>. False
+/// means the privileges exist but only after an explicit <c>SET ROLE</c> — the
+/// distinction that makes a permission look missing when it is merely dormant.
+/// </param>
+public sealed record RoleMembership(
+    string Member,
+    string Group,
+    bool AdminOption,
+    bool InheritOption,
+    bool SetOption,
+    string? Grantor);
+
+/// <summary>
+/// A node of the rendered membership tree. Built in both directions — the roles
+/// a role belongs to, and the roles that belong to it.
+/// </summary>
+/// <param name="Inherits">
+/// The <see cref="RoleMembership.InheritOption"/> of the edge that reached this
+/// node; the root's is always true.
+/// </param>
+public sealed record RoleTreeNode(string Role, bool Inherits, IReadOnlyList<RoleTreeNode> Children);
+
+/// <summary>
+/// Answers the two questions the effective-privilege resolver needs about the
+/// role graph, so the resolver can stay pure and be tested without a server.
+/// Implemented by <c>RoleGraph</c>.
+/// </summary>
+public interface IRoleMembershipLookup
+{
+    /// <summary>
+    /// Every role whose privileges <paramref name="role"/> holds automatically,
+    /// transitively, nearest first, excluding <paramref name="role"/> itself.
+    /// A <c>NOINHERIT</c> edge stops the walk — those privileges need
+    /// <c>SET ROLE</c> and must not be reported as effective.
+    /// </summary>
+    IReadOnlyList<string> InheritedGroups(string role);
+
+    /// <summary>True when the role bypasses permission checks entirely.</summary>
+    bool IsSuperuser(string role);
+}
+
+/// <summary>
+/// One <c>GRANT</c> recorded in an object's ACL, as <c>aclexplode()</c> returns
+/// it. <paramref name="Grantee"/> is null for <c>PUBLIC</c>.
+/// </summary>
+public sealed record AclEntry(
+    string? Grantee,
+    string? Grantor,
+    PrivilegeKind Privilege,
+    bool WithGrantOption)
+{
+    public bool IsPublic => Grantee is null;
+
+    /// <summary>What the UI shows in the grantee column.</summary>
+    public string GranteeLabel => Grantee ?? "PUBLIC";
+}
+
+/// <summary>
+/// An object's stored access control list.
+/// </summary>
+/// <param name="IsDefaultAcl">
+/// The catalog column was NULL, which in Postgres means "nobody has touched the
+/// privileges: the owner has everything and the built-in defaults apply" — not
+/// "no privileges". Rendering that state as an empty grid is the single most
+/// common way a permissions UI teaches the wrong thing, so it is modelled
+/// explicitly here instead of collapsing to an empty list.
+/// </param>
+public sealed record ObjectAcl(
+    SecurableRef Object,
+    string Owner,
+    bool IsDefaultAcl,
+    IReadOnlyList<AclEntry> Entries);
+
+/// <summary>Per-column grants (<c>pg_attribute.attacl</c>) on one table.</summary>
+public sealed record ColumnAcl(string Column, bool IsDefaultAcl, IReadOnlyList<AclEntry> Entries);
+
+/// <summary>
+/// One <c>pg_default_acl</c> row: what a future object created by
+/// <paramref name="OwnerRole"/> in <paramref name="Schema"/> will be granted.
+/// </summary>
+/// <param name="Schema">
+/// Null for the database-wide default. Per-schema defaults *add* to the
+/// database-wide ones and cannot subtract from them — a trap worth surfacing in
+/// the panel rather than a doc.
+/// </param>
+public sealed record DefaultPrivilege(
+    string OwnerRole,
+    string? Schema,
+    SecurableKind AppliesTo,
+    IReadOnlyList<AclEntry> Entries);
+
+/// <summary>One row-level security policy, as <c>pg_policies</c> describes it.</summary>
+/// <param name="Roles">The roles it applies to; a single "public" entry means everyone.</param>
+/// <param name="Command">ALL / SELECT / INSERT / UPDATE / DELETE.</param>
+public sealed record RlsPolicyInfo(
+    string Schema,
+    string Table,
+    string Name,
+    bool Permissive,
+    IReadOnlyList<string> Roles,
+    string Command,
+    string? Using,
+    string? WithCheck);
+
+/// <summary>
+/// A table's RLS state plus its policies. <paramref name="BypassedByCurrentRole"/>
+/// is the footgun that makes RLS "work for me but not for the app": the table
+/// owner and any BYPASSRLS role never see the policies apply, unless the table
+/// is FORCE ROW LEVEL SECURITY.
+/// </summary>
+public sealed record RlsTableState(
+    string Schema,
+    string Table,
+    bool RowSecurityEnabled,
+    bool ForceRowSecurity,
+    bool BypassedByCurrentRole,
+    IReadOnlyList<RlsPolicyInfo> Policies)
+{
+    /// <summary>Policies exist but RLS was never switched on, so none of them do anything.</summary>
+    public bool HasInertPolicies => !RowSecurityEnabled && Policies.Count > 0;
+}
+
+/// <summary>
+/// The resolved answer for one role × one privilege on one object: whether the
+/// server will allow it, and which grant explains that.
+/// </summary>
+/// <param name="Via">The intermediate role for <see cref="PrivilegeSource.Inherited"/>; null otherwise.</param>
+public sealed record EffectivePrivilege(
+    string Role,
+    PrivilegeKind Privilege,
+    bool Granted,
+    PrivilegeSource Source,
+    string? Via = null,
+    string? GrantedBy = null,
+    bool WithGrantOption = false)
+{
+    /// <summary>The one-line explanation the "why?" column and the access sentence share.</summary>
+    public string Explanation => Source switch
+    {
+        PrivilegeSource.None => "not granted",
+        PrivilegeSource.Direct => GrantedBy is { Length: > 0 } g ? $"granted directly by {g}" : "granted directly",
+        PrivilegeSource.Inherited => $"inherited from {Via}",
+        PrivilegeSource.Public => "granted to PUBLIC",
+        PrivilegeSource.Owner => "owns the object",
+        PrivilegeSource.Superuser => "superuser",
+        PrivilegeSource.Unknown => "granted, source not visible from here",
+        _ => "",
+    };
+}
+
+/// <summary>
+/// Something that stops a role being dropped — an object it owns, or a privilege
+/// it has been granted elsewhere. Listing these up front is what turns
+/// Postgres's opaque 2BP01 into an actionable dialog.
+/// </summary>
+public sealed record RoleDependency(string Kind, string Identity);

--- a/PgNimbus.Core/Security/SecurityModel.cs
+++ b/PgNimbus.Core/Security/SecurityModel.cs
@@ -405,9 +405,10 @@ public sealed record RlsPolicyInfo(
 
 /// <summary>
 /// A table's RLS state plus its policies. <paramref name="BypassedByCurrentRole"/>
-/// is the footgun that makes RLS "work for me but not for the app": the table
-/// owner and any BYPASSRLS role never see the policies apply, unless the table
-/// is FORCE ROW LEVEL SECURITY.
+/// is the footgun that makes RLS "work for me but not for the app". The two
+/// bypass routes are not symmetric: a superuser or a BYPASSRLS role skips row
+/// security always, while the table's owner skips it only while the table is
+/// not FORCE ROW LEVEL SECURITY.
 /// </summary>
 public sealed record RlsTableState(
     string Schema,

--- a/docs/design/accounts-permissions.md
+++ b/docs/design/accounts-permissions.md
@@ -1,0 +1,202 @@
+# Design: Accounts and permissions (roles, grants, RLS)
+
+Status: research / proposal · Owner: pgNimbus · Created 2026-08-23
+
+## Motivation
+
+pgNimbus today has exactly one thing in this area: a read-only `Roles` group in
+the schema tree (`SchemaService.GetRolesAsync` → `RolesGroupNode`/`RoleNode`),
+listing non-`pg_*` roles with four attribute flags. There is no way to see who
+can read a table, no way to grant anything, and no way to see why a query got
+`permission denied`.
+
+That is a real gap for the "second job" of a GUI client. Query editing is the
+first job; the second is answering *"can this app user read this table, and if
+not, why?"* — and the current answer is "go write `aclexplode` by hand".
+
+The opportunity is that the incumbents are all weak here in the **same** way:
+they render `GRANT` forms, but none of them answers the effective-permission
+question. That is where a Postgres-first tool can win, exactly like the plan
+analyzer did against pgAdmin's plain plan tree.
+
+## What the incumbents actually ship
+
+| Tool | Roles | Object grants | Effective / resolved view | Default privileges | RLS |
+|---|---|---|---|---|---|
+| **pgAdmin 4** | Full Login/Group Role dialog: General / Definition / Privileges / Membership / Parameters / Security. Also the 3-step **Grant Wizard** (objects → privileges → review SQL). | Yes, per object, plus the wizard for bulk | **No** — it shows stored ACLs, not what a role can do | Yes, a tab on Database/Schema | Yes, RLS Policy dialog |
+| **DBeaver CE** | Role node with a Permissions tab | Per-object permission grid | **No** | No | Requested in 2019 ([#5499](https://github.com/dbeaver/dbeaver/issues/5499)), not shipped as an editor |
+| **DataGrip** | Create/Modify Role dialogs, Grants pane with a "with grant option" dropdown, SQL preview | Yes, via the Grants pane | **No** | No | No |
+| **TablePlus** | Tools → User Management; database-level privileges | **"Coming soon"** placeholder for per-table privileges ([#3375](https://github.com/TablePlus/TablePlus/issues/3375), open) | No | No | No |
+| **HeidiSQL / Navicat / Beekeeper** | User manager exists but is MySQL-shaped (per-database privilege matrix); Postgres role semantics (inheritance, default ACLs, ownership) are not modeled | Partial | No | No | No |
+| **psql / scripts** | `\du`, `\dp`, `pg_permissions`, hand-written `aclexplode` queries | — | `has_*_privilege()` if you know to reach for it | `\ddp` | `pg_policies` |
+
+Everyone renders the *stored* ACL. Nobody renders the *resolved* answer.
+
+## What users complain about
+
+Grouped by how often the complaint shows up, with the underlying Postgres
+behaviour that causes it:
+
+1. **"What can this user actually do?"** Postgres has no built-in view of final
+   computed rights. `information_schema.role_table_grants` does **not** expand
+   role inheritance; `has_table_privilege()` does, but you have to know it
+   exists. Every tool shows the raw ACL, so a permission granted through a group
+   role is invisible in the UI even though it works. *(see
+   [Geeky Tidbits](https://www.geekytidbits.com/postgres-privilege-helper-queries/),
+   [Illuminated Computing](https://illuminatedcomputing.com/posts/2017/03/postgres-permissions/))*
+2. **The `GRANT ON ALL TABLES` trap.** `GRANT … ON ALL TABLES IN SCHEMA` applies
+   only to tables that exist *right now*; the next migration creates a table the
+   role cannot read. The fix is `ALTER DEFAULT PRIVILEGES`, which most tools do
+   not expose at all, and which has its own trap — per-schema defaults *add* to
+   global defaults and cannot subtract from them. *(pgsql-general threads;
+   [Cybertec](https://www.cybertec-postgresql.com/en/postgresql-alter-default-privileges-permissions-explained/),
+   [Percona](https://www.percona.com/blog/dispelling-myths-about-postgresql-default-privileges/))*
+3. **`role … cannot be dropped because some objects depend on it` (2BP01).** The
+   correct recipe is `REASSIGN OWNED BY … TO …; DROP OWNED BY …; DROP ROLE …`,
+   repeated per database, and it is not discoverable from any error message.
+   Cloud users hit this constantly. *(AWS, Azure and Neon all publish
+   knowledge-base articles for this single error —
+   [repost.aws](https://repost.aws/knowledge-center/rds-postgresql-drop-user-role),
+   [Microsoft Q&A](https://learn.microsoft.com/en-us/answers/questions/2169271/postgres-16-2bp01-role-prod-infra-dt-sp-cannot-be),
+   [PG docs 21.4](https://www.postgresql.org/docs/current/role-removal.html))*
+4. **Bulk grants are painful, and the bulk tool is buggy.** pgAdmin's Grant
+   Wizard can only grant, never revoke or edit
+   ([#7891](https://github.com/pgadmin-org/pgadmin4/issues/7891)), and granting
+   "everything in a schema" silently skips the schema's own `USAGE`
+   ([#8954](https://github.com/pgadmin-org/pgadmin4/issues/8954)) — which means
+   the user grants all the table privileges and still gets `permission denied`.
+5. **The privilege UI lies or goes blank.** DBeaver dropped `SELECT` on
+   materialized views from its permission list
+   ([#6288](https://github.com/dbeaver/dbeaver/issues/6288)); pgAdmin silently
+   turned saved privileges into `WITH GRANT OPTION`
+   ([#8369](https://github.com/pgadmin-org/pgadmin4/issues/8369)). A NULL
+   `relacl` means *"owner has everything, defaults apply"*, not *"no
+   privileges"* — tools that render it as an empty grid teach the wrong thing.
+6. **Per-table privileges are simply missing** in the fast/modern clients — the
+   TablePlus issue is literally a "coming soon" screen with a user asking to
+   stop typing `GRANT` statements by hand.
+7. **Column-level grants and RLS are invisible.** Both are Postgres-first
+   features; only pgAdmin edits RLS, nobody surfaces column ACLs well.
+8. **Non-superuser reality.** On RDS / Neon / Supabase you are not superuser,
+   `pg_authid` is unreadable, and tools that assume superuser show errors
+   instead of the (perfectly readable) `pg_roles` data.
+
+## Design principles for our version
+
+Same shape as the plan analyzer, and the same reason it worked:
+
+- **Answer the question, don't render the catalog.** The headline feature is
+  "who can do what, and through which grant" — resolved through role
+  inheritance, ownership, `PUBLIC`, and superuser, not a raw ACL dump.
+- **Every mutation is generated SQL the user can read and run.** No hidden
+  writes. Follows the existing `DdlTemplates` precedent: a `CREATE TABLE`
+  template in a tab beats a dialog that can only express what its combo box
+  lists. Grants are the same — show the `GRANT`/`REVOKE` script, let it be
+  edited, then run it.
+- **Core-pure and unit-tested where the logic is.** ACL parsing, the effective
+  matrix, the drop-role recipe are `PgNimbus.Core` siblings of `PlanAnalyzer` /
+  `BlockingTree` / `JsonTree`. No Avalonia types.
+- **UI rule 1 still applies.** Zero new toolbar buttons. Entry points are the
+  schema tree context menu and the command palette.
+- **Never let a password reach disk.** `QueryHistoryStore` and `CrashLog` both
+  persist statement text. Any `PASSWORD` literal must be redacted before it can
+  reach either, and password entry must not flow through the normal query path.
+
+## Proposed plan
+
+### v1 — read and explain (no writes)
+
+The differentiator, and the lowest-risk half.
+
+1. **`Security/RoleService`** (Core) — extend beyond `GetRolesAsync`: full role
+   detail (`rolvaliduntil`, `rolconnlimit`, `rolbypassrls`, `rolreplication`,
+   `rolinherit`, `rolconfig`), membership edges from `pg_auth_members`
+   (including `admin_option`, and `inherit_option`/`set_option` guarded by
+   server version ≥ 16), and role comments from `pg_shdescription`.
+2. **`Security/RoleGraph`** (Core-pure, unit-tested) — flattens membership into
+   an inheritance forest: direct members, transitive members, cycle-safe, with
+   the `NOINHERIT` distinction marked (member but does not inherit → must
+   `SET ROLE`). Same builder shape as `BlockingTree.Build`.
+3. **Role detail panel** — a tab in the object panel showing attributes, the
+   membership tree (both directions: "member of" / "members"), and role-level
+   `ALTER ROLE … SET` settings.
+4. **`Security/PrivilegeService` + `AclEntry`** (Core) — `aclexplode()` over
+   `pg_class`/`pg_namespace`/`pg_proc`/`pg_type`/`pg_database` plus
+   `pg_attribute.attacl` for column grants, and `pg_default_acl` for defaults.
+   NULL ACL is modeled explicitly as `DefaultAcl`, never as "empty".
+5. **Object → Permissions tab** — per table/view/schema/function: a grid of
+   grantee × privilege, with a **Source** column saying *direct*, *via role X*,
+   *PUBLIC*, *owner*, or *superuser*. This is the thing nobody else has.
+6. **"Explain access…" command** — pick a role and an object, get a plain
+   sentence: *"`app_ro` can SELECT `sales.orders` — inherited from `readers`,
+   granted by `postgres`. It cannot INSERT."* Cross-checked against
+   `has_table_privilege()` so the answer matches what the server will actually
+   do, with the `USAGE`-on-schema prerequisite called out separately (complaint
+   4 above).
+7. **Default privileges view** — `pg_default_acl` rendered per creator-role and
+   schema, with the "this does not affect existing objects / per-schema adds to
+   global" caveat stated in the panel, not in a doc.
+8. **RLS visibility** — `pg_policies` on the table's Permissions tab, plus the
+   `relrowsecurity` / `relforcerowsecurity` flags, and a warning when RLS is
+   enabled but the connected role bypasses it (owner or `BYPASSRLS`) — which is
+   the classic "it works for me, not for the app" footgun.
+
+### v2 — write, as generated SQL
+
+9. **Grant editor** — toggle a cell in the permissions grid, accumulate a
+   pending change set (the `PendingChangeSet` pattern the results grid already
+   uses), preview the `GRANT`/`REVOKE` script, apply in one transaction. Must
+   include the schema `USAGE` grant that pgAdmin forgets.
+10. **Bulk grant across a schema** — grant to all tables/sequences/functions,
+    *and* offer the matching `ALTER DEFAULT PRIVILEGES` in the same generated
+    script, since that is the only correct answer to "give this role read access
+    to this schema".
+11. **Create / alter role** — name, login, password, `VALID UNTIL`,
+    `CONNECTION LIMIT`, memberships. Password handling: never interpolated into
+    history-visible text; redacted in query history and the crash log; the
+    generated-SQL preview shows `PASSWORD '••••'` while the executed statement
+    carries the real value. Offer the predefined roles (`pg_read_all_data`,
+    `pg_write_all_data`, `pg_monitor`) as one-click memberships, since that is
+    now the sane answer to "make a read-only user".
+12. **Drop role, done properly** — detect 2BP01 up front by listing what the
+    role owns and what it has been granted, then offer the real recipe
+    (`REASSIGN OWNED BY … TO …` → `DROP OWNED BY …` → `DROP ROLE …`) as an
+    editable script, with the "run it in every database" caveat surfaced. This
+    alone answers the single most-searched Postgres role error.
+
+### Out of scope (stated so it is not re-litigated)
+
+- `pg_hba.conf` editing — needs filesystem access to the server; wrong tool.
+- Password *policies*, expiry alerts, rotation workflows — DBA-suite territory.
+- Reading `pg_authid` (password hashes) — superuser-only and pointless here.
+- Cluster-wide role sync across databases — we hold one connection.
+- Our own app-level user management (DBeaver Team Edition's model). pgNimbus
+  manages *Postgres* accounts; it does not have accounts of its own.
+
+## Landmines
+
+- **Server version.** `pg_auth_members.inherit_option`/`set_option` are PG16+;
+  `rolbypassrls` is PG9.5+; predefined roles `pg_read_all_data` /
+  `pg_write_all_data` are PG14+. Every catalog query needs a version guard or a
+  fallback column list.
+- **Not superuser.** `pg_roles` is world-readable, `pg_authid` is not.
+  `pg_default_acl`, `pg_policies`, `pg_class.relacl` are all readable by
+  ordinary roles. Nothing in v1 needs superuser — keep it that way, and let
+  v2's writes fail with the server's own error rather than a pre-flight check
+  that guesses wrong on RDS.
+- **NULL ACL ≠ no privileges.** Model it as a distinct state or repeat
+  complaint 5.
+- **`has_table_privilege` on a dropped or invisible object throws** rather than
+  returning false; wrap per-object lookups so one bad row does not fail the
+  grid (same discipline as `QueryEngine.ReadValue`).
+- **Passwords in history.** `QueryHistoryStore` writes SQL to disk in the clear.
+  Redaction must live in Core, next to the statement inspector, and be
+  unit-tested — not bolted onto one call site in the App.
+
+## Suggested first PR
+
+v1 items 1, 2, 3 — `RoleService` + `RoleGraph` + the role detail panel. Purely
+additive, no writes, testable without a privileged server, and it makes the
+existing dead-end `Roles` node worth expanding. Items 4–6 (the effective
+permission matrix) are the actual differentiator and should follow immediately
+as the second PR.

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -79,6 +79,7 @@ way in Preferences → Hotkey scheme.
 | Preview a table (in the schema tree) | Double-click | Double-click |
 | Server activity | Ctrl+Shift+M | Cmd+Shift+M |
 | Database overview | Ctrl+Shift+G | Cmd+Shift+G |
+| Roles and permissions | Ctrl+Shift+U | Cmd+Shift+U |
 | Switch connection… | Ctrl+Shift+O | Cmd+Shift+O |
 | Open connection in new window… | Ctrl+Shift+N | Cmd+Shift+N |
 | Preferences… | Ctrl+, | Cmd+, |

--- a/tools/Screenshot/Fixtures.cs
+++ b/tools/Screenshot/Fixtures.cs
@@ -6,6 +6,7 @@ using PgNimbus.Core.Monitoring;
 using PgNimbus.Core.Notifications;
 using PgNimbus.Core.Query;
 using PgNimbus.Core.Schema;
+using PgNimbus.Core.Security;
 
 namespace PgNimbus.Screenshot;
 
@@ -57,6 +58,9 @@ public static class Fixtures
             new NotifyMonitorViewModel(new NotificationListener(dataSource)),
             new ActivityService(dataSource),
             new DatabaseStatsService(dataSource),
+            new RoleService(dataSource),
+            new PrivilegeService(dataSource),
+            new SecurityEditor(dataSource),
             new ImportService(dataSource),
             connectionHost: "localhost",
             connectionDatabase: "shop");


### PR DESCRIPTION
## What and why

The engine and the SQL generation behind **roles, grants, default privileges and RLS** — the 0.11 headline feature. Research, competitive landscape and the full plan are in [`docs/design/accounts-permissions.md`](docs/design/accounts-permissions.md).

The gap this closes: every incumbent client renders an object's **stored ACL**, and a stored ACL omits everything a role reaches through group membership, ownership or PUBLIC. So a permission that works looks missing, and "what can this role actually do?" has no answer in pgAdmin, DBeaver, DataGrip or TablePlus. `EffectivePrivilegeResolver` answers it and attributes each answer to a source (direct / inherited-via-X / PUBLIC / owner / superuser), reconciled against `has_*_privilege()` — which the server evaluates with inheritance and ownership already expanded, so it is ground truth rather than another guess. A yes the catalog cannot explain is reported as `Unknown`, not dressed up.

What landed here:

- **`SecurityModel`** — the shared contract. Two decisions worth a reviewer's eye: `ObjectAcl.IsDefaultAcl` models a NULL catalog ACL as its own state (in Postgres that means "untouched: owner has everything, defaults apply", not "no privileges" — rendering it as an empty grid is how a permissions UI teaches the wrong thing), and `PrivilegeSource` carries the *why*.
- **`RoleService` + `RoleGraph`** — attributes, membership, and what blocks a `DROP ROLE`. Every read is runnable by a non-superuser: `pg_roles`, never `pg_authid`. `NOINHERIT` memberships appear in the tree but never in `InheritedGroups`, because claiming a privilege the server will refuse is worse than showing none. Membership reads are two SQL texts, since PG16 split `admin_option` into admin/inherit/set and naming a missing column is a parse error, not a NULL.
- **`PrivilegeService` + `EffectivePrivilegeResolver`** — ACLs, column ACLs, `pg_default_acl`, `pg_policy`, and the effective matrix.
- **`GrantScriptBuilder` + `RoleScriptBuilder` + `SecretRedactor`** — nothing applies anything; changes leave as a script the user reads and runs, following the `DdlTemplates` precedent. `BuildBulk` is deliberately more correct than pgAdmin's Grant Wizard on three counts users report against it ([#8954](https://github.com/pgadmin-org/pgadmin4/issues/8954) — it emits `GRANT USAGE ON SCHEMA` first; [#7891](https://github.com/pgadmin-org/pgadmin4/issues/7891) — revoke is a preset; and it offers the matching `ALTER DEFAULT PRIVILEGES`, naming the creating role). `RoleScriptBuilder.Drop` emits the full `REASSIGN OWNED` → `DROP OWNED` → `DROP ROLE` recipe with the "current database only" caveat, which is the answer to the most-searched Postgres role error.
- **`SecurityWindow`** — the shell, in the shape of `DatabaseOverviewWindow`: one live instance, opened from the palette (Ctrl/Cmd+Shift+U), no toolbar button. A window rather than an `OverlayPanel` because it is read beside the editor while a grant is being fixed.

**Two bugs caught only by running the SQL against a live server**, both of which would have shipped:

1. `GetAclAsync` wrapped a NULL ACL in `COALESCE(…, ARRAY[]::aclitem[])` before `aclexplode`. An empty array literal is *zero*-dimensional and `aclexplode` rejects it — so **every object nobody had ever run a GRANT on**, the common case, failed with `ACL arrays must be one-dimensional` instead of reporting default privileges. The COALESCE guarded against a strictness `aclexplode` does not have (`proisstrict = t`; NULL already yields no rows and the outer join supplies the placeholder).
2. The RLS bypass check treated superuser/BYPASSRLS and ownership symmetrically. They are not: the first bypasses row security **always**, the second only while the table is not `FORCE ROW LEVEL SECURITY`.

`SecurityCatalogTests` now exercises every catalog query against a live Postgres, gated on `PGNIMBUS_TEST_CONN`. The pure halves had tests from the start; the SQL had none, which is how bug 1 survived.

Password handling: `SecurityEditor` is the only execution path for a statement carrying a `PASSWORD` literal (Postgres has no parameter form, so it must be interpolated, and a query tab would put it on screen and in the on-disk history). The role editor's preview is always masked. `SecretRedactor` runs at `SavedQueriesViewModel.RecordExecution`, the single choke point into `QueryHistoryStore`, so a password typed by hand into the editor is caught too.

## Still in flight

**The four tabs are empty stubs.** `SecurityViewModel` composes them behind `ISecuritySection` and the window renders, but Roles / Permissions / Default privileges / Row-level security have no content yet — that work is in progress and will be pushed to this branch. Draft until then.

## Verified

- [x] `dotnet build PgNimbus.slnx` — clean, 0 errors, no new warnings
- [x] `dotnet test --project PgNimbus.Core.Tests/PgNimbus.Core.Tests.csproj` — 763 tests, 748 passed, 15 skipped
      — against a live Postgres? **yes** — `postgres:17`, and the 6 new `SecurityCatalogTests` pass against it (they skip cleanly without one)
- [x] `dotnet test --project PgNimbus.App.Tests/PgNimbus.App.Tests.csproj` — 33/33
- [ ] NativeAOT publish — **not run.** `dotnet build` runs the trim/AOT analyzers (`EnableTrimAnalyzer`/`EnableAotAnalyzer`) and is at zero warnings, but a real publish was not done.
- [ ] Baselines refreshed — **not done, and one will need it.** The new palette entry changes what `main-window-palette` renders. Deferred deliberately: the tabs land next and would invalidate a refresh done now.
- [ ] `update-published.sh` — not applicable yet

Beyond the automated suites, every generated SQL shape was executed against the live server by hand: all four bulk presets, `ALTER DEFAULT PRIVILEGES`, column grants, and the `REASSIGN OWNED` / `DROP OWNED` / `DROP ROLE` recipe.

Anything left unverified: the window has not been opened in a running app — no tab has content to look at yet.

## Screenshots

None — no tab renders anything yet.

## Checklist

- [ ] [CLAUDE.md](../CLAUDE.md) updated — **not yet**, deliberately. It documents shipped behaviour, and the feature is half-built; it lands with the tabs.
- [x] Touches `shared/nimbusUi`? No.
- [x] Nothing here is general enough for kubeNimbus — it is all Postgres role/ACL semantics.
- [ ] No UI state renders as a blank rectangle — **currently violated by construction**: the four tabs are blank. Resolved by the tab work, and each tab's empty state is called out in its brief.
- [x] `PgNimbus.Core` still has zero UI dependencies
- [x] No credentials persisted anywhere they weren't already — and `SecretRedactor` removes one path that already existed
