### PR TITLE
macOS: ad-hoc code signing and drag-to-Applications .dmg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,25 @@ jobs:
           # either way rather than encoding a guess into the gate.
           app=$(find "$mount_point" -maxdepth 1 -name '*.app' | head -1)
           [ -n "$app" ] || app="$mount_point"
-          ls -la "$app"
+          ls -la "$mount_point"
+
+          # The drag-to-install target. Without it the only gesture the window
+          # offers is double-clicking the app on the read-only image.
+          [ -L "$mount_point/Applications" ] || {
+            echo "::error::.dmg is missing the /Applications symlink" >&2
+            exit 1
+          }
+
+          # The signature is what decides whether Gatekeeper calls a quarantined
+          # download "damaged" (unrecoverable without a Terminal command) or
+          # "cannot be checked for malicious software" (right-click -> Open
+          # clears it). Verify it survived hdiutil, not just codesign.
+          codesign --verify --deep --strict --verbose=2 "$app"
+          codesign -dv "$app" 2>&1 | tee /tmp/codesign.txt
+          grep -q 'Signature=adhoc' /tmp/codesign.txt || {
+            echo "::error::app bundle in the .dmg is not signed" >&2
+            exit 1
+          }
 
           ./scripts/release/smoke-launch.sh "mounted .dmg" "$app/Contents/MacOS/PgNimbus.App"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1183,12 +1183,33 @@ It produces, per tag:
   ("symbol(s) not found for architecture arm64" / `pal_swiftbindings`),
   closed "not planned" upstream
   ([dotnet/runtime#116448](https://github.com/dotnet/runtime/issues/116448)).
-  The publish output is wrapped into an unsigned/unnotarized `.app` + `.dmg`
-  by [`scripts/macos/build-app-bundle.sh`](scripts/macos/build-app-bundle.sh),
+  The publish output is wrapped into an **ad-hoc signed** (`codesign --sign -`),
+  un-notarized `.app` + `.dmg` by
+  [`scripts/macos/build-app-bundle.sh`](scripts/macos/build-app-bundle.sh),
   which also generates `.icns` directly from the `design/masters/icon/` tiles
   via `sips`/`iconutil` (stock macOS tools, no extra dependency) — each
   iconset slot uses the exact-size master when one exists, else downscales
   from `icon-1024.png`.
+  **The ad-hoc signature is not decoration, it picks which Gatekeeper dialog a
+  user sees** (added 2026-08, after 0.11.1 shipped with none): a quarantined
+  bundle carrying *no* signature is reported as "pgNimbus is damaged and can't
+  be opened. You should eject the disk image", which reads as a corrupt
+  download, sends people back to Releases for the same bytes, and has no
+  right-click → Open escape. The same bundle ad-hoc signed fails the same
+  Gatekeeper check as "Apple cannot check it for malicious software" — true,
+  and clearable by right-click → Open (System Settings → Privacy & Security →
+  Open Anyway on Sequoia). It is also what makes an arm64 binary loadable at
+  all. Two consequences for the script: the NativeAOT `*.dsym` is deleted
+  before signing (a `.dsym` is itself a bundle directory, the one shape
+  `codesign --deep` won't seal inside `Contents/MacOS`, mirroring the Linux
+  packages' `*.dbg` exclusion), and dylibs are signed inside-out before the
+  bundle. The `.dmg` also carries the `/Applications` symlink it had always
+  claimed to (the volume used to hold the app alone, so the obvious gesture was
+  double-clicking it on the read-only image — that is where "the disk image
+  should be ejected" came from). `release.yml`'s mounted-`.dmg` smoke step
+  gates both: `Signature=adhoc` present after `hdiutil`, and the symlink there.
+  None of this substitutes for a Developer ID signature plus notarization,
+  which needs a paid Apple account and would remove the warning outright.
 - **Linux** — `linux-x64` + `linux-arm64` (the arm64 leg runs natively on
   GitHub's free `ubuntu-24.04-arm` runners — no cross-compile toolchain).
   Each RID is packaged three ways by

--- a/README.md
+++ b/README.md
@@ -79,22 +79,25 @@ Grab `pgNimbus-<version>-win-x64.msi` from [Releases](https://github.com/Shman4i
 
 ### macOS (early beta)
 
-`pgNimbus-<version>-macos-arm64.dmg` from [Releases](https://github.com/Shman4ik/pgNimbus/releases) (Apple Silicon only). The beta is unsigned and unnotarized, so Gatekeeper shows a misleading *"pgNimbus is damaged"* dialog on first launch.
+`pgNimbus-<version>-macos-arm64.dmg` from [Releases](https://github.com/Shman4ik/pgNimbus/releases) (Apple Silicon only). Open the disk image, drag pgNimbus to the Applications folder, then eject the image.
+
+The build carries an ad-hoc signature rather than an Apple Developer ID one, so macOS asks about it the first time you open it:
+
+1. Right-click (or Control-click) pgNimbus in Applications and choose **Open**, then **Open** again in the dialog.
+2. On macOS 15 Sequoia and later, double-click it, dismiss the warning, then go to **System Settings → Privacy & Security** and click **Open Anyway**.
+
+You do this once. Every later launch opens normally.
 
 <details>
-<summary>Fixing the Gatekeeper "App is damaged" error</summary>
+<summary>If macOS says the app is damaged</summary>
 
-The file is safe. This is standard macOS behavior for unsigned apps. Clear the quarantine flag once per downloaded update:
+That is what Gatekeeper says about a download with no signature at all, which is what pgNimbus 0.11.1 and earlier shipped. Later builds are signed and give you the **Open Anyway** path above instead. To open an older download, clear the quarantine flag:
 
 ```bash
-# If you moved the app to the Applications folder:
-xattr -cr /Applications/pgNimbus.app
-
-# If the app is still in your Downloads folder:
-xattr -cr ~/Downloads/pgNimbus.app
+xattr -dr com.apple.quarantine /Applications/pgNimbus.app
 ```
 
-Then launch `pgNimbus.app` normally. Proper signing and notarization are planned, see [Roadmap](#-roadmap).
+The same command also works as a fallback on any version. Signing with a real Developer ID and notarizing, which removes the warning entirely, is on the [Roadmap](#-roadmap).
 
 </details>
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,22 +39,39 @@ installer: it writes to `%LocalAppData%` and needs no administrator rights.
 ## macOS
 
 Apple Silicon only. Download `pgNimbus-<version>-macos-arm64.dmg` from the
-[releases page](https://github.com/Shman4ik/pgNimbus/releases).
+[releases page](https://github.com/Shman4ik/pgNimbus/releases). Open the disk
+image, drag pgNimbus onto the Applications folder beside it, then eject the
+image. Running the app from the mounted image works, but it disappears the
+moment you eject.
 
-The beta is unsigned and unnotarized, so Gatekeeper shows a misleading
-*"pgNimbus is damaged and can't be opened"* dialog on first launch. The file is
-fine. That is what macOS says about any unsigned app. Clear the quarantine flag
-once per downloaded update:
+The build carries an ad-hoc signature instead of an Apple Developer ID one, so
+macOS asks about it the first time you open it:
 
-```bash
-# If you moved the app to Applications:
-xattr -cr /Applications/pgNimbus.app
+=== "macOS 14 and earlier"
 
-# If it is still in Downloads:
-xattr -cr ~/Downloads/pgNimbus.app
-```
+    Right-click (or Control-click) pgNimbus in Applications, choose **Open**,
+    then **Open** again in the dialog.
 
-Then launch it normally.
+=== "macOS 15 Sequoia and later"
+
+    Double-click pgNimbus and dismiss the warning. Open
+    **System Settings → Privacy & Security**, scroll to the security section,
+    and click **Open Anyway** next to the message about pgNimbus.
+
+You do this once per installed version. Later launches open normally.
+
+!!! warning "If macOS says the app is damaged"
+
+    That dialog means the download carries no signature at all, which is what
+    0.11.1 and earlier shipped. There is no **Open Anyway** path out of it.
+    Either download a later build, or clear the quarantine flag by hand:
+
+    ```bash
+    xattr -dr com.apple.quarantine /Applications/pgNimbus.app
+    ```
+
+    The command works as a fallback on any version, including from Downloads if
+    you have not moved the app yet.
 
 !!! note "No Intel build"
 

--- a/scripts/macos/build-app-bundle.sh
+++ b/scripts/macos/build-app-bundle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Packages a `dotnet publish` NativeAOT output into an unsigned PgNimbus.app
+# Packages a `dotnet publish` NativeAOT output into an ad-hoc signed PgNimbus.app
 # bundle and wraps it in a drag-to-Applications .dmg. macOS-only (sips /
-# iconutil / hdiutil are stock tools on GitHub's macos-* runners).
+# iconutil / hdiutil / codesign are stock tools on GitHub's macos-* runners).
 #
 # Usage: build-app-bundle.sh <publish-dir> <version> <rid> <out-dir>
 #   publish-dir  output of `dotnet publish -r <rid> ...`
@@ -23,7 +23,10 @@ esac
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORK_DIR="$(mktemp -d)"
-APP_DIR="$WORK_DIR/pgNimbus.app"
+# The .dmg's volume root, not just the bundle: it carries the drag-to-install
+# /Applications symlink beside the app (see below).
+DMG_ROOT="$WORK_DIR/dmg"
+APP_DIR="$DMG_ROOT/pgNimbus.app"
 
 mkdir -p "$APP_DIR/Contents/MacOS" "$APP_DIR/Contents/Resources"
 
@@ -57,14 +60,47 @@ for size in 16 32 64 128 256 512; do
 done
 iconutil -c icns "$ICONSET_DIR" -o "$APP_DIR/Contents/Resources/app.icns"
 
-# Publish output -> Contents/MacOS.
+# Publish output -> Contents/MacOS. The NativeAOT debug symbols are dropped the
+# way the Linux packages drop *.dbg: nobody debugging a release build has the
+# .dmg to hand, and a .dsym is itself a bundle directory, which is the one shape
+# `codesign --deep` below refuses to seal inside Contents/MacOS.
 cp -R "$PUBLISH_DIR/." "$APP_DIR/Contents/MacOS/"
+rm -rf "$APP_DIR"/Contents/MacOS/*.dsym
 chmod +x "$APP_DIR/Contents/MacOS/PgNimbus.App"
+
+# Ad-hoc code signature (`--sign -`), signed inside-out: nested Mach-O first,
+# then the bundle, which seals everything else into _CodeSignature/CodeResources.
+#
+# This is not about trusting the build, it is about which Gatekeeper dialog a
+# user gets. A quarantined bundle carrying NO signature is reported as
+# *"pgNimbus is damaged and can't be opened. You should eject the disk image"* —
+# which reads as a corrupt download, sends people back to Releases to re-download
+# the same file, and cannot be dismissed by right-click -> Open. An ad-hoc
+# signature fails the same Gatekeeper check, but fails it as *"Apple cannot check
+# it for malicious software"*, which says what is true and which the standard
+# right-click -> Open (or System Settings -> Privacy & Security -> Open Anyway)
+# path actually clears. Ad-hoc signing is also what makes the arm64 binary
+# loadable at all, since Apple Silicon refuses to execute unsigned code.
+#
+# It is not a substitute for a Developer ID signature plus notarization, which
+# would remove the warning entirely and still needs a paid Apple account.
+while IFS= read -r lib; do
+  codesign --force --timestamp=none --sign - "$lib"
+done < <(find "$APP_DIR/Contents/MacOS" -type f -name '*.dylib')
+
+codesign --force --deep --timestamp=none --sign - "$APP_DIR"
+codesign --verify --deep --strict --verbose=2 "$APP_DIR"
+
+# Drag-to-Applications: without this the .dmg holds the app alone, so the
+# obvious gesture is to double-click it where it sits. Running from a read-only
+# disk image is what puts "the disk image should be ejected" in the failure
+# dialog, and an app left on an unmounted image is gone at the next launch.
+ln -s /Applications "$DMG_ROOT/Applications"
 
 mkdir -p "$OUT_DIR"
 DMG_NAME="pgNimbus-$VERSION-macos-$ARCH_LABEL.dmg"
 hdiutil create -volname "pgNimbus $VERSION" \
-  -srcfolder "$APP_DIR" \
+  -srcfolder "$DMG_ROOT" \
   -ov -format UDZO \
   "$OUT_DIR/$DMG_NAME"
 

--- a/website/index.html
+++ b/website/index.html
@@ -371,13 +371,13 @@
       </div>
       <div class="dl">
         <h3>macOS <span style="font-weight:400;color:var(--ink-soft)">(early beta)</span></h3>
-        <p>Apple Silicon <code>.dmg</code> from GitHub Releases. Unsigned for now, so Gatekeeper needs one command:</p>
-        <p><code>xattr -cr /Applications/pgNimbus.app</code></p>
+        <p>Apple Silicon <code>.dmg</code> from GitHub Releases. Drag pgNimbus to Applications, then right-click it and choose <strong>Open</strong> the first time:</p>
+        <p><code>Right-click &rarr; Open &rarr; Open</code></p>
         <a class="btn" href="https://github.com/Shman4ik/pgNimbus/releases/latest">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Download .dmg
         </a>
-        <p class="note">Full macOS support (signing, notarization) is planned. <a href="https://github.com/Shman4ik/pgNimbus#fixing-the-gatekeeper-app-is-damaged-error">Details in the README.</a></p>
+        <p class="note">The build is ad-hoc signed, not notarized, so macOS asks once. Full signing and notarization are planned. <a href="https://github.com/Shman4ik/pgNimbus#macos-early-beta">Details in the README.</a></p>
       </div>
       <div class="dl">
         <h3>Linux <span style="font-weight:400;color:var(--ink-soft)">(early beta)</span></h3>


### PR DESCRIPTION
## What and why

Improves the macOS release experience by adding ad-hoc code signing to the app bundle and restructuring the `.dmg` to include a drag-to-Applications workflow.

**The signing change:** Previously, the unsigned bundle triggered Gatekeeper's "pgNimbus is damaged and can't be opened. You should eject the disk image" dialog — which reads as a corrupt download, sends users back to Releases to re-download, and has no right-click → Open escape. An ad-hoc signature (`codesign --sign -`) fails the same Gatekeeper check but as "Apple cannot check it for malicious software" — which is true, clearable by right-click → Open (or System Settings → Privacy & Security → Open Anyway on Sequoia), and also what makes arm64 binaries loadable at all on Apple Silicon. This is not a substitute for a Developer ID signature + notarization (which needs a paid account), but it materially improves the first-launch experience.

**The `.dmg` structure change:** The volume now carries an `/Applications` symlink beside the app, making the drag-to-install gesture obvious. Previously the `.dmg` held only the app, so the obvious gesture was double-clicking it on the read-only image — which is where "the disk image should be ejected" came from.

**Implementation details:**
- `build-app-bundle.sh` now signs dylibs inside-out before the bundle (required by `codesign --deep`)
- NativeAOT `*.dsym` files are deleted before signing (a `.dsym` is itself a bundle directory, the one shape `codesign --deep` refuses to seal inside `Contents/MacOS` — mirrors the Linux packages' `*.dbg` exclusion)
- The `.dmg` is created from a `dmg/` root directory containing both the app and the `/Applications` symlink
- `release.yml`'s smoke test now verifies the signature survived `hdiutil` and the symlink is present

Documentation updated across README, installation guide, CLAUDE.md, and website to reflect the new workflow and explain why the ad-hoc signature matters.

## Verified

- [x] `build-app-bundle.sh` changes reviewed for correctness (no live macOS runner available)
- [x] Documentation changes reviewed for accuracy and clarity
- [x] `release.yml` smoke test additions reviewed

Anything left unverified: Live macOS build and `.dmg` creation (requires macOS runner).

## Checklist

- [x] [CLAUDE.md](../CLAUDE.md) updated — added explanation of ad-hoc signing rationale, `.dsym` deletion, and `.dmg` structure changes
- [ ] No UI changes
- [ ] No shared code changes
- [ ] No new credentials or state persistence

https://claude.ai/code/session_01T3eTgXDZbRcTKLBHwH2xKk