### PR TITLE
Roles and permissions: the four tabs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,51 @@ Three rules about it:
    whole script failed at the second one ("syntax error at or near SET"). The design
    doc + competitive research is in
    [`docs/design/explain-improvements.md`](docs/design/explain-improvements.md).
+7. **Permissions are answered, not dumped — and never applied behind the user's
+   back.** `PgNimbus.Core/Security/` reads roles and ACLs, but the headline is
+   that it answers *"can this role do this, and why?"* rather than rendering
+   what the catalog stores. pgAdmin, DBeaver, DataGrip and TablePlus all render
+   the stored ACL, which omits everything a role reaches through group
+   membership, ownership or PUBLIC — so a permission that works looks missing.
+   `PrivilegeService.GetServerAnswersAsync` asks the server itself through
+   `has_*_privilege()` (which expands inheritance, ownership and superuser
+   server-side, so it is ground truth), and the Core-pure, unit-tested
+   `EffectivePrivilegeResolver` — a sibling of `PlanAnalyzer`/`BlockingTree` —
+   attributes each answer to a `PrivilegeSource` (direct / inherited-via-X /
+   PUBLIC / owner / superuser) and reconciles against the server, which always
+   wins: a yes the catalog cannot explain is reported `Unknown`, never dressed
+   up as a direct grant. `RoleGraph` is the other pure half; its load-bearing
+   rule is that a `NOINHERIT` membership shows in the tree but never counts as
+   inherited, because claiming a privilege the server will refuse is worse than
+   showing none.
+   **Three landmines, all found the hard way.** `ObjectAcl.IsDefaultAcl` models
+   a NULL catalog ACL as its own state — in Postgres that means "untouched: the
+   owner has everything and the built-in defaults apply", not "no privileges",
+   and rendering it as an empty grid is how a permissions UI teaches the wrong
+   thing. `aclexplode` is *strict*, so a NULL ACL must be passed to it as-is;
+   "defending" that with `COALESCE(acl, ARRAY[]::aclitem[])` fails every
+   untouched object with `ACL arrays must be one-dimensional`, because an empty
+   array literal is zero-dimensional. And `Privileges.For` must be given the
+   real server version — asking a pre-PG17 server about `MAINTAIN` raises
+   `unrecognized privilege type` and takes the whole matrix down.
+   **Nothing writes from the window.** Every privilege change leaves as a script
+   in a new editor tab (`MainViewModel.OpenGeneratedSql`), following the
+   `DdlTemplates` precedent. The single exception is a statement carrying a
+   `PASSWORD` literal: Postgres has no parameter form for one, so it would land
+   on screen and in the on-disk query history — those run through
+   `SecurityEditor` instead, are never shown, and `SecretRedactor` guards
+   `SavedQueriesViewModel.RecordExecution`, the one choke point into
+   `QueryHistoryStore`, for the case where a user types one by hand.
+   `GrantScriptBuilder.BuildBulk` is deliberately more correct than pgAdmin's
+   Grant Wizard: `GRANT USAGE ON SCHEMA` comes first (theirs skips it and the
+   user still gets `permission denied`), revoke is a preset rather than an
+   impossibility, and the matching `ALTER DEFAULT PRIVILEGES` is offered with
+   the creating role named, since one set for the wrong creator silently does
+   nothing. `RoleScriptBuilder.Drop` emits the whole `REASSIGN OWNED` →
+   `DROP OWNED` → `DROP ROLE` recipe with its "current database only" caveat —
+   the answer to 2BP01, which Postgres reports without naming either the
+   blocking objects or the fix. The research and the plan are in
+   [`docs/design/accounts-permissions.md`](docs/design/accounts-permissions.md).
 
 ## UI design rules
 

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -446,6 +446,7 @@ public sealed partial class MainViewModel : ObservableObject
         // Every privilege change leaves the security window as a script in a new
         // editor tab rather than being applied from there - see OpenGeneratedSql.
         Security.OpenSqlInNewTab = (title, sql) => OpenGeneratedSql(title, sql);
+        Security.RolesChanged = SchemaTree.RefreshRolesAsync;
         Importer = importService;
         AccentColor = accentColor;
 

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -227,6 +227,22 @@ public sealed partial class MainViewModel : ObservableObject
     [RelayCommand]
     private void ShowSecurity() => SecurityRequested?.Invoke();
 
+    /// <summary>
+    /// The schema tree's route into the Roles &amp; Permissions window, on a
+    /// named role when the user right-clicked one. The name is parked on the
+    /// view model rather than passed to the window, because the window may be
+    /// opening for the first time (its snapshot has not been read yet) or may
+    /// already be up (nothing will refresh) - so both paths have to pick it up,
+    /// and ApplyPendingRoleSelection covers the second.
+    /// </summary>
+    private Task ManageRolesAsync(string? role)
+    {
+        Security.PendingRoleSelection = role;
+        SecurityRequested?.Invoke();
+        Security.ApplyPendingRoleSelection();
+        return Task.CompletedTask;
+    }
+
     // Relations rarely change mid-session, so the palette's "jump to a table"
     // list is fetched once and reused across opens.
     private IReadOnlyList<RelationInfo>? _relationCache;
@@ -402,6 +418,7 @@ public sealed partial class MainViewModel : ObservableObject
         SchemaTree.NewTableRequested = NewTableAsync;
         SchemaTree.DropSchemaRequested = DropSchemaAsync;
         SchemaTree.SetSchemaExcludedFromCompletionRequested = SetSchemaExcludedFromCompletionAsync;
+        SchemaTree.ManageRolesRequested = ManageRolesAsync;
         SchemaTree.IsSchemaExcludedFromCompletion = _excludedSchemas.Contains;
         _schemaService = schemaService;
         _schemaEditor = schemaEditor;

--- a/PgNimbus.App/ViewModels/SchemaTreeNode.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeNode.cs
@@ -11,6 +11,13 @@ public abstract partial class SchemaTreeNode : ObservableObject
 {
     private bool _loaded;
 
+    /// <summary>
+    /// True once this node's children have actually been fetched. Lets a caller
+    /// refresh a node it knows the user has opened without forcing a catalog
+    /// read for one they never expanded.
+    /// </summary>
+    public bool IsLoaded => _loaded;
+
     [ObservableProperty]
     private bool _isExpanded;
 

--- a/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
@@ -112,6 +112,17 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
     public Func<string?, Task>? ManageRolesRequested { get; set; }
 
     /// <summary>
+    /// Reloads the sidebar's Roles group after a role was created, altered or
+    /// dropped elsewhere, so the tree does not keep showing a role that no
+    /// longer exists. Only touches that one node — a full catalog refresh would
+    /// collapse the tree the user is working in.
+    /// </summary>
+    public Task RefreshRolesAsync() =>
+        Schemas.OfType<RolesGroupNode>().FirstOrDefault() is { IsLoaded: true } roles
+            ? roles.RefreshAsync()
+            : Task.CompletedTask;
+
+    /// <summary>
     /// Whether a schema name is currently excluded from completion. Consulted
     /// when <see cref="RefreshAsync"/> rebuilds the nodes, so a refresh (or a
     /// reconnect) doesn't lose the markers the host persisted.

--- a/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
+++ b/PgNimbus.App/ViewModels/SchemaTreeViewModel.cs
@@ -104,6 +104,14 @@ public sealed partial class SchemaTreeViewModel : ObservableObject
     public Func<SchemaNode, bool, Task>? SetSchemaExcludedFromCompletionRequested { get; set; }
 
     /// <summary>
+    /// Opens the Roles &amp; Permissions window, optionally on a named role.
+    /// The tree lists roles but can only ever show their headline attributes;
+    /// the window is where "what can this role actually do" gets answered, so
+    /// the node is a route to it rather than a dead end.
+    /// </summary>
+    public Func<string?, Task>? ManageRolesRequested { get; set; }
+
+    /// <summary>
     /// Whether a schema name is currently excluded from completion. Consulted
     /// when <see cref="RefreshAsync"/> rebuilds the nodes, so a refresh (or a
     /// reconnect) doesn't lose the markers the host persisted.

--- a/PgNimbus.App/ViewModels/Security/BulkGrantViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/BulkGrantViewModel.cs
@@ -1,0 +1,123 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.App.ViewModels.Security;
+
+/// <summary>One entry of the preset combo: the enum value plus the words a person reads.</summary>
+public sealed record BulkGrantPresetOption(BulkGrantPreset Preset, string Label, string Description);
+
+/// <summary>
+/// Backs the bulk-grant dialog — "give this role access to a whole schema",
+/// which is the request behind most hand-written GRANT scripts.
+///
+/// It composes a <see cref="BulkGrantRequest"/> and re-renders
+/// <see cref="Script"/> on every edit. It never executes anything: the dialog's
+/// affirmative hands the script to the editor, following the rule that every
+/// privilege change in this feature is SQL the user reads first.
+/// </summary>
+public sealed partial class BulkGrantViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string? _schema;
+
+    [ObservableProperty]
+    private string? _grantee;
+
+    [ObservableProperty]
+    private BulkGrantPresetOption? _preset;
+
+    [ObservableProperty]
+    private bool _includeFutureObjects = true;
+
+    [ObservableProperty]
+    private string? _futureObjectsOwner;
+
+    [ObservableProperty]
+    private string _script = "";
+
+    public BulkGrantViewModel(
+        IEnumerable<string> schemas,
+        IEnumerable<string> roles,
+        string? initialSchema,
+        string? currentRole)
+    {
+        Schemas = [.. schemas];
+        Grantees = [.. roles];
+
+        // The creator list is the same set of roles: default privileges are keyed
+        // to whoever CREATES an object, which in practice is the role migrations
+        // connect as — most often the one connected right now.
+        CreatorRoles = [.. roles];
+
+        Presets =
+        [
+            new(BulkGrantPreset.ReadOnly, "Read only",
+                "SELECT on every table and view, plus USAGE and SELECT on sequences."),
+            new(BulkGrantPreset.ReadWrite, "Read and write",
+                "SELECT, INSERT, UPDATE and DELETE on tables, plus USAGE, SELECT and UPDATE on sequences."),
+            new(BulkGrantPreset.Full, "Everything in the schema",
+                "ALL PRIVILEGES on tables, sequences and functions, plus CREATE on the schema itself."),
+            new(BulkGrantPreset.RevokeAll, "Revoke everything",
+                "REVOKE ALL on tables, sequences, functions and the schema — and on default privileges too."),
+        ];
+
+        _schema = initialSchema is not null && Schemas.Contains(initialSchema) ? initialSchema : Schemas.FirstOrDefault();
+        _preset = Presets[0];
+        _futureObjectsOwner = currentRole is not null && CreatorRoles.Contains(currentRole)
+            ? currentRole
+            : CreatorRoles.FirstOrDefault();
+
+        Rebuild();
+    }
+
+    public ObservableCollection<string> Schemas { get; }
+
+    public ObservableCollection<string> Grantees { get; }
+
+    public ObservableCollection<string> CreatorRoles { get; }
+
+    public IReadOnlyList<BulkGrantPresetOption> Presets { get; }
+
+    public string PresetDescription => Preset?.Description ?? "";
+
+    /// <summary>A script with no schema or no grantee names nothing — the button stays off.</summary>
+    public bool CanOpen => Schema is { Length: > 0 } && Grantee is { Length: > 0 } && Script.Length > 0;
+
+    /// <summary>The tab title the generated script gets in the editor.</summary>
+    public string ScriptTitle => $"grants · {Schema}";
+
+    partial void OnSchemaChanged(string? value) => Rebuild();
+
+    partial void OnGranteeChanged(string? value) => Rebuild();
+
+    partial void OnPresetChanged(BulkGrantPresetOption? value)
+    {
+        OnPropertyChanged(nameof(PresetDescription));
+        Rebuild();
+    }
+
+    partial void OnIncludeFutureObjectsChanged(bool value) => Rebuild();
+
+    partial void OnFutureObjectsOwnerChanged(string? value) => Rebuild();
+
+    private void Rebuild()
+    {
+        if (Schema is not { Length: > 0 } schema || Preset is not { } preset)
+        {
+            Script = "";
+            OnPropertyChanged(nameof(CanOpen));
+            return;
+        }
+
+        Script = GrantScriptBuilder.BuildBulk(new BulkGrantRequest(
+            schema,
+            Grantee,
+            preset.Preset,
+            IncludeFutureObjects,
+            IncludeFutureObjects ? FutureObjectsOwner : null));
+
+        OnPropertyChanged(nameof(CanOpen));
+        OnPropertyChanged(nameof(ScriptTitle));
+    }
+}

--- a/PgNimbus.App/ViewModels/Security/DefaultPrivilegesTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/DefaultPrivilegesTabViewModel.cs
@@ -1,13 +1,135 @@
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core.Query;
 using PgNimbus.Core.Security;
 
 namespace PgNimbus.App.ViewModels.Security;
 
-/// <summary>pg_default_acl: what a future object created by a given role will already be granted.</summary>
+/// <summary>
+/// One row of the default-privileges grid: a single grantee's share of one
+/// <c>pg_default_acl</c> entry, which is exactly one
+/// <c>ALTER DEFAULT PRIVILEGES</c> statement.
+///
+/// <para>The catalog groups by (creator, schema, object class) and can carry
+/// several grantees under one key, so the rows are flattened per grantee — and
+/// per grant-option, because <c>WITH GRANT OPTION</c> is a property of the
+/// statement, not a footnote on a privilege. Two rows that differ only in it
+/// really are two statements.</para>
+/// </summary>
+public sealed record DefaultPrivilegeRow(
+    string OwnerRole,
+    string? Schema,
+    SecurableKind AppliesTo,
+    string? Grantee,
+    bool WithGrantOption,
+    IReadOnlyList<PrivilegeKind> GrantedPrivileges)
+{
+    /// <summary>
+    /// Null means <c>defaclnamespace = 0</c>: the database-wide default, which
+    /// applies wherever the creating role puts the object. Said in words rather
+    /// than left as an empty cell, since a blank there reads as "unknown".
+    /// </summary>
+    public string SchemaLabel => Schema ?? "(all schemas)";
+
+    public string AppliesToLabel => AppliesTo switch
+    {
+        SecurableKind.Table => "Tables",
+        SecurableKind.Sequence => "Sequences",
+        SecurableKind.Function => "Functions",
+        SecurableKind.Type => "Types",
+        SecurableKind.Schema => "Schemas",
+        _ => AppliesTo.ToString(),
+    };
+
+    /// <summary>The <c>ON …</c> keyword of the statement — plural, unlike <c>GRANT</c>'s.</summary>
+    public string ObjectClassKeyword => AppliesTo switch
+    {
+        SecurableKind.Table => "TABLES",
+        SecurableKind.Sequence => "SEQUENCES",
+        SecurableKind.Function => "FUNCTIONS",
+        SecurableKind.Type => "TYPES",
+        SecurableKind.Schema => "SCHEMAS",
+        _ => AppliesTo.ToString().ToUpperInvariant(),
+    };
+
+    public string GranteeLabel => Grantee ?? GrantScriptBuilder.PublicGrantee;
+
+    /// <summary>
+    /// What makes this the same row across a re-read. Record equality is no use
+    /// here: the synthesized comparison reaches the privilege list, which is a
+    /// fresh <c>List</c> every refresh and compares by reference.
+    /// </summary>
+    public string Identity =>
+        $"{OwnerRole}{Schema}{AppliesTo}{Grantee}{WithGrantOption}";
+
+    public string PrivilegesText => string.Join(", ", GrantedPrivileges.Select(Privileges.Sql));
+
+    /// <summary>Shown beside the privilege list rather than folded into it — it changes the statement.</summary>
+    public string GrantOptionNote => WithGrantOption ? "WITH GRANT OPTION" : "";
+
+    /// <summary>The tab title for <see cref="Sql"/>, in the app's "subject · what" shape.</summary>
+    public string TabTitle => $"{OwnerRole} · default privileges";
+
+    /// <summary>
+    /// The statement this row represents, ready to be edited into a REVOKE or
+    /// re-pointed at another creating role. The two comment lines are the two
+    /// things people get wrong about default privileges, kept with the SQL
+    /// because that is where they will be read.
+    /// </summary>
+    public string Sql
+    {
+        get
+        {
+            var owner = SqlIdentifier.QuoteIfNeeded(OwnerRole);
+            var scope = Schema is null ? "" : $" IN SCHEMA {SqlIdentifier.QuoteIfNeeded(Schema)}";
+            var grantee = Grantee is null
+                ? GrantScriptBuilder.PublicGrantee
+                : SqlIdentifier.QuoteIfNeeded(Grantee);
+            var option = WithGrantOption ? " WITH GRANT OPTION" : "";
+
+            var where = Schema is null ? "in any schema" : $"in schema {Schema}";
+            return $"""
+                -- Applies to {ObjectClassKeyword.ToLowerInvariant()} created from now on by {OwnerRole} {where}.
+                -- Objects that already exist are untouched: those need
+                -- GRANT … ON ALL {ObjectClassKeyword} IN SCHEMA …, which this does not replace.
+                --
+                -- The key is the CREATING role, not the schema. Pointed at the wrong creator
+                -- this statement runs fine and does nothing.
+                ALTER DEFAULT PRIVILEGES FOR ROLE {owner}{scope}
+                    GRANT {PrivilegesText} ON {ObjectClassKeyword} TO {grantee}{option};
+                """;
+        }
+    }
+}
+
+/// <summary>
+/// pg_default_acl: what a future object created by a given role will already be
+/// granted.
+///
+/// <para>Nearly a pure explanation tab, and deliberately so. Almost no client
+/// surfaces <c>pg_default_acl</c> at all, and a grid on its own would not say
+/// either of the things people actually get wrong — that these do not touch
+/// objects that already exist, and that they key off the role that *creates* an
+/// object rather than the schema it lands in. Both live under the grid, in the
+/// note idiom the Database Overview uses for its unused-index caveat.</para>
+/// </summary>
 public sealed partial class DefaultPrivilegesTabViewModel : ObservableObject, ISecuritySection
 {
     private readonly PrivilegeService _privileges;
     private readonly SecurityViewModel _host;
+
+    /// <summary>
+    /// False when nothing is configured, which is a state worth spelling out
+    /// rather than rendering as an empty grid — the built-in defaults still
+    /// apply, and they are not "nothing".
+    /// </summary>
+    [ObservableProperty]
+    private bool _hasRows;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(CopySelectedAsSqlCommand))]
+    private DefaultPrivilegeRow? _selectedRow;
 
     public DefaultPrivilegesTabViewModel(PrivilegeService privileges, SecurityViewModel host)
     {
@@ -15,5 +137,111 @@ public sealed partial class DefaultPrivilegesTabViewModel : ObservableObject, IS
         _host = host;
     }
 
-    public Task RefreshAsync(CancellationToken ct) => Task.CompletedTask;
+    public ObservableCollection<DefaultPrivilegeRow> Rows { get; } = [];
+
+    public async Task RefreshAsync(CancellationToken ct)
+    {
+        try
+        {
+            var defaults = await _privileges.GetDefaultPrivilegesAsync(ct);
+
+            var selected = SelectedRow;
+            Rows.Clear();
+            foreach (var row in Flatten(defaults))
+            {
+                Rows.Add(row);
+            }
+
+            HasRows = Rows.Count > 0;
+
+            // The selection survives a Refresh when the row still exists.
+            SelectedRow = selected is null
+                ? null
+                : Rows.FirstOrDefault(r => r.Identity == selected.Identity);
+        }
+        catch (OperationCanceledException)
+        {
+            // A superseded snapshot — not an error worth surfacing.
+        }
+        catch (Exception ex)
+        {
+            _host.ReportError("Default privileges", ex);
+        }
+    }
+
+    /// <summary>
+    /// One row per (creator, schema, object class, grantee, grant option),
+    /// ordered creator-then-schema so the shape of a role's setup reads down the
+    /// grid instead of being scattered through it. The database-wide default
+    /// sorts above the per-schema ones because that is the order they apply in:
+    /// per-schema defaults *add* to it and cannot subtract from it.
+    /// </summary>
+    private static IEnumerable<DefaultPrivilegeRow> Flatten(IReadOnlyList<DefaultPrivilege> defaults) =>
+        defaults
+            .SelectMany(d => d.Entries
+                .GroupBy(e => (e.Grantee, e.WithGrantOption))
+                .Select(g => new DefaultPrivilegeRow(
+                    d.OwnerRole,
+                    d.Schema,
+                    d.AppliesTo,
+                    g.Key.Grantee,
+                    g.Key.WithGrantOption,
+                    SortPrivileges(g.Select(e => e.Privilege), d.AppliesTo))))
+            .OrderBy(r => r.OwnerRole, StringComparer.Ordinal)
+            .ThenBy(r => r.Schema is not null)
+            .ThenBy(r => r.Schema ?? "", StringComparer.Ordinal)
+            .ThenBy(r => r.AppliesToLabel, StringComparer.Ordinal)
+            .ThenBy(r => r.GranteeLabel, StringComparer.Ordinal)
+            .ThenBy(r => r.WithGrantOption);
+
+    /// <summary>
+    /// Privileges in <see cref="Privileges.For"/> order — the order the
+    /// permissions matrix shows its columns in — so the generated statement and
+    /// the grid agree with the rest of the window. Anything outside that list
+    /// sorts last rather than disappearing.
+    /// </summary>
+    private static IReadOnlyList<PrivilegeKind> SortPrivileges(
+        IEnumerable<PrivilegeKind> privileges,
+        SecurableKind kind)
+    {
+        var order = Privileges.For(kind);
+        return privileges
+            .Distinct()
+            .OrderBy(p => IndexOf(order, p) is var i && i >= 0 ? i : int.MaxValue)
+            .ThenBy(p => (int)p)
+            .ToList();
+    }
+
+    /// <summary>Position of <paramref name="privilege"/> in <paramref name="order"/>, or -1.</summary>
+    private static int IndexOf(IReadOnlyList<PrivilegeKind> order, PrivilegeKind privilege)
+    {
+        for (var i = 0; i < order.Count; i++)
+        {
+            if (order[i] == privilege)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Hands the selected row's statement to the editor, in a new tab (never the
+    /// active one), where it can be turned into a REVOKE or aimed at a different
+    /// creating role. Null-checked because the screenshot harness has no main
+    /// window to open a tab in.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanCopySelectedAsSql))]
+    private void CopySelectedAsSql()
+    {
+        if (SelectedRow is not { } row)
+        {
+            return;
+        }
+
+        _host.OpenSqlInNewTab?.Invoke(row.TabTitle, row.Sql);
+    }
+
+    private bool CanCopySelectedAsSql() => SelectedRow is not null;
 }

--- a/PgNimbus.App/ViewModels/Security/PermissionsTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/PermissionsTabViewModel.cs
@@ -154,8 +154,9 @@ public sealed partial class PermissionsTabViewModel : ObservableObject, ISecurit
     private readonly List<SecurableRef> _allObjects = [];
     private readonly List<PrivilegeChange> _pending = [];
 
-    // Set only by SeedForHarness, so seeding a snapshot cannot kick off the
-    // catalog reads the property setters normally trigger.
+    // Set while this view model is driving its own loads - by SeedForHarness,
+    // and by RefreshAsync - so the property setters do not start a second,
+    // overlapping read of what is already being fetched.
     private bool _suppressLoads;
 
     [ObservableProperty]
@@ -244,23 +245,44 @@ public sealed partial class PermissionsTabViewModel : ObservableObject, ISecurit
         $"No GRANT or REVOKE has ever been run on this object. {OwnerLabel} owns it and holds every privilege; "
         + "everyone else has only what Postgres grants by default for this object type.";
 
+    /// <summary>
+    /// Re-reads schemas, objects and the matrix. The matrix reload is driven
+    /// explicitly rather than left to the property setters, because the setters
+    /// only fire on a *change*: a refresh rebuilds the object list into equal
+    /// <see cref="SecurableRef"/> records, so re-selecting the same object is a
+    /// no-op and nothing would reload. That is what left a role created in this
+    /// window missing from the matrix until Refresh was pressed a second time.
+    /// The loads the setters would have started are suppressed for the same
+    /// reason, so this is one reload rather than two.
+    /// </summary>
     public async Task RefreshAsync(CancellationToken ct)
     {
         try
         {
             var schemas = await _privileges.GetSecurablesAsync(SecurableKind.Schema, null, ct);
             var previous = SelectedSchema;
-            Schemas.Clear();
-            foreach (var schema in schemas)
+
+            _suppressLoads = true;
+            try
             {
-                Schemas.Add(schema.Name);
+                Schemas.Clear();
+                foreach (var schema in schemas)
+                {
+                    Schemas.Add(schema.Name);
+                }
+
+                SelectedSchema = previous is not null && Schemas.Contains(previous)
+                    ? previous
+                    : Schemas.FirstOrDefault();
+
+                await LoadObjectsAsync(ct);
+            }
+            finally
+            {
+                _suppressLoads = false;
             }
 
-            SelectedSchema = previous is not null && Schemas.Contains(previous)
-                ? previous
-                : Schemas.FirstOrDefault();
-
-            await LoadObjectsAsync(ct);
+            await LoadMatrixAsync(ct);
         }
         catch (OperationCanceledException)
         {

--- a/PgNimbus.App/ViewModels/Security/PermissionsTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/PermissionsTabViewModel.cs
@@ -1,13 +1,195 @@
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using PgNimbus.Core.Security;
 
 namespace PgNimbus.App.ViewModels.Security;
 
-/// <summary>Pick an object, see which role can do what to it -- and which grant explains that.</summary>
+/// <summary>One column of the matrix: a privilege, and the header text for it.</summary>
+public sealed record PrivilegeColumn(PrivilegeKind Privilege, string Header);
+
+/// <summary>
+/// One cell: whether the role holds the privilege, and — the part no other
+/// client shows — which grant explains that.
+/// </summary>
+public sealed partial class PrivilegeCellViewModel : ObservableObject
+{
+    private readonly Action<PrivilegeCellViewModel> _toggle;
+
+    [ObservableProperty]
+    private bool _isPending;
+
+    public PrivilegeCellViewModel(EffectivePrivilege effective, bool editable, Action<PrivilegeCellViewModel> toggle)
+    {
+        Effective = effective;
+        IsEditable = editable;
+        _toggle = toggle;
+    }
+
+    public EffectivePrivilege Effective { get; }
+
+    public PrivilegeKind Privilege => Effective.Privilege;
+
+    public string Role => Effective.Role;
+
+    /// <summary>
+    /// False where a GRANT/REVOKE would not change the answer: ownership and
+    /// superuser are not privileges you can revoke, so offering a toggle there
+    /// would promise something the statement cannot deliver.
+    /// </summary>
+    public bool IsEditable { get; }
+
+    public bool Granted => Effective.Granted;
+
+    /// <summary>A filled mark for granted, a quiet dash for not — never a checkbox that only looks editable.</summary>
+    public string Glyph => IsPending
+        ? Granted ? "✕" : "✚"
+        : Granted ? "●" : "–";
+
+    /// <summary>
+    /// A grant reached through inheritance, PUBLIC, ownership or superuser is
+    /// real but derived, and reads dimmer than one that names the role.
+    /// </summary>
+    public double Weight => Effective.Source switch
+    {
+        PrivilegeSource.Direct => 1.0,
+        PrivilegeSource.None => 0.35,
+        _ => 0.7,
+    };
+
+    /// <summary>
+    /// Unknown means the server said yes and the catalog could not explain why.
+    /// It has to look different from a direct grant — dressing it up as one is
+    /// exactly the dishonesty this feature exists to avoid.
+    /// </summary>
+    public bool IsUnexplained => Effective.Source == PrivilegeSource.Unknown;
+
+    public string Tooltip
+    {
+        get
+        {
+            var head = $"{Privileges.Sql(Privilege)} — {Effective.Explanation}";
+            if (IsPending)
+            {
+                return head + (Granted ? "\nPending: REVOKE" : "\nPending: GRANT");
+            }
+
+            return IsEditable
+                ? head
+                : head + "\nOwnership and superuser are not grants, so this cannot be revoked.";
+        }
+    }
+
+    [RelayCommand]
+    private void Toggle()
+    {
+        if (IsEditable)
+        {
+            _toggle(this);
+        }
+    }
+
+    partial void OnIsPendingChanged(bool value)
+    {
+        OnPropertyChanged(nameof(Glyph));
+        OnPropertyChanged(nameof(Tooltip));
+    }
+}
+
+/// <summary>One role's row of the matrix, plus the one-word answer to "how?".</summary>
+public sealed class PermissionRowViewModel
+{
+    public PermissionRowViewModel(string role, IReadOnlyList<PrivilegeCellViewModel> cells)
+    {
+        Role = role;
+        Cells = cells;
+
+        // The dominant source, so the answer is readable without hovering every
+        // cell. Superuser and owner win outright; otherwise the most common
+        // explanation among the privileges actually held.
+        var held = cells.Where(c => c.Granted).ToList();
+        SourceSummary = held.Count == 0
+            ? "—"
+            : held.Any(c => c.Effective.Source == PrivilegeSource.Superuser) ? "superuser"
+            : held.Any(c => c.Effective.Source == PrivilegeSource.Owner) ? "owner"
+            : held.GroupBy(c => c.Effective.Source == PrivilegeSource.Inherited
+                    ? $"via {c.Effective.Via}"
+                    : c.Effective.Source switch
+                    {
+                        PrivilegeSource.Direct => "direct",
+                        PrivilegeSource.Public => "PUBLIC",
+                        PrivilegeSource.Unknown => "not visible",
+                        _ => "—",
+                    })
+                .OrderByDescending(g => g.Count())
+                .First().Key;
+    }
+
+    public string Role { get; }
+
+    public IReadOnlyList<PrivilegeCellViewModel> Cells { get; }
+
+    public string SourceSummary { get; }
+}
+
+/// <summary>A column that carries grants of its own, on top of the table's.</summary>
+public sealed record ColumnGrantRow(string Column, string Grants);
+
+/// <summary>
+/// The permissions matrix — the reason this feature exists.
+///
+/// Every other Postgres client renders an object's stored ACL, and a stored ACL
+/// omits everything a role reaches through group membership, ownership or
+/// PUBLIC, so a working permission looks missing. This asks the server directly
+/// (<c>has_*_privilege</c>, which expands all of that server-side) and then uses
+/// <see cref="EffectivePrivilegeResolver"/> to attribute each answer to a source.
+///
+/// Nothing here writes. Toggling cells accumulates a change set and produces a
+/// GRANT/REVOKE script that opens in the editor.
+/// </summary>
 public sealed partial class PermissionsTabViewModel : ObservableObject, ISecuritySection
 {
     private readonly PrivilegeService _privileges;
     private readonly SecurityViewModel _host;
+    private readonly List<SecurableRef> _allObjects = [];
+    private readonly List<PrivilegeChange> _pending = [];
+
+    // Set only by SeedForHarness, so seeding a snapshot cannot kick off the
+    // catalog reads the property setters normally trigger.
+    private bool _suppressLoads;
+
+    [ObservableProperty]
+    private SecurableKind _selectedKind = SecurableKind.Table;
+
+    [ObservableProperty]
+    private string? _selectedSchema;
+
+    [ObservableProperty]
+    private string _objectFilter = "";
+
+    [ObservableProperty]
+    private SecurableRef? _selectedObject;
+
+    [ObservableProperty]
+    private string _roleFilter = "";
+
+    [ObservableProperty]
+    private bool _showPredefinedRoles;
+
+    [ObservableProperty]
+    private bool _isEditing;
+
+    [ObservableProperty]
+    private bool _isDefaultAcl;
+
+    [ObservableProperty]
+    private string _ownerLabel = "";
+
+    [ObservableProperty]
+    private string _accessSentence = "";
+
+    [ObservableProperty]
+    private PermissionRowViewModel? _selectedRow;
 
     public PermissionsTabViewModel(PrivilegeService privileges, SecurityViewModel host)
     {
@@ -15,5 +197,412 @@ public sealed partial class PermissionsTabViewModel : ObservableObject, ISecurit
         _host = host;
     }
 
-    public Task RefreshAsync(CancellationToken ct) => Task.CompletedTask;
+    public IReadOnlyList<SecurableKind> Kinds { get; } =
+    [
+        SecurableKind.Table, SecurableKind.Sequence, SecurableKind.Schema,
+        SecurableKind.Database, SecurableKind.Function, SecurableKind.Type,
+    ];
+
+    public ObservableCollection<string> Schemas { get; } = [];
+
+    public ObservableCollection<SecurableRef> Objects { get; } = [];
+
+    public ObservableCollection<PrivilegeColumn> PrivilegeColumns { get; } = [];
+
+    public ObservableCollection<PermissionRowViewModel> Rows { get; } = [];
+
+    public ObservableCollection<ColumnGrantRow> ColumnGrants { get; } = [];
+
+    /// <summary>Set by the view, which owns the dialog. Null in the screenshot harness.</summary>
+    public Func<BulkGrantViewModel, Task<bool>>? ShowBulkGrantDialog { get; set; }
+
+    /// <summary>True where the object class has a schema to pick — a database or a schema has none.</summary>
+    public bool KindHasSchema => SelectedKind is not (SecurableKind.Database or SecurableKind.Schema);
+
+    public bool HasColumnGrants => ColumnGrants.Count > 0;
+
+    public bool HasObject => SelectedObject is not null;
+
+    public bool HasAccessSentence => AccessSentence.Length > 0;
+
+    public bool HasPending => _pending.Count > 0;
+
+    public string PendingLabel => _pending.Count switch
+    {
+        0 => "No pending changes",
+        1 => "1 pending change",
+        var n => $"{n} pending changes",
+    };
+
+    /// <summary>
+    /// Shown instead of an empty grid when the catalog ACL column is NULL. In
+    /// Postgres that means nobody has ever run GRANT or REVOKE here — the owner
+    /// holds everything and the built-in defaults apply — and rendering it as
+    /// "no privileges" is how a permissions UI teaches the wrong thing.
+    /// </summary>
+    public string DefaultAclNote =>
+        $"No GRANT or REVOKE has ever been run on this object. {OwnerLabel} owns it and holds every privilege; "
+        + "everyone else has only what Postgres grants by default for this object type.";
+
+    public async Task RefreshAsync(CancellationToken ct)
+    {
+        try
+        {
+            var schemas = await _privileges.GetSecurablesAsync(SecurableKind.Schema, null, ct);
+            var previous = SelectedSchema;
+            Schemas.Clear();
+            foreach (var schema in schemas)
+            {
+                Schemas.Add(schema.Name);
+            }
+
+            SelectedSchema = previous is not null && Schemas.Contains(previous)
+                ? previous
+                : Schemas.FirstOrDefault();
+
+            await LoadObjectsAsync(ct);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            _host.ReportError("Permissions", ex);
+        }
+    }
+
+    partial void OnSelectedKindChanged(SecurableKind value)
+    {
+        OnPropertyChanged(nameof(KindHasSchema));
+        if (!_suppressLoads)
+        {
+            _ = LoadObjectsAsync(CancellationToken.None);
+        }
+    }
+
+    partial void OnSelectedSchemaChanged(string? value)
+    {
+        if (!_suppressLoads)
+        {
+            _ = LoadObjectsAsync(CancellationToken.None);
+        }
+    }
+
+    partial void OnObjectFilterChanged(string value) => ApplyObjectFilter();
+
+    partial void OnSelectedObjectChanged(SecurableRef? value)
+    {
+        OnPropertyChanged(nameof(HasObject));
+        _pending.Clear();
+        NotifyPending();
+        if (!_suppressLoads)
+        {
+            _ = LoadMatrixAsync(CancellationToken.None);
+        }
+    }
+
+    partial void OnRoleFilterChanged(string value)
+    {
+        if (!_suppressLoads)
+        {
+            _ = LoadMatrixAsync(CancellationToken.None);
+        }
+    }
+
+    partial void OnShowPredefinedRolesChanged(bool value)
+    {
+        if (!_suppressLoads)
+        {
+            _ = LoadMatrixAsync(CancellationToken.None);
+        }
+    }
+
+    partial void OnSelectedRowChanged(PermissionRowViewModel? value)
+    {
+        if (!_suppressLoads)
+        {
+            _ = UpdateSentenceAsync(CancellationToken.None);
+        }
+    }
+
+    partial void OnAccessSentenceChanged(string value) => OnPropertyChanged(nameof(HasAccessSentence));
+
+    /// <summary>
+    /// Harness-only: points the matrix at a snapshot that was never read from a
+    /// server, so the screenshot scenarios and the headless UI tests can render
+    /// a populated tab with no database behind them. Production always goes
+    /// through <see cref="RefreshAsync"/>; this suppresses the catalog reads the
+    /// property setters would otherwise start.
+    /// </summary>
+    public void SeedForHarness(
+        IEnumerable<string> schemas,
+        IReadOnlyList<SecurableRef> objects,
+        IReadOnlyList<PrivilegeColumn> columns,
+        IReadOnlyList<PermissionRowViewModel> rows,
+        string accessSentence,
+        IEnumerable<ColumnGrantRow> columnGrants)
+    {
+        _suppressLoads = true;
+        try
+        {
+            Schemas.Clear();
+            foreach (var schema in schemas)
+            {
+                Schemas.Add(schema);
+            }
+
+            SelectedSchema = Schemas.FirstOrDefault();
+
+            Objects.Clear();
+            _allObjects.Clear();
+            foreach (var obj in objects)
+            {
+                Objects.Add(obj);
+                _allObjects.Add(obj);
+            }
+
+            SelectedObject = Objects.FirstOrDefault();
+
+            PrivilegeColumns.Clear();
+            foreach (var column in columns)
+            {
+                PrivilegeColumns.Add(column);
+            }
+
+            Rows.Clear();
+            foreach (var row in rows)
+            {
+                Rows.Add(row);
+            }
+
+            SelectedRow = Rows.FirstOrDefault();
+            AccessSentence = accessSentence;
+
+            ColumnGrants.Clear();
+            foreach (var grant in columnGrants)
+            {
+                ColumnGrants.Add(grant);
+            }
+
+            OnPropertyChanged(nameof(HasColumnGrants));
+        }
+        finally
+        {
+            _suppressLoads = false;
+        }
+    }
+
+    private async Task LoadObjectsAsync(CancellationToken ct)
+    {
+        try
+        {
+            var schema = KindHasSchema ? SelectedSchema : null;
+            var objects = await _privileges.GetSecurablesAsync(SelectedKind, schema, ct);
+
+            _allObjects.Clear();
+            _allObjects.AddRange(objects);
+            ApplyObjectFilter();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            _host.ReportError("Objects", ex);
+        }
+    }
+
+    private void ApplyObjectFilter()
+    {
+        var previous = SelectedObject;
+        Objects.Clear();
+        foreach (var obj in _allObjects.Where(o =>
+                     ObjectFilter.Length == 0 || o.Name.Contains(ObjectFilter, StringComparison.OrdinalIgnoreCase)))
+        {
+            Objects.Add(obj);
+        }
+
+        SelectedObject = previous is not null && Objects.Contains(previous) ? previous : Objects.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Two reads and one pure resolve. The privilege list must come from the
+    /// real server version — asking a pre-PG17 server about MAINTAIN raises
+    /// "unrecognized privilege type" and takes the whole matrix with it.
+    /// </summary>
+    private async Task LoadMatrixAsync(CancellationToken ct)
+    {
+        Rows.Clear();
+        ColumnGrants.Clear();
+        OnPropertyChanged(nameof(HasColumnGrants));
+        AccessSentence = "";
+
+        if (SelectedObject is not { } obj || _host.Graph is not { } graph)
+        {
+            return;
+        }
+
+        try
+        {
+            var kinds = Privileges.For(obj.Kind, _host.ServerVersion);
+            PrivilegeColumns.Clear();
+            foreach (var kind in kinds)
+            {
+                PrivilegeColumns.Add(new PrivilegeColumn(kind, Privileges.Sql(kind)));
+            }
+
+            var roles = graph.Roles
+                .Where(r => ShowPredefinedRoles || !r.IsPredefined)
+                .Where(r => RoleFilter.Length == 0 || r.Name.Contains(RoleFilter, StringComparison.OrdinalIgnoreCase))
+                .Select(r => r.Name)
+                .ToList();
+
+            var acl = await _privileges.GetAclAsync(obj, ct);
+            IsDefaultAcl = acl.IsDefaultAcl;
+            OwnerLabel = acl.Owner;
+            OnPropertyChanged(nameof(DefaultAclNote));
+
+            var answers = await _privileges.GetServerAnswersAsync(obj, roles, kinds, ct);
+            var effective = EffectivePrivilegeResolver.Resolve(acl, roles, kinds, graph, answers);
+            var byRole = effective.ToLookup(e => e.Role);
+
+            foreach (var role in roles)
+            {
+                var cells = kinds
+                    .Select(kind => byRole[role].First(e => e.Privilege == kind))
+                    .Select(e => new PrivilegeCellViewModel(
+                        e,
+                        e.Source is not (PrivilegeSource.Owner or PrivilegeSource.Superuser),
+                        OnCellToggled))
+                    .ToList();
+                Rows.Add(new PermissionRowViewModel(role, cells));
+            }
+
+            SelectedRow = Rows.FirstOrDefault();
+
+            if (obj.Kind == SecurableKind.Table)
+            {
+                foreach (var column in await _privileges.GetColumnAclsAsync(obj, ct))
+                {
+                    var grants = string.Join(", ", column.Entries
+                        .GroupBy(e => e.GranteeLabel)
+                        .Select(g => $"{g.Key}: {string.Join('/', g.Select(e => Privileges.Sql(e.Privilege)))}"));
+                    ColumnGrants.Add(new ColumnGrantRow(column.Column, grants));
+                }
+
+                OnPropertyChanged(nameof(HasColumnGrants));
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            _host.ReportError("Permissions", ex);
+        }
+    }
+
+    /// <summary>
+    /// The plain-English answer, for the selected role. It also carries the trap
+    /// where every table privilege is granted and the role still cannot reach
+    /// the table for want of USAGE on its schema.
+    /// </summary>
+    private async Task UpdateSentenceAsync(CancellationToken ct)
+    {
+        if (SelectedObject is not { } obj || SelectedRow is not { } row)
+        {
+            AccessSentence = "";
+            return;
+        }
+
+        try
+        {
+            var usage = obj.Schema is null || await _privileges.HasSchemaUsageAsync(row.Role, obj.Schema, ct);
+            AccessSentence = EffectivePrivilegeResolver.ExplainSentence(
+                row.Role, obj, row.Cells.Select(c => c.Effective).ToList(), usage);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            _host.ReportError("Access", ex);
+        }
+    }
+
+    private void OnCellToggled(PrivilegeCellViewModel cell)
+    {
+        if (SelectedObject is not { } obj)
+        {
+            return;
+        }
+
+        var existing = _pending.FindIndex(c =>
+            c.Privilege == cell.Privilege && string.Equals(c.Grantee, cell.Role, StringComparison.Ordinal));
+
+        if (existing >= 0)
+        {
+            _pending.RemoveAt(existing);
+            cell.IsPending = false;
+        }
+        else
+        {
+            // Granted means the pending change is a REVOKE, and vice versa.
+            _pending.Add(new PrivilegeChange(obj, cell.Role, cell.Privilege, Grant: !cell.Granted));
+            cell.IsPending = true;
+        }
+
+        NotifyPending();
+    }
+
+    private void NotifyPending()
+    {
+        OnPropertyChanged(nameof(HasPending));
+        OnPropertyChanged(nameof(PendingLabel));
+        ReviewChangesCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(HasPending))]
+    private void ReviewChanges()
+    {
+        // Null in the screenshot harness, which has no main window to open a tab in.
+        if (SelectedObject is not { } obj || _host.OpenSqlInNewTab is not { } openSql)
+        {
+            return;
+        }
+
+        openSql($"grants · {obj.Display}", GrantScriptBuilder.Build(_pending));
+    }
+
+    [RelayCommand]
+    private void ClearPending()
+    {
+        _pending.Clear();
+        foreach (var cell in Rows.SelectMany(r => r.Cells))
+        {
+            cell.IsPending = false;
+        }
+
+        NotifyPending();
+    }
+
+    [RelayCommand]
+    private async Task BulkGrantAsync()
+    {
+        if (ShowBulkGrantDialog is not { } show || _host.Graph is not { } graph)
+        {
+            return;
+        }
+
+        var model = new BulkGrantViewModel(
+            Schemas,
+            graph.Roles.Where(r => !r.IsPredefined).Select(r => r.Name),
+            SelectedSchema,
+            _host.CurrentRole);
+
+        if (await show(model) && _host.OpenSqlInNewTab is { } openSql)
+        {
+            openSql(model.ScriptTitle, model.Script);
+        }
+    }
 }

--- a/PgNimbus.App/ViewModels/Security/RlsTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/RlsTabViewModel.cs
@@ -1,19 +1,356 @@
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core.Query;
 using PgNimbus.Core.Security;
 
 namespace PgNimbus.App.ViewModels.Security;
 
-/// <summary>Row-level security: which tables have it, which policies apply, and who bypasses it.</summary>
+/// <summary>
+/// One policy, shaped for the detail pane. The <c>USING</c> and
+/// <c>WITH CHECK</c> quals are SQL expressions, so they are carried whole and
+/// rendered monospace and selectable — truncating them into a grid cell is how
+/// the only part of a policy that says what it does becomes unreadable.
+/// </summary>
+public sealed record RlsPolicyRow(RlsPolicyInfo Policy, bool RowSecurityEnabled)
+{
+    public string Name => Policy.Name;
+
+    /// <summary>
+    /// PERMISSIVE policies are OR-ed together and RESTRICTIVE ones are AND-ed on
+    /// top, so which one a policy is decides whether it widens or narrows access.
+    /// </summary>
+    public string Kind => Policy.Permissive ? "PERMISSIVE" : "RESTRICTIVE";
+
+    public string Command => Policy.Command;
+
+    /// <summary>A lone "public" entry is not a role — it is every role.</summary>
+    public string RolesLabel => IsForEveryone
+        ? "public (every role)"
+        : string.Join(", ", Policy.Roles);
+
+    public bool IsForEveryone =>
+        Policy.Roles.Count == 0
+        || Policy.Roles.Any(r => r.Equals("public", StringComparison.OrdinalIgnoreCase));
+
+    public string? Using => Policy.Using;
+
+    public bool HasUsing => !string.IsNullOrWhiteSpace(Policy.Using);
+
+    public string? WithCheck => Policy.WithCheck;
+
+    public bool HasWithCheck => !string.IsNullOrWhiteSpace(Policy.WithCheck);
+
+    public string TabTitle => $"{Policy.Table} · {Policy.Name}";
+
+    /// <summary>
+    /// The <c>CREATE POLICY</c> this row was read back from, which is how a
+    /// policy gets edited: Postgres has no way to change a policy's command or
+    /// its permissiveness in place, so re-creating it is the real workflow.
+    /// </summary>
+    public string Sql
+    {
+        get
+        {
+            var table = $"{SqlIdentifier.QuoteIfNeeded(Policy.Schema)}.{SqlIdentifier.QuoteIfNeeded(Policy.Table)}";
+            var roles = IsForEveryone
+                ? GrantScriptBuilder.PublicGrantee
+                : string.Join(", ", Policy.Roles.Select(SqlIdentifier.QuoteIfNeeded));
+
+            var lines = new List<string>();
+
+            // A policy on a table with row security switched off is inert, and
+            // re-creating it changes nothing until that is fixed. Say so where
+            // the statement is about to be edited.
+            if (!RowSecurityEnabled)
+            {
+                lines.Add($"-- {Policy.Schema}.{Policy.Table} does not have row-level security enabled, so this");
+                lines.Add("-- policy is not applied to anyone. It takes effect only after:");
+                lines.Add($"--   ALTER TABLE {table} ENABLE ROW LEVEL SECURITY;");
+            }
+
+            lines.Add($"CREATE POLICY {SqlIdentifier.QuoteIfNeeded(Policy.Name)} ON {table}");
+            lines.Add($"    AS {Kind}");
+            lines.Add($"    FOR {Policy.Command}");
+            lines.Add($"    TO {roles}");
+
+            if (HasUsing)
+            {
+                lines.Add($"    USING ({Policy.Using})");
+            }
+
+            if (HasWithCheck)
+            {
+                lines.Add($"    WITH CHECK ({Policy.WithCheck})");
+            }
+
+            return string.Join("\n", lines) + ";";
+        }
+    }
+}
+
+/// <summary>
+/// One table's row-level security state, plus the sentence that explains a
+/// bypass when there is one.
+/// </summary>
+/// <param name="BypassReason">
+/// Why the connected role sees every row anyway, or null when it does not. Built
+/// by the view model, which is the only place that knows the connected role's
+/// attributes.
+/// </param>
+public sealed record RlsTableRow(RlsTableState State, string? BypassReason)
+{
+    public string Schema => State.Schema;
+
+    public string Table => State.Table;
+
+    public string Display => $"{State.Schema}.{State.Table}";
+
+    /// <summary>
+    /// What makes this the same table across a re-read. Record equality is no
+    /// use here: the synthesized comparison reaches the policy list, which is a
+    /// fresh <c>List</c> every refresh and compares by reference.
+    /// </summary>
+    public string Identity => Display;
+
+    public string StatusLabel => State.RowSecurityEnabled
+        ? State.ForceRowSecurity ? "Enabled · FORCE" : "Enabled"
+        : "Not enabled";
+
+    public string PolicyCountLabel =>
+        State.Policies.Count == 1 ? "1 policy" : $"{State.Policies.Count} policies";
+
+    /// <summary>Policies exist and none of them does anything — protection that only looks like protection.</summary>
+    public bool IsInert => State.HasInertPolicies;
+
+    /// <summary>
+    /// RLS on with no policies at all: the default-deny state, which hides every
+    /// row from every role that does not bypass. Usually deliberate, occasionally
+    /// a half-finished migration, and invisible either way without saying it.
+    /// </summary>
+    public bool DeniesEverything => State.RowSecurityEnabled && State.Policies.Count == 0;
+
+    public bool IsBypassed => State.BypassedByCurrentRole;
+
+    public bool IsForced => State.ForceRowSecurity;
+
+    public IReadOnlyList<RlsPolicyRow> Policies { get; } =
+        State.Policies.Select(p => new RlsPolicyRow(p, State.RowSecurityEnabled)).ToList();
+
+    public bool HasPolicies => Policies.Count > 0;
+}
+
+/// <summary>
+/// Row-level security: which tables have it, which policies apply, and who
+/// bypasses it.
+///
+/// <para>Read-only, like the rest of v1. The value is in the two states a plain
+/// policy listing cannot show: policies that exist on a table where row security
+/// was never switched on (they look like protection and are not), and a
+/// connected role that bypasses row security entirely (the policies are right
+/// and the person testing them cannot tell).</para>
+/// </summary>
 public sealed partial class RlsTabViewModel : ObservableObject, ISecuritySection
 {
+    /// <summary>The schema-filter entry that means "do not filter". Not a schema name.</summary>
+    public const string AllSchemas = "(all schemas)";
+
     private readonly PrivilegeService _privileges;
     private readonly SecurityViewModel _host;
+
+    /// <summary>
+    /// Every table read, before the schema filter. Kept so the filter is a local
+    /// re-slice rather than a round trip — and so the schema list stays whole
+    /// once a schema is picked, instead of collapsing to the one selected.
+    /// </summary>
+    private IReadOnlyList<RlsTableRow> _allTables = [];
+
+    /// <summary>
+    /// Nullable because a <c>ComboBox</c> whose items are being rebuilt pushes a
+    /// null selection back through the binding before the new list settles; the
+    /// filter reads null as "no filter" rather than as a schema named nothing.
+    /// </summary>
+    [ObservableProperty]
+    private string? _selectedSchema = AllSchemas;
+
+    [ObservableProperty]
+    private RlsTableRow? _selectedTable;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(CopyPolicyAsSqlCommand))]
+    private RlsPolicyRow? _selectedPolicy;
+
+    [ObservableProperty]
+    private bool _hasTables;
 
     public RlsTabViewModel(PrivilegeService privileges, SecurityViewModel host)
     {
         _privileges = privileges;
         _host = host;
+        Schemas.Add(AllSchemas);
     }
 
-    public Task RefreshAsync(CancellationToken ct) => Task.CompletedTask;
+    /// <summary>The schema filter's entries: <see cref="AllSchemas"/> first, then every schema that has RLS.</summary>
+    public ObservableCollection<string> Schemas { get; } = [];
+
+    public ObservableCollection<RlsTableRow> Tables { get; } = [];
+
+    public async Task RefreshAsync(CancellationToken ct)
+    {
+        try
+        {
+            // Read every schema, always. The filter below is a view over this
+            // one snapshot: re-reading per schema would cost a round trip per
+            // selection and leave nothing to build the schema list from.
+            var states = await _privileges.GetRlsAsync(null, ct);
+
+            _allTables = states.Select(s => new RlsTableRow(s, BypassReasonFor(s))).ToList();
+
+            var schemas = _allTables
+                .Select(t => t.Schema)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(s => s, StringComparer.Ordinal)
+                .ToList();
+
+            var previous = SelectedSchema;
+
+            // Rebuild the combo only when the set of schemas actually moved.
+            // Clearing it makes the ComboBox push a null selection back through
+            // the binding, so doing it on every refresh would churn the filter
+            // for nothing.
+            if (!Schemas.Skip(1).SequenceEqual(schemas, StringComparer.Ordinal))
+            {
+                Schemas.Clear();
+                Schemas.Add(AllSchemas);
+                foreach (var schema in schemas)
+                {
+                    Schemas.Add(schema);
+                }
+            }
+
+            // Setting the property re-filters; when it is unchanged, filter by
+            // hand so a refresh still picks up new tables.
+            var kept = previous is not null && schemas.Contains(previous, StringComparer.Ordinal)
+                ? previous
+                : AllSchemas;
+
+            if (SelectedSchema == kept)
+            {
+                ApplyFilter();
+            }
+            else
+            {
+                SelectedSchema = kept;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // A superseded snapshot — not an error worth surfacing.
+        }
+        catch (Exception ex)
+        {
+            _host.ReportError("Row-level security", ex);
+        }
+    }
+
+    partial void OnSelectedSchemaChanged(string? value) => ApplyFilter();
+
+    /// <summary>
+    /// Re-points the policy selection whenever the table changes — never left
+    /// pointing at a policy belonging to a table that is no longer on screen,
+    /// and landing on the new table's first policy so the Copy action has a
+    /// target the moment a table is picked.
+    /// </summary>
+    partial void OnSelectedTableChanged(RlsTableRow? value) =>
+        SelectedPolicy = value?.Policies.FirstOrDefault();
+
+    private void ApplyFilter()
+    {
+        var selected = SelectedTable;
+        var schema = SelectedSchema;
+        var all = schema is null || schema == AllSchemas;
+
+        Tables.Clear();
+        foreach (var table in _allTables)
+        {
+            if (all || string.Equals(table.Schema, schema, StringComparison.Ordinal))
+            {
+                Tables.Add(table);
+            }
+        }
+
+        HasTables = Tables.Count > 0;
+
+        // Keep the user where they were across a refresh, falling back to the
+        // first table so the detail pane is never blank next to a populated list.
+        SelectedTable = (selected is null
+            ? null
+            : Tables.FirstOrDefault(t => t.Identity == selected.Identity))
+            ?? Tables.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Why the connected role sees every row of <paramref name="state"/>
+    /// regardless of its policies, or null when it does not.
+    ///
+    /// <para>The two routes are not the same thing and the wording must not blur
+    /// them: a superuser or a <c>BYPASSRLS</c> role skips row security on every
+    /// table, always, and <c>FORCE ROW LEVEL SECURITY</c> does not touch that;
+    /// the table's owner skips it only while the table is not FORCE, so FORCE is
+    /// the fix in that case and no fix at all in the other.</para>
+    /// </summary>
+    private string? BypassReasonFor(RlsTableState state)
+    {
+        if (!state.BypassedByCurrentRole)
+        {
+            return null;
+        }
+
+        var role = _host.CurrentRole;
+        var attributes = _host.Graph?.Find(role);
+
+        if (attributes is null)
+        {
+            return $"{role} sees every row in this table, whatever the policies below say. "
+                + "Its role attributes could not be read, so this is either a superuser or BYPASSRLS role "
+                + "(which bypasses every table, always) or ownership of a table that is not FORCE ROW LEVEL SECURITY.";
+        }
+
+        if (attributes.IsSuperuser)
+        {
+            return $"{role} is a superuser, so it bypasses row-level security on every table in the cluster. "
+                + "That is unconditional: FORCE ROW LEVEL SECURITY does not apply the policies to it. "
+                + "Test these policies as the role your application connects as.";
+        }
+
+        if (attributes.BypassRls)
+        {
+            return $"{role} has the BYPASSRLS attribute, so it bypasses row-level security on every table, always. "
+                + "FORCE ROW LEVEL SECURITY does not apply the policies to it. "
+                + "Test these policies as the role your application connects as.";
+        }
+
+        return $"{role} owns this table, or is a member of the role that does, and the table is not "
+            + "FORCE ROW LEVEL SECURITY — so the policies below are not applied to it, though they are "
+            + "applied to every other role. ALTER TABLE … FORCE ROW LEVEL SECURITY makes them apply to the owner too.";
+    }
+
+    /// <summary>
+    /// Drops the selected policy's <c>CREATE POLICY</c> into a new editor tab —
+    /// how a policy is edited, since Postgres cannot alter a policy's command or
+    /// permissiveness in place. Null-checked: the screenshot harness has no main
+    /// window to open a tab in.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanCopyPolicyAsSql))]
+    private void CopyPolicyAsSql()
+    {
+        if (SelectedPolicy is not { } policy)
+        {
+            return;
+        }
+
+        _host.OpenSqlInNewTab?.Invoke(policy.TabTitle, policy.Sql);
+    }
+
+    private bool CanCopyPolicyAsSql() => SelectedPolicy is not null;
 }

--- a/PgNimbus.App/ViewModels/Security/RoleEditorViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/RoleEditorViewModel.cs
@@ -1,0 +1,615 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using PgNimbus.Core.Security;
+
+namespace PgNimbus.App.ViewModels.Security;
+
+/// <summary>
+/// Creates a role, or alters one. Both modes are the same form over the same
+/// <see cref="RoleDefinition"/>; what differs is what the generated script says,
+/// and that difference is the whole point of showing the script at all — create
+/// emits the full statement, alter emits only what actually changed.
+///
+/// <para><b>The preview is masked and the execution is not.</b> Postgres has no
+/// parameter form for <c>PASSWORD</c>, so a new password has to be interpolated
+/// into statement text. <see cref="LivePreview"/> is built with
+/// <c>maskPassword: true</c> and <see cref="ApplyAsync"/> with false — the real
+/// literal exists only inside that one call and the connection it goes down. It
+/// is never bound to a <c>TextBlock</c>, never handed to the editor tab (which
+/// would file it in the on-disk query history), and never logged. This is a
+/// security property, not a formatting choice: change it and the password ends
+/// up in a screenshot and in <c>queries.json</c>.</para>
+/// </summary>
+public sealed partial class RoleEditorViewModel : ObservableObject
+{
+    /// <summary>
+    /// The predefined roles that answer "make me a read-only user" on their own.
+    /// PG14 added the data pair; <c>pg_monitor</c> is older but belongs in the
+    /// same one-click group because it solves the same shape of problem.
+    /// </summary>
+    private static readonly (string Name, string Hint)[] PredefinedGrantable =
+    [
+        ("pg_read_all_data", "SELECT on every table, view and sequence, in every schema"),
+        ("pg_write_all_data", "INSERT, UPDATE and DELETE on every table"),
+        ("pg_monitor", "read the statistics and monitoring views without superuser"),
+    ];
+
+    private readonly SecurityEditor _editor;
+
+    /// <summary>Null in create mode; the catalog's current state in alter mode.</summary>
+    private readonly RoleAttributes? _current;
+
+    /// <summary>
+    /// The groups the role belongs to today. Empty in create mode; in alter mode
+    /// it is what <see cref="RoleScriptBuilder.Alter"/> diffs against, and passing
+    /// it is what makes a membership removable at all.
+    /// </summary>
+    private readonly IReadOnlyList<string> _currentMemberOf;
+
+    private bool _loaded;
+
+    /// <summary>
+    /// Re-entrancy guard. <see cref="Recompute"/> raises change notifications of
+    /// its own, and the blanket <see cref="OnPropertyChanged"/> hook below would
+    /// otherwise call it back into itself forever.
+    /// </summary>
+    private bool _recomputing;
+
+    [ObservableProperty]
+    private string _name = "";
+
+    [ObservableProperty]
+    private bool _canLogin = true;
+
+    [ObservableProperty]
+    private string _password = "";
+
+    [ObservableProperty]
+    private string _passwordConfirm = "";
+
+    [ObservableProperty]
+    private bool _isSuperuser;
+
+    [ObservableProperty]
+    private bool _inherit = true;
+
+    [ObservableProperty]
+    private bool _canCreateDb;
+
+    [ObservableProperty]
+    private bool _canCreateRole;
+
+    [ObservableProperty]
+    private bool _canReplicate;
+
+    [ObservableProperty]
+    private bool _bypassRls;
+
+    /// <summary>Blank means no limit, which Postgres stores as -1.</summary>
+    [ObservableProperty]
+    private int? _connectionLimit;
+
+    [ObservableProperty]
+    private DateTimeOffset? _validUntil;
+
+    [ObservableProperty]
+    private string _comment = "";
+
+    /// <summary>The masked script. Never the executed one — see the type remarks.</summary>
+    [ObservableProperty]
+    private string _livePreview = "";
+
+    /// <summary>Why Apply is refused, or empty when it is not.</summary>
+    [ObservableProperty]
+    private string _validationMessage = "";
+
+    /// <summary>Legal but probably not what you meant. Shown, never blocking.</summary>
+    [ObservableProperty]
+    private string _warningMessage = "";
+
+    /// <summary>The server's own refusal, kept in the dialog because its wording is the useful part.</summary>
+    [ObservableProperty]
+    private string _errorMessage = "";
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    private RoleEditorViewModel(
+        SecurityEditor editor,
+        SecurityViewModel host,
+        RoleAttributes? current,
+        IReadOnlyList<string> currentMemberOf)
+    {
+        _editor = editor;
+        _current = current;
+        _currentMemberOf = currentMemberOf;
+
+        var existing = new HashSet<string>(currentMemberOf, StringComparer.Ordinal);
+        var graph = host.Graph;
+
+        // Only offer a predefined role the server actually has. On PG13 the data
+        // pair does not exist, and a checkbox whose GRANT is guaranteed to fail
+        // is worse than no checkbox.
+        if (PgFeatures.SupportsPredefinedDataRoles(host.ServerVersion))
+        {
+            foreach (var (name, hint) in PredefinedGrantable)
+            {
+                if (graph is not null && graph.Find(name) is null)
+                {
+                    continue;
+                }
+
+                PredefinedMemberships.Add(new RoleMembershipOption(name, hint, existing.Contains(name), Recompute));
+            }
+        }
+
+        if (graph is not null)
+        {
+            foreach (var role in graph.Roles)
+            {
+                if (role.IsPredefined || string.Equals(role.Name, current?.Name, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                GroupMemberships.Add(new RoleMembershipOption(
+                    role.Name,
+                    role.CanLogin ? "login role" : "group role",
+                    existing.Contains(role.Name),
+                    Recompute));
+            }
+        }
+
+        if (current is not null)
+        {
+            Name = current.Name;
+            CanLogin = current.CanLogin;
+            IsSuperuser = current.IsSuperuser;
+            Inherit = current.Inherit;
+            CanCreateDb = current.CanCreateDb;
+            CanCreateRole = current.CanCreateRole;
+            CanReplicate = current.CanReplicate;
+            BypassRls = current.BypassRls;
+            ConnectionLimit = current.ConnectionLimit < 0 ? null : current.ConnectionLimit;
+            ValidUntil = current.ValidUntil;
+            Comment = current.Comment ?? "";
+        }
+
+        _loaded = true;
+        Recompute();
+    }
+
+    /// <summary>Closes the dialog. True means a script ran and the caller should re-read the catalog.</summary>
+    public Action<bool>? CloseRequested { get; set; }
+
+    public bool IsCreate => _current is null;
+
+    public string Title => IsCreate ? "New role" : $"Alter role “{_current!.Name}”";
+
+    /// <summary>A role's name is its identity for every grant; renaming is <c>ALTER ROLE … RENAME</c>, not this form.</summary>
+    public bool CanEditName => IsCreate;
+
+    /// <summary>Hidden entirely on a server too old to have the predefined data roles.</summary>
+    public bool HasPredefinedMemberships => PredefinedMemberships.Count > 0;
+
+    public ObservableCollection<RoleMembershipOption> PredefinedMemberships { get; } = [];
+
+    public ObservableCollection<RoleMembershipOption> GroupMemberships { get; } = [];
+
+    public bool HasValidationMessage => ValidationMessage.Length > 0;
+
+    public bool HasWarningMessage => WarningMessage.Length > 0;
+
+    public bool HasErrorMessage => ErrorMessage.Length > 0;
+
+    /// <summary>
+    /// <c>NumericUpDown</c> speaks <c>decimal?</c>; blank is "no limit". The
+    /// equality guard keeps the control's own re-write of the value it was just
+    /// given from registering as a change the diff would then emit.
+    /// </summary>
+    public decimal? ConnectionLimitValue
+    {
+        get => ConnectionLimit;
+        set
+        {
+            if (value == ConnectionLimitValue)
+            {
+                return;
+            }
+
+            ConnectionLimit = value is { } limit ? (int)Math.Clamp(limit, 0m, int.MaxValue) : null;
+        }
+    }
+
+    /// <summary>
+    /// <c>CalendarDatePicker</c> speaks <c>DateTime?</c> and clears to null when
+    /// its text is emptied, which is how an expiry is removed. Normalized to the
+    /// date so the picker's write-back of what it was given is a no-op.
+    /// </summary>
+    public DateTime? ValidUntilDate
+    {
+        get => ValidUntil?.LocalDateTime.Date;
+        set
+        {
+            if (value == ValidUntilDate)
+            {
+                return;
+            }
+
+            ValidUntil = value is { } date
+                ? new DateTimeOffset(date.Date, TimeZoneInfo.Local.GetUtcOffset(date.Date))
+                : null;
+        }
+    }
+
+    public static RoleEditorViewModel ForCreate(SecurityEditor editor, SecurityViewModel host) =>
+        new(editor, host, current: null, currentMemberOf: []);
+
+    public static RoleEditorViewModel ForAlter(
+        SecurityEditor editor,
+        SecurityViewModel host,
+        RoleAttributes current,
+        IReadOnlyList<string> currentMemberOf) =>
+        new(editor, host, current, currentMemberOf);
+
+    /// <summary>
+    /// Any field change re-derives the preview and the validation state. Done
+    /// here rather than with a NotifyPropertyChangedFor attribute per field
+    /// because there are fifteen of them and one forgotten attribute is a
+    /// preview that quietly stops matching the form.
+    /// </summary>
+    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+    {
+        base.OnPropertyChanged(e);
+
+        if (e.PropertyName is nameof(LivePreview) or nameof(ValidationMessage) or nameof(WarningMessage)
+            or nameof(ErrorMessage) or nameof(IsBusy))
+        {
+            return;
+        }
+
+        Recompute();
+    }
+
+    private void Recompute()
+    {
+        if (!_loaded || _recomputing)
+        {
+            return;
+        }
+
+        _recomputing = true;
+        try
+        {
+            RecomputeCore();
+        }
+        finally
+        {
+            _recomputing = false;
+        }
+    }
+
+    private void RecomputeCore()
+    {
+        LivePreview = BuildScript(maskPassword: true);
+
+        ValidationMessage =
+            Name.Trim().Length == 0 ? "A role needs a name."
+            : Password != PasswordConfirm ? "The two passwords do not match."
+            : LivePreview.Length == 0 ? "Nothing has changed yet."
+            : "";
+
+        // Legal, and sometimes right: pg_hba.conf may authenticate this role by
+        // peer, trust or an external method. So it is said out loud, not refused.
+        WarningMessage = IsCreate && CanLogin && Password.Length == 0
+            ? "This role can log in but has no password. That works only if pg_hba.conf authenticates it another way."
+            : "";
+
+        OnPropertyChanged(nameof(HasValidationMessage));
+        OnPropertyChanged(nameof(HasWarningMessage));
+        OnPropertyChanged(nameof(ConnectionLimitValue));
+        OnPropertyChanged(nameof(ValidUntilDate));
+        ApplyCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// The script, in the one shape both callers need.
+    /// <paramref name="maskPassword"/> false is only ever passed by
+    /// <see cref="ApplyAsync"/>.
+    /// </summary>
+    private string BuildScript(bool maskPassword)
+    {
+        var trimmed = Name.Trim();
+        if (trimmed.Length == 0)
+        {
+            return "";
+        }
+
+        var definition = new RoleDefinition(
+            trimmed,
+            CanLogin,
+            IsSuperuser,
+            Inherit,
+            CanCreateDb,
+            CanCreateRole,
+            CanReplicate,
+            BypassRls,
+            ConnectionLimit,
+            ValidUntil,
+            SelectedMemberships(),
+            Comment.Trim().Length == 0 ? null : Comment.Trim());
+
+        if (_current is null)
+        {
+            return RoleScriptBuilder.Create(definition, Password.Length == 0 ? null : Password, maskPassword);
+        }
+
+        // Alter returns "" when nothing changed, which is what disables Apply —
+        // running an empty script would report success for a no-op.
+        var statements = new List<string>();
+        var diff = RoleScriptBuilder.Alter(_current, definition, _currentMemberOf);
+        if (diff.Length > 0)
+        {
+            statements.Add(diff);
+        }
+
+        // A password is not part of RoleAttributes and cannot be diffed, so it is
+        // a change exactly when the field was typed into.
+        if (Password.Length > 0)
+        {
+            statements.Add(RoleScriptBuilder.SetPassword(_current.Name, Password, maskPassword));
+        }
+
+        return string.Join("\n", statements);
+    }
+
+    private IReadOnlyList<string> SelectedMemberships() =>
+        PredefinedMemberships.Concat(GroupMemberships)
+            .Where(o => o.IsMember)
+            .Select(o => o.Name)
+            .ToList();
+
+    private bool CanApply() => !IsBusy && ValidationMessage.Length == 0;
+
+    [RelayCommand(CanExecute = nameof(CanApply))]
+    private async Task ApplyAsync()
+    {
+        ErrorMessage = "";
+        IsBusy = true;
+        ApplyCommand.NotifyCanExecuteChanged();
+
+        try
+        {
+            // The only place maskPassword is false. The result is not stored,
+            // shown or logged - it goes straight down the connection.
+            await _editor.ExecuteScriptAsync(BuildScript(maskPassword: false), CancellationToken.None);
+            CloseRequested?.Invoke(true);
+        }
+        catch (Exception ex)
+        {
+            // Staying open with the server's own words: on a managed server this
+            // is "permission denied to create role", which is the answer.
+            ErrorMessage = ex.Message;
+            OnPropertyChanged(nameof(HasErrorMessage));
+        }
+        finally
+        {
+            IsBusy = false;
+            ApplyCommand.NotifyCanExecuteChanged();
+        }
+    }
+}
+
+/// <summary>One membership checkbox: a role this one may belong to.</summary>
+public sealed partial class RoleMembershipOption : ObservableObject
+{
+    private readonly Action _changed;
+
+    [ObservableProperty]
+    private bool _isMember;
+
+    public RoleMembershipOption(string name, string hint, bool isMember, Action changed)
+    {
+        Name = name;
+        Hint = hint;
+        _isMember = isMember;
+        _changed = changed;
+    }
+
+    public string Name { get; }
+
+    public string Hint { get; }
+
+    partial void OnIsMemberChanged(bool value) => _changed();
+}
+
+/// <summary>
+/// The answer to Postgres's 2BP01. <c>DROP ROLE</c> fails the moment the role
+/// owns anything or holds a grant, and the server's error names neither the
+/// objects nor the fix — so this reads both lists up front and generates the
+/// <c>REASSIGN OWNED</c> / <c>DROP OWNED</c> / <c>DROP ROLE</c> recipe that
+/// actually works.
+/// </summary>
+public sealed partial class DropRoleViewModel : ObservableObject
+{
+    private readonly RoleService _roleService;
+    private readonly SecurityEditor _editor;
+    private readonly Action<string, string>? _openSqlInNewTab;
+
+    [ObservableProperty]
+    private ReassignOption? _reassignTo;
+
+    [ObservableProperty]
+    private string _script = "";
+
+    [ObservableProperty]
+    private string _errorMessage = "";
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    [ObservableProperty]
+    private bool _isLoading = true;
+
+    [ObservableProperty]
+    private string _ownedHeader = "Objects it owns";
+
+    [ObservableProperty]
+    private string _grantsHeader = "Privileges it holds";
+
+    public DropRoleViewModel(
+        RoleService roleService,
+        SecurityEditor editor,
+        string roleName,
+        string currentRole,
+        IReadOnlyList<string> otherRoles,
+        Action<string, string>? openSqlInNewTab)
+    {
+        _roleService = roleService;
+        _editor = editor;
+        _openSqlInNewTab = openSqlInNewTab;
+        RoleName = roleName;
+
+        // "Nobody" first, so the destructive choice is a deliberate pick rather
+        // than the one you land on by leaving the combo alone.
+        ReassignTargets.Add(ReassignOption.Nobody);
+        foreach (var role in otherRoles)
+        {
+            ReassignTargets.Add(new ReassignOption(role));
+        }
+
+        _reassignTo = ReassignTargets.FirstOrDefault(o => string.Equals(o.Role, currentRole, StringComparison.Ordinal))
+                      ?? ReassignTargets.Skip(1).FirstOrDefault()
+                      ?? ReassignOption.Nobody;
+
+        Rebuild();
+    }
+
+    public Action<bool>? CloseRequested { get; set; }
+
+    public string RoleName { get; }
+
+    public ObservableCollection<ReassignOption> ReassignTargets { get; } = [];
+
+    public ObservableCollection<RoleDependency> Owned { get; } = [];
+
+    public ObservableCollection<RoleDependency> GrantsHeld { get; } = [];
+
+    public bool HasOwned => Owned.Count > 0;
+
+    public bool HasGrantsHeld => GrantsHeld.Count > 0;
+
+    /// <summary>Nothing was named to take the objects over, so DROP OWNED deletes them.</summary>
+    public bool WillDeleteOwnedObjects => ReassignTo is null || ReassignTo.Role is null;
+
+    public bool HasErrorMessage => ErrorMessage.Length > 0;
+
+    public bool CanRun => !IsBusy && !IsLoading;
+
+    /// <summary>
+    /// Reads what would make the drop fail. Both queries cover the
+    /// <em>current database only</em>, which is why the dialog says so: a role
+    /// with objects in three databases needs the recipe run in each.
+    /// </summary>
+    public async Task LoadAsync(CancellationToken ct)
+    {
+        try
+        {
+            var ownedTask = _roleService.GetOwnedObjectsAsync(RoleName, ct);
+            var grantsTask = _roleService.GetGrantsHeldAsync(RoleName, ct);
+            await Task.WhenAll(ownedTask, grantsTask);
+
+            foreach (var dependency in await ownedTask)
+            {
+                Owned.Add(dependency);
+            }
+
+            foreach (var dependency in await grantsTask)
+            {
+                GrantsHeld.Add(dependency);
+            }
+
+            OwnedHeader = $"Objects it owns ({Owned.Count})";
+
+            // A full page means the query hit its cap, not that this is the whole
+            // list - saying "200" there would be a number the user could act on
+            // and be wrong about.
+            GrantsHeader = GrantsHeld.Count >= RoleService.GrantsHeldLimit
+                ? $"Privileges it holds ({RoleService.GrantsHeldLimit}+, list truncated)"
+                : $"Privileges it holds ({GrantsHeld.Count})";
+        }
+        catch (OperationCanceledException)
+        {
+            // The dialog closed while the read was in flight.
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            OnPropertyChanged(nameof(HasErrorMessage));
+        }
+        finally
+        {
+            IsLoading = false;
+            OnPropertyChanged(nameof(HasOwned));
+            OnPropertyChanged(nameof(HasGrantsHeld));
+            OnPropertyChanged(nameof(CanRun));
+            RunCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    partial void OnReassignToChanged(ReassignOption? value) => Rebuild();
+
+    private void Rebuild()
+    {
+        Script = RoleScriptBuilder.Drop(RoleName, ReassignTo?.Role);
+        OnPropertyChanged(nameof(WillDeleteOwnedObjects));
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRun))]
+    private async Task RunAsync()
+    {
+        ErrorMessage = "";
+        IsBusy = true;
+        RunCommand.NotifyCanExecuteChanged();
+
+        try
+        {
+            await _editor.ExecuteScriptAsync(Script, CancellationToken.None);
+            CloseRequested?.Invoke(true);
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            OnPropertyChanged(nameof(HasErrorMessage));
+        }
+        finally
+        {
+            IsBusy = false;
+            RunCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    /// <summary>
+    /// Hands the recipe to the editor instead of running it here. REASSIGN and
+    /// DROP OWNED act on the current database only, so a role with objects in
+    /// several databases needs the same script run against each connection —
+    /// which is the editor's job, not a modal dialog's.
+    /// </summary>
+    [RelayCommand]
+    private void OpenInEditor()
+    {
+        // Null in the screenshot harness, which has no main window.
+        _openSqlInNewTab?.Invoke($"drop role · {RoleName}", Script);
+        CloseRequested?.Invoke(false);
+    }
+}
+
+/// <summary>A choice in the "reassign owned objects to" combo; <see cref="Role"/> null is the destructive one.</summary>
+public sealed record ReassignOption(string? Role)
+{
+    public static ReassignOption Nobody { get; } = new((string?)null);
+
+    public string Label => Role ?? "Nobody — delete the owned objects";
+}

--- a/PgNimbus.App/ViewModels/Security/RoleEditorViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/RoleEditorViewModel.cs
@@ -459,14 +459,25 @@ public sealed partial class DropRoleViewModel : ObservableObject
     [ObservableProperty]
     private string _grantsHeader = "Privileges it holds";
 
+    /// <summary>
+    /// Whether the script grants the executing role the memberships REASSIGN
+    /// OWNED and DROP OWNED need. Defaults on for a non-superuser, which is
+    /// everyone on managed Postgres — without it the server answers 42501
+    /// "permission denied to reassign objects".
+    /// </summary>
+    [ObservableProperty]
+    private bool _grantMembershipFirst;
+
     public DropRoleViewModel(
         RoleService roleService,
         SecurityEditor editor,
         string roleName,
         string currentRole,
         IReadOnlyList<string> otherRoles,
-        Action<string, string>? openSqlInNewTab)
+        Action<string, string>? openSqlInNewTab,
+        bool currentRoleIsSuperuser = false)
     {
+        _grantMembershipFirst = !currentRoleIsSuperuser;
         _roleService = roleService;
         _editor = editor;
         _openSqlInNewTab = openSqlInNewTab;
@@ -563,9 +574,11 @@ public sealed partial class DropRoleViewModel : ObservableObject
 
     private void Rebuild()
     {
-        Script = RoleScriptBuilder.Drop(RoleName, ReassignTo?.Role);
+        Script = RoleScriptBuilder.Drop(RoleName, ReassignTo?.Role, GrantMembershipFirst);
         OnPropertyChanged(nameof(WillDeleteOwnedObjects));
     }
+
+    partial void OnGrantMembershipFirstChanged(bool value) => Rebuild();
 
     [RelayCommand(CanExecute = nameof(CanRun))]
     private async Task RunAsync()

--- a/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
@@ -1,4 +1,6 @@
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using PgNimbus.Core.Security;
 
 namespace PgNimbus.App.ViewModels.Security;
@@ -10,6 +12,42 @@ public sealed partial class RolesTabViewModel : ObservableObject, ISecuritySecti
     private readonly SecurityEditor _editor;
     private readonly SecurityViewModel _host;
 
+    /// <summary>Every role the last refresh saw; <see cref="FilteredRoles"/> is the view onto it.</summary>
+    private readonly List<RoleRowViewModel> _all = [];
+
+    [ObservableProperty]
+    private string _filter = "";
+
+    /// <summary>
+    /// Off by default: a stock server carries a dozen <c>pg_*</c> roles nobody
+    /// created and nobody edits, and on a managed one they outnumber the real
+    /// roles. They stay one click away rather than being hidden outright,
+    /// because "why is pg_monitor not listed" is a fair question.
+    /// </summary>
+    [ObservableProperty]
+    private bool _showPredefinedRoles;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(EditRoleCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DropRoleCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CopyCreateScriptCommand))]
+    private RoleRowViewModel? _selectedRole;
+
+    [ObservableProperty]
+    private bool _hasSettings;
+
+    [ObservableProperty]
+    private bool _hasSelection;
+
+    [ObservableProperty]
+    private bool _hasFilteredRoles;
+
+    [ObservableProperty]
+    private bool _hasMemberOf;
+
+    [ObservableProperty]
+    private bool _hasMembers;
+
     public RolesTabViewModel(RoleService roleService, SecurityEditor editor, SecurityViewModel host)
     {
         _roleService = roleService;
@@ -17,5 +55,382 @@ public sealed partial class RolesTabViewModel : ObservableObject, ISecuritySecti
         _host = host;
     }
 
-    public Task RefreshAsync(CancellationToken ct) => Task.CompletedTask;
+    /// <summary>One row per role on the server, predefined ones included.</summary>
+    public ObservableCollection<RoleRowViewModel> Roles { get; } = [];
+
+    /// <summary>What the list actually shows: <see cref="Roles"/> after the name filter and the predefined toggle.</summary>
+    public ObservableCollection<RoleRowViewModel> FilteredRoles { get; } = [];
+
+    /// <summary>The groups the selected role belongs to, walking upward.</summary>
+    public ObservableCollection<RoleTreeNodeViewModel> MemberOf { get; } = [];
+
+    /// <summary>The roles that belong to the selected one, walking downward.</summary>
+    public ObservableCollection<RoleTreeNodeViewModel> Members { get; } = [];
+
+    /// <summary>The selected role's <c>ALTER ROLE … SET</c> entries; the section hides itself when empty.</summary>
+    public ObservableCollection<string> Settings { get; } = [];
+
+    /// <summary>
+    /// Shows the create/alter dialog and reports whether it applied anything.
+    /// Set by the view: a view model that news up a <c>Window</c> would drag
+    /// Avalonia into the layer that has to stay bindable and testable, so this
+    /// follows the <c>AlterTableViewModelFactory</c> precedent — the view model
+    /// builds the dialog's view model, the view opens the dialog.
+    /// </summary>
+    public Func<RoleEditorViewModel, Task<bool>>? ShowRoleDialog { get; set; }
+
+    /// <inheritdoc cref="ShowRoleDialog" />
+    public Func<DropRoleViewModel, Task<bool>>? ShowDropDialog { get; set; }
+
+    /// <summary>
+    /// Re-reads from the snapshot the host already built. Nothing here opens a
+    /// connection: the graph is the shared read, and doing it again per section
+    /// would cost four round trips for one answer.
+    /// </summary>
+    public Task RefreshAsync(CancellationToken ct)
+    {
+        try
+        {
+            if (_host.Graph is not { } graph)
+            {
+                return Task.CompletedTask;
+            }
+
+            var previous = SelectedRole?.Name;
+
+            _all.Clear();
+            foreach (var role in graph.Roles)
+            {
+                _all.Add(new RoleRowViewModel(role, graph.MemberOf(role.Name).Count));
+            }
+
+            Roles.Clear();
+            foreach (var row in _all)
+            {
+                Roles.Add(row);
+            }
+
+            ApplyFilter();
+
+            // A refresh must not silently move the detail pane to another role,
+            // so the selection is restored by name rather than by identity.
+            SelectedRole = previous is null
+                ? null
+                : FilteredRoles.FirstOrDefault(r => string.Equals(r.Name, previous, StringComparison.Ordinal));
+        }
+        catch (Exception ex)
+        {
+            _host.ReportError("Roles", ex);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    partial void OnFilterChanged(string value) => ApplyFilter();
+
+    partial void OnShowPredefinedRolesChanged(bool value) => ApplyFilter();
+
+    partial void OnSelectedRoleChanged(RoleRowViewModel? value)
+    {
+        MemberOf.Clear();
+        Members.Clear();
+        Settings.Clear();
+
+        if (value is not null && _host.Graph is { } graph)
+        {
+            foreach (var node in RoleTreeNodeViewModel.Build(graph.MemberOf(value.Name)))
+            {
+                MemberOf.Add(node);
+            }
+
+            foreach (var node in RoleTreeNodeViewModel.Build(graph.Members(value.Name)))
+            {
+                Members.Add(node);
+            }
+
+            foreach (var setting in value.Attributes.Settings)
+            {
+                Settings.Add(setting);
+            }
+        }
+
+        // Explicit "is this empty" flags rather than a `!Collection.Count`
+        // binding: negating an int is not something a compiled binding converts
+        // reliably, and each empty state gets its own sentence anyway.
+        HasSelection = value is not null;
+        HasSettings = Settings.Count > 0;
+        HasMemberOf = MemberOf.Count > 0;
+        HasMembers = Members.Count > 0;
+    }
+
+    private void ApplyFilter()
+    {
+        var needle = Filter.Trim();
+
+        FilteredRoles.Clear();
+        foreach (var row in _all)
+        {
+            if (!ShowPredefinedRoles && row.IsPredefined)
+            {
+                continue;
+            }
+
+            if (needle.Length > 0 && !row.Name.Contains(needle, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            FilteredRoles.Add(row);
+        }
+
+        HasFilteredRoles = FilteredRoles.Count > 0;
+
+        // Filtering the selected row away would leave the detail pane describing
+        // a role the list no longer shows.
+        if (SelectedRole is { } selected && !FilteredRoles.Contains(selected))
+        {
+            SelectedRole = null;
+        }
+    }
+
+    /// <summary>Predefined roles are the server's, not the user's — nothing here may edit or drop one.</summary>
+    private bool CanEditSelected() => SelectedRole is { IsPredefined: false };
+
+    /// <summary>
+    /// Also refuses the role you are connected as. Dropping it would succeed
+    /// only by breaking the connection that ran the statement.
+    /// </summary>
+    private bool CanDropSelected() =>
+        CanEditSelected() && !string.Equals(SelectedRole!.Name, _host.CurrentRole, StringComparison.Ordinal);
+
+    private bool CanScriptSelected() => SelectedRole is not null;
+
+    [RelayCommand]
+    private async Task NewRoleAsync()
+    {
+        if (ShowRoleDialog is not { } show)
+        {
+            return;
+        }
+
+        var editor = RoleEditorViewModel.ForCreate(_editor, _host);
+        if (await show(editor))
+        {
+            await _host.RefreshAsync(CancellationToken.None);
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanEditSelected))]
+    private async Task EditRoleAsync()
+    {
+        if (SelectedRole is not { } row || ShowRoleDialog is not { } show)
+        {
+            return;
+        }
+
+        var editor = RoleEditorViewModel.ForAlter(_editor, _host, row.Attributes, DirectGroupsOf(row.Name));
+        if (await show(editor))
+        {
+            await _host.RefreshAsync(CancellationToken.None);
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanDropSelected))]
+    private async Task DropRoleAsync()
+    {
+        if (SelectedRole is not { } row || ShowDropDialog is not { } show)
+        {
+            return;
+        }
+
+        var drop = new DropRoleViewModel(
+            _roleService,
+            _editor,
+            row.Name,
+            _host.CurrentRole,
+            _all.Where(r => !string.Equals(r.Name, row.Name, StringComparison.Ordinal) && !r.IsPredefined)
+                .Select(r => r.Name)
+                .ToList(),
+            _host.OpenSqlInNewTab);
+
+        if (await show(drop))
+        {
+            await _host.RefreshAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// Hands the selected role's <c>CREATE ROLE</c> statement to the editor.
+    /// The password is passed as null — a role's password is not in
+    /// <c>pg_roles</c> and this app deliberately never reads <c>pg_authid</c>,
+    /// so the generated script is a recipe to re-create the role, not a copy of
+    /// its credentials.
+    /// </summary>
+    [RelayCommand(CanExecute = nameof(CanScriptSelected))]
+    private void CopyCreateScript()
+    {
+        // Null in the screenshot harness, which has no main window to open a tab in.
+        if (SelectedRole is not { } row || _host.OpenSqlInNewTab is not { } openSql)
+        {
+            return;
+        }
+
+        var definition = ToDefinition(row.Attributes, DirectGroupsOf(row.Name));
+        openSql($"role · {row.Name}", RoleScriptBuilder.Create(definition, password: null));
+    }
+
+    /// <summary>
+    /// The groups a role is a member of directly — the roots of the membership
+    /// tree, not the whole transitive closure. Re-granting an indirect
+    /// membership would flatten the group hierarchy the server already has.
+    /// </summary>
+    private IReadOnlyList<string> DirectGroupsOf(string role) =>
+        _host.Graph is { } graph ? graph.MemberOf(role).Select(n => n.Role).ToList() : [];
+
+    internal static RoleDefinition ToDefinition(RoleAttributes role, IReadOnlyList<string> memberOf) =>
+        new(
+            role.Name,
+            role.CanLogin,
+            role.IsSuperuser,
+            role.Inherit,
+            role.CanCreateDb,
+            role.CanCreateRole,
+            role.CanReplicate,
+            role.BypassRls,
+            role.ConnectionLimit < 0 ? null : role.ConnectionLimit,
+            role.ValidUntil,
+            memberOf,
+            role.Comment);
+}
+
+/// <summary>One role in the list, and the detail rows the pane beside it shows.</summary>
+public sealed class RoleRowViewModel
+{
+    public RoleRowViewModel(RoleAttributes attributes, int memberOfCount)
+    {
+        Attributes = attributes;
+        MemberOfCount = memberOfCount;
+
+        // Same shape and vocabulary as RoleNode in the schema tree, extended by
+        // the attributes that tree does not carry — one role must not read as
+        // two different things in two places in the same app.
+        var flags = new List<string>();
+        if (attributes.IsSuperuser)
+        {
+            flags.Add("superuser");
+        }
+
+        if (attributes.CanLogin)
+        {
+            flags.Add("login");
+        }
+
+        if (attributes.CanCreateDb)
+        {
+            flags.Add("createdb");
+        }
+
+        if (attributes.CanCreateRole)
+        {
+            flags.Add("createrole");
+        }
+
+        if (attributes.CanReplicate)
+        {
+            flags.Add("replication");
+        }
+
+        if (attributes.BypassRls)
+        {
+            flags.Add("bypassrls");
+        }
+
+        if (!attributes.Inherit)
+        {
+            flags.Add("noinherit");
+        }
+
+        AttributesLabel = string.Join(" · ", flags);
+
+        ValidUntilText = attributes.ValidUntil is not { } until
+            ? ""
+            : attributes.IsExpired
+                ? "expired"
+                : until.LocalDateTime.ToString("yyyy-MM-dd");
+
+        Details =
+        [
+            new RoleDetailRow("Login", YesNo(attributes.CanLogin)),
+            new RoleDetailRow("Superuser", YesNo(attributes.IsSuperuser)),
+            new RoleDetailRow("Inherit", YesNo(attributes.Inherit),
+                IsWarning: !attributes.Inherit,
+                Note: attributes.Inherit ? null : "group privileges need SET ROLE"),
+            new RoleDetailRow("Create DB", YesNo(attributes.CanCreateDb)),
+            new RoleDetailRow("Create role", YesNo(attributes.CanCreateRole)),
+            new RoleDetailRow("Replication", YesNo(attributes.CanReplicate)),
+            new RoleDetailRow("Bypass RLS", YesNo(attributes.BypassRls)),
+            new RoleDetailRow("Connection limit",
+                attributes.ConnectionLimit < 0 ? "no limit" : attributes.ConnectionLimit.ToString()),
+            new RoleDetailRow("Valid until",
+                ValidUntilText.Length == 0 ? "no expiry" : ValidUntilText,
+                IsWarning: attributes.IsExpired),
+            new RoleDetailRow("Comment", attributes.Comment is { Length: > 0 } c ? c : "—"),
+        ];
+    }
+
+    public RoleAttributes Attributes { get; }
+
+    public string Name => Attributes.Name;
+
+    public string AttributesLabel { get; }
+
+    public int MemberOfCount { get; }
+
+    /// <summary>Empty when the role never expires, "expired" once it has — the state worth spotting in a list.</summary>
+    public string ValidUntilText { get; }
+
+    public bool IsExpired => Attributes.IsExpired;
+
+    public bool IsPredefined => Attributes.IsPredefined;
+
+    public IReadOnlyList<RoleDetailRow> Details { get; }
+
+    private static string YesNo(bool value) => value ? "yes" : "no";
+}
+
+/// <summary>One label/value line of the detail pane.</summary>
+public sealed record RoleDetailRow(string Label, string Value, bool IsWarning = false, string? Note = null)
+{
+    public bool HasNote => Note is { Length: > 0 };
+}
+
+/// <summary>
+/// A node of the membership tree. The one thing this adds over
+/// <see cref="RoleTreeNode"/> is making <c>NOINHERIT</c> visible: such a
+/// membership looks granted in every other client and behaves as if it is not,
+/// because the privileges only arrive after an explicit <c>SET ROLE</c>.
+/// </summary>
+public sealed class RoleTreeNodeViewModel
+{
+    private RoleTreeNodeViewModel(RoleTreeNode node)
+    {
+        Role = node.Role;
+        Inherits = node.Inherits;
+        Children = Build(node.Children);
+    }
+
+    public string Role { get; }
+
+    public bool Inherits { get; }
+
+    public IReadOnlyList<RoleTreeNodeViewModel> Children { get; }
+
+    /// <summary>True for a membership whose privileges are dormant until <c>SET ROLE</c>.</summary>
+    public bool IsDormant => !Inherits;
+
+    /// <summary>Dimmed rather than hidden: the relationship is real, the privileges are not automatic.</summary>
+    public double RowOpacity => Inherits ? 1.0 : 0.55;
+
+    public static IReadOnlyList<RoleTreeNodeViewModel> Build(IReadOnlyList<RoleTreeNode> nodes) =>
+        nodes.Select(n => new RoleTreeNodeViewModel(n)).ToList();
 }

--- a/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
@@ -245,7 +245,7 @@ public sealed partial class RolesTabViewModel : ObservableObject, ISecuritySecti
         var editor = RoleEditorViewModel.ForCreate(_editor, _host);
         if (await show(editor))
         {
-            await _host.RefreshAsync(CancellationToken.None);
+            await _host.ReloadAfterRoleChangeAsync(CancellationToken.None);
         }
     }
 
@@ -260,7 +260,7 @@ public sealed partial class RolesTabViewModel : ObservableObject, ISecuritySecti
         var editor = RoleEditorViewModel.ForAlter(_editor, _host, row.Attributes, DirectGroupsOf(row.Name));
         if (await show(editor))
         {
-            await _host.RefreshAsync(CancellationToken.None);
+            await _host.ReloadAfterRoleChangeAsync(CancellationToken.None);
         }
     }
 
@@ -284,7 +284,7 @@ public sealed partial class RolesTabViewModel : ObservableObject, ISecuritySecti
 
         if (await show(drop))
         {
-            await _host.RefreshAsync(CancellationToken.None);
+            await _host.ReloadAfterRoleChangeAsync(CancellationToken.None);
         }
     }
 

--- a/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
@@ -117,6 +117,13 @@ public sealed partial class RolesTabViewModel : ObservableObject, ISecuritySecti
             SelectedRole = previous is null
                 ? null
                 : FilteredRoles.FirstOrDefault(r => string.Equals(r.Name, previous, StringComparison.Ordinal));
+
+            // A role the schema tree asked for outranks the restored selection:
+            // the user right-clicked that name to get here.
+            if (_host.PendingRoleSelection is { } pending && SelectRole(pending))
+            {
+                _host.PendingRoleSelection = null;
+            }
         }
         catch (Exception ex)
         {
@@ -124,6 +131,28 @@ public sealed partial class RolesTabViewModel : ObservableObject, ISecuritySecti
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Selects a role by name, returning false when this snapshot has no such
+    /// role. A <c>pg_*</c> name turns the built-in filter on first — being asked
+    /// for a role and silently not showing it would read as the command doing
+    /// nothing, which is worse than changing a toggle the user can flip back.
+    /// </summary>
+    public bool SelectRole(string name)
+    {
+        if (name.StartsWith("pg_", StringComparison.Ordinal) && !ShowPredefinedRoles)
+        {
+            ShowPredefinedRoles = true; // ApplyFilter runs on the change
+        }
+
+        if (FilteredRoles.FirstOrDefault(r => string.Equals(r.Name, name, StringComparison.Ordinal)) is not { } match)
+        {
+            return false;
+        }
+
+        SelectedRole = match;
+        return true;
     }
 
     partial void OnFilterChanged(string value) => ApplyFilter();

--- a/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
@@ -280,7 +280,8 @@ public sealed partial class RolesTabViewModel : ObservableObject, ISecuritySecti
             _all.Where(r => !string.Equals(r.Name, row.Name, StringComparison.Ordinal) && !r.IsPredefined)
                 .Select(r => r.Name)
                 .ToList(),
-            _host.OpenSqlInNewTab);
+            _host.OpenSqlInNewTab,
+            _host.Graph?.IsSuperuser(_host.CurrentRole) ?? false);
 
         if (await show(drop))
         {

--- a/PgNimbus.App/ViewModels/Security/SecurityViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/SecurityViewModel.cs
@@ -108,7 +108,13 @@ public sealed partial class SecurityViewModel : ObservableObject
     {
         try
         {
-            Status = "Reading roles…";
+            // Only on the first read: a refresh that already has a snapshot behind
+            // it should not blank the status line, and the screenshot harness
+            // seeds a snapshot before the window's Opened refresh fires.
+            if (Graph is null)
+            {
+                Status = "Reading roles…";
+            }
 
             var rolesTask = _roleService.GetRolesAsync(includePredefined: true, ct);
             var membershipsTask = _roleService.GetMembershipsAsync(ct);

--- a/PgNimbus.App/ViewModels/Security/SecurityViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/SecurityViewModel.cs
@@ -98,6 +98,26 @@ public sealed partial class SecurityViewModel : ObservableObject
     public Action<string, string>? OpenSqlInNewTab { get; set; }
 
     /// <summary>
+    /// A role the window should land on once it has a snapshot — set by the
+    /// schema tree's "Roles and permissions…" before the window opens. Cleared
+    /// by whichever path consumes it first.
+    /// </summary>
+    public string? PendingRoleSelection { get; set; }
+
+    /// <summary>
+    /// Applies <see cref="PendingRoleSelection"/> against the roles already
+    /// listed. Called for the case where the window was already open, so no
+    /// refresh is coming to pick the name up.
+    /// </summary>
+    public void ApplyPendingRoleSelection()
+    {
+        if (PendingRoleSelection is { } role && Roles.SelectRole(role))
+        {
+            PendingRoleSelection = null;
+        }
+    }
+
+    /// <summary>
     /// Re-reads the shared role snapshot, then fans out to the four sections.
     /// Sections run in parallel because their reads are independent — one round
     /// trip's worth of latency instead of four, which is what makes this bearable

--- a/PgNimbus.App/ViewModels/Security/SecurityViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/SecurityViewModel.cs
@@ -105,6 +105,30 @@ public sealed partial class SecurityViewModel : ObservableObject
     public string? PendingRoleSelection { get; set; }
 
     /// <summary>
+    /// Raised after a role was created, altered or dropped, so surfaces outside
+    /// this window — the schema tree's Roles group — stop showing the old set.
+    /// Set by the host; null in the screenshot harness.
+    /// </summary>
+    public Func<Task>? RolesChanged { get; set; }
+
+    /// <summary>
+    /// Re-reads everything after a write, then tells the host. Every role
+    /// dialog ends here rather than refreshing its own tab, because a new role
+    /// is a row in the permissions matrix and a possible grantee in the default
+    /// privileges list too — refreshing only the tab that made the change is
+    /// what makes the others look stale.
+    /// </summary>
+    public async Task ReloadAfterRoleChangeAsync(CancellationToken ct)
+    {
+        await RefreshAsync(ct);
+
+        if (RolesChanged is { } notify)
+        {
+            await notify();
+        }
+    }
+
+    /// <summary>
     /// Applies <see cref="PendingRoleSelection"/> against the roles already
     /// listed. Called for the case where the window was already open, so no
     /// refresh is coming to pick the name up.

--- a/PgNimbus.App/Views/SchemaTreePanel.axaml
+++ b/PgNimbus.App/Views/SchemaTreePanel.axaml
@@ -126,12 +126,27 @@
         </DataTemplate>
         <DataTemplate DataType="vm:RolesGroupNode">
             <StackPanel Orientation="Horizontal" Spacing="6">
+                <StackPanel.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="Roles and permissions..." Click="OnManageRolesClick" />
+                        <MenuItem Header="Refresh" Tag="{Binding}" Click="OnRefreshNodeClick" />
+                    </ContextMenu>
+                </StackPanel.ContextMenu>
                 <PathIcon Data="{StaticResource AccountMultipleIconGeometry}" Width="12" Height="12" VerticalAlignment="Center" />
                 <TextBlock Text="{Binding Name}" FontWeight="SemiBold" />
             </StackPanel>
         </DataTemplate>
         <DataTemplate DataType="vm:RoleNode">
             <StackPanel Orientation="Horizontal" Spacing="6">
+                <!-- The tree can only ever show a role's headline attributes.
+                     "Roles and permissions..." opens the window on this role,
+                     which is where the effective-privilege answer lives. -->
+                <StackPanel.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="Roles and permissions..." Tag="{Binding}" Click="OnManageRoleClick" />
+                        <MenuItem Header="Copy name" Tag="{Binding}" Click="OnCopyRoleNameClick" />
+                    </ContextMenu>
+                </StackPanel.ContextMenu>
                 <Panel Width="14" VerticalAlignment="Center">
                     <PathIcon Data="{StaticResource KeyIconGeometry}" Width="11" Height="11" IsVisible="{Binding IsSuperuser}" ToolTip.Tip="Superuser" />
                 </Panel>

--- a/PgNimbus.App/Views/SchemaTreePanel.axaml.cs
+++ b/PgNimbus.App/Views/SchemaTreePanel.axaml.cs
@@ -164,6 +164,49 @@ public partial class SchemaTreePanel : UserControl
         }
     }
 
+    private async void OnManageRolesClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is SchemaTreeViewModel { ManageRolesRequested: { } manage })
+        {
+            await manage(null);
+        }
+    }
+
+    private async void OnManageRoleClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem { Tag: RoleNode role }
+            && DataContext is SchemaTreeViewModel { ManageRolesRequested: { } manage })
+        {
+            await manage(role.Name);
+        }
+    }
+
+    private async void OnCopyRoleNameClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem { Tag: RoleNode role } || TopLevel.GetTopLevel(this)?.Clipboard is not { } clipboard)
+        {
+            return;
+        }
+
+        try
+        {
+            await clipboard.SetTextAsync(role.Name);
+        }
+        catch (Exception)
+        {
+            // Another app holding the clipboard locked is not worth a crash.
+        }
+    }
+
+    /// <summary>Reloads one group node's children, leaving the rest of the tree alone.</summary>
+    private async void OnRefreshNodeClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem { Tag: SchemaTreeNode node })
+        {
+            await node.RefreshAsync();
+        }
+    }
+
     private async void OnRefreshSchemaClick(object? sender, RoutedEventArgs e)
     {
         // Just this schema's own children — the sidebar's refresh button is

--- a/PgNimbus.App/Views/Security/BulkGrantDialog.axaml
+++ b/PgNimbus.App/Views/Security/BulkGrantDialog.axaml
@@ -1,0 +1,97 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:PgNimbus.App.ViewModels.Security"
+        x:Class="PgNimbus.App.Views.Security.BulkGrantDialog"
+        x:DataType="vm:BulkGrantViewModel"
+        Title="Bulk grant"
+        Width="660" Height="640"
+        MinWidth="520" MinHeight="480"
+        WindowStartupLocation="CenterOwner"
+        FontFamily="{StaticResource InterFont}">
+
+    <Grid Margin="20" RowDefinitions="Auto,Auto,*,Auto">
+
+        <StackPanel Grid.Row="0" Spacing="4" Margin="0,0,0,12">
+            <TextBlock Text="Give a role access to a whole schema" FontWeight="SemiBold" FontSize="14" />
+            <TextBlock TextWrapping="Wrap" FontSize="12" Opacity="0.7"
+                       Text="The script always starts with USAGE on the schema itself — without it every table grant below is inert. Nothing runs from here: the script opens in the editor for you to read and run." />
+        </StackPanel>
+
+        <Border Grid.Row="1" Classes="card" Padding="14" Margin="0,0,0,12">
+            <StackPanel Spacing="10">
+
+                <Grid ColumnDefinitions="110,*,110,*">
+                    <TextBlock Grid.Column="0" Text="Schema" VerticalAlignment="Center" FontSize="12" />
+                    <ComboBox Grid.Column="1" HorizontalAlignment="Stretch"
+                              ItemsSource="{Binding Schemas}"
+                              SelectedItem="{Binding Schema, Mode=TwoWay}"
+                              PlaceholderText="Pick a schema" />
+
+                    <TextBlock Grid.Column="2" Text="Grantee" VerticalAlignment="Center" FontSize="12" Margin="16,0,0,0" />
+                    <ComboBox Grid.Column="3" HorizontalAlignment="Stretch"
+                              ItemsSource="{Binding Grantees}"
+                              SelectedItem="{Binding Grantee, Mode=TwoWay}"
+                              PlaceholderText="Pick a role" />
+                </Grid>
+
+                <Grid ColumnDefinitions="110,*">
+                    <TextBlock Grid.Column="0" Text="Preset" VerticalAlignment="Center" FontSize="12" />
+                    <ComboBox Grid.Column="1" HorizontalAlignment="Stretch"
+                              ItemsSource="{Binding Presets}"
+                              SelectedItem="{Binding Preset, Mode=TwoWay}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate x:DataType="vm:BulkGrantPresetOption">
+                                <TextBlock Text="{Binding Label}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </Grid>
+
+                <TextBlock Text="{Binding PresetDescription}" TextWrapping="Wrap" FontSize="11.5"
+                           Opacity="0.7" Margin="110,0,0,0" />
+
+                <!-- The trap complaint 2 in the design doc is about: ON ALL TABLES
+                     covers only what exists right now, so the next migration
+                     creates a table the role cannot read. -->
+                <CheckBox IsChecked="{Binding IncludeFutureObjects, Mode=TwoWay}"
+                          Content="Also cover objects created later (adds ALTER DEFAULT PRIVILEGES)" />
+
+                <TextBlock TextWrapping="Wrap" FontSize="11.5" Opacity="0.7" Margin="26,-4,0,0"
+                           Text="Without this, the grant reaches only the tables, views and sequences that exist at the moment it runs. Anything a later migration creates is not covered." />
+
+                <Grid ColumnDefinitions="110,*" IsEnabled="{Binding IncludeFutureObjects}">
+                    <TextBlock Grid.Column="0" Text="Created by" VerticalAlignment="Center" FontSize="12" />
+                    <ComboBox Grid.Column="1" HorizontalAlignment="Stretch"
+                              ItemsSource="{Binding CreatorRoles}"
+                              SelectedItem="{Binding FutureObjectsOwner, Mode=TwoWay}"
+                              PlaceholderText="The role that will create the objects" />
+                </Grid>
+
+                <TextBlock TextWrapping="Wrap" FontSize="11.5" Margin="110,-4,0,0"
+                           Foreground="{StaticResource AppWarningBrush}"
+                           IsVisible="{Binding IncludeFutureObjects}"
+                           Text="ALTER DEFAULT PRIVILEGES is keyed to the role that creates an object, not to the schema the object lands in. Point it at the wrong creator and it runs cleanly and does nothing — name the role your migrations connect as." />
+
+            </StackPanel>
+        </Border>
+
+        <Border Grid.Row="2" BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1" CornerRadius="6">
+            <TextBox Text="{Binding Script, Mode=OneWay}"
+                     IsReadOnly="True"
+                     AcceptsReturn="True" TextWrapping="NoWrap"
+                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                     ScrollViewer.VerticalScrollBarVisibility="Auto"
+                     FontFamily="Cascadia Code,Consolas,Menlo,monospace" FontSize="12.5"
+                     BorderThickness="0" Background="Transparent" />
+        </Border>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8"
+                    HorizontalAlignment="Right" Margin="0,14,0,0">
+            <Button Classes="accent" Content="Open in editor" Click="OnOpenClick"
+                    IsEnabled="{Binding CanOpen}" />
+            <Button Classes="soft" Content="Cancel" Click="OnCancelClick" />
+        </StackPanel>
+
+    </Grid>
+
+</Window>

--- a/PgNimbus.App/Views/Security/BulkGrantDialog.axaml.cs
+++ b/PgNimbus.App/Views/Security/BulkGrantDialog.axaml.cs
@@ -1,0 +1,27 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace PgNimbus.App.Views.Security;
+
+/// <summary>
+/// "Give this role read access to this schema", as a script. The form edits a
+/// <c>BulkGrantRequest</c> and the preview re-renders live; the affirmative is
+/// <b>Open in editor</b>, which hands the script to the main window's editor
+/// through the caller.
+///
+/// There is deliberately no Apply. Every privilege change in this feature leaves
+/// as SQL the user can read, edit and keep — this dialog never writes to the
+/// database, so it returns nothing but "the user accepted".
+/// </summary>
+public partial class BulkGrantDialog : Window
+{
+    public BulkGrantDialog()
+    {
+        InitializeComponent();
+        ThemedWindowChrome.Attach(this);
+    }
+
+    private void OnOpenClick(object? sender, RoutedEventArgs e) => Close(true);
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e) => Close(false);
+}

--- a/PgNimbus.App/Views/Security/DefaultPrivilegesTabView.axaml
+++ b/PgNimbus.App/Views/Security/DefaultPrivilegesTabView.axaml
@@ -3,5 +3,72 @@
              xmlns:vm="using:PgNimbus.App.ViewModels.Security"
              x:Class="PgNimbus.App.Views.Security.DefaultPrivilegesTabView"
              x:DataType="vm:DefaultPrivilegesTabViewModel">
-    <Panel />
+
+    <Grid RowDefinitions="Auto,*,Auto" Margin="0,8,0,0">
+
+        <!-- One action, and it leaves through the editor like every other write
+             path in this window: the statement lands in a new tab where it can be
+             edited into a REVOKE or aimed at a different creating role. -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="6" Margin="0,0,0,8">
+            <Button Classes="soft"
+                    Command="{Binding CopySelectedAsSqlCommand}"
+                    ToolTip.Tip="Open the ALTER DEFAULT PRIVILEGES statement this row represents in a new editor tab">
+                <TextBlock Text="Copy as SQL" VerticalAlignment="Center" />
+            </Button>
+        </StackPanel>
+
+        <Border Grid.Row="1" ClipToBounds="True"
+                BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                CornerRadius="{StaticResource CardCornerRadius}">
+            <Panel>
+                <DataGrid ItemsSource="{Binding Rows}" SelectedItem="{Binding SelectedRow, Mode=TwoWay}"
+                          IsVisible="{Binding HasRows}"
+                          IsReadOnly="True" SelectionMode="Single"
+                          CanUserResizeColumns="True" CanUserSortColumns="False"
+                          GridLinesVisibility="Horizontal" HeadersVisibility="Column">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Created by" Binding="{Binding OwnerRole}" Width="160" />
+                        <DataGridTextColumn Header="In schema" Binding="{Binding SchemaLabel}" Width="160" />
+                        <DataGridTextColumn Header="Applies to" Binding="{Binding AppliesToLabel}" Width="110" />
+                        <DataGridTextColumn Header="Grantee" Binding="{Binding GranteeLabel}" Width="160" />
+                        <DataGridTemplateColumn Header="Privileges" Width="*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate x:DataType="vm:DefaultPrivilegeRow">
+                                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="12,0" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding PrivilegesText}" VerticalAlignment="Center" />
+                                        <!-- The grant option is part of the statement, not a footnote
+                                             on one privilege - kept visibly beside the list. -->
+                                        <TextBlock Text="{Binding GrantOptionNote}" VerticalAlignment="Center"
+                                                   FontSize="11" Opacity="0.6"
+                                                   IsVisible="{Binding WithGrantOption}" />
+                                    </StackPanel>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                    </DataGrid.Columns>
+                </DataGrid>
+
+                <!-- Nothing configured is a real state with real consequences, and an
+                     empty grid says none of them. -->
+                <StackPanel IsVisible="{Binding !HasRows}" Spacing="6" MaxWidth="560"
+                            HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <TextBlock Text="No default privileges are configured."
+                               FontWeight="SemiBold" HorizontalAlignment="Center" />
+                    <TextBlock TextWrapping="Wrap" TextAlignment="Center" Opacity="0.65" FontSize="12"
+                               Text="Every object created from now on will carry only the built-in defaults: its owner gets everything, PUBLIC gets EXECUTE on functions and USAGE on types, and nothing at all on tables and sequences." />
+                </StackPanel>
+            </Panel>
+        </Border>
+
+        <!-- The two things people get wrong about pg_default_acl. Neither is
+             visible in the grid above, and both are why the tab exists. -->
+        <StackPanel Grid.Row="2" Margin="4,8,4,0" Spacing="4">
+            <TextBlock FontSize="11" Opacity="0.6" TextWrapping="Wrap"
+                       Text="These do not affect objects that already exist. They apply to objects created from now on, which is why a GRANT … ON ALL TABLES IN SCHEMA … and a default privilege are both needed: neither replaces the other." />
+            <TextBlock FontSize="11" Opacity="0.6" TextWrapping="Wrap"
+                       Text="They are keyed to the role that creates the object, not to the schema it lands in. A default privilege set for the wrong creator runs fine and silently does nothing — the single most common reason someone says they set default privileges and nothing changed." />
+        </StackPanel>
+
+    </Grid>
+
 </UserControl>

--- a/PgNimbus.App/Views/Security/DefaultPrivilegesTabView.axaml.cs
+++ b/PgNimbus.App/Views/Security/DefaultPrivilegesTabView.axaml.cs
@@ -2,6 +2,12 @@ using Avalonia.Controls;
 
 namespace PgNimbus.App.Views.Security;
 
+/// <summary>
+/// The Roles &amp; Permissions window's default-privileges tab. No code-behind
+/// beyond loading the XAML: the grid, the empty state and the one action are all
+/// bindings onto <see cref="ViewModels.Security.DefaultPrivilegesTabViewModel"/>,
+/// and there is no interaction here that needs to touch a <c>Control</c>.
+/// </summary>
 public partial class DefaultPrivilegesTabView : UserControl
 {
     public DefaultPrivilegesTabView()

--- a/PgNimbus.App/Views/Security/DropRoleDialog.axaml
+++ b/PgNimbus.App/Views/Security/DropRoleDialog.axaml
@@ -23,13 +23,20 @@
 
         <Grid Grid.Row="1" ColumnDefinitions="*,12,*">
 
-            <StackPanel Grid.Column="0" Spacing="6">
-                <TextBlock Text="{Binding OwnedHeader}" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
-                <Border Background="{StaticResource CardBackgroundBrush}"
+            <!-- Grid, not StackPanel: the card has to fill the row so the layout
+                 does not jump between the empty and the populated state. -->
+            <Grid Grid.Column="0" RowDefinitions="Auto,*">
+                <TextBlock Grid.Row="0" Text="{Binding OwnedHeader}" FontSize="10" Opacity="0.55"
+                           FontWeight="SemiBold" Margin="0,0,0,6" />
+                <Border Grid.Row="1" Background="{StaticResource CardBackgroundBrush}"
                         BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
                         CornerRadius="{StaticResource CardCornerRadius}">
                     <Panel>
-                        <DataGrid ItemsSource="{Binding Owned}" IsReadOnly="True" SelectionMode="Single"
+                        <!-- Hidden rather than left under the empty-state text: a DataGrid with
+                             no rows still draws its column headers, and they showed
+                             through the sentence explaining there is nothing to show. -->
+                        <DataGrid IsVisible="{Binding HasOwned}"
+                                  ItemsSource="{Binding Owned}" IsReadOnly="True" SelectionMode="Single"
                                   CanUserSortColumns="False" GridLinesVisibility="Horizontal" HeadersVisibility="Column">
                             <DataGrid.Columns>
                                 <DataGridTextColumn Header="Kind" Binding="{Binding Kind}" Width="110" />
@@ -37,19 +44,27 @@
                             </DataGrid.Columns>
                         </DataGrid>
                         <TextBlock Text="Owns nothing in this database." FontSize="12" Opacity="0.6"
-                                   Margin="12" VerticalAlignment="Top"
+                                   Margin="16" TextWrapping="Wrap" TextAlignment="Center"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"
                                    IsVisible="{Binding !HasOwned}" />
                     </Panel>
                 </Border>
-            </StackPanel>
+            </Grid>
 
-            <StackPanel Grid.Column="2" Spacing="6">
-                <TextBlock Text="{Binding GrantsHeader}" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
-                <Border Background="{StaticResource CardBackgroundBrush}"
+            <!-- Grid, not StackPanel: the card has to fill the row so the layout
+                 does not jump between the empty and the populated state. -->
+            <Grid Grid.Column="2" RowDefinitions="Auto,*">
+                <TextBlock Grid.Row="0" Text="{Binding GrantsHeader}" FontSize="10" Opacity="0.55"
+                           FontWeight="SemiBold" Margin="0,0,0,6" />
+                <Border Grid.Row="1" Background="{StaticResource CardBackgroundBrush}"
                         BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
                         CornerRadius="{StaticResource CardCornerRadius}">
                     <Panel>
-                        <DataGrid ItemsSource="{Binding GrantsHeld}" IsReadOnly="True" SelectionMode="Single"
+                        <!-- Hidden rather than left under the empty-state text: a DataGrid with
+                             no rows still draws its column headers, and they showed
+                             through the sentence explaining there is nothing to show. -->
+                        <DataGrid IsVisible="{Binding HasGrantsHeld}"
+                                  ItemsSource="{Binding GrantsHeld}" IsReadOnly="True" SelectionMode="Single"
                                   CanUserSortColumns="False" GridLinesVisibility="Horizontal" HeadersVisibility="Column">
                             <DataGrid.Columns>
                                 <DataGridTextColumn Header="Kind" Binding="{Binding Kind}" Width="140" />
@@ -57,11 +72,12 @@
                             </DataGrid.Columns>
                         </DataGrid>
                         <TextBlock Text="Holds no privileges in this database." FontSize="12" Opacity="0.6"
-                                   Margin="12" VerticalAlignment="Top"
+                                   Margin="16" TextWrapping="Wrap" TextAlignment="Center"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"
                                    IsVisible="{Binding !HasGrantsHeld}" />
                     </Panel>
                 </Border>
-            </StackPanel>
+            </Grid>
 
         </Grid>
 

--- a/PgNimbus.App/Views/Security/DropRoleDialog.axaml
+++ b/PgNimbus.App/Views/Security/DropRoleDialog.axaml
@@ -1,0 +1,113 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:PgNimbus.App.ViewModels.Security"
+        xmlns:sec="using:PgNimbus.Core.Security"
+        x:Class="PgNimbus.App.Views.Security.DropRoleDialog"
+        x:DataType="vm:DropRoleViewModel"
+        Title="Drop role"
+        Width="820" Height="680"
+        MinWidth="640" MinHeight="480"
+        WindowStartupLocation="CenterOwner"
+        FontFamily="{StaticResource InterFont}">
+
+    <Grid RowDefinitions="Auto,*,Auto,Auto" Margin="16">
+
+        <StackPanel Grid.Row="0" Spacing="4" Margin="0,0,0,12">
+            <TextBlock Text="{Binding RoleName}" FontSize="17" FontWeight="SemiBold" />
+            <!-- Postgres's own 2BP01 says a role cannot be dropped and nothing
+                 else: not which objects block it, not that the fix is three
+                 statements, not that all three act on one database only. -->
+            <TextBlock FontSize="12" Opacity="0.7" TextWrapping="Wrap"
+                       Text="A role that owns objects or holds privileges cannot be dropped outright. Reassigning its objects and clearing its privileges first is what makes DROP ROLE succeed." />
+        </StackPanel>
+
+        <Grid Grid.Row="1" ColumnDefinitions="*,12,*">
+
+            <StackPanel Grid.Column="0" Spacing="6">
+                <TextBlock Text="{Binding OwnedHeader}" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                <Border Background="{StaticResource CardBackgroundBrush}"
+                        BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                        CornerRadius="{StaticResource CardCornerRadius}">
+                    <Panel>
+                        <DataGrid ItemsSource="{Binding Owned}" IsReadOnly="True" SelectionMode="Single"
+                                  CanUserSortColumns="False" GridLinesVisibility="Horizontal" HeadersVisibility="Column">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Kind" Binding="{Binding Kind}" Width="110" />
+                                <DataGridTextColumn Header="Object" Binding="{Binding Identity}" Width="*" />
+                            </DataGrid.Columns>
+                        </DataGrid>
+                        <TextBlock Text="Owns nothing in this database." FontSize="12" Opacity="0.6"
+                                   Margin="12" VerticalAlignment="Top"
+                                   IsVisible="{Binding !HasOwned}" />
+                    </Panel>
+                </Border>
+            </StackPanel>
+
+            <StackPanel Grid.Column="2" Spacing="6">
+                <TextBlock Text="{Binding GrantsHeader}" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                <Border Background="{StaticResource CardBackgroundBrush}"
+                        BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                        CornerRadius="{StaticResource CardCornerRadius}">
+                    <Panel>
+                        <DataGrid ItemsSource="{Binding GrantsHeld}" IsReadOnly="True" SelectionMode="Single"
+                                  CanUserSortColumns="False" GridLinesVisibility="Horizontal" HeadersVisibility="Column">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Kind" Binding="{Binding Kind}" Width="140" />
+                                <DataGridTextColumn Header="Object" Binding="{Binding Identity}" Width="*" />
+                            </DataGrid.Columns>
+                        </DataGrid>
+                        <TextBlock Text="Holds no privileges in this database." FontSize="12" Opacity="0.6"
+                                   Margin="12" VerticalAlignment="Top"
+                                   IsVisible="{Binding !HasGrantsHeld}" />
+                    </Panel>
+                </Border>
+            </StackPanel>
+
+        </Grid>
+
+        <StackPanel Grid.Row="2" Spacing="8" Margin="0,12,0,0">
+
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="Reassign owned objects to" VerticalAlignment="Center" FontSize="12" />
+                <ComboBox ItemsSource="{Binding ReassignTargets}" SelectedItem="{Binding ReassignTo, Mode=TwoWay}"
+                          MinWidth="260">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="vm:ReassignOption">
+                            <TextBlock Text="{Binding Label}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </StackPanel>
+
+            <TextBlock IsVisible="{Binding WillDeleteOwnedObjects}"
+                       Foreground="{StaticResource AppWarningBrush}" FontSize="12" TextWrapping="Wrap"
+                       Text="With no successor named, DROP OWNED deletes the objects this role owns instead of transferring them." />
+
+            <TextBlock FontSize="11" Opacity="0.6" TextWrapping="Wrap"
+                       Text="REASSIGN OWNED and DROP OWNED act on the current database only. If this role owns objects in other databases, run the script again while connected to each of them before the role will drop." />
+
+            <Border Background="{StaticResource CardBackgroundBrush}"
+                    BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                    CornerRadius="{StaticResource CardCornerRadius}" Padding="12,10" MaxHeight="170">
+                <ScrollViewer>
+                    <SelectableTextBlock Text="{Binding Script}" FontFamily="Consolas,Menlo,monospace"
+                                         FontSize="12" TextWrapping="NoWrap" />
+                </ScrollViewer>
+            </Border>
+
+        </StackPanel>
+
+        <StackPanel Grid.Row="3" Margin="0,12,0,0" Spacing="8">
+            <TextBlock Text="{Binding ErrorMessage}" IsVisible="{Binding HasErrorMessage}"
+                       Foreground="{StaticResource AppDangerBrush}" FontSize="12" TextWrapping="Wrap" />
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+                <Button Classes="soft" Content="Cancel" Click="OnCancelClick" IsCancel="True" />
+                <Button Classes="soft" Content="Open in editor" Command="{Binding OpenInEditorCommand}"
+                        ToolTip.Tip="Run it yourself — and re-run it in every other database this role owns objects in" />
+                <Button Classes="danger" Content="Run it" Command="{Binding RunCommand}" />
+            </StackPanel>
+        </StackPanel>
+
+    </Grid>
+
+</Window>

--- a/PgNimbus.App/Views/Security/DropRoleDialog.axaml
+++ b/PgNimbus.App/Views/Security/DropRoleDialog.axaml
@@ -10,7 +10,10 @@
         WindowStartupLocation="CenterOwner"
         FontFamily="{StaticResource InterFont}">
 
-    <Grid RowDefinitions="Auto,*,Auto,Auto" Margin="16">
+    <!-- Two growing rows: the dependency lists and the script. Dragging the
+         window taller has to give the script the room, because reading it is
+         what the dialog is for. -->
+    <Grid RowDefinitions="Auto,*,Auto,2*,Auto" Margin="16">
 
         <StackPanel Grid.Row="0" Spacing="4" Margin="0,0,0,12">
             <TextBlock Text="{Binding RoleName}" FontSize="17" FontWeight="SemiBold" />
@@ -110,18 +113,22 @@
             <TextBlock FontSize="11" Opacity="0.6" TextWrapping="Wrap"
                        Text="REASSIGN OWNED and DROP OWNED act on the current database only. If this role owns objects in other databases, run the script again while connected to each of them before the role will drop." />
 
-            <Border Background="{StaticResource CardBackgroundBrush}"
-                    BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
-                    CornerRadius="{StaticResource CardCornerRadius}" Padding="12,10" MaxHeight="170">
-                <ScrollViewer>
-                    <SelectableTextBlock Text="{Binding Script}" FontFamily="Consolas,Menlo,monospace"
-                                         FontSize="12" TextWrapping="NoWrap" />
-                </ScrollViewer>
-            </Border>
-
         </StackPanel>
 
-        <StackPanel Grid.Row="3" Margin="0,12,0,0" Spacing="8">
+        <!-- Uncapped: it fills its row and grows with the window, rather than
+             scrolling inside a fixed 170px box while the dialog has space to
+             spare. -->
+        <Border Grid.Row="3" Margin="0,10,0,0"
+                Background="{StaticResource CardBackgroundBrush}"
+                BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                CornerRadius="{StaticResource CardCornerRadius}" Padding="12,10">
+            <ScrollViewer>
+                <SelectableTextBlock Text="{Binding Script}" FontFamily="Consolas,Menlo,monospace"
+                                     FontSize="12" TextWrapping="NoWrap" />
+            </ScrollViewer>
+        </Border>
+
+        <StackPanel Grid.Row="4" Margin="0,12,0,0" Spacing="8">
             <TextBlock Text="{Binding ErrorMessage}" IsVisible="{Binding HasErrorMessage}"
                        Foreground="{StaticResource AppDangerBrush}" FontSize="12" TextWrapping="Wrap" />
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">

--- a/PgNimbus.App/Views/Security/DropRoleDialog.axaml
+++ b/PgNimbus.App/Views/Security/DropRoleDialog.axaml
@@ -95,6 +95,14 @@
                 </ComboBox>
             </StackPanel>
 
+            <!-- Off only for a superuser, who holds these privileges implicitly.
+                 On managed Postgres nobody is one, and without the grants the
+                 server refuses with 42501 no matter what the role owns. -->
+            <CheckBox IsChecked="{Binding GrantMembershipFirst, Mode=TwoWay}"
+                      ToolTip.Tip="REASSIGN OWNED and DROP OWNED require the privileges of the role being emptied. The script grants them to you and gives back the one that outlives it.">
+                <TextBlock Text="Grant myself the memberships the script needs" TextWrapping="Wrap" />
+            </CheckBox>
+
             <TextBlock IsVisible="{Binding WillDeleteOwnedObjects}"
                        Foreground="{StaticResource AppWarningBrush}" FontSize="12" TextWrapping="Wrap"
                        Text="With no successor named, DROP OWNED deletes the objects this role owns instead of transferring them." />

--- a/PgNimbus.App/Views/Security/DropRoleDialog.axaml.cs
+++ b/PgNimbus.App/Views/Security/DropRoleDialog.axaml.cs
@@ -1,0 +1,22 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace PgNimbus.App.Views.Security;
+
+/// <summary>
+/// Shown via <c>ShowDialog&lt;bool&gt;</c> by <see cref="RolesTabView"/>. The view
+/// model closes it through its <c>CloseRequested</c> callback, so an error from
+/// the server keeps the dialog up with its message rather than dismissing it —
+/// on a managed server that message ("permission denied to create role") is the
+/// useful part.
+/// </summary>
+public partial class DropRoleDialog : Window
+{
+    public DropRoleDialog()
+    {
+        InitializeComponent();
+        ThemedWindowChrome.Attach(this);
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e) => Close(false);
+}

--- a/PgNimbus.App/Views/Security/PermissionsTabView.axaml
+++ b/PgNimbus.App/Views/Security/PermissionsTabView.axaml
@@ -33,7 +33,10 @@
 
         <Grid Grid.Row="1" ColumnDefinitions="210,12,*">
 
-            <Border Grid.Column="0" Background="{StaticResource CardBackgroundBrush}"
+            <!-- Same resizable split as the roles tab: object names run long, and
+                 the matrix wants every pixel once a table carries eight privileges. -->
+
+            <Border Grid.Column="0" MinWidth="140" Background="{StaticResource CardBackgroundBrush}"
                     BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
                     CornerRadius="{StaticResource CardCornerRadius}">
                 <ListBox ItemsSource="{Binding Objects}" SelectedItem="{Binding SelectedObject, Mode=TwoWay}">
@@ -45,7 +48,22 @@
                 </ListBox>
             </Border>
 
-            <Grid Grid.Column="2" RowDefinitions="Auto,Auto,*,Auto">
+            <GridSplitter Grid.Column="1"
+                          HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                          ResizeDirection="Columns" ResizeBehavior="PreviousAndNext"
+                          Background="Transparent">
+                <GridSplitter.Template>
+                    <ControlTemplate>
+                        <Border Background="{TemplateBinding Background}">
+                            <Rectangle Width="2" Height="36" RadiusX="1" RadiusY="1"
+                                       VerticalAlignment="Center" HorizontalAlignment="Center"
+                                       Fill="{DynamicResource CardBorderBrush}" />
+                        </Border>
+                    </ControlTemplate>
+                </GridSplitter.Template>
+            </GridSplitter>
+
+            <Grid Grid.Column="2" RowDefinitions="Auto,Auto,*,Auto" MinWidth="420">
 
                 <!-- A NULL catalog ACL means "untouched", not "no privileges". An
                      empty grid with no explanation is the bug this banner prevents. -->

--- a/PgNimbus.App/Views/Security/PermissionsTabView.axaml
+++ b/PgNimbus.App/Views/Security/PermissionsTabView.axaml
@@ -1,7 +1,164 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:PgNimbus.App.ViewModels.Security"
+             xmlns:sec="using:PgNimbus.Core.Security"
              x:Class="PgNimbus.App.Views.Security.PermissionsTabView"
              x:DataType="vm:PermissionsTabViewModel">
-    <Panel />
+
+    <Grid RowDefinitions="Auto,*,Auto" Margin="0,10,0,0">
+
+        <!-- Picker and edit strip, one band: the window already carries a toolbar. -->
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,Auto,Auto,*,Auto,Auto,Auto" Margin="0,0,0,10">
+            <ComboBox Grid.Column="0" ItemsSource="{Binding Kinds}" SelectedItem="{Binding SelectedKind, Mode=TwoWay}"
+                      MinWidth="110" VerticalAlignment="Center" />
+            <ComboBox Grid.Column="1" ItemsSource="{Binding Schemas}" SelectedItem="{Binding SelectedSchema, Mode=TwoWay}"
+                      MinWidth="150" Margin="8,0,0,0" VerticalAlignment="Center"
+                      IsVisible="{Binding KindHasSchema}" PlaceholderText="Schema" />
+            <TextBox Grid.Column="2" Text="{Binding ObjectFilter}" Watermark="Filter objects"
+                     MinWidth="160" Margin="8,0,0,0" VerticalAlignment="Center" />
+            <Button Grid.Column="3" Classes="soft" Content="Bulk grant…" Margin="8,0,0,0"
+                    Command="{Binding BulkGrantCommand}"
+                    ToolTip.Tip="Give a role access to a whole schema, including objects created later" />
+
+            <ToggleButton Grid.Column="5" Classes="soft" Content="Edit grants" IsChecked="{Binding IsEditing, Mode=TwoWay}"
+                          ToolTip.Tip="Click cells to stage a GRANT or REVOKE; nothing runs until you review the script" />
+            <TextBlock Grid.Column="6" Text="{Binding PendingLabel}" VerticalAlignment="Center"
+                       FontSize="11" Opacity="0.7" Margin="10,0,0,0" IsVisible="{Binding IsEditing}" />
+            <StackPanel Grid.Column="7" Orientation="Horizontal" Spacing="6" Margin="10,0,0,0"
+                        IsVisible="{Binding HasPending}">
+                <Button Classes="soft" Content="Discard" Command="{Binding ClearPendingCommand}" />
+                <Button Classes="accent" Content="Review changes" Command="{Binding ReviewChangesCommand}" />
+            </StackPanel>
+        </Grid>
+
+        <Grid Grid.Row="1" ColumnDefinitions="210,12,*">
+
+            <Border Grid.Column="0" Background="{StaticResource CardBackgroundBrush}"
+                    BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                    CornerRadius="{StaticResource CardCornerRadius}">
+                <ListBox ItemsSource="{Binding Objects}" SelectedItem="{Binding SelectedObject, Mode=TwoWay}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="sec:SecurableRef">
+                            <TextBlock Text="{Binding Display}" TextTrimming="CharacterEllipsis" />
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Border>
+
+            <Grid Grid.Column="2" RowDefinitions="Auto,Auto,*,Auto">
+
+                <!-- A NULL catalog ACL means "untouched", not "no privileges". An
+                     empty grid with no explanation is the bug this banner prevents. -->
+                <Border Grid.Row="0" IsVisible="{Binding IsDefaultAcl}"
+                        Background="{StaticResource CardBackgroundBrush}"
+                        BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                        CornerRadius="{StaticResource CardCornerRadius}" Padding="12,9" Margin="0,0,0,8">
+                    <TextBlock Text="{Binding DefaultAclNote}" TextWrapping="Wrap" FontSize="12" Opacity="0.8" />
+                </Border>
+
+                <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Margin="0,0,0,6">
+                    <TextBox Grid.Column="0" Text="{Binding RoleFilter}" Watermark="Filter roles" MaxWidth="240"
+                             HorizontalAlignment="Left" />
+                    <ToggleButton Grid.Column="1" Classes="chip" Content="Built-in roles"
+                                  IsChecked="{Binding ShowPredefinedRoles, Mode=TwoWay}"
+                                  ToolTip.Tip="Show the pg_* roles initdb created" />
+                </Grid>
+
+                <!-- Fixed widths keep the header aligned with the rows; a DataGrid
+                     cannot carry a per-cell source tint this cheaply. -->
+                <Border Grid.Row="2" Background="{StaticResource CardBackgroundBrush}"
+                        BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                        CornerRadius="{StaticResource CardCornerRadius}" Padding="10,8">
+                    <ScrollViewer HorizontalScrollBarVisibility="Auto">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="12,0,0,6">
+                                <TextBlock Text="ROLE" Width="150" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                                <ItemsControl ItemsSource="{Binding PrivilegeColumns}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <StackPanel Orientation="Horizontal" />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="vm:PrivilegeColumn">
+                                            <TextBlock Text="{Binding Header}" Width="66" FontSize="10"
+                                                       Opacity="0.55" FontWeight="SemiBold" TextAlignment="Center" />
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                                <TextBlock Text="HOW" Width="120" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                            </StackPanel>
+
+                            <ListBox ItemsSource="{Binding Rows}" SelectedItem="{Binding SelectedRow, Mode=TwoWay}"
+                                     Background="Transparent" BorderThickness="0">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:PermissionRowViewModel">
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="{Binding Role}" Width="150" VerticalAlignment="Center"
+                                                       TextTrimming="CharacterEllipsis" />
+                                            <ItemsControl ItemsSource="{Binding Cells}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel Orientation="Horizontal" />
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="vm:PrivilegeCellViewModel">
+                                                        <Button Classes="toolbar" Width="66" Padding="0"
+                                                                Command="{Binding ToggleCommand}"
+                                                                ToolTip.Tip="{Binding Tooltip}">
+                                                            <Panel>
+                                                                <TextBlock Text="{Binding Glyph}" HorizontalAlignment="Center"
+                                                                           Opacity="{Binding Weight}" FontSize="13"
+                                                                           IsVisible="{Binding !IsUnexplained}" />
+                                                                <!-- Granted, but nothing in the catalog explains it. -->
+                                                                <TextBlock Text="{Binding Glyph}" HorizontalAlignment="Center"
+                                                                           Foreground="{StaticResource AppWarningBrush}"
+                                                                           FontSize="13" IsVisible="{Binding IsUnexplained}" />
+                                                            </Panel>
+                                                        </Button>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                            <TextBlock Text="{Binding SourceSummary}" Width="120" VerticalAlignment="Center"
+                                                       FontSize="11" Opacity="0.7" TextTrimming="CharacterEllipsis" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </StackPanel>
+                    </ScrollViewer>
+                </Border>
+
+                <!-- Column grants are additive on top of the table's, and no other
+                     client surfaces them. A compact list is enough. -->
+                <StackPanel Grid.Row="3" Spacing="4" Margin="0,8,0,0" IsVisible="{Binding HasColumnGrants}">
+                    <TextBlock Text="COLUMN GRANTS" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <ItemsControl ItemsSource="{Binding ColumnGrants}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:ColumnGrantRow">
+                                <StackPanel Orientation="Horizontal" Spacing="10">
+                                    <TextBlock Text="{Binding Column}" FontWeight="SemiBold" FontSize="12" MinWidth="120" />
+                                    <TextBlock Text="{Binding Grants}" FontSize="12" Opacity="0.75" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+            </Grid>
+
+        </Grid>
+
+        <!-- The plain-English answer, given real space on purpose: it is the thing
+             no other client can tell you. -->
+        <Border Grid.Row="2" IsVisible="{Binding HasAccessSentence}" Margin="0,10,0,0"
+                Background="{StaticResource CardBackgroundBrush}"
+                BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                CornerRadius="{StaticResource CardCornerRadius}" Padding="14,11">
+            <SelectableTextBlock Text="{Binding AccessSentence}" TextWrapping="Wrap" FontSize="13" />
+        </Border>
+
+    </Grid>
+
 </UserControl>

--- a/PgNimbus.App/Views/Security/PermissionsTabView.axaml.cs
+++ b/PgNimbus.App/Views/Security/PermissionsTabView.axaml.cs
@@ -1,11 +1,37 @@
 using Avalonia.Controls;
+using PgNimbus.App.ViewModels.Security;
 
 namespace PgNimbus.App.Views.Security;
 
+/// <summary>
+/// The permissions matrix. The view owns the bulk-grant modal; the view model
+/// asks for it through a callback rather than constructing a
+/// <see cref="Window"/> itself.
+/// </summary>
 public partial class PermissionsTabView : UserControl
 {
     public PermissionsTabView()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, System.EventArgs e)
+    {
+        if (DataContext is PermissionsTabViewModel vm)
+        {
+            vm.ShowBulkGrantDialog = ShowBulkGrantAsync;
+        }
+    }
+
+    private async Task<bool> ShowBulkGrantAsync(BulkGrantViewModel model)
+    {
+        if (TopLevel.GetTopLevel(this) is not Window owner)
+        {
+            return false;
+        }
+
+        var dialog = new BulkGrantDialog { DataContext = model };
+        return await dialog.ShowDialog<bool>(owner);
     }
 }

--- a/PgNimbus.App/Views/Security/RlsTabView.axaml
+++ b/PgNimbus.App/Views/Security/RlsTabView.axaml
@@ -2,6 +2,166 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:PgNimbus.App.ViewModels.Security"
              x:Class="PgNimbus.App.Views.Security.RlsTabView"
+             x:Name="Root"
              x:DataType="vm:RlsTabViewModel">
-    <Panel />
+
+    <Grid RowDefinitions="Auto,*" Margin="0,8,0,0">
+
+        <!-- Filter on the left, the one action on the right: one band of chrome,
+             like the monitoring windows. -->
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,*,Auto" Margin="0,0,0,8">
+            <TextBlock Grid.Column="0" Text="Schema" VerticalAlignment="Center"
+                       FontSize="12" Opacity="0.6" Margin="2,0,8,0" />
+            <ComboBox Grid.Column="1" MinWidth="180"
+                      ItemsSource="{Binding Schemas}"
+                      SelectedItem="{Binding SelectedSchema, Mode=TwoWay}"
+                      ToolTip.Tip="Only schemas that have row-level security anywhere are listed" />
+
+            <Button Grid.Column="3" Classes="soft"
+                    Command="{Binding CopyPolicyAsSqlCommand}"
+                    ToolTip.Tip="Open the selected policy's CREATE POLICY statement in a new editor tab — Postgres cannot change a policy's command or permissiveness in place, so re-creating it is how one gets edited">
+                <TextBlock Text="Copy policy as SQL" VerticalAlignment="Center" />
+            </Button>
+        </Grid>
+
+        <Panel Grid.Row="1">
+
+            <Grid ColumnDefinitions="300,12,*" IsVisible="{Binding HasTables}">
+
+                <!-- Master: every table that has RLS on, or has policies at all -->
+                <Border Grid.Column="0" ClipToBounds="True"
+                        BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                        CornerRadius="{StaticResource CardCornerRadius}">
+                    <ListBox ItemsSource="{Binding Tables}" SelectedItem="{Binding SelectedTable, Mode=TwoWay}"
+                             Background="Transparent" BorderThickness="0">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate x:DataType="vm:RlsTableRow">
+                                <StackPanel Spacing="2" Margin="0,3">
+                                    <TextBlock Text="{Binding Display}" FontWeight="SemiBold"
+                                               TextTrimming="CharacterEllipsis" />
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <TextBlock Text="{Binding StatusLabel}" FontSize="11" Opacity="0.6" />
+                                        <TextBlock Text="{Binding PolicyCountLabel}" FontSize="11" Opacity="0.6" />
+                                    </StackPanel>
+                                    <!-- Amber, not red: nothing is broken, but this table looks
+                                         protected and is not. -->
+                                    <TextBlock Text="Policies inert — RLS is off" FontSize="11" FontWeight="SemiBold"
+                                               Foreground="{StaticResource AppWarningBrush}"
+                                               IsVisible="{Binding IsInert}" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </Border>
+
+                <!-- Detail. The selected table hangs off the DataContext rather than
+                     sitting inside every binding path: SelectedTable is null whenever
+                     nothing is picked, and a null in the middle of a path is what fills
+                     the log with "Value is null" on every re-evaluation. -->
+                <Border Grid.Column="2" ClipToBounds="True"
+                        BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                        CornerRadius="{StaticResource CardCornerRadius}">
+                    <Grid RowDefinitions="Auto,*" Margin="16,14"
+                          DataContext="{Binding SelectedTable}" x:DataType="vm:RlsTableRow">
+
+                        <StackPanel Grid.Row="0" Spacing="12" Margin="0,0,0,12">
+
+                            <StackPanel Spacing="3">
+                                <TextBlock Text="{Binding Display}" FontSize="16" FontWeight="SemiBold" />
+                                <StackPanel Orientation="Horizontal" Spacing="10">
+                                    <TextBlock Text="{Binding StatusLabel}" FontSize="12" Opacity="0.65" />
+                                    <TextBlock Text="{Binding PolicyCountLabel}" FontSize="12" Opacity="0.65" />
+                                </StackPanel>
+                            </StackPanel>
+
+                            <!-- Warning 1: policies that look like protection and are not -->
+                            <Border Classes="card" Padding="12,10" IsVisible="{Binding IsInert}">
+                                <StackPanel Spacing="4">
+                                    <TextBlock Text="These policies do nothing." FontWeight="SemiBold" FontSize="12"
+                                               Foreground="{StaticResource AppWarningBrush}" />
+                                    <TextBlock TextWrapping="Wrap" FontSize="12" Opacity="0.75"
+                                               Text="Row-level security was never switched on for this table, so every policy below is inert and every role reads every row. Writing policies does not enable it — ALTER TABLE … ENABLE ROW LEVEL SECURITY does." />
+                                </StackPanel>
+                            </Border>
+
+                            <!-- Warning 2: works for me, not for the app -->
+                            <Border Classes="card" Padding="12,10" IsVisible="{Binding IsBypassed}">
+                                <StackPanel Spacing="4">
+                                    <TextBlock Text="You bypass these policies." FontWeight="SemiBold" FontSize="12"
+                                               Foreground="{StaticResource AppWarningBrush}" />
+                                    <TextBlock Text="{Binding BypassReason}" TextWrapping="Wrap"
+                                               FontSize="12" Opacity="0.75" />
+                                </StackPanel>
+                            </Border>
+
+                            <!-- RLS on with nothing to permit: default deny, easy to reach by half a migration -->
+                            <TextBlock IsVisible="{Binding DeniesEverything}" TextWrapping="Wrap"
+                                       FontSize="12" Opacity="0.7"
+                                       Text="Row-level security is enabled and this table has no policies, so it returns no rows to any role that does not bypass it. That is the default-deny state, not a misconfiguration in itself." />
+
+                        </StackPanel>
+
+                        <!-- Policies are selectable because the Copy button acts on one.
+                             The quals are SQL, so they are monospace, selectable and never
+                             trimmed - they are the only part of a policy that says what it
+                             actually does. -->
+                        <ListBox Grid.Row="1" ItemsSource="{Binding Policies}"
+                                 SelectedItem="{Binding #Root.((vm:RlsTabViewModel)DataContext).SelectedPolicy, Mode=TwoWay}"
+                                 Background="Transparent" BorderThickness="0"
+                                 IsVisible="{Binding HasPolicies}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="vm:RlsPolicyRow">
+                                    <StackPanel Spacing="7" Margin="0,4">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" VerticalAlignment="Center" />
+                                            <TextBlock Text="{Binding Kind}" FontSize="11" Opacity="0.55" VerticalAlignment="Center" />
+                                            <TextBlock Text="{Binding Command}" FontSize="11" Opacity="0.55" VerticalAlignment="Center" />
+                                        </StackPanel>
+
+                                        <StackPanel Orientation="Horizontal" Spacing="6">
+                                            <TextBlock Text="Applies to" FontSize="11" Opacity="0.5" VerticalAlignment="Center" />
+                                            <TextBlock Text="{Binding RolesLabel}" FontSize="11" VerticalAlignment="Center"
+                                                       TextWrapping="Wrap" />
+                                        </StackPanel>
+
+                                        <StackPanel Spacing="3" IsVisible="{Binding HasUsing}">
+                                            <TextBlock Text="USING — which existing rows are visible"
+                                                       FontSize="10" Opacity="0.5" FontWeight="SemiBold" />
+                                            <SelectableTextBlock Text="{Binding Using}" TextWrapping="Wrap"
+                                                                 FontFamily="Cascadia Code,Consolas,Menlo,monospace"
+                                                                 FontSize="12" />
+                                        </StackPanel>
+
+                                        <StackPanel Spacing="3" IsVisible="{Binding HasWithCheck}">
+                                            <TextBlock Text="WITH CHECK — which new or updated rows are allowed"
+                                                       FontSize="10" Opacity="0.5" FontWeight="SemiBold" />
+                                            <SelectableTextBlock Text="{Binding WithCheck}" TextWrapping="Wrap"
+                                                                 FontFamily="Cascadia Code,Consolas,Menlo,monospace"
+                                                                 FontSize="12" />
+                                        </StackPanel>
+                                    </StackPanel>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+
+                        <TextBlock Grid.Row="1" IsVisible="{Binding !HasPolicies}" FontSize="12" Opacity="0.55"
+                                   Text="This table has no policies." />
+
+                    </Grid>
+                </Border>
+
+            </Grid>
+
+            <StackPanel IsVisible="{Binding !HasTables}" Spacing="6" MaxWidth="520"
+                        HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="No table here uses row-level security."
+                           FontWeight="SemiBold" HorizontalAlignment="Center" />
+                <TextBlock TextWrapping="Wrap" TextAlignment="Center" Opacity="0.65" FontSize="12"
+                           Text="Tables appear here as soon as they have row security enabled or carry a policy, in either order." />
+            </StackPanel>
+
+        </Panel>
+
+    </Grid>
+
 </UserControl>

--- a/PgNimbus.App/Views/Security/RlsTabView.axaml.cs
+++ b/PgNimbus.App/Views/Security/RlsTabView.axaml.cs
@@ -2,6 +2,11 @@ using Avalonia.Controls;
 
 namespace PgNimbus.App.Views.Security;
 
+/// <summary>
+/// Row-level security: which tables have it, which policies apply, and who
+/// bypasses them. Read-only — the one action hands a CREATE POLICY statement to
+/// the editor rather than applying anything here.
+/// </summary>
 public partial class RlsTabView : UserControl
 {
     public RlsTabView()

--- a/PgNimbus.App/Views/Security/RoleDialog.axaml
+++ b/PgNimbus.App/Views/Security/RoleDialog.axaml
@@ -11,8 +11,11 @@
 
     <Grid RowDefinitions="*,Auto" Margin="16">
 
-        <ScrollViewer Grid.Row="0">
-            <StackPanel Spacing="14">
+        <!-- The scrollbar is an overlay in this theme, so the content needs a
+             gutter of its own: without it the text boxes run underneath the bar
+             and the right edge of every input is unreachable. -->
+        <ScrollViewer Grid.Row="0" HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Spacing="14" Margin="0,0,14,0">
 
                 <!-- Identity -->
                 <StackPanel Spacing="6">
@@ -100,10 +103,14 @@
 
                 <StackPanel Spacing="6">
                     <TextBlock Text="MEMBER OF" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
-                    <Border MaxHeight="150" Background="{StaticResource CardBackgroundBrush}"
+                    <!-- No inner scroll: a capped, scrolling list inside a dialog
+                         that already scrolls gives two bars competing for the
+                         same wheel, and on a server with a handful of roles the
+                         inner one appeared with nothing to scroll. The list grows
+                         to its content and the dialog's own scroll handles it. -->
+                    <Border Background="{StaticResource CardBackgroundBrush}"
                             BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
                             CornerRadius="{StaticResource CardCornerRadius}" Padding="10,8">
-                        <ScrollViewer>
                             <ItemsControl ItemsSource="{Binding GroupMemberships}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate x:DataType="vm:RoleMembershipOption">
@@ -116,7 +123,6 @@
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
-                        </ScrollViewer>
                     </Border>
                 </StackPanel>
 

--- a/PgNimbus.App/Views/Security/RoleDialog.axaml
+++ b/PgNimbus.App/Views/Security/RoleDialog.axaml
@@ -1,0 +1,137 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:PgNimbus.App.ViewModels.Security"
+        x:Class="PgNimbus.App.Views.Security.RoleDialog"
+        x:DataType="vm:RoleEditorViewModel"
+        Title="{Binding Title}"
+        Width="760" Height="660"
+        MinWidth="620" MinHeight="480"
+        WindowStartupLocation="CenterOwner"
+        FontFamily="{StaticResource InterFont}">
+
+    <Grid RowDefinitions="*,Auto" Margin="16">
+
+        <ScrollViewer Grid.Row="0">
+            <StackPanel Spacing="14">
+
+                <!-- Identity -->
+                <StackPanel Spacing="6">
+                    <TextBlock Text="NAME" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <TextBox Text="{Binding Name}" IsEnabled="{Binding CanEditName}" Watermark="app_ro" />
+                </StackPanel>
+
+                <!-- Login and password -->
+                <Border Background="{StaticResource CardBackgroundBrush}"
+                        BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                        CornerRadius="{StaticResource CardCornerRadius}" Padding="14,12">
+                    <StackPanel Spacing="10">
+                        <CheckBox Content="Can log in" IsChecked="{Binding CanLogin}" />
+                        <Grid ColumnDefinitions="*,12,*" IsVisible="{Binding CanLogin}">
+                            <StackPanel Grid.Column="0" Spacing="4">
+                                <TextBlock Text="PASSWORD" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                                <TextBox Text="{Binding Password}" PasswordChar="•" />
+                            </StackPanel>
+                            <StackPanel Grid.Column="2" Spacing="4">
+                                <TextBlock Text="CONFIRM" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                                <TextBox Text="{Binding PasswordConfirm}" PasswordChar="•" />
+                            </StackPanel>
+                        </Grid>
+                    </StackPanel>
+                </Border>
+
+                <!-- Attributes -->
+                <StackPanel Spacing="6">
+                    <TextBlock Text="ATTRIBUTES" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <WrapPanel Orientation="Horizontal">
+                        <CheckBox Content="Inherit" IsChecked="{Binding Inherit}" Margin="0,0,18,4"
+                                  ToolTip.Tip="Off means the role must SET ROLE before a group's privileges apply" />
+                        <CheckBox Content="Superuser" IsChecked="{Binding IsSuperuser}" Margin="0,0,18,4" />
+                        <CheckBox Content="Create DB" IsChecked="{Binding CanCreateDb}" Margin="0,0,18,4" />
+                        <CheckBox Content="Create role" IsChecked="{Binding CanCreateRole}" Margin="0,0,18,4" />
+                        <CheckBox Content="Replication" IsChecked="{Binding CanReplicate}" Margin="0,0,18,4" />
+                        <CheckBox Content="Bypass RLS" IsChecked="{Binding BypassRls}" Margin="0,0,18,4"
+                                  ToolTip.Tip="Skips every row-level security policy, always" />
+                    </WrapPanel>
+                </StackPanel>
+
+                <Grid ColumnDefinitions="*,12,*">
+                    <StackPanel Grid.Column="0" Spacing="4">
+                        <TextBlock Text="CONNECTION LIMIT" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                        <NumericUpDown Value="{Binding ConnectionLimitValue}" Minimum="0" Increment="1"
+                                       Watermark="no limit" FormatString="0" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="2" Spacing="4">
+                        <TextBlock Text="VALID UNTIL" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                        <DatePicker SelectedDate="{Binding ValidUntilDate}" />
+                    </StackPanel>
+                </Grid>
+
+                <!-- Predefined roles first: on PG14+ this is the whole answer to
+                     "make a read-only user", instead of a per-schema grant script. -->
+                <StackPanel Spacing="6" IsVisible="{Binding HasPredefinedMemberships}">
+                    <TextBlock Text="BUILT-IN ROLES" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <ItemsControl ItemsSource="{Binding PredefinedMemberships}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:RoleMembershipOption">
+                                <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,2">
+                                    <CheckBox Content="{Binding Name}" IsChecked="{Binding IsMember}" />
+                                    <TextBlock Text="{Binding Hint}" FontSize="11" Opacity="0.6" VerticalAlignment="Center" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <StackPanel Spacing="6">
+                    <TextBlock Text="MEMBER OF" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <Border MaxHeight="150" Background="{StaticResource CardBackgroundBrush}"
+                            BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                            CornerRadius="{StaticResource CardCornerRadius}" Padding="10,8">
+                        <ScrollViewer>
+                            <ItemsControl ItemsSource="{Binding GroupMemberships}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:RoleMembershipOption">
+                                        <CheckBox Content="{Binding Name}" IsChecked="{Binding IsMember}" Margin="0,1" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </Border>
+                </StackPanel>
+
+                <StackPanel Spacing="4">
+                    <TextBlock Text="COMMENT" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <TextBox Text="{Binding Comment}" Watermark="what this role is for" />
+                </StackPanel>
+
+                <!-- The preview is always the masked build. The real password goes
+                     straight to SecurityEditor and is never rendered anywhere. -->
+                <StackPanel Spacing="4">
+                    <TextBlock Text="GENERATED SQL" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
+                    <Border Background="{StaticResource CardBackgroundBrush}"
+                            BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                            CornerRadius="{StaticResource CardCornerRadius}" Padding="12,10">
+                        <SelectableTextBlock Text="{Binding LivePreview}" FontFamily="Consolas,Menlo,monospace"
+                                             FontSize="12" TextWrapping="Wrap" />
+                    </Border>
+                </StackPanel>
+
+            </StackPanel>
+        </ScrollViewer>
+
+        <StackPanel Grid.Row="1" Margin="0,14,0,0" Spacing="8">
+            <TextBlock Text="{Binding ValidationMessage}" IsVisible="{Binding HasValidationMessage}"
+                       Foreground="{StaticResource AppDangerBrush}" FontSize="12" TextWrapping="Wrap" />
+            <TextBlock Text="{Binding WarningMessage}" IsVisible="{Binding HasWarningMessage}"
+                       Foreground="{StaticResource AppWarningBrush}" FontSize="12" TextWrapping="Wrap" />
+            <TextBlock Text="{Binding ErrorMessage}" IsVisible="{Binding HasErrorMessage}"
+                       Foreground="{StaticResource AppDangerBrush}" FontSize="12" TextWrapping="Wrap" />
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
+                <Button Classes="soft" Content="Cancel" Click="OnCancelClick" IsCancel="True" />
+                <Button Classes="accent" Content="Apply" Command="{Binding ApplyCommand}" IsDefault="True" />
+            </StackPanel>
+        </StackPanel>
+
+    </Grid>
+
+</Window>

--- a/PgNimbus.App/Views/Security/RoleDialog.axaml
+++ b/PgNimbus.App/Views/Security/RoleDialog.axaml
@@ -62,7 +62,15 @@
                     </StackPanel>
                     <StackPanel Grid.Column="2" Spacing="4">
                         <TextBlock Text="VALID UNTIL" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
-                        <DatePicker SelectedDate="{Binding ValidUntilDate}" />
+                        <!-- CalendarDatePicker, not Fluent's segmented DatePicker:
+                             the segmented one is a three-box month/day/year control
+                             that the shared input styling does not reach, so it
+                             stood a good deal taller than the NumericUpDown beside
+                             it. This is also the picker AddRowDialog already uses,
+                             so dates look the same everywhere in the app. -->
+                        <CalendarDatePicker SelectedDate="{Binding ValidUntilDate, Mode=TwoWay}"
+                                            PlaceholderText="no expiry"
+                                            HorizontalAlignment="Stretch" />
                     </StackPanel>
                 </Grid>
 
@@ -74,7 +82,15 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="vm:RoleMembershipOption">
                                 <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,2">
-                                    <CheckBox Content="{Binding Name}" IsChecked="{Binding IsMember}" />
+                                    <!-- The name goes in a TextBlock rather than
+                                         straight into Content: a string Content is
+                                         parsed for access keys, and "_" is the
+                                         mnemonic prefix, so pg_read_all_data would
+                                         render as "pgread_all_data". Underscores are
+                                         the norm in Postgres role names. -->
+                                    <CheckBox IsChecked="{Binding IsMember}">
+                                        <TextBlock Text="{Binding Name}" />
+                                    </CheckBox>
                                     <TextBlock Text="{Binding Hint}" FontSize="11" Opacity="0.6" VerticalAlignment="Center" />
                                 </StackPanel>
                             </DataTemplate>
@@ -91,7 +107,12 @@
                             <ItemsControl ItemsSource="{Binding GroupMemberships}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate x:DataType="vm:RoleMembershipOption">
-                                        <CheckBox Content="{Binding Name}" IsChecked="{Binding IsMember}" Margin="0,1" />
+                                        <!-- TextBlock, not a string Content: see the
+                                             built-in roles list above — "_" would be
+                                             eaten as an access-key prefix. -->
+                                        <CheckBox IsChecked="{Binding IsMember}" Margin="0,1">
+                                            <TextBlock Text="{Binding Name}" />
+                                        </CheckBox>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>

--- a/PgNimbus.App/Views/Security/RoleDialog.axaml
+++ b/PgNimbus.App/Views/Security/RoleDialog.axaml
@@ -112,6 +112,15 @@
                             BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
                             CornerRadius="{StaticResource CardCornerRadius}" Padding="10,8">
                             <ItemsControl ItemsSource="{Binding GroupMemberships}">
+                                <!-- Two columns: role names are short, and a single
+                                     column turned a server's worth of them into a
+                                     long thin list that pushed the generated SQL
+                                     below the fold. -->
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <UniformGrid Columns="2" />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate x:DataType="vm:RoleMembershipOption">
                                         <!-- TextBlock, not a string Content: see the

--- a/PgNimbus.App/Views/Security/RoleDialog.axaml.cs
+++ b/PgNimbus.App/Views/Security/RoleDialog.axaml.cs
@@ -1,0 +1,22 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace PgNimbus.App.Views.Security;
+
+/// <summary>
+/// Shown via <c>ShowDialog&lt;bool&gt;</c> by <see cref="RolesTabView"/>. The view
+/// model closes it through its <c>CloseRequested</c> callback, so an error from
+/// the server keeps the dialog up with its message rather than dismissing it —
+/// on a managed server that message ("permission denied to create role") is the
+/// useful part.
+/// </summary>
+public partial class RoleDialog : Window
+{
+    public RoleDialog()
+    {
+        InitializeComponent();
+        ThemedWindowChrome.Attach(this);
+    }
+
+    private void OnCancelClick(object? sender, RoutedEventArgs e) => Close(false);
+}

--- a/PgNimbus.App/Views/Security/RolesTabView.axaml
+++ b/PgNimbus.App/Views/Security/RolesTabView.axaml
@@ -3,5 +3,197 @@
              xmlns:vm="using:PgNimbus.App.ViewModels.Security"
              x:Class="PgNimbus.App.Views.Security.RolesTabView"
              x:DataType="vm:RolesTabViewModel">
-    <Panel />
+
+    <!-- The list answers "who exists"; the pane beside it answers "and what is
+         that role, really" - which is mostly the membership chain, because a
+         role's attributes rarely explain what it can do and its groups always
+         do. -->
+    <Grid ColumnDefinitions="470,*" Margin="0,8,0,0">
+
+        <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto" Margin="0,0,10,0">
+
+            <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,8">
+                <TextBox Grid.Column="0" Text="{Binding Filter}" PlaceholderText="Filter roles…" FontSize="12" />
+                <!-- A stock server carries a dozen pg_* roles nobody made and
+                     nobody edits. Off by default, one click from visible. -->
+                <ToggleButton Grid.Column="1" Classes="chip" Margin="6,0,0,0" VerticalAlignment="Center"
+                              IsChecked="{Binding ShowPredefinedRoles}"
+                              ToolTip.Tip="Also list the built-in pg_* roles the server ships with">
+                    <TextBlock Text="pg_*" />
+                </ToggleButton>
+            </Grid>
+
+            <Border Grid.Row="1" ClipToBounds="True"
+                    BorderBrush="{StaticResource CardBorderBrush}" BorderThickness="1"
+                    CornerRadius="{StaticResource CardCornerRadius}">
+                <Panel>
+                    <DataGrid Name="RolesGrid"
+                              ItemsSource="{Binding FilteredRoles}"
+                              SelectedItem="{Binding SelectedRole, Mode=TwoWay}"
+                              IsReadOnly="True" SelectionMode="Single"
+                              CanUserResizeColumns="True" CanUserSortColumns="False"
+                              GridLinesVisibility="Horizontal" HeadersVisibility="Column">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn Header="Role" Binding="{Binding Name}" Width="*" />
+                            <DataGridTextColumn Header="Attributes" Binding="{Binding AttributesLabel}" Width="160" />
+                            <DataGridTemplateColumn Header="Valid until" Width="112">
+                                <DataGridTemplateColumn.CellTemplate>
+                                    <DataTemplate x:DataType="vm:RoleRowViewModel">
+                                        <Panel Margin="12,0">
+                                            <!-- A login role nobody can log in as any more is
+                                                 worth spotting from the list - amber + bold -->
+                                            <TextBlock Text="{Binding ValidUntilText}" VerticalAlignment="Center"
+                                                       Foreground="{StaticResource AppWarningBrush}" FontWeight="SemiBold"
+                                                       IsVisible="{Binding IsExpired}" />
+                                            <TextBlock Text="{Binding ValidUntilText}" VerticalAlignment="Center"
+                                                       Opacity="0.7" IsVisible="{Binding !IsExpired}" />
+                                        </Panel>
+                                    </DataTemplate>
+                                </DataGridTemplateColumn.CellTemplate>
+                            </DataGridTemplateColumn>
+                        </DataGrid.Columns>
+                    </DataGrid>
+
+                    <!-- "No role is called that" and "this server has no roles"
+                         send you looking for opposite problems, but only the
+                         first can happen here: every server has roles. -->
+                    <TextBlock Text="No role matches that filter." Opacity="0.55" FontSize="12"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               IsVisible="{Binding !HasFilteredRoles}" />
+                </Panel>
+            </Border>
+
+            <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="6" Margin="0,8,0,0">
+                <Button Classes="soft" Content="New role…" Command="{Binding NewRoleCommand}"
+                        ToolTip.Tip="Create a role, with the CREATE ROLE statement shown before it runs" />
+                <Button Classes="soft" Content="Edit…" Command="{Binding EditRoleCommand}"
+                        ToolTip.Tip="Change the selected role's attributes and memberships" />
+                <Button Classes="soft danger" Content="Drop…" Command="{Binding DropRoleCommand}"
+                        ToolTip.Tip="Work out what the role owns and holds, then generate the drop recipe" />
+                <Button Classes="soft" Content="CREATE ROLE script" Command="{Binding CopyCreateScriptCommand}"
+                        ToolTip.Tip="Open this role's CREATE ROLE statement in a new query tab. It carries no password — pgNimbus never reads password hashes." />
+            </StackPanel>
+
+        </Grid>
+
+        <Border Grid.Column="1" Classes="card" Padding="0">
+            <Panel>
+
+                <TextBlock Text="Select a role to see its attributes and where it sits in the membership graph."
+                           Opacity="0.55" FontSize="12" TextWrapping="Wrap" MaxWidth="320"
+                           TextAlignment="Center" HorizontalAlignment="Center" VerticalAlignment="Center"
+                           IsVisible="{Binding !HasSelection}" />
+
+                <ScrollViewer IsVisible="{Binding HasSelection}">
+                    <StackPanel Spacing="16" Margin="16">
+
+                        <!-- The row's own view model, hung off the DataContext
+                             rather than reached through SelectedRole.* : a null
+                             in the middle of a binding path is logged as an
+                             error on every re-evaluation, a null DataContext is
+                             just an unset binding. -->
+                        <StackPanel Spacing="10" x:DataType="vm:RoleRowViewModel" DataContext="{Binding SelectedRole}">
+                            <StackPanel Spacing="2">
+                                <TextBlock Text="{Binding Name}" FontSize="16" FontWeight="SemiBold" />
+                                <TextBlock Text="{Binding AttributesLabel}" FontSize="11" Opacity="0.6" />
+                            </StackPanel>
+
+                            <ItemsControl ItemsSource="{Binding Details}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:RoleDetailRow">
+                                        <Grid ColumnDefinitions="130,*" Margin="0,2">
+                                            <TextBlock Grid.Column="0" Text="{Binding Label}" FontSize="12" Opacity="0.55" />
+                                            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                                                <TextBlock Text="{Binding Value}" FontSize="12" TextWrapping="Wrap"
+                                                           IsVisible="{Binding !IsWarning}" />
+                                                <TextBlock Text="{Binding Value}" FontSize="12" FontWeight="SemiBold"
+                                                           Foreground="{StaticResource AppWarningBrush}"
+                                                           IsVisible="{Binding IsWarning}" />
+                                                <TextBlock Text="{Binding Note}" FontSize="11" Opacity="0.55"
+                                                           VerticalAlignment="Center" IsVisible="{Binding HasNote}" />
+                                            </StackPanel>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Classes="sectionHeader" Text="MEMBER OF" />
+                            <TreeView ItemsSource="{Binding MemberOf}" MaxHeight="200">
+                                <TreeView.Styles>
+                                    <!-- The whole chain at a glance: a privilege
+                                         three groups up is still the answer to
+                                         "why can this role do that". -->
+                                    <Style Selector="TreeViewItem">
+                                        <Setter Property="IsExpanded" Value="True" />
+                                    </Style>
+                                </TreeView.Styles>
+                                <TreeView.ItemTemplate>
+                                    <TreeDataTemplate x:DataType="vm:RoleTreeNodeViewModel" ItemsSource="{Binding Children}">
+                                        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,2">
+                                            <TextBlock Text="{Binding Role}" VerticalAlignment="Center"
+                                                       Opacity="{Binding RowOpacity}" />
+                                            <!-- The membership that looks granted and behaves
+                                                 as if it is not: NOINHERIT privileges are
+                                                 dormant until an explicit SET ROLE. -->
+                                            <TextBlock Text="NOINHERIT · needs SET ROLE" FontSize="11"
+                                                       VerticalAlignment="Center"
+                                                       Foreground="{StaticResource AppWarningBrush}"
+                                                       IsVisible="{Binding IsDormant}" />
+                                        </StackPanel>
+                                    </TreeDataTemplate>
+                                </TreeView.ItemTemplate>
+                            </TreeView>
+                            <TextBlock Text="Belongs to no group." FontSize="12" Opacity="0.5"
+                                       IsVisible="{Binding !HasMemberOf}" />
+                        </StackPanel>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Classes="sectionHeader" Text="MEMBERS" />
+                            <TreeView ItemsSource="{Binding Members}" MaxHeight="200">
+                                <TreeView.Styles>
+                                    <Style Selector="TreeViewItem">
+                                        <Setter Property="IsExpanded" Value="True" />
+                                    </Style>
+                                </TreeView.Styles>
+                                <TreeView.ItemTemplate>
+                                    <TreeDataTemplate x:DataType="vm:RoleTreeNodeViewModel" ItemsSource="{Binding Children}">
+                                        <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,2">
+                                            <TextBlock Text="{Binding Role}" VerticalAlignment="Center"
+                                                       Opacity="{Binding RowOpacity}" />
+                                            <TextBlock Text="NOINHERIT · needs SET ROLE" FontSize="11"
+                                                       VerticalAlignment="Center"
+                                                       Foreground="{StaticResource AppWarningBrush}"
+                                                       IsVisible="{Binding IsDormant}" />
+                                        </StackPanel>
+                                    </TreeDataTemplate>
+                                </TreeView.ItemTemplate>
+                            </TreeView>
+                            <TextBlock Text="No role belongs to this one." FontSize="12" Opacity="0.5"
+                                       IsVisible="{Binding !HasMembers}" />
+                        </StackPanel>
+
+                        <!-- ALTER ROLE … SET entries. Hidden when there are none,
+                             which is the overwhelmingly common case. -->
+                        <StackPanel Spacing="4" IsVisible="{Binding HasSettings}">
+                            <TextBlock Classes="sectionHeader" Text="SESSION DEFAULTS" />
+                            <ItemsControl ItemsSource="{Binding Settings}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="x:String">
+                                        <TextBlock Text="{Binding}" FontSize="12" Margin="0,1"
+                                                   FontFamily="Cascadia Code,Consolas,Menlo,monospace" />
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+
+                    </StackPanel>
+                </ScrollViewer>
+
+            </Panel>
+        </Border>
+
+    </Grid>
+
 </UserControl>

--- a/PgNimbus.App/Views/Security/RolesTabView.axaml
+++ b/PgNimbus.App/Views/Security/RolesTabView.axaml
@@ -8,9 +8,9 @@
          that role, really" - which is mostly the membership chain, because a
          role's attributes rarely explain what it can do and its groups always
          do. -->
-    <Grid ColumnDefinitions="470,*" Margin="0,8,0,0">
+    <Grid ColumnDefinitions="470,12,*" Margin="0,8,0,0">
 
-        <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto" Margin="0,0,10,0">
+        <Grid Grid.Column="0" RowDefinitions="Auto,*,Auto" MinWidth="300">
 
             <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,8">
                 <TextBox Grid.Column="0" Text="{Binding Filter}" PlaceholderText="Filter roles…" FontSize="12" />
@@ -76,7 +76,28 @@
 
         </Grid>
 
-        <Border Grid.Column="1" Classes="card" Padding="0">
+        <!-- Drag to resize the list/detail split. Same idiom as the window's
+             editor/results divider: the whole 12px strip is the grab target,
+             with a faint centred hairline so it is discoverable without
+             shouting. The list needs to widen because a role's attribute
+             string ("superuser - login - createdb - createrole") does not fit
+             any width that is right for every server. -->
+        <GridSplitter Grid.Column="1"
+                      HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                      ResizeDirection="Columns" ResizeBehavior="PreviousAndNext"
+                      Background="Transparent">
+            <GridSplitter.Template>
+                <ControlTemplate>
+                    <Border Background="{TemplateBinding Background}">
+                        <Rectangle Width="2" Height="36" RadiusX="1" RadiusY="1"
+                                   VerticalAlignment="Center" HorizontalAlignment="Center"
+                                   Fill="{DynamicResource CardBorderBrush}" />
+                    </Border>
+                </ControlTemplate>
+            </GridSplitter.Template>
+        </GridSplitter>
+
+        <Border Grid.Column="2" Classes="card" Padding="0" MinWidth="320">
             <Panel>
 
                 <TextBlock Text="Select a role to see its attributes and where it sits in the membership graph."

--- a/PgNimbus.App/Views/Security/RolesTabView.axaml.cs
+++ b/PgNimbus.App/Views/Security/RolesTabView.axaml.cs
@@ -1,11 +1,69 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using PgNimbus.App.ViewModels.Security;
 
 namespace PgNimbus.App.Views.Security;
 
+/// <summary>
+/// The roles list and one role's detail. The view owns the two modal dialogs
+/// the tab can raise: the view model asks for one through a callback and never
+/// constructs a <see cref="Window"/> itself, which is how the rest of this
+/// codebase splits the two (see <c>SchemaTreeViewModel.AlterTableViewModelFactory</c>).
+/// </summary>
 public partial class RolesTabView : UserControl
 {
     public RolesTabView()
     {
         InitializeComponent();
+
+        // The DataContext arrives after construction (the TabItem binds it), and
+        // can in principle be re-pointed, so the callbacks are wired on change
+        // rather than once in the constructor.
+        DataContextChanged += OnDataContextChanged;
+        RolesGrid.DoubleTapped += OnRolesGridDoubleTapped;
+    }
+
+    private void OnDataContextChanged(object? sender, System.EventArgs e)
+    {
+        if (DataContext is not RolesTabViewModel vm)
+        {
+            return;
+        }
+
+        vm.ShowRoleDialog = editor => ShowDialogAsync(new RoleDialog { DataContext = editor }, editor);
+        vm.ShowDropDialog = drop => ShowDialogAsync(new DropRoleDialog { DataContext = drop }, drop);
+    }
+
+    /// <summary>
+    /// Shows a modal whose view model closes it through a <c>CloseRequested</c>
+    /// callback, and reports whether anything was applied — the tab refreshes
+    /// only on true, so a cancelled dialog costs no catalog round trip.
+    /// </summary>
+    private async Task<bool> ShowDialogAsync(Window dialog, object viewModel)
+    {
+        switch (viewModel)
+        {
+            case RoleEditorViewModel editor:
+                editor.CloseRequested = result => dialog.Close(result);
+                break;
+            case DropRoleViewModel drop:
+                drop.CloseRequested = result => dialog.Close(result);
+                // The dependency lists are a catalog read, so they load once the
+                // dialog is up rather than blocking the click that opened it.
+                dialog.Opened += async (_, _) => await drop.LoadAsync(CancellationToken.None);
+                break;
+        }
+
+        var owner = TopLevel.GetTopLevel(this) as Window;
+        return owner is null ? false : await dialog.ShowDialog<bool>(owner);
+    }
+
+    /// <summary>Double-click performs the default action for a role — edit it (UI design rule 2).</summary>
+    private void OnRolesGridDoubleTapped(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is RolesTabViewModel { EditRoleCommand: { } edit } && edit.CanExecute(null))
+        {
+            edit.Execute(null);
+        }
     }
 }

--- a/PgNimbus.App/Views/Security/RolesTabView.axaml.cs
+++ b/PgNimbus.App/Views/Security/RolesTabView.axaml.cs
@@ -1,5 +1,9 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
+using Avalonia.VisualTree;
 using PgNimbus.App.ViewModels.Security;
 
 namespace PgNimbus.App.Views.Security;
@@ -21,6 +25,7 @@ public partial class RolesTabView : UserControl
         // rather than once in the constructor.
         DataContextChanged += OnDataContextChanged;
         RolesGrid.DoubleTapped += OnRolesGridDoubleTapped;
+        RolesGrid.ContextRequested += OnRolesGridContextRequested;
     }
 
     private void OnDataContextChanged(object? sender, System.EventArgs e)
@@ -56,6 +61,74 @@ public partial class RolesTabView : UserControl
 
         var owner = TopLevel.GetTopLevel(this) as Window;
         return owner is null ? false : await dialog.ShowDialog<bool>(owner);
+    }
+
+    /// <summary>
+    /// The right-click menu, built in code rather than as a XAML
+    /// <c>ContextFlyout</c> for the same two reasons the tab strip's is: the
+    /// handler has to re-target the selection before the menu opens, and a
+    /// flyout on the grid itself would also fire on its empty space.
+    ///
+    /// Four items, each one a route to something the button row already does
+    /// (UI design rule 1 — a context menu is not a dumping ground either). The
+    /// odd one out is Copy name, which earns its place because every one of
+    /// these roles ends up typed into a GRANT sooner or later.
+    /// </summary>
+    private void OnRolesGridContextRequested(object? sender, ContextRequestedEventArgs e)
+    {
+        if (DataContext is not RolesTabViewModel vm
+            || (e.Source as Visual)?.FindAncestorOfType<DataGridRow>(includeSelf: true) is not { } row
+            || row.DataContext is not RoleRowViewModel role)
+        {
+            return; // right-click on the header or the empty space below the rows
+        }
+
+        // Right-click targets what it points at, the way VS and Notepad++ do, so
+        // the menu's verbs read against the role the user is looking at.
+        vm.SelectedRole = role;
+
+        _roleMenu ??= BuildRoleMenu(vm);
+        _roleMenu.ShowAt(row, showAtPointer: true);
+        e.Handled = true;
+    }
+
+    private MenuFlyout? _roleMenu;
+
+    private MenuFlyout BuildRoleMenu(RolesTabViewModel vm)
+    {
+        var copyName = new MenuItem { Header = "Copy name" };
+        copyName.Click += OnCopyRoleNameClick;
+
+        return new MenuFlyout
+        {
+            Items =
+            {
+                new MenuItem { Header = "Edit…", Command = vm.EditRoleCommand },
+                copyName,
+                new MenuItem { Header = "CREATE ROLE script", Command = vm.CopyCreateScriptCommand },
+                new Separator(),
+                new MenuItem { Header = "Drop role…", Command = vm.DropRoleCommand },
+            },
+        };
+    }
+
+    private async void OnCopyRoleNameClick(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not RolesTabViewModel { SelectedRole: { } role }
+            || TopLevel.GetTopLevel(this)?.Clipboard is not { } clipboard)
+        {
+            return;
+        }
+
+        try
+        {
+            await clipboard.SetTextAsync(role.Name);
+        }
+        catch (Exception)
+        {
+            // Clipboard access can throw if another app holds it locked; a failed
+            // copy is not worth surfacing, let alone crashing over.
+        }
     }
 
     /// <summary>Double-click performs the default action for a role — edit it (UI design rule 2).</summary>

--- a/PgNimbus.Core.Tests/Security/RoleScriptBuilderTests.cs
+++ b/PgNimbus.Core.Tests/Security/RoleScriptBuilderTests.cs
@@ -230,6 +230,57 @@ public class RoleScriptBuilderTests
             """));
     }
 
+    /// <summary>
+    /// The managed-Postgres path. REASSIGN OWNED and DROP OWNED need the
+    /// privileges of the role being emptied, and nobody on RDS/Neon/Supabase is
+    /// a superuser holding them implicitly — without the grants the server
+    /// answers 42501 rather than doing anything.
+    /// </summary>
+    [Test]
+    public async Task DropCanGrantItselfTheMembershipsItNeeds()
+    {
+        var sql = RoleScriptBuilder.Drop("app", "postgres", grantMembershipFirst: true);
+
+        // Both grants come before REASSIGN, and the one that outlives the script
+        // — membership in the target — is handed back before the role is dropped.
+        await Assert.That(N(sql)).IsEqualTo(N("""
+            -- "app" may own objects or hold grants, and DROP ROLE alone
+            -- then fails with 2BP01 without naming either the objects or the fix.
+            -- REASSIGN OWNED and DROP OWNED require the privileges of the role being
+            -- emptied. Without them the server answers 42501, however many objects the
+            -- role owns. A superuser holds them implicitly; otherwise grant the
+            -- membership to yourself first -- it is revoked again below.
+            GRANT app TO CURRENT_USER;
+            GRANT postgres TO CURRENT_USER;
+            -- REASSIGN OWNED hands the objects to another role; DROP OWNED then removes
+            -- the privileges REASSIGN OWNED leaves behind. Both act on the current
+            -- database only -- repeat them while connected to every other database that
+            -- contains objects owned by this role, then drop it.
+            REASSIGN OWNED BY app TO postgres;
+            DROP OWNED BY app;
+            REVOKE postgres FROM CURRENT_USER;
+            DROP ROLE app;
+            """));
+    }
+
+    /// <summary>
+    /// With nobody to reassign to there is no second membership to grant, and
+    /// nothing to hand back — DROP ROLE takes the membership in the dropped role
+    /// with it.
+    /// </summary>
+    [Test]
+    public async Task DropWithoutAReassignTargetGrantsAndRevokesNothingExtra()
+    {
+        var sql = RoleScriptBuilder.Drop("app", reassignTo: null, grantMembershipFirst: true);
+
+        await Assert.That(sql).Contains("GRANT app TO CURRENT_USER;");
+        await Assert.That(sql).DoesNotContain("REVOKE");
+        await Assert.That(sql).DoesNotContain("REASSIGN OWNED BY");
+
+        // The explanation names only the statement the script actually runs.
+        await Assert.That(sql).Contains("-- DROP OWNED requires the privileges");
+    }
+
     [Test]
     public async Task DropQuotesTheRoleInEveryStatement()
     {

--- a/PgNimbus.Core/Security/RoleScriptBuilder.cs
+++ b/PgNimbus.Core/Security/RoleScriptBuilder.cs
@@ -234,7 +234,7 @@ public static class RoleScriptBuilder
     /// difference is the entire reason the parameter exists, and it is not
     /// recoverable.</para>
     /// </summary>
-    public static string Drop(string role, string? reassignTo)
+    public static string Drop(string role, string? reassignTo, bool grantMembershipFirst = false)
     {
         var name = SqlIdentifier.QuoteIfNeeded(role);
         var display = CommentSafe(role);
@@ -242,6 +242,30 @@ public static class RoleScriptBuilder
 
         sb.Append("-- \"").Append(display).Append("\" may own objects or hold grants, and DROP ROLE alone").Append(Newline);
         sb.Append("-- then fails with 2BP01 without naming either the objects or the fix.").Append(Newline);
+
+        // REASSIGN OWNED and DROP OWNED are not superuser-only, but they do
+        // require the executing role to hold the privileges of the role being
+        // emptied (and of the one taking over), or the server answers 42501
+        // "permission denied to reassign objects". A superuser has them
+        // implicitly; on RDS, Neon or Supabase nobody is, so the membership has
+        // to be granted first -- and since CREATEROLE is what let the user make
+        // this role in the first place, it is also what lets them grant it.
+        if (grantMembershipFirst)
+        {
+            sb.Append(reassignTo is null
+                    ? "-- DROP OWNED requires the privileges of the role being"
+                    : "-- REASSIGN OWNED and DROP OWNED require the privileges of the role being")
+                .Append(Newline);
+            sb.Append("-- emptied. Without them the server answers 42501, however many objects the").Append(Newline);
+            sb.Append("-- role owns. A superuser holds them implicitly; otherwise grant the").Append(Newline);
+            sb.Append("-- membership to yourself first -- it is revoked again below.").Append(Newline);
+            sb.Append("GRANT ").Append(name).Append(" TO CURRENT_USER;").Append(Newline);
+
+            if (reassignTo is not null)
+            {
+                sb.Append("GRANT ").Append(SqlIdentifier.QuoteIfNeeded(reassignTo)).Append(" TO CURRENT_USER;").Append(Newline);
+            }
+        }
 
         if (reassignTo is not null)
         {
@@ -263,6 +287,16 @@ public static class RoleScriptBuilder
         }
 
         sb.Append("DROP OWNED BY ").Append(name).Append(';').Append(Newline);
+
+        // DROP ROLE takes the membership in the dropped role with it, but a
+        // membership granted in the *target* role outlives this script and has
+        // to be given back, or the drop quietly leaves the user holding
+        // privileges they did not have before.
+        if (grantMembershipFirst && reassignTo is not null)
+        {
+            sb.Append("REVOKE ").Append(SqlIdentifier.QuoteIfNeeded(reassignTo)).Append(" FROM CURRENT_USER;").Append(Newline);
+        }
+
         sb.Append("DROP ROLE ").Append(name).Append(';');
 
         return sb.ToString();

--- a/tools/Screenshot/Fixtures.cs
+++ b/tools/Screenshot/Fixtures.cs
@@ -1,6 +1,7 @@
 using Npgsql;
 using PgNimbus.App.Completion;
 using PgNimbus.App.ViewModels;
+using PgNimbus.App.ViewModels.Security;
 using PgNimbus.Core.Import;
 using PgNimbus.Core.Monitoring;
 using PgNimbus.Core.Notifications;
@@ -287,4 +288,128 @@ public static class Fixtures
         new("analytics", "sessions", "sessions_started_at_idx", 20_971_520),
         new("public", "customers", "customers_full_name_idx", 8_388_608),
     ];
+
+    // --- Roles & permissions --------------------------------------------
+
+    /// <summary>
+    /// The role snapshot the security window renders: an inheritance chain
+    /// (app_ro -&gt; readers), a group in the middle (writers), and a NOINHERIT
+    /// membership whose privileges are dormant until SET ROLE - the case the
+    /// membership tree exists to make visible.
+    /// </summary>
+    public static IReadOnlyList<RoleAttributes> Roles() =>
+    [
+        new(16390, "app_ro", true, false, true, false, false, false, false, 5,
+            new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero), ["statement_timeout=30s"], "the read-only API user"),
+        new(16391, "app_rw", true, false, true, false, false, false, false, -1, null, [], null),
+        new(16392, "readers", false, false, true, false, false, false, false, -1, null, [], "read-only group"),
+        new(16393, "writers", false, false, true, false, false, false, false, -1, null, [], null),
+        new(16394, "legacy_etl", true, false, false, false, false, false, false, -1,
+            new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero), [], "kept for the nightly job"),
+        new(10, "postgres", true, true, true, true, true, true, true, -1, null, [], null),
+    ];
+
+    public static IReadOnlyList<RoleMembership> RoleMemberships() =>
+    [
+        new("app_ro", "readers", false, true, true, "postgres"),
+        new("writers", "readers", false, true, true, "postgres"),
+        new("app_rw", "writers", false, true, true, "postgres"),
+        // Dormant until SET ROLE - shown in the tree, never counted as inherited.
+        new("app_ro", "legacy_etl", true, false, true, "postgres"),
+    ];
+
+    /// <summary>
+    /// A security window with its shared snapshot seeded, so the tabs render
+    /// without a server. Same seam as the other fixtures: the public ViewModel
+    /// surface production sets, never the views.
+    /// </summary>
+    public static SecurityViewModel SecurityViewModel()
+    {
+        var dataSource = DataSource;
+        var vm = new SecurityViewModel(
+            new RoleService(dataSource),
+            new PrivilegeService(dataSource),
+            new SecurityEditor(dataSource),
+            "shop")
+        {
+            CurrentRole = "postgres",
+            ServerVersion = new Version(17, 2),
+            ServerVersionText = "PostgreSQL 17.2",
+            Graph = RoleGraph.Build(Roles(), RoleMemberships()),
+            Status = "5 roles · 09:41:02",
+        };
+
+        SeedRolesTab(vm);
+        SeedPermissionsTab(vm);
+        return vm;
+    }
+
+    /// <summary>
+    /// The roles tab has no server call in its refresh — it reads the snapshot
+    /// the host already holds — so the harness drives the real path rather than
+    /// filling its collections behind its back.
+    /// </summary>
+    private static void SeedRolesTab(SecurityViewModel vm)
+    {
+        vm.Roles.RefreshAsync(CancellationToken.None).GetAwaiter().GetResult();
+        vm.Roles.SelectedRole = vm.Roles.FilteredRoles.FirstOrDefault(r => r.Name == "app_ro");
+    }
+
+    /// <summary>
+    /// One object's matrix, showing the thing no other client shows: SELECT that
+    /// app_ro holds only through readers, two memberships up.
+    /// </summary>
+    private static void SeedPermissionsTab(SecurityViewModel vm)
+    {
+        var kinds = Privileges.For(SecurableKind.Table, new Version(17, 2));
+        var columns = kinds.Select(k => new PrivilegeColumn(k, Privileges.Sql(k))).ToList();
+
+        var objects = new[] { "orders", "order_items", "customers", "shipments" }
+            .Select((name, i) => new SecurableRef(SecurableKind.Table, (uint)(16400 + i), "sales", name))
+            .ToList();
+
+        List<PermissionRowViewModel> rows =
+        [
+            Row("app_ro", kinds, PrivilegeSource.Inherited, "readers", PrivilegeKind.Select),
+            Row("app_rw", kinds, PrivilegeSource.Inherited, "writers",
+                PrivilegeKind.Select, PrivilegeKind.Insert, PrivilegeKind.Update, PrivilegeKind.Delete),
+            Row("readers", kinds, PrivilegeSource.Direct, null, PrivilegeKind.Select),
+            Row("legacy_etl", kinds, PrivilegeSource.None, null),
+            Row("postgres", kinds, PrivilegeSource.Superuser, null),
+        ];
+
+        vm.Permissions.SeedForHarness(
+            ["sales", "public", "analytics"],
+            objects,
+            columns,
+            rows,
+            "app_ro can SELECT sales.orders — inherited from readers. It cannot INSERT, UPDATE or DELETE.",
+            [new ColumnGrantRow("email", "app_ro: SELECT")]);
+
+        static PermissionRowViewModel Row(
+            string role,
+            IReadOnlyList<PrivilegeKind> kinds,
+            PrivilegeSource source,
+            string? via,
+            params PrivilegeKind[] granted)
+        {
+            var held = new HashSet<PrivilegeKind>(granted);
+            var everything = source == PrivilegeSource.Superuser;
+
+            var cells = kinds.Select(kind =>
+            {
+                var isGranted = everything || held.Contains(kind);
+                var effective = new EffectivePrivilege(
+                    role, kind, isGranted,
+                    isGranted ? source : PrivilegeSource.None,
+                    isGranted ? via : null,
+                    isGranted && source == PrivilegeSource.Direct ? "postgres" : null);
+
+                // Ownership and superuser are not grants, so their cells do not toggle.
+                return new PrivilegeCellViewModel(effective, !everything, _ => { });
+            }).ToList();
+
+            return new PermissionRowViewModel(role, cells);
+        }
+    }
 }

--- a/tools/Screenshot/Scenarios.cs
+++ b/tools/Screenshot/Scenarios.cs
@@ -62,6 +62,7 @@ public static class Scenarios
         ("security-window-default-privileges", SecurityDefaultPrivileges),
         ("security-window-rls", SecurityRls),
         ("security-role-dialog", SecurityRoleDialog),
+        ("security-drop-role-dialog", SecurityDropRoleDialog),
         ("shortcuts-window", Shortcuts),
         ("preferences-window", Preferences),
         ("about-window", About),
@@ -215,6 +216,31 @@ public static class Scenarios
         editor.ConnectionLimit = 10;
         editor.Comment = "read-only user for the reporting job";
         return new RoleDialog { DataContext = editor, Width = 760, Height = 660 };
+    }
+
+    /// <summary>
+    /// The drop-role dialog on a role that blocks nothing — the empty state,
+    /// deliberately, because both of its lists are usually empty and a grid
+    /// drawing bare column headers over the sentence explaining that is exactly
+    /// the failure this shot catches.
+    /// </summary>
+    public static Window SecurityDropRoleDialog()
+    {
+        var host = Fixtures.SecurityViewModel();
+        var drop = new DropRoleViewModel(
+            new RoleService(Fixtures.DataSource),
+            new SecurityEditor(Fixtures.DataSource),
+            "legacy_etl",
+            "postgres",
+            ["postgres", "app_rw", "readers"],
+            null)
+        {
+            // LoadAsync is the view's job on Opened; the harness stands in for it
+            // with the answer a role that owns nothing would have produced.
+            IsLoading = false,
+        };
+
+        return new DropRoleDialog { DataContext = drop, Width = 820, Height = 680 };
     }
 
     /// <summary>Selects a tab by index once the window's template is up.</summary>

--- a/tools/Screenshot/Scenarios.cs
+++ b/tools/Screenshot/Scenarios.cs
@@ -1,6 +1,8 @@
 using Avalonia.Controls;
 using PgNimbus.App.ViewModels;
 using PgNimbus.App.Views;
+using PgNimbus.App.Views.Security;
+using Avalonia.VisualTree;
 using PgNimbus.Core.Connections;
 using PgNimbus.Core.Monitoring;
 using PgNimbus.Core.Query;
@@ -53,6 +55,10 @@ public static class Scenarios
         ("activity-window", Activity),
         ("activity-window-blocking", ActivityBlocking),
         ("database-overview-window", DatabaseOverview),
+        ("security-window", Security),
+        ("security-window-permissions", SecurityPermissions),
+        ("security-window-default-privileges", SecurityDefaultPrivileges),
+        ("security-window-rls", SecurityRls),
         ("shortcuts-window", Shortcuts),
         ("preferences-window", Preferences),
         ("about-window", About),
@@ -148,6 +154,55 @@ public static class Scenarios
         // completes against the offline data source (see Fixtures).
         _ = vm.OpenCommandPaletteAsync();
         return HostMainWindow(vm);
+    }
+
+    /// <summary>Roles: the list, one role's attributes, and its membership tree.</summary>
+    public static Window Security()
+    {
+        var vm = Fixtures.SecurityViewModel();
+        return new SecurityWindow { DataContext = vm, Width = 1100, Height = 720 };
+    }
+
+    /// <summary>
+    /// The permissions matrix, on the tab that is the feature's whole point:
+    /// SELECT that app_ro holds only through a group two memberships up, with
+    /// the source spelled out rather than left to be inferred from an ACL.
+    /// </summary>
+    public static Window SecurityPermissions()
+    {
+        var vm = Fixtures.SecurityViewModel();
+        var window = new SecurityWindow { DataContext = vm, Width = 1100, Height = 720 };
+        window.Opened += (_, _) => SelectTab(window, 1);
+        return window;
+    }
+
+    /// <summary>
+    /// Default privileges and row-level security, unseeded on purpose: both tabs
+    /// have to say something useful when the catalog has nothing to show, and an
+    /// empty state that renders as a blank rectangle is the failure these two
+    /// shots exist to catch.
+    /// </summary>
+    public static Window SecurityDefaultPrivileges()
+    {
+        var window = new SecurityWindow { DataContext = Fixtures.SecurityViewModel(), Width = 1100, Height = 720 };
+        window.Opened += (_, _) => SelectTab(window, 2);
+        return window;
+    }
+
+    public static Window SecurityRls()
+    {
+        var window = new SecurityWindow { DataContext = Fixtures.SecurityViewModel(), Width = 1100, Height = 720 };
+        window.Opened += (_, _) => SelectTab(window, 3);
+        return window;
+    }
+
+    /// <summary>Selects a tab by index once the window's template is up.</summary>
+    private static void SelectTab(Window window, int index)
+    {
+        if (window.GetVisualDescendants().OfType<TabControl>().FirstOrDefault() is { } tabs)
+        {
+            tabs.SelectedIndex = index;
+        }
     }
 
     /// <summary>The sidebar filter narrowing the tree to matching relations.</summary>

--- a/tools/Screenshot/Scenarios.cs
+++ b/tools/Screenshot/Scenarios.cs
@@ -1,11 +1,13 @@
 using Avalonia.Controls;
 using PgNimbus.App.ViewModels;
+using PgNimbus.App.ViewModels.Security;
 using PgNimbus.App.Views;
 using PgNimbus.App.Views.Security;
 using Avalonia.VisualTree;
 using PgNimbus.Core.Connections;
 using PgNimbus.Core.Monitoring;
 using PgNimbus.Core.Query;
+using PgNimbus.Core.Security;
 
 namespace PgNimbus.Screenshot;
 
@@ -59,6 +61,7 @@ public static class Scenarios
         ("security-window-permissions", SecurityPermissions),
         ("security-window-default-privileges", SecurityDefaultPrivileges),
         ("security-window-rls", SecurityRls),
+        ("security-role-dialog", SecurityRoleDialog),
         ("shortcuts-window", Shortcuts),
         ("preferences-window", Preferences),
         ("about-window", About),
@@ -194,6 +197,24 @@ public static class Scenarios
         var window = new SecurityWindow { DataContext = Fixtures.SecurityViewModel(), Width = 1100, Height = 720 };
         window.Opened += (_, _) => SelectTab(window, 3);
         return window;
+    }
+
+    /// <summary>
+    /// The role editor, mid-edit. Worth its own shot because it is the one
+    /// surface in this feature that writes, and because its generated-SQL
+    /// preview is always the masked build — a password appearing here would be
+    /// the bug.
+    /// </summary>
+    public static Window SecurityRoleDialog()
+    {
+        var host = Fixtures.SecurityViewModel();
+        var editor = RoleEditorViewModel.ForCreate(new SecurityEditor(Fixtures.DataSource), host);
+        editor.Name = "reporting_ro";
+        editor.Password = "hunter2";
+        editor.PasswordConfirm = "hunter2";
+        editor.ConnectionLimit = 10;
+        editor.Comment = "read-only user for the reporting job";
+        return new RoleDialog { DataContext = editor, Width = 760, Height = 660 };
     }
 
     /// <summary>Selects a tab by index once the window's template is up.</summary>


### PR DESCRIPTION
## What and why

Fills in the four tabs of the Roles & Permissions window whose shell shipped empty in #201. Research and plan: [`docs/design/accounts-permissions.md`](docs/design/accounts-permissions.md).

**The permissions matrix is the point of the feature.** Rows are roles, columns are privileges, and every cell carries its *source*. A grant reached through a group, PUBLIC, ownership or superuser reads dimmer than one that names the role; a HOW column gives the dominant answer without hovering anything; and `PrivilegeSource.Unknown` — the server said yes and the catalog cannot say why — is tinted rather than dressed up as a direct grant. Under the grid sits the sentence no other client produces: *"app_ro can SELECT sales.orders — inherited from readers. It cannot INSERT, UPDATE or DELETE"*, including the case where every table privilege is granted and the role still cannot reach the table for want of `USAGE` on its schema.

Two states the tabs make visible that a catalog dump cannot:

- a **NOINHERIT** membership appears in the tree, dimmed and annotated *needs SET ROLE*, because it looks granted and behaves as if it is not;
- an object whose ACL column is **NULL** gets a banner saying nobody has ever run GRANT or REVOKE on it, instead of an empty grid that would read as "no privileges".

**Nothing writes from the window.** Toggling cells stages a change set; *Review changes* hands a `GRANT`/`REVOKE` script to a new editor tab. The one path that executes is the role editor, because a `PASSWORD` literal cannot be a parameter and must not reach the editor or the on-disk history — its preview is always the masked build, and only Apply sees the real value.

The **drop-role dialog** lists what the role owns and what it holds before anything is clickable, then generates the `REASSIGN OWNED` → `DROP OWNED` → `DROP ROLE` recipe, with the warning that naming no successor deletes the objects rather than transferring them, and that all three statements act on the current database only.

Also here: `CLAUDE.md` gains the rule this feature is now bound by — it is the contract, and the three landmines in it (strict `aclexplode`, NULL-ACL semantics, the server version `Privileges.For` needs) are the ones that already bit once.

## Verified

- [x] `dotnet build PgNimbus.slnx` — 0 errors, **0 warnings**
- [x] `dotnet test --project PgNimbus.Core.Tests/PgNimbus.Core.Tests.csproj` — 763 total, 748 passed, 15 skipped
      — against a live Postgres? **yes**, `postgres:17` (the 6 `SecurityCatalogTests` run there; they skip cleanly without one)
- [x] `dotnet test --project PgNimbus.App.Tests/PgNimbus.App.Tests.csproj` — **37/37**, up from 33: the data-driven open-and-close test picked up the four new scenarios for free
- [ ] NativeAOT publish — **not run**
- [ ] Baselines refreshed — **not done.** The four new scenarios have no baseline yet; a missing one is reported `NEW` and does not fail CI, and refreshing needs a Linux render (`scripts/screenshots/update-baselines.sh`). Worth doing before merge.
- [ ] `update-published.sh` — not run; the marketing shots do not include this window yet

Anything left unverified: **the window has still not been opened in a running app against a real database.** Everything below is headless rendering plus the live catalog tests. Driving the write paths (Apply in the role editor, Run in the drop dialog) end-to-end against a server has not been done.

## Screenshots

Rendered headlessly in both themes; the four scenarios are `security-window`, `security-window-permissions`, `security-window-default-privileges`, `security-window-rls`.

Rendering them caught three real layout bugs, which is the argument for the scenarios existing: the matrix header sat a `ListBoxItem`'s padding left of its own column, the HOW column and `MAINTAIN` were pushed off the right edge, and the roles grid was truncating its headers. The group-count column went with the fix — the membership tree beside it is the real answer, so the count was noise taking room the useful columns needed.

Two scenarios are deliberately **unseeded**: default privileges and RLS have to say something useful when the catalog has nothing to show, and an empty state rendering as a blank rectangle is exactly what those shots exist to catch.

## Checklist

- [x] [CLAUDE.md](../CLAUDE.md) updated — hard rule 7 now covers the security model, the write policy and the landmines
- [x] Touches `shared/nimbusUi`? No.
- [x] Nothing here is general enough for kubeNimbus — it is all Postgres role/ACL semantics
- [x] No new UI state renders as a blank rectangle — the empty states are written, and two screenshot scenarios exist to keep them that way
- [x] `PgNimbus.Core` still has zero UI dependencies
- [x] No credentials persisted anywhere they weren't already — the password never reaches the preview, the editor, or `QueryHistoryStore`

## Note on how this was built

Most of these view models were written by parallel subagents that hit a session limit mid-run and had their worktrees pruned. The salvageable output was recovered and finished by hand; the permissions tab and the three dialogs were lost entirely and rewritten. Everything here builds, renders and is covered by the suites above, but it is worth a closer read than usual.
