### PR TITLE
Stop macOS quit from aborting the process on the way out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -630,6 +630,28 @@ Three rules about it:
   `ClassicDesktopStyleApplicationLifetime` routes straight to `DoShutdown`
   without consulting `ShutdownMode`, as does the `Shutdown()` that
   `CrashReporter` and `StartupProbe` call directly.
+- **macOS: the app ends its own process, and must (2026-08).** Shipped 0.7.5
+  aborted with SIGABRT on every quit, *after* the shutdown had already run
+  cleanly (windows closed, workspace and placement saved). AppKit's
+  `-[NSApplication terminate:]` asks Avalonia's delegate first — that is the
+  whole managed shutdown, answering `NSTerminateNow` — and then calls C's
+  `exit()`, which runs libAvaloniaNative's C++ static destructors. One of them
+  releases a `ComPtr<IAvnDispatcher>` whose vtable is a managed MicroCom proxy,
+  so `__cxa_finalize` reverse-P/Invokes into managed code on a main thread whose
+  NativeAOT runtime state is already torn down: a `RhFailFast`, not a catchable
+  exception (`ThreadStore::AttachCurrentThread` → "Attempt to execute managed
+  code after the .NET runtime thread state has been destroyed";
+  AvaloniaUI/Avalonia#12459). No frame in that trace is ours, so the fix is to
+  never reach `__cxa_finalize`: `MacShutdown.ExitProcessOnShutdown` hooks the
+  lifetime's `Exit` event — raised after every window has closed and only when
+  the shutdown really goes through — and calls libc `_exit(2)`, which skips
+  atexit handlers and static destructors entirely. Consequences to keep in mind:
+  an `Exit` handler registered after that one never runs, nothing `Program.Main`
+  would do on the way out runs either, and `_exit` flushes nothing — hence the
+  explicit `Console` flush, without which `StartupProbe`'s single line (the
+  release smoke gate) can be lost. `Environment.Exit` is not a substitute: it
+  runs the very `exit()` teardown this avoids. macOS-only; Windows and Linux
+  exit through their own teardown cleanly.
 - **Windows** — every remaining window still calls `ThemedWindowChrome.Attach(this)`
   for the **icon** (details in the icon section below). Its caption-colour half is
   moot on `MainWindow`, whose caption is ours, and still applies to the dialogs and

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -193,6 +193,10 @@ public partial class App : Application
         {
             KeepRunningWithNoWindowsOnMac(desktop);
 
+            // macOS: quitting must not hand the process back to AppKit's exit()
+            // — it aborts on the way out (see MacShutdown).
+            MacShutdown.ExitProcessOnShutdown(desktop);
+
             var envConnectionString = Environment.GetEnvironmentVariable("PGNIMBUS_CONN");
             if (!string.IsNullOrWhiteSpace(envConnectionString))
             {

--- a/PgNimbus.App/MacShutdown.cs
+++ b/PgNimbus.App/MacShutdown.cs
@@ -1,0 +1,103 @@
+using System.Runtime.InteropServices;
+using Avalonia.Controls.ApplicationLifetimes;
+using PgNimbus.Core.Diagnostics;
+
+namespace PgNimbus.App;
+
+/// <summary>
+/// macOS only: end the process ourselves the moment Avalonia's shutdown has
+/// run, rather than letting AppKit finish the quit.
+///
+/// Cmd+Q (and the app menu's Quit, and a logout) reaches
+/// <c>-[NSApplication terminate:]</c>, which asks Avalonia's app delegate
+/// first. That runs the entire managed shutdown — every window closes, so the
+/// workspace snapshot and the window placement are written — and answers
+/// <c>NSTerminateNow</c>. AppKit then calls C's <c>exit()</c>, and that is
+/// where a shipped 0.7.5 died with SIGABRT, on a quit that had already done
+/// everything it needed to:
+///
+/// <code>
+/// exit -> __cxa_finalize_ranges -> ComPtr&lt;IAvnDispatcher&gt;::~ComPtr()
+///      -> MicroComVtblBase__Release          (back into managed code)
+///      -> Thread::ReversePInvokeAttachOrTrapThread
+///      -> ThreadStore::AttachCurrentThread -> RhFailFast -> abort()
+/// </code>
+///
+/// <c>exit()</c> runs libAvaloniaNative's C++ static destructors, and one of
+/// them releases a <c>ComPtr</c> whose vtable is a managed MicroCom proxy — a
+/// reverse P/Invoke. By then NativeAOT has torn down the main thread's runtime
+/// state, and calling managed code on a detached thread is a deliberate
+/// fail-fast ("Attempt to execute managed code after the .NET runtime thread
+/// state has been destroyed"), not an exception any handler can catch. Every
+/// frame in that trace is Avalonia's or the runtime's
+/// (AvaloniaUI/Avalonia#12459), so the only move available here is to never
+/// reach <c>__cxa_finalize</c>: <c>_exit(2)</c> ends the process without
+/// running one atexit handler or static destructor.
+///
+/// It hangs off the lifetime's <c>Exit</c> event, which Avalonia raises after
+/// all windows have closed and only when the shutdown is really going through
+/// (a window that cancels its close returns before it) — so everything the app
+/// saves on close is already on disk. Two consequences worth knowing: an
+/// <c>Exit</c> handler registered after this one never runs, and neither does
+/// anything <c>Program.Main</c> would have done on the way out.
+///
+/// The programmatic <c>Shutdown()</c> callers — the crash reporter and the
+/// startup probe — raise the same event and are covered by the same handler.
+/// They reach process exit from the other side (the message loop ends and
+/// <c>Main</c> returns), but into the identical teardown.
+/// </summary>
+internal static class MacShutdown
+{
+    /// <summary>
+    /// Hooks the lifetime so a completed shutdown ends the process directly.
+    /// No-op off macOS: Windows and Linux exit through this teardown cleanly,
+    /// and skipping it there would buy nothing.
+    /// </summary>
+    public static void ExitProcessOnShutdown(IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        desktop.Exit += (_, e) => ExitNow(e.ApplicationExitCode);
+    }
+
+    private static void ExitNow(int exitCode)
+    {
+        try
+        {
+            // _exit runs no atexit handler, so nothing downstream will flush
+            // these. The startup probe writes exactly one line to stdout and
+            // the release pipeline's smoke check greps for it.
+            Console.Out.Flush();
+            Console.Error.Flush();
+        }
+        catch
+        {
+            // A console that can't be flushed is not a reason to stay alive.
+        }
+
+        try
+        {
+            Exit(exitCode);
+        }
+        catch (Exception ex)
+        {
+            // _exit didn't resolve. Log it and return, which leaves the old
+            // behaviour (AppKit exits and the process aborts on the way out) —
+            // still better than throwing out of a shutdown handler, which would
+            // unwind into Objective-C.
+            CrashLogger.LogCritical("Could not end the process directly on shutdown", ex);
+        }
+    }
+
+    /// <summary>
+    /// <c>_exit(2)</c>: ends the process immediately, skipping atexit handlers,
+    /// C++ static destructors and stdio flushing. Deliberately not
+    /// <c>Environment.Exit</c>, which runs the same <c>exit()</c> teardown this
+    /// exists to avoid.
+    /// </summary>
+    [DllImport("libc", EntryPoint = "_exit")]
+    private static extern void Exit(int status);
+}


### PR DESCRIPTION
Quitting on macOS ended in SIGABRT every time, after the app had already
shut down cleanly: AppKit's -[NSApplication terminate:] asks Avalonia's
delegate first (that is the whole managed shutdown - windows close, the
workspace snapshot and window placement are saved) and then calls exit(),
which runs libAvaloniaNative's C++ static destructors. One of those
releases a ComPtr<IAvnDispatcher> whose vtable is a managed MicroCom
proxy, so __cxa_finalize reverse-P/Invokes into managed code on a main
thread whose NativeAOT runtime state is already gone - a RhFailFast, not
a catchable exception (AvaloniaUI/Avalonia#12459). No frame in that trace
is ours, so the fix is to never reach __cxa_finalize.

MacShutdown hooks the lifetime's Exit event - raised after every window
has closed and only when the shutdown really goes through - and calls
libc _exit(2), which skips atexit handlers and static destructors
outright. Console is flushed first, since _exit flushes nothing and the
startup probe's single stdout line is the release smoke gate; a _exit
that fails to resolve is logged and falls back to today's behaviour
rather than throwing out of a shutdown handler into Objective-C.

macOS-only: Windows and Linux exit through that teardown cleanly.

Verified by forcing the hook on under Linux/Xvfb: the probe line still
reaches redirected stdout and the process exits with the code passed to
_exit (checked with a deliberate 42), then reverted to the macOS guard.
Core (765) and headless UI (39) suites green.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X82hiDp1ke4EEP6XUEpSbr