### PR TITLE
Let the macOS About menu land on the connect form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -663,8 +663,18 @@ Three rules about it:
   pgNimbus, pgNimbus on GitHub, and Settings… (Cmd+,). The first and last both
   route to the *active* MainWindow's view model through
   `App.ActiveMainViewModel()`, because both are overlays on a window now rather
-  than free-standing boxes — which also makes About a no-op while only the
-  connection dialog is up, exactly as Settings… already was. Window-level:
+  than free-standing boxes. **About falls back to the connection dialog** when
+  there is no main window yet (2026-08): `ConnectionDialog` hosts its own
+  `AboutView` overlay against `ConnectionDialogViewModel.IsAboutOpen`, because
+  the connect form is the app's first screen and often its only one — with the
+  ☰ menu absent there and no window for the overlay to land on, the menu item
+  used to do nothing exactly where a Mac user is most likely to reach for it.
+  One consequence to keep: `ConnectAsync` returns early while that overlay is
+  open, since the profiles list binds Enter to Connect and the Connect button is
+  the window's `IsDefault`, so Escape-the-overlay's sibling gesture would
+  otherwise connect instead of dismissing. Settings… keeps the no-op — the
+  preferences page hangs off a connected window's view model, so there is
+  nothing for it to show. Window-level:
   `MainWindow.BuildMacNativeMenu()` builds File / Query / View / Window via
   `NativeMenu.SetMenu`, rebuilt from `BuildKeyBindings` so gestures track
   the live Ctrl/Cmd scheme. Landmines, all learned the hard way: (a) menu

--- a/PgNimbus.App.Tests/ShellTests.cs
+++ b/PgNimbus.App.Tests/ShellTests.cs
@@ -1,5 +1,8 @@
 using Avalonia;
 using Avalonia.Input;
+using Avalonia.VisualTree;
+using PgNimbus.App.ViewModels;
+using PgNimbus.App.Views;
 using PgNimbus.Core.Commands;
 using PgNimbus.Screenshot;
 
@@ -119,6 +122,44 @@ public class ShellTests
 
             Ui.Press(window, Key.Escape);
             await Assert.That(vm.IsShortcutsOpen).IsFalse();
+
+            window.Close();
+        });
+    }
+
+    /// <summary>
+    /// The About box reaches the connect form too, not just the shell. On macOS the
+    /// app menu is the only route to it and the connect form is often the only window
+    /// open, so before this the menu item did nothing on the app's first screen.
+    /// Three things, all of which were broken by hand once: it becomes visible, Enter
+    /// does not connect out from under it (the profiles list and the default Connect
+    /// button both bind that key), and Escape takes it back down.
+    /// </summary>
+    [Test]
+    public async Task About_overlay_opens_over_the_connection_dialog()
+    {
+        await Ui.Run(async () =>
+        {
+            var window = Scenarios.ConnectionDialog();
+            var vm = (ConnectionDialogViewModel)window.DataContext!;
+            Ui.Show(window);
+
+            // Nothing to find yet: a closed panel's backdrop is collapsed, so the
+            // ContentPresenter under it never realizes the box in the first place.
+            await Assert.That(window.GetVisualDescendants().OfType<AboutView>().Any()).IsFalse();
+
+            vm.IsAboutOpen = true;
+            Ui.Settle();
+            var about = window.GetVisualDescendants().OfType<AboutView>().Single();
+            await Assert.That(about.IsEffectivelyVisible).IsTrue();
+
+            // StatusMessage is set synchronously by ConnectAsync before its first
+            // await, so a connect that got past the guard would have left one here.
+            vm.ConnectCommand.Execute(null);
+            await Assert.That(vm.StatusMessage).IsNull();
+
+            Ui.Press(window, Key.Escape);
+            await Assert.That(vm.IsAboutOpen).IsFalse();
 
             window.Close();
         });

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -120,12 +120,27 @@ public partial class App : Application
     /// "About pgNimbus" in the macOS app menu (see App.axaml): opens the About panel
     /// on the active main window (or the first one — the app menu is global, windows
     /// are not). The box is an <c>OverlayPanel</c> over a window rather than a window
-    /// of its own now, so like "Settings…" below this is a no-op while only the
-    /// connection dialog is up; the ☰ menu is the in-window route, and on Windows and
-    /// Linux the only one.
+    /// of its own, so it needs a host; when there is no main window yet it falls back
+    /// to the connection dialog, which hosts its own copy for exactly this reason.
+    /// Without that fallback the menu item did nothing on the app's first screen —
+    /// the one place a Mac user is most likely to reach for it, and the one place the
+    /// ☰ menu (the in-window route, and on Windows and Linux the only one) is absent.
+    /// "Settings…" below has no such fallback on purpose: preferences hang off a
+    /// connected window's view model, so there is nothing for it to show.
     /// </summary>
-    private void OnAboutMenuItemClicked(object? sender, EventArgs e) =>
-        ActiveMainViewModel()?.ShowAboutCommand.Execute(null);
+    private void OnAboutMenuItemClicked(object? sender, EventArgs e)
+    {
+        if (ActiveMainViewModel() is { } main)
+        {
+            main.ShowAboutCommand.Execute(null);
+            return;
+        }
+
+        if (ActiveWindow<ConnectionDialog>()?.DataContext is ConnectionDialogViewModel dialog)
+        {
+            dialog.IsAboutOpen = true;
+        }
+    }
 
     /// <summary>"pgNimbus on GitHub" in the macOS app menu: opens the project page.</summary>
     private void OnGitHubMenuItemClicked(object? sender, EventArgs e)
@@ -150,20 +165,24 @@ public partial class App : Application
         ActiveMainViewModel()?.ShowPreferencesCommand.Execute(null);
 
     /// <summary>
-    /// The main window an app-menu item should act on: the active one, or the first
-    /// if none is (the app menu is global, windows are not). Null while only the
-    /// connection dialog is up — nothing in this menu has a window-less meaning.
+    /// The main window's view model an app-menu item should act on. Null while only
+    /// the connection dialog is up — every item here but About then has nothing to do.
     /// </summary>
-    private MainViewModel? ActiveMainViewModel()
+    private MainViewModel? ActiveMainViewModel() => ActiveWindow<MainWindow>()?.DataContext as MainViewModel;
+
+    /// <summary>
+    /// The open window of type <typeparamref name="T"/> an app-menu item should act on:
+    /// the active one, or the first if none is (the app menu is global, windows are not).
+    /// </summary>
+    private T? ActiveWindow<T>() where T : Window
     {
         if (ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
         {
             return null;
         }
 
-        var window = desktop.Windows.OfType<MainWindow>().FirstOrDefault(w => w.IsActive)
-            ?? desktop.Windows.OfType<MainWindow>().FirstOrDefault();
-        return window?.DataContext as MainViewModel;
+        return desktop.Windows.OfType<T>().FirstOrDefault(w => w.IsActive)
+            ?? desktop.Windows.OfType<T>().FirstOrDefault();
     }
 
     public override void Initialize()

--- a/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
+++ b/PgNimbus.App/ViewModels/ConnectionDialogViewModel.cs
@@ -49,6 +49,16 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
     /// <summary>Drives the empty-state hint over the Saved Connections list.</summary>
     public bool HasNoProfiles => Profiles.Count == 0;
 
+    /// <summary>
+    /// Whether the About overlay is showing over the connect form. The dialog hosts its
+    /// own copy of the box because it is the app's first screen and often its only one:
+    /// with no <c>MainWindow</c> open yet, macOS's app-menu "About pgNimbus" has nowhere
+    /// else to land, and the ☰ menu the other platforms reach it through does not exist
+    /// here. Two-way from the overlay, which closes itself (see <c>OverlayPanel</c>).
+    /// </summary>
+    [ObservableProperty]
+    private bool _isAboutOpen;
+
     public IReadOnlyList<SslMode> SslModes { get; } = Enum.GetValues<SslMode>();
 
     public IReadOnlyList<SshAuthMethod> SshAuthMethods { get; } = Enum.GetValues<SshAuthMethod>();
@@ -594,6 +604,15 @@ public sealed partial class ConnectionDialogViewModel : ObservableObject
         // could otherwise start a second connect and spin up a duplicate SSH
         // tunnel while the first is still in flight.
         if (IsConnecting)
+        {
+            return;
+        }
+
+        // Enter still reaches Connect while the About overlay is up - the button is
+        // the window's IsDefault and the profiles list binds Enter to this command
+        // too - so dismissing the box with the key that dismisses every other overlay
+        // would connect instead. Escape and the backdrop are the way out of it.
+        if (IsAboutOpen)
         {
             return;
         }

--- a/PgNimbus.App/Views/ConnectionDialog.axaml
+++ b/PgNimbus.App/Views/ConnectionDialog.axaml
@@ -4,6 +4,8 @@
         xmlns:conn="using:PgNimbus.Core.Connections"
         xmlns:conv="using:Avalonia.Data.Converters"
         xmlns:converters="using:PgNimbus.App.Converters"
+        xmlns:views="using:PgNimbus.App.Views"
+        xmlns:nui="using:Nimbus.Ui.Controls"
         xmlns:sys="using:System"
         x:Class="PgNimbus.App.Views.ConnectionDialog"
         x:DataType="vm:ConnectionDialogViewModel"
@@ -11,6 +13,10 @@
         Width="720" Height="600"
         MinWidth="620" MinHeight="520"
         WindowStartupLocation="CenterScreen">
+
+    <!-- Outer grid carries no margin so the About overlay's backdrop can reach the
+         window edges; the form keeps its own inset. -->
+    <Grid>
 
     <Grid Margin="16" RowDefinitions="*,Auto,Auto">
 
@@ -237,6 +243,16 @@
     <!-- Thin full-width footer strip, below the buttons like everything else. -->
     <TextBlock Grid.Row="2" Text="{Binding FooterText}" FontSize="10" Opacity="0.4"
                HorizontalAlignment="Center" Margin="0,10,0,0" />
+
+    </Grid>
+
+    <!-- The same About box the shell hosts, with the same sizing. Here because the
+         connect form is often the only window open, and macOS's app-menu "About
+         pgNimbus" has to land somewhere (see ConnectionDialogViewModel.IsAboutOpen). -->
+    <nui:OverlayPanel IsOpen="{Binding IsAboutOpen, Mode=TwoWay}"
+                      Title="About" PanelWidth="340" PanelMaxHeight="400">
+        <views:AboutView />
+    </nui:OverlayPanel>
 
     </Grid>
 


### PR DESCRIPTION
On macOS the app menu's "About pgNimbus" routed to the active `MainWindow`'s view model, so it did nothing while only the connection dialog was open. That is the app's first screen, often its only one, and the place a Mac user is most likely to reach for About. Windows and Linux get there through the hamburger menu, which the dialog does not have either.

## What changed

- `ConnectionDialog` hosts its own `AboutView` overlay, bound to a new `ConnectionDialogViewModel.IsAboutOpen`. Same box, same sizing, same version string and GitHub button as the shell's.
- `App.OnAboutMenuItemClicked` falls back to that dialog when no main window exists. `ActiveMainViewModel()` is now a thin wrapper over a generic `ActiveWindow<T>()`.
- `ConnectAsync` returns early while the overlay is open. The profiles list binds Enter to Connect and the Connect button is the window's `IsDefault`, so pressing the key that dismisses every other overlay would have connected instead of closing the box.
- "Settings…" keeps its no-op on purpose: the preferences page hangs off a connected window's view model, so there is nothing for it to show.
- `CLAUDE.md`'s macOS native menu section updated; it still said About was a no-op there.

## Verification

- New headless UI test `About_overlay_opens_over_the_connection_dialog`: the box becomes visible, `ConnectCommand` is a no-op while it is up, Escape takes it down. Checked it goes red with the guard removed.
- `PgNimbus.Core.Tests` 750 passed / 15 skipped, `PgNimbus.App.Tests` 40 passed.
- Rendered the dialog with the overlay open through the screenshot harness in both themes: backdrop reaches the window edges, card centered.

No paired kubeNimbus PR needed. Nothing under `shared/nimbusUi` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
