### PR TITLE
Fix macOS smoke-launch failing on bash 3.2's empty-array nounset bug

### DIFF
--- a/scripts/release/smoke-launch.sh
+++ b/scripts/release/smoke-launch.sh
@@ -57,7 +57,15 @@ echo "   $*"
 # The app has no natural exit outside the probe, so a hang is a real failure
 # mode and needs its own deadline. `timeout` is GNU-only and macOS runners do
 # not ship it, hence the hand-rolled wait.
-PGNIMBUS_STARTUP_PROBE=1 "${launcher[@]}" "$@" >"$log" 2>&1 &
+#
+# The empty/non-empty branch (rather than a bare "${launcher[@]}") is
+# deliberate: macOS runners' system bash is 3.2, which treats expanding an
+# empty-but-declared array under `set -u` as an unbound variable.
+if [ ${#launcher[@]} -eq 0 ]; then
+    PGNIMBUS_STARTUP_PROBE=1 "$@" >"$log" 2>&1 &
+else
+    PGNIMBUS_STARTUP_PROBE=1 "${launcher[@]}" "$@" >"$log" 2>&1 &
+fi
 pid=$!
 
 deadline=$(( $(date +%s) + timeout_seconds ))


### PR DESCRIPTION
## What and why

The v0.11.1 release run's `build-macos` job failed before the app ever launched: `smoke-launch.sh` errored with `launcher[@]: unbound variable` on the "Smoke test (publish output)" step.

`launcher=()` stays empty on macOS (the Xvfb branch is Linux-only), and `"${launcher[@]}"` under `set -u` throws unbound-variable when expanding a declared-but-empty array on bash 3.2 — the system `/bin/bash` shipped on macOS runners. Bash 4.4+ (used on Linux runners) doesn't have this bug, which is why it went unnoticed until the release pipeline actually gated on this job.

Fix: branch on `${#launcher[@]}` instead of expanding the array directly when it may be empty.

## Verified

- [x] Shellcheck-clean read-through; the branch avoids the exact expansion bash 3.2 chokes on
- [ ] Not re-run on a real macOS runner yet — will confirm via the next release pipeline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)