### PR TITLE
Let the results grid's columns be dragged to a width

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -679,6 +679,28 @@ Three rules about it:
   menu titled "View"; (d) the File → Open Recent submenu rebuilds on the
   menu's `NeedsUpdate`, same contract as the ☰ menu's, and View's
   Show/Hide Sidebar header re-resolves the same way.
+- **Results-grid columns resize by dragging, and the drag lifts the auto-width
+  cap.** Every generated column is `Width=Auto` with `MaxWidth=AutoWidthCap`
+  (560), so one long value can't blow a column past the viewport — but
+  `DataGridColumnHeader` clamps *every* step of a resize drag to the column's
+  `ActualMaxWidth` too, so with the cap left on, widening a capped column stops
+  dead with nothing on screen saying why. `ResultsGridPanel` therefore lifts the
+  cap for the column a press is about to resize. Three things make that work:
+  the handler is **tunneled** (the header marks a resize press handled before it
+  bubbles, so `DataGridColumn.HeaderPointerPressed` — an ordinary bubbling
+  subscription — never fires for the very presses that matter); it repeats the
+  grid's own 5px-edge test to decide *which* column the press resizes (the right
+  grip resizes this column, the left one its neighbour); and it pins
+  `Width = ActualWidth` **before** raising `MaxWidth`, because
+  `DataGrid.OnColumnMaxWidthChanged` re-expands a column sitting exactly at its
+  cap to the full width its content wants — without the pin the column jumps on
+  mouse-down, before the drag. The header→column mapping rides on the header
+  content's `Tag` (`DataGridColumnHeader.OwningColumn` is internal). Dragged
+  widths are handed back to the tab in `QueryViewModel.ColumnWidths`, keyed by
+  column name, because the grid is window-central and rebuilds its columns from
+  scratch on every re-run, page turn, `EditContext` arrival and tab switch;
+  only dragged columns are saved, so an untouched column keeps growing with the
+  values that scroll into view.
 - **Results-grid scrolling is the DataGrid's own.** Avalonia 12's DataGrid
   handles both wheel axes natively (`UpdateScroll`). Don't reintroduce a
   tunneled wheel handler that writes `ScrollBar.Value` directly — the

--- a/PgNimbus.App.Tests/ResultsGridTests.cs
+++ b/PgNimbus.App.Tests/ResultsGridTests.cs
@@ -1,6 +1,10 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
 using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
+using PgNimbus.Core.Query;
 using PgNimbus.Screenshot;
 
 namespace PgNimbus.App.Tests;
@@ -78,6 +82,122 @@ public class ResultsGridTests
             await Assert.That(rowsNow).IsEqualTo(0);
         });
     }
+
+    /// <summary>
+    /// Dragging a header's right edge resizes that column — and lifts the
+    /// auto-width cap the columns are built with, which otherwise clamps the
+    /// drag itself (DataGridColumnHeader clamps every step to MaxWidth), so a
+    /// widening drag would stop dead partway with nothing on screen saying why.
+    /// </summary>
+    [Test]
+    public async Task Dragging_a_column_edge_resizes_that_column()
+    {
+        await Ui.Run(async () =>
+        {
+            var (window, _) = Scenarios.Shell();
+            Ui.Show(window);
+
+            var grid = FindResultsGrid(window)!;
+            var header = FindHeader(window, 0);
+            await Assert.That(header).IsNotNull();
+
+            var before = grid.Columns[0].ActualWidth;
+            Drag(window, header!, by: 60);
+
+            await Assert.That(grid.Columns[0].ActualWidth).IsGreaterThan(before);
+            await Assert.That(double.IsPositiveInfinity(grid.Columns[0].MaxWidth)).IsTrue();
+
+            window.Close();
+        });
+    }
+
+    /// <summary>
+    /// The case the cap is actually in the way of: a column whose content is
+    /// long enough that auto-sizing parks it at the cap. Widening it has to
+    /// work — a drag that stops at an invisible ceiling is the reported bug this
+    /// feature would otherwise ship with.
+    /// </summary>
+    [Test]
+    public async Task A_capped_column_can_be_dragged_past_the_cap()
+    {
+        await Ui.Run(async () =>
+        {
+            var (window, vm) = Scenarios.Shell();
+            Ui.Show(window);
+
+            // One column, one very long value: auto-sizing wants far more than
+            // the cap, so the column lands exactly on it.
+            vm.ActiveTab.SeedResult(
+                [new ColumnInfo("payload", "text", typeof(string))],
+                [[new string('x', 400)]]);
+            Ui.Settle();
+
+            var grid = FindResultsGrid(window)!;
+            var capped = grid.Columns[0].ActualWidth;
+            // Without this the drag assertion below would also pass on a column
+            // the cap was never in the way of, proving nothing.
+            await Assert.That(capped).IsEqualTo(560).Within(1);
+
+            Drag(window, FindHeader(window, 0)!, by: 120);
+
+            await Assert.That(grid.Columns[0].ActualWidth).IsGreaterThan(capped + 100);
+
+            window.Close();
+        });
+    }
+
+    /// <summary>
+    /// The grid is window-central and rebuilds its columns from scratch every
+    /// time the active tab changes, so a drag only survives because the width is
+    /// handed back to the tab it was made on (QueryViewModel.ColumnWidths).
+    /// </summary>
+    [Test]
+    public async Task A_resized_column_keeps_its_width_across_a_tab_switch()
+    {
+        await Ui.Run(async () =>
+        {
+            var (window, vm) = Scenarios.Shell();
+            Ui.Show(window);
+
+            var grid = FindResultsGrid(window)!;
+            var original = vm.ActiveTab;
+            Drag(window, FindHeader(window, 0)!, by: 60);
+            var resized = grid.Columns[0].ActualWidth;
+
+            vm.AddTabCommand.Execute(null);
+            Ui.Settle();
+            vm.ActiveTab = original;
+            Ui.Settle();
+
+            await Assert.That(grid.Columns[0].ActualWidth).IsEqualTo(resized).Within(1);
+
+            window.Close();
+        });
+    }
+
+    // A resize drag on a header's right edge: press inside the grip strip, move,
+    // release. Sent as real pointer input so the DataGrid's own resize handling
+    // runs — the point of these two tests is the interaction, not the property.
+    private static void Drag(Window window, DataGridColumnHeader header, double by)
+    {
+        var grip = header.TranslatePoint(
+            new Point(header.Bounds.Width - 2, header.Bounds.Height / 2), window)!.Value;
+
+        window.MouseDown(grip, MouseButton.Left);
+        Ui.Settle();
+        window.MouseMove(grip.WithX(grip.X + by));
+        Ui.Settle();
+        window.MouseUp(grip.WithX(grip.X + by), MouseButton.Left);
+        Ui.Settle();
+    }
+
+    // Headers carry their column index on the content this panel built for them
+    // (ResultsGridPanel.CreateColumnHeader), which is also how the panel maps a
+    // press back to a column.
+    private static DataGridColumnHeader? FindHeader(Window window, int index) =>
+        window.GetVisualDescendants()
+            .OfType<DataGridColumnHeader>()
+            .FirstOrDefault(header => header.Content is Control { Tag: int tag } && tag == index);
 
     private static DataGrid? FindResultsGrid(Window window) =>
         window.GetVisualDescendants().OfType<DataGrid>().FirstOrDefault();

--- a/PgNimbus.App/ViewModels/QueryViewModel.cs
+++ b/PgNimbus.App/ViewModels/QueryViewModel.cs
@@ -327,6 +327,22 @@ public sealed partial class QueryViewModel : ObservableObject
     public ObservableCollection<string> ColumnNames { get; } = [];
 
     /// <summary>
+    /// Results-grid column widths the user dragged, by column name — the tab's
+    /// memory of its own layout, written and read by <c>ResultsGridPanel</c>
+    /// (the grid itself is window-central and rebuilds its columns from scratch
+    /// on every re-run, page turn, EditContext arrival and tab switch, so
+    /// without this a drag would be undone by the next of those).
+    ///
+    /// Keyed by name rather than position and deliberately never cleared: a
+    /// re-run of the same query, a page turn, or a browse whose columns arrive
+    /// twice all have to match, and a later query that happens to share a
+    /// column name inheriting its width is the same answer the user already
+    /// gave for that column. Widths are view state and stay out of the
+    /// workspace snapshot.
+    /// </summary>
+    public Dictionary<string, double> ColumnWidths { get; } = [];
+
+    /// <summary>
     /// The Postgres type name of result column <paramref name="index"/> (as the
     /// wire protocol reports it — "jsonb", "integer[]", "timestamp with time
     /// zone", …), or null when out of range. Available for every result set, not

--- a/PgNimbus.App/Views/ResultsGridPanel.axaml
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml
@@ -75,6 +75,8 @@
                               Background="Transparent"
                               CanUserReorderColumns="False"
                               CanUserSortColumns="True"
+                              CanUserResizeColumns="True"
+                              MinColumnWidth="44"
                               SelectionMode="Extended"
                               ClipboardCopyMode="None"
                               AutoGenerateColumns="False"

--- a/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
@@ -70,6 +70,17 @@ public partial class ResultsGridPanel : UserControl
     // space bar - a TextBox doesn't mark Space's KeyDown handled, it inserts
     // the space on TextInput, so the key would otherwise bubble up here.
     private bool _isCellEditing;
+    // Column widths the user dragged, as indexes into the columns currently
+    // built, plus the names those indexes stood for. Saved onto the tab (by
+    // name, in QueryViewModel.ColumnWidths) whenever the grid is rebuilt, which
+    // is the only reason a drag survives a re-run, a page turn or a tab switch.
+    private readonly HashSet<int> _resizedColumns = [];
+    private readonly List<string> _builtColumnNames = [];
+    // The tab the columns currently in the grid were built for — not the same
+    // thing as _activeQuery, which has already been swapped by the time
+    // AttachQuery rebuilds.
+    private QueryViewModel? _builtFor;
+
     // One-shot: set when a double-click lands on an editable json/jsonb cell,
     // consumed by OnResultsGridBeginningEdit to cancel the grid's inline edit so
     // the click opens the cell inspector's JSON editor instead (see
@@ -93,6 +104,13 @@ public partial class ResultsGridPanel : UserControl
             _model.CellInspector.EditText = JsonInspectorEditor.Text;
         };
         LoadJsonHighlighting();
+
+        // Column resizing is the DataGrid's own, but the cap that keeps one long
+        // value from blowing a column past the viewport has to be lifted for the
+        // column about to be dragged — tunneled, because the header marks the
+        // press handled before it bubbles (see OnResultsGridPointerPressed).
+        ResultsGrid.AddHandler(
+            InputElement.PointerPressedEvent, OnResultsGridPointerPressed, RoutingStrategies.Tunnel);
 
         ResultsGrid.CellEditEnding += OnCellEditEnding;
         ResultsGrid.CellEditEnded += OnCellEditEnded;
@@ -1171,7 +1189,14 @@ public partial class ResultsGridPanel : UserControl
         Justification = "Pathless binding uses a converter only; no dynamic code.")]
     private void RebuildColumns(QueryViewModel query)
     {
+        // The columns about to be discarded may carry widths the user dragged;
+        // hand them back to the tab they belong to before they go.
+        SaveUserColumnWidths();
+
         ResultsGrid.Columns.Clear();
+        _resizedColumns.Clear();
+        _builtColumnNames.Clear();
+        _builtFor = query;
 
         for (var i = 0; i < query.ColumnNames.Count; i++)
         {
@@ -1191,9 +1216,9 @@ public partial class ResultsGridPanel : UserControl
                 ? PgTypeCategorizer.CategorizeColumn(declaredType, meta.DomainBaseType, meta.Editor)
                 : PgTypeCategorizer.Categorize(PgTypeCategorizer.ClassifierType(declaredType, null));
 
-            ResultsGrid.Columns.Add(new ResultTextColumn(i, editorMeta, category)
+            var column = new ResultTextColumn(i, editorMeta, category)
             {
-                Header = CreateColumnHeader(name, declaredType, category, editorMeta),
+                Header = CreateColumnHeader(i, name, declaredType, category, editorMeta),
                 // Avalonia 12's DataGrid infers "read-only" from a column's
                 // binding path — and a pathless converter binding (the
                 // AOT-safe pattern used here) has none, which silently made
@@ -1216,9 +1241,114 @@ public partial class ResultsGridPanel : UserControl
                 CanUserSort = true,
                 // Auto width sizes to the widest cell, so one long text value
                 // used to blow the column past the viewport; cap it and let
-                // the cell inspector carry the full value.
-                MaxWidth = 560,
-            });
+                // the cell inspector carry the full value. The cap is only for
+                // *automatic* sizing — a user drag lifts it (UnclampColumn).
+                MaxWidth = AutoWidthCap,
+            };
+
+            ResultsGrid.Columns.Add(column);
+            _builtColumnNames.Add(name);
+
+            // A width this tab was already dragged to wins over auto-sizing, and
+            // keeps the cap lifted so the next drag starts where the last ended.
+            if (query.ColumnWidths.TryGetValue(name, out var width))
+            {
+                column.MaxWidth = double.PositiveInfinity;
+                column.Width = new DataGridLength(width);
+                _resizedColumns.Add(i);
+            }
+        }
+    }
+
+    // The widest a column sizes itself to. Only bounds auto-sizing: past this,
+    // a value belongs in the cell inspector, not in a column that has pushed
+    // every other one off screen.
+    private const double AutoWidthCap = 560;
+
+    // The strip at each header edge the DataGrid treats as the resize grip
+    // (DataGridColumnHeader's own private constant — repeated here because
+    // deciding which column a press is about to resize means repeating its test).
+    private const double ResizeGripWidth = 5;
+
+    /// <summary>
+    /// Lifts <see cref="AutoWidthCap"/> off the column a press is about to
+    /// resize, so a widening drag isn't stopped dead at the cap
+    /// (DataGridColumnHeader clamps every drag step to the column's MaxWidth).
+    ///
+    /// Tunneled: the header marks a resize press handled, so a bubbling handler
+    /// — including <c>DataGridColumn.HeaderPointerPressed</c>, which is raised
+    /// from an ordinary bubbling subscription — never sees it.
+    /// </summary>
+    private void OnResultsGridPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(ResultsGrid).Properties.IsLeftButtonPressed
+            || e.Source is not Visual source
+            || source.FindAncestorOfType<DataGridColumnHeader>(includeSelf: true) is not { } header
+            || HeaderColumnIndex(header) is not { } index)
+        {
+            return;
+        }
+
+        // Same test the grid makes: the right grip resizes this column, the left
+        // one resizes its neighbour.
+        var x = e.GetPosition(header).X;
+        if (header.Bounds.Width - x <= ResizeGripWidth)
+        {
+            UnclampColumn(index);
+        }
+        else if (x <= ResizeGripWidth)
+        {
+            UnclampColumn(index - 1);
+        }
+    }
+
+    // Which result column a header belongs to. DataGridColumnHeader.OwningColumn
+    // is internal, so the index rides on the header content this panel built
+    // (CreateColumnHeader) instead.
+    private static int? HeaderColumnIndex(DataGridColumnHeader header) =>
+        header.Content is Control content && content.Tag is int index ? index : null;
+
+    private void UnclampColumn(int index)
+    {
+        if (index < 0 || index >= ResultsGrid.Columns.Count)
+        {
+            return;
+        }
+
+        // Marked before the early-out: an already-uncapped column is one a drag
+        // has been through before, and this drag still has to be remembered.
+        _resizedColumns.Add(index);
+
+        var column = ResultsGrid.Columns[index];
+        if (double.IsPositiveInfinity(column.MaxWidth))
+        {
+            return;
+        }
+
+        // Pin the width the column is actually at before lifting the cap.
+        // Raising MaxWidth on a column sitting *at* its cap re-expands it to the
+        // full width its content wants (DataGrid.OnColumnMaxWidthChanged), so
+        // without this the column would jump on mouse-down, before the drag.
+        column.Width = new DataGridLength(column.ActualWidth);
+        column.MaxWidth = double.PositiveInfinity;
+    }
+
+    // Hands the dragged widths back to the tab that owns them. Only the columns
+    // a drag touched: saving the auto-sized ones would pin them, and a column
+    // nobody resized should keep growing with the values that scroll into view.
+    private void SaveUserColumnWidths()
+    {
+        if (_builtFor is null)
+        {
+            return;
+        }
+
+        foreach (var index in _resizedColumns)
+        {
+            if (index < _builtColumnNames.Count && index < ResultsGrid.Columns.Count)
+            {
+                _builtFor.ColumnWidths[_builtColumnNames[index]] = ResultsGrid.Columns[index].ActualWidth;
+            }
         }
     }
 
@@ -1227,10 +1357,14 @@ public partial class ResultsGridPanel : UserControl
     // and — in browse mode, where the table's real columns are known — its
     // primary-key / not-null flags. The type name comes from the wire protocol so
     // every result set gets the icon, not just editable ones.
-    private static Control CreateColumnHeader(string name, string? displayType, PgTypeCategory category, ColumnDetail? meta)
+    private static Control CreateColumnHeader(
+        int index, string name, string? displayType, PgTypeCategory category, ColumnDetail? meta)
     {
         var panel = new StackPanel
         {
+            // Which column this header stands for — the only public way back
+            // from a DataGridColumnHeader to its column (see HeaderColumnIndex).
+            Tag = index,
             Orientation = Avalonia.Layout.Orientation.Horizontal,
             Spacing = 5,
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,

--- a/docs/guide/results.md
+++ b/docs/guide/results.md
@@ -9,6 +9,17 @@ hundred-million-row table costs the same as any other single page.
 The SQL that produces the view sits in the editor, and doubles as the filter: add
 a `WHERE` clause and run it.
 
+## Column widths
+
+Columns size themselves to their content, up to a limit that keeps one long
+value from pushing every other column off screen. Drag the divider between two
+headers to set a width yourself, and that column stops sizing itself and keeps
+the width you gave it. Dragging is not bound by the limit, so a column holding
+long JSON can be pulled as wide as you need.
+
+Widths you set are remembered per tab, by column name, so re-running the query,
+turning a page, or switching to another tab and back keeps them.
+
 ## Editing cells
 
 | Action | How |


### PR DESCRIPTION
## What and why

The results grid had `CanUserResizeColumns` off, so column widths were whatever auto-sizing decided. A `jsonb` payload column parks at the 560px auto-width cap and there was no way to see more of it in the grid.

Turning the flag on is not enough by itself. `DataGridColumnHeader` clamps every step of a resize drag to the column's `ActualMaxWidth`, so dragging a capped column would stop dead partway with nothing on screen explaining why. `ResultsGridPanel` now lifts the cap for the column a press is about to resize. Three parts of that are load-bearing, and all three are commented in place and in CLAUDE.md:

- the handler is **tunneled**, because the header marks a resize press handled before it bubbles, so `DataGridColumn.HeaderPointerPressed` never fires for exactly the presses that matter;
- it repeats the grid's own 5px-edge test to decide which column a press resizes (right grip this column, left grip its neighbour), mapping header to column through the header content's `Tag` since `OwningColumn` is internal;
- it pins `Width = ActualWidth` **before** raising `MaxWidth`, because `DataGrid.OnColumnMaxWidthChanged` re-expands a column sitting exactly at its cap to its full desired width, which would make the column jump on mouse-down.

Dragged widths are handed back to the tab (`QueryViewModel.ColumnWidths`, keyed by column name). The grid is window-central and rebuilds its columns from scratch on every re-run, page turn, `EditContext` arrival and tab switch, so without that a drag would be undone by the next of those. Only dragged columns are saved, so an untouched column keeps growing with the values that scroll into view.

`MinColumnWidth=44` so a column cannot be dragged down to the 20px default, where nothing of the header survives.

## Verified

- [x] `dotnet build PgNimbus.slnx` — 0 warnings, 0 errors
- [x] `dotnet test --project PgNimbus.Core.Tests/PgNimbus.Core.Tests.csproj` — 750 passed, 15 skipped, no live Postgres
- [x] `dotnet test --project PgNimbus.App.Tests/PgNimbus.App.Tests.csproj` — 42 passed, including three new ones that drive a real pointer drag on a header edge: the drag widens the column, a capped column can be dragged past the cap (asserting first that it really was at 560, so the test cannot pass vacuously), and a dragged width survives a tab switch. Each was checked to go red when its subject is broken.
- [x] UI changes: rendered every screenshot scenario before and after the change on this machine and compared them — all 44 frames identical, so the committed Linux baselines still hold and no refresh is needed.
- [ ] NativeAOT publish — not run
- [ ] `scripts/screenshots/update-published.sh` — not needed, no published shot changes

The author also exercised the drag by hand in the running app.

## Checklist

- [x] [CLAUDE.md](../CLAUDE.md) updated — new bullet next to the results-grid scrolling rule, carrying the three landmines above
- [x] Does not touch `shared/nimbusUi`
- [x] `docs/guide/results.md` gains a short "Column widths" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
