### PR TITLE
Fix obsolete Watermark usages and clean up build warnings

### DIFF
--- a/PgNimbus.App.Tests/NotifyMonitorTests.cs
+++ b/PgNimbus.App.Tests/NotifyMonitorTests.cs
@@ -80,7 +80,7 @@ public class NotifyMonitorTests
         await Ui.Run(async () =>
         {
             List<string>? persisted = null;
-            var vm = Monitor(persist: channels => persisted = channels.ToList());
+            var vm = Monitor(persist: channels => persisted = [.. channels]);
 
             vm.ChannelName = "  order_events  ";
             vm.AddChannelCommand.Execute(null);

--- a/PgNimbus.App/App.axaml.cs
+++ b/PgNimbus.App/App.axaml.cs
@@ -84,7 +84,7 @@ public partial class App : Application
 
     /// <summary>Remembers the command palette's recent-.sql-files list so it survives a restart.</summary>
     private static void PersistRecentSqlFiles(IReadOnlyList<string> value) =>
-        SettingsStore.Save(SettingsStore.Load() with { RecentSqlFiles = value.ToList() });
+        SettingsStore.Save(SettingsStore.Load() with { RecentSqlFiles = [.. value] });
 
     /// <summary>
     /// Remembers which saved profile was last connected to, so the next

--- a/PgNimbus.App/Completion/SqlCompletionData.cs
+++ b/PgNimbus.App/Completion/SqlCompletionData.cs
@@ -22,38 +22,30 @@ public enum SqlCompletionKind
     JoinCondition,
 }
 
-public sealed class SqlCompletionData : ICompletionData
+/// <param name="text">The name shown in the list and matched against what the user typed.</param>
+/// <param name="kind">What the item names — picks the row glyph/color and the default tooltip label.</param>
+/// <param name="insertText">
+/// What actually gets written when the item is accepted. Defaults to
+/// <paramref name="text"/>; a schema/table/column passes its quote-if-needed
+/// form (<c>"Spells"</c>) so the user filters on the bare name but inserts a
+/// spelling Postgres will resolve.
+/// </param>
+/// <param name="priority">
+/// Ranking hint the completion list uses to pre-select the best match among
+/// equally-good textual matches — higher wins. Lets context-aware
+/// completion float the current table's columns above the rest of the
+/// catalog (see <see cref="SqlCompletionProvider"/>).
+/// </param>
+public sealed class SqlCompletionData(string text, SqlCompletionKind kind, string? insertText = null, double priority = 0) : ICompletionData
 {
-    /// <param name="text">The name shown in the list and matched against what the user typed.</param>
-    /// <param name="kind">What the item names — picks the row glyph/color and the default tooltip label.</param>
-    /// <param name="insertText">
-    /// What actually gets written when the item is accepted. Defaults to
-    /// <paramref name="text"/>; a schema/table/column passes its quote-if-needed
-    /// form (<c>"Spells"</c>) so the user filters on the bare name but inserts a
-    /// spelling Postgres will resolve.
-    /// </param>
-    /// <param name="priority">
-    /// Ranking hint the completion list uses to pre-select the best match among
-    /// equally-good textual matches — higher wins. Lets context-aware
-    /// completion float the current table's columns above the rest of the
-    /// catalog (see <see cref="SqlCompletionProvider"/>).
-    /// </param>
-    public SqlCompletionData(string text, SqlCompletionKind kind, string? insertText = null, double priority = 0)
-    {
-        Text = text;
-        Kind = kind;
-        InsertText = insertText ?? text;
-        Priority = priority;
-    }
-
     public IImage? Image => null;
 
-    public string Text { get; }
+    public string Text { get; } = text;
 
-    public SqlCompletionKind Kind { get; }
+    public SqlCompletionKind Kind { get; } = kind;
 
     /// <summary>The literal inserted on completion — may be quoted even when <see cref="Text"/> isn't.</summary>
-    public string InsertText { get; }
+    public string InsertText { get; } = insertText ?? text;
 
     /// <summary>
     /// Dim right-aligned text in the popup row: a column's data type, a table's
@@ -95,7 +87,7 @@ public sealed class SqlCompletionData : ICompletionData
 
     public IBrush KindBrush => CompletionKindVisuals.Brush(Kind);
 
-    public double Priority { get; }
+    public double Priority { get; } = priority;
 
     public void Complete(TextArea textArea, ISegment completionSegment, EventArgs insertionRequestEventArgs)
     {

--- a/PgNimbus.App/Completion/SqlCompletionProvider.cs
+++ b/PgNimbus.App/Completion/SqlCompletionProvider.cs
@@ -32,7 +32,7 @@ namespace PgNimbus.App.Completion;
 /// caches below; per-keystroke work is one scan of the editor text and a few
 /// dictionary lookups.
 /// </summary>
-public sealed class SqlCompletionProvider
+public sealed class SqlCompletionProvider(SchemaService schemaService)
 {
     private static readonly string[] Keywords =
     [
@@ -125,7 +125,7 @@ public sealed class SqlCompletionProvider
     private const double FunctionPriority = 3;
     private const double SchemaPriority = 1;
 
-    private readonly SchemaService _schemaService;
+    private readonly SchemaService _schemaService = schemaService;
 
     // Structured snapshot of the catalog, rebuilt by RefreshAsync.
     private IReadOnlyList<(string Schema, string Table)> _tables = [];
@@ -145,11 +145,6 @@ public sealed class SqlCompletionProvider
     // what condition connects two of them) is pure Core logic in ForeignKeyMatcher —
     // this is just its input, refreshed alongside everything else below.
     private IReadOnlyList<ForeignKeyInfo> _foreignKeys = [];
-
-    public SqlCompletionProvider(SchemaService schemaService)
-    {
-        _schemaService = schemaService;
-    }
 
     /// <summary>
     /// Schemas to leave out of every candidate list — the sidebar's "Exclude
@@ -419,7 +414,7 @@ public sealed class SqlCompletionProvider
     }
 
     private static List<TableReference> ToTableReferences(IReadOnlyList<SqlCompletionContext.TableRef> tables) =>
-        tables.Select(t => new TableReference(t.Schema, t.Table, t.Alias)).ToList();
+        [.. tables.Select(t => new TableReference(t.Schema, t.Table, t.Alias))];
 
     // Bare identifier: the whole catalog, with the columns of the statement's
     // tables hoisted to the front (and top priority) so the statement's own
@@ -625,7 +620,7 @@ public sealed class SqlCompletionProvider
     }
 
     private static List<SqlCompletionData> ColumnItems(IReadOnlyList<TableColumn> columns) =>
-        columns.Select(c => ColumnItem(c, CurrentColumnPriority)).ToList();
+        [.. columns.Select(c => ColumnItem(c, CurrentColumnPriority))];
 
     // The data type rides in Detail (right-aligned in the row); the tooltip
     // names the owning table, which the row itself doesn't show.

--- a/PgNimbus.App/Converters/RowIndexConverter.cs
+++ b/PgNimbus.App/Converters/RowIndexConverter.cs
@@ -17,13 +17,11 @@ namespace PgNimbus.App.Converters;
 /// empty string; MainWindow's cell-edit preparation clears the placeholder
 /// out of the editor so it can't be committed back as a literal string.
 /// </summary>
-public sealed class RowIndexConverter : IValueConverter
+public sealed class RowIndexConverter(int index) : IValueConverter
 {
     public const string NullPlaceholder = "NULL";
 
-    private readonly int _index;
-
-    public RowIndexConverter(int index) => _index = index;
+    private readonly int _index = index;
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         value is object?[] row && _index < row.Length
@@ -88,7 +86,7 @@ public sealed class RowIndexConverter : IValueConverter
 /// Returns null for anything that is not a bool (SQL NULL, or a surprise value);
 /// <see cref="BoolCellTextConverter"/> covers those cases with text.
 /// </summary>
-public sealed class BoolCellIconConverter : IValueConverter
+public sealed class BoolCellIconConverter(int index) : IValueConverter
 {
     // UI-thread only (cells are generated and rendered there), so a plain
     // lazily-filled cache is fine.
@@ -96,9 +94,7 @@ public sealed class BoolCellIconConverter : IValueConverter
     private static Geometry? _cross;
     private static bool _resolved;
 
-    private readonly int _index;
-
-    public BoolCellIconConverter(int index) => _index = index;
+    private readonly int _index = index;
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         value is object?[] row && _index < row.Length && row[_index] is bool b ? Icon(b) : null;
@@ -129,11 +125,9 @@ public sealed class BoolCellIconConverter : IValueConverter
 /// and, defensively, the text form of a value a boolean column should never
 /// hold. Empty for a real bool — <see cref="BoolCellIconConverter"/> draws that.
 /// </summary>
-public sealed class BoolCellTextConverter : IValueConverter
+public sealed class BoolCellTextConverter(int index) : IValueConverter
 {
-    private readonly int _index;
-
-    public BoolCellTextConverter(int index) => _index = index;
+    private readonly int _index = index;
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         value is object?[] row && _index < row.Length
@@ -150,11 +144,9 @@ public sealed class BoolCellTextConverter : IValueConverter
 }
 
 /// <summary>Dims cells whose underlying value is SQL NULL, so the "NULL" placeholder reads as a marker, not data.</summary>
-public sealed class NullCellOpacityConverter : IValueConverter
+public sealed class NullCellOpacityConverter(int index) : IValueConverter
 {
-    private readonly int _index;
-
-    public NullCellOpacityConverter(int index) => _index = index;
+    private readonly int _index = index;
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         value is object?[] row && _index < row.Length && row[_index] is null ? 0.4 : 1.0;

--- a/PgNimbus.App/RowCellComparer.cs
+++ b/PgNimbus.App/RowCellComparer.cs
@@ -11,11 +11,9 @@ namespace PgNimbus.App;
 /// strings...) compare natively, anything else falls back to an ordinal
 /// string comparison.
 /// </summary>
-public sealed class RowCellComparer : IComparer
+public sealed class RowCellComparer(int index) : IComparer
 {
-    private readonly int _index;
-
-    public RowCellComparer(int index) => _index = index;
+    private readonly int _index = index;
 
     public int Compare(object? x, object? y)
     {

--- a/PgNimbus.App/ViewModels/ActivityViewModel.cs
+++ b/PgNimbus.App/ViewModels/ActivityViewModel.cs
@@ -61,15 +61,9 @@ public sealed record ActivityRow(BackendActivity Backend)
 /// (<see cref="IsBlocked"/>); a root holding a lock is the one to cancel to
 /// unstick its whole subtree.
 /// </summary>
-public sealed class BlockingNode
+public sealed class BlockingNode(BlockingTreeNode node)
 {
-    private readonly BlockingTreeNode _node;
-
-    public BlockingNode(BlockingTreeNode node)
-    {
-        _node = node;
-        Children = node.Children.Select(c => new BlockingNode(c)).ToList();
-    }
+    private readonly BlockingTreeNode _node = node;
 
     public int Pid => _node.Backend.Pid;
 
@@ -109,7 +103,7 @@ public sealed class BlockingNode
 
     public string Query => ActivityFormat.OneLine(_node.Backend.Query);
 
-    public IReadOnlyList<BlockingNode> Children { get; }
+    public IReadOnlyList<BlockingNode> Children { get; } = node.Children.Select(c => new BlockingNode(c)).ToList();
 }
 
 /// <summary>
@@ -118,9 +112,9 @@ public sealed class BlockingNode
 /// tree built from pg_blocking_pids. The 2s auto-refresh timer lives in the
 /// window (a UI concern); this just exposes RefreshCommand for it to tick.
 /// </summary>
-public sealed partial class ActivityViewModel : ObservableObject
+public sealed partial class ActivityViewModel(ActivityService service) : ObservableObject
 {
-    private readonly ActivityService _service;
+    private readonly ActivityService _service = service;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(TargetPid))]
@@ -179,11 +173,6 @@ public sealed partial class ActivityViewModel : ObservableObject
 
     /// <summary>Roots of the blocking forest — the lock holders to cancel to unstick everyone below.</summary>
     public ObservableCollection<BlockingNode> BlockingRoots { get; } = [];
-
-    public ActivityViewModel(ActivityService service)
-    {
-        _service = service;
-    }
 
     [RelayCommand]
     private async Task RefreshAsync()

--- a/PgNimbus.App/ViewModels/AddRowViewModel.cs
+++ b/PgNimbus.App/ViewModels/AddRowViewModel.cs
@@ -14,19 +14,24 @@ namespace PgNimbus.App.ViewModels;
 /// Postgres does the parsing and the statement stays injection-safe. Columns
 /// left blank are omitted so their defaults apply.
 /// </summary>
-public sealed partial class AddRowViewModel : ObservableObject
+public sealed partial class AddRowViewModel(
+    QueryEngine engine,
+    SchemaService schemaService,
+    string schema,
+    string table,
+    Func<IReadOnlyList<PendingInsertValue>, string?>? stageInsert = null) : ObservableObject
 {
-    private readonly QueryEngine _engine;
-    private readonly SchemaService _schemaService;
+    private readonly QueryEngine _engine = engine;
+    private readonly SchemaService _schemaService = schemaService;
 
     // Safe mode's staging hook: non-null means Insert stages the row into the
     // owning tab's pending change set (returning an error message, or null on
     // success) instead of executing. Supplied by the view at dialog-open time.
-    private readonly Func<IReadOnlyList<PendingInsertValue>, string?>? _stageInsert;
+    private readonly Func<IReadOnlyList<PendingInsertValue>, string?>? _stageInsert = stageInsert;
 
-    public string Schema { get; }
+    public string Schema { get; } = schema;
 
-    public string Table { get; }
+    public string Table { get; } = table;
 
     public string QualifiedName => $"{Schema}.{Table}";
 
@@ -45,20 +50,6 @@ public sealed partial class AddRowViewModel : ObservableObject
 
     /// <summary>Raised after a successful INSERT so the grid can refresh and the dialog can close.</summary>
     public event Action? Inserted;
-
-    public AddRowViewModel(
-        QueryEngine engine,
-        SchemaService schemaService,
-        string schema,
-        string table,
-        Func<IReadOnlyList<PendingInsertValue>, string?>? stageInsert = null)
-    {
-        _engine = engine;
-        _schemaService = schemaService;
-        Schema = schema;
-        Table = table;
-        _stageInsert = stageInsert;
-    }
 
     public async Task LoadAsync()
     {

--- a/PgNimbus.App/ViewModels/AlterTableViewModel.cs
+++ b/PgNimbus.App/ViewModels/AlterTableViewModel.cs
@@ -6,14 +6,14 @@ using PgNimbus.Core.Schema;
 namespace PgNimbus.App.ViewModels;
 
 /// <summary>Drives the no-SQL "alter table" dialog: lists a table's columns and lets the user add/drop/rename one without writing DDL by hand.</summary>
-public sealed partial class AlterTableViewModel : ObservableObject
+public sealed partial class AlterTableViewModel(SchemaEditor schemaEditor, SchemaService schemaService, string schema, string table) : ObservableObject
 {
-    private readonly SchemaEditor _schemaEditor;
-    private readonly SchemaService _schemaService;
+    private readonly SchemaEditor _schemaEditor = schemaEditor;
+    private readonly SchemaService _schemaService = schemaService;
 
-    public string Schema { get; }
+    public string Schema { get; } = schema;
 
-    public string Table { get; }
+    public string Table { get; } = table;
 
     public ObservableCollection<ColumnDetail> Columns { get; } = [];
 
@@ -42,14 +42,6 @@ public sealed partial class AlterTableViewModel : ObservableObject
 
     /// <summary>Raised after a successful ALTER TABLE so the schema tree node for this table can refresh.</summary>
     public event Action? SchemaChanged;
-
-    public AlterTableViewModel(SchemaEditor schemaEditor, SchemaService schemaService, string schema, string table)
-    {
-        _schemaEditor = schemaEditor;
-        _schemaService = schemaService;
-        Schema = schema;
-        Table = table;
-    }
 
     public async Task LoadAsync()
     {

--- a/PgNimbus.App/ViewModels/DatabaseOverviewViewModel.cs
+++ b/PgNimbus.App/ViewModels/DatabaseOverviewViewModel.cs
@@ -75,11 +75,11 @@ public sealed record UnusedIndexRow(UnusedIndex Index)
 /// indexes. Everything is read-only, so unlike the activity view there's no
 /// auto-refresh timer — the user hits Refresh to re-snapshot.
 /// </summary>
-public sealed partial class DatabaseOverviewViewModel : ObservableObject
+public sealed partial class DatabaseOverviewViewModel(DatabaseStatsService service) : ObservableObject
 {
     private const int LargestRelationsLimit = 50;
 
-    private readonly DatabaseStatsService _service;
+    private readonly DatabaseStatsService _service = service;
 
     [ObservableProperty]
     private string _databaseName = "";
@@ -101,11 +101,6 @@ public sealed partial class DatabaseOverviewViewModel : ObservableObject
     public ObservableCollection<TableScanRow> TableScans { get; } = [];
 
     public ObservableCollection<UnusedIndexRow> UnusedIndexes { get; } = [];
-
-    public DatabaseOverviewViewModel(DatabaseStatsService service)
-    {
-        _service = service;
-    }
 
     // AllowConcurrentExecutions = false disables the Refresh button while a
     // snapshot is in flight, so repeated clicks can't race the ObservableCollection

--- a/PgNimbus.App/ViewModels/ImportViewModel.cs
+++ b/PgNimbus.App/ViewModels/ImportViewModel.cs
@@ -6,21 +6,15 @@ using PgNimbus.Core.Import;
 namespace PgNimbus.App.ViewModels;
 
 /// <summary>One target column in the import dialog: renameable, retypeable (types locked to the inference allow-list).</summary>
-public sealed partial class ImportColumnViewModel : ObservableObject
+public sealed partial class ImportColumnViewModel(string name, string dataType) : ObservableObject
 {
     public static IReadOnlyList<string> TypeChoices => TypeInferrer.Types;
 
     [ObservableProperty]
-    private string _name;
+    private string _name = name;
 
     [ObservableProperty]
-    private string _dataType;
-
-    public ImportColumnViewModel(string name, string dataType)
-    {
-        _name = name;
-        _dataType = dataType;
-    }
+    private string _dataType = dataType;
 }
 
 /// <summary>

--- a/PgNimbus.App/ViewModels/MainViewModel.cs
+++ b/PgNimbus.App/ViewModels/MainViewModel.cs
@@ -450,7 +450,7 @@ public sealed partial class MainViewModel : ObservableObject
         _persistSafeModeEdits = persistSafeModeEdits;
         _wordWrapEditor = wordWrapEditor;
         _persistWordWrapEditor = persistWordWrapEditor;
-        _recentSqlFiles = recentSqlFiles is null ? [] : recentSqlFiles.ToList();
+        _recentSqlFiles = recentSqlFiles is null ? [] : [.. recentSqlFiles];
         _persistRecentSqlFiles = persistRecentSqlFiles;
         _excludedSchemas = new HashSet<string>(excludedSchemas ?? [], StringComparer.Ordinal);
         _persistExcludedSchemas = persistExcludedSchemas;

--- a/PgNimbus.App/ViewModels/PlanWarningViewModel.cs
+++ b/PgNimbus.App/ViewModels/PlanWarningViewModel.cs
@@ -8,14 +8,9 @@ namespace PgNimbus.App.ViewModels;
 /// glyph and accent brush. Keeps <see cref="PlanWarning"/> itself UI-free
 /// (hard rule 1) while the warnings strip binds glyph/brush directly.
 /// </summary>
-public sealed class PlanWarningViewModel
+public sealed class PlanWarningViewModel(PlanWarning warning)
 {
-    public PlanWarningViewModel(PlanWarning warning)
-    {
-        Warning = warning;
-    }
-
-    public PlanWarning Warning { get; }
+    public PlanWarning Warning { get; } = warning;
 
     public string Title => Warning.Title;
 

--- a/PgNimbus.App/ViewModels/Security/DefaultPrivilegesTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/DefaultPrivilegesTabViewModel.cs
@@ -114,10 +114,10 @@ public sealed record DefaultPrivilegeRow(
 /// object rather than the schema it lands in. Both live under the grid, in the
 /// note idiom the Database Overview uses for its unused-index caveat.</para>
 /// </summary>
-public sealed partial class DefaultPrivilegesTabViewModel : ObservableObject, ISecuritySection
+public sealed partial class DefaultPrivilegesTabViewModel(PrivilegeService privileges, SecurityViewModel host) : ObservableObject, ISecuritySection
 {
-    private readonly PrivilegeService _privileges;
-    private readonly SecurityViewModel _host;
+    private readonly PrivilegeService _privileges = privileges;
+    private readonly SecurityViewModel _host = host;
 
     /// <summary>
     /// False when nothing is configured, which is a state worth spelling out
@@ -130,12 +130,6 @@ public sealed partial class DefaultPrivilegesTabViewModel : ObservableObject, IS
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(CopySelectedAsSqlCommand))]
     private DefaultPrivilegeRow? _selectedRow;
-
-    public DefaultPrivilegesTabViewModel(PrivilegeService privileges, SecurityViewModel host)
-    {
-        _privileges = privileges;
-        _host = host;
-    }
 
     public ObservableCollection<DefaultPrivilegeRow> Rows { get; } = [];
 

--- a/PgNimbus.App/ViewModels/Security/PermissionsTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/PermissionsTabViewModel.cs
@@ -12,21 +12,14 @@ public sealed record PrivilegeColumn(PrivilegeKind Privilege, string Header);
 /// One cell: whether the role holds the privilege, and — the part no other
 /// client shows — which grant explains that.
 /// </summary>
-public sealed partial class PrivilegeCellViewModel : ObservableObject
+public sealed partial class PrivilegeCellViewModel(EffectivePrivilege effective, bool editable, Action<PrivilegeCellViewModel> toggle) : ObservableObject
 {
-    private readonly Action<PrivilegeCellViewModel> _toggle;
+    private readonly Action<PrivilegeCellViewModel> _toggle = toggle;
 
     [ObservableProperty]
     private bool _isPending;
 
-    public PrivilegeCellViewModel(EffectivePrivilege effective, bool editable, Action<PrivilegeCellViewModel> toggle)
-    {
-        Effective = effective;
-        IsEditable = editable;
-        _toggle = toggle;
-    }
-
-    public EffectivePrivilege Effective { get; }
+    public EffectivePrivilege Effective { get; } = effective;
 
     public PrivilegeKind Privilege => Effective.Privilege;
 
@@ -37,7 +30,7 @@ public sealed partial class PrivilegeCellViewModel : ObservableObject
     /// superuser are not privileges you can revoke, so offering a toggle there
     /// would promise something the statement cannot deliver.
     /// </summary>
-    public bool IsEditable { get; }
+    public bool IsEditable { get; } = editable;
 
     public bool Granted => Effective.Granted;
 
@@ -147,10 +140,10 @@ public sealed record ColumnGrantRow(string Column, string Grants);
 /// Nothing here writes. Toggling cells accumulates a change set and produces a
 /// GRANT/REVOKE script that opens in the editor.
 /// </summary>
-public sealed partial class PermissionsTabViewModel : ObservableObject, ISecuritySection
+public sealed partial class PermissionsTabViewModel(PrivilegeService privileges, SecurityViewModel host) : ObservableObject, ISecuritySection
 {
-    private readonly PrivilegeService _privileges;
-    private readonly SecurityViewModel _host;
+    private readonly PrivilegeService _privileges = privileges;
+    private readonly SecurityViewModel _host = host;
     private readonly List<SecurableRef> _allObjects = [];
     private readonly List<PrivilegeChange> _pending = [];
 
@@ -191,12 +184,6 @@ public sealed partial class PermissionsTabViewModel : ObservableObject, ISecurit
 
     [ObservableProperty]
     private PermissionRowViewModel? _selectedRow;
-
-    public PermissionsTabViewModel(PrivilegeService privileges, SecurityViewModel host)
-    {
-        _privileges = privileges;
-        _host = host;
-    }
 
     public IReadOnlyList<SecurableKind> Kinds { get; } =
     [

--- a/PgNimbus.App/ViewModels/Security/RoleEditorViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/RoleEditorViewModel.cs
@@ -403,24 +403,16 @@ public sealed partial class RoleEditorViewModel : ObservableObject
 }
 
 /// <summary>One membership checkbox: a role this one may belong to.</summary>
-public sealed partial class RoleMembershipOption : ObservableObject
+public sealed partial class RoleMembershipOption(string name, string hint, bool isMember, Action changed) : ObservableObject
 {
-    private readonly Action _changed;
+    private readonly Action _changed = changed;
 
     [ObservableProperty]
-    private bool _isMember;
+    private bool _isMember = isMember;
 
-    public RoleMembershipOption(string name, string hint, bool isMember, Action changed)
-    {
-        Name = name;
-        Hint = hint;
-        _isMember = isMember;
-        _changed = changed;
-    }
+    public string Name { get; } = name;
 
-    public string Name { get; }
-
-    public string Hint { get; }
+    public string Hint { get; } = hint;
 
     partial void OnIsMemberChanged(bool value) => _changed();
 }

--- a/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
+++ b/PgNimbus.App/ViewModels/Security/RolesTabViewModel.cs
@@ -6,11 +6,11 @@ using PgNimbus.Core.Security;
 namespace PgNimbus.App.ViewModels.Security;
 
 /// <summary>The roles list, one role's attributes, and its membership tree in both directions.</summary>
-public sealed partial class RolesTabViewModel : ObservableObject, ISecuritySection
+public sealed partial class RolesTabViewModel(RoleService roleService, SecurityEditor editor, SecurityViewModel host) : ObservableObject, ISecuritySection
 {
-    private readonly RoleService _roleService;
-    private readonly SecurityEditor _editor;
-    private readonly SecurityViewModel _host;
+    private readonly RoleService _roleService = roleService;
+    private readonly SecurityEditor _editor = editor;
+    private readonly SecurityViewModel _host = host;
 
     /// <summary>Every role the last refresh saw; <see cref="FilteredRoles"/> is the view onto it.</summary>
     private readonly List<RoleRowViewModel> _all = [];
@@ -47,13 +47,6 @@ public sealed partial class RolesTabViewModel : ObservableObject, ISecuritySecti
 
     [ObservableProperty]
     private bool _hasMembers;
-
-    public RolesTabViewModel(RoleService roleService, SecurityEditor editor, SecurityViewModel host)
-    {
-        _roleService = roleService;
-        _editor = editor;
-        _host = host;
-    }
 
     /// <summary>One row per role on the server, predefined ones included.</summary>
     public ObservableCollection<RoleRowViewModel> Roles { get; } = [];

--- a/PgNimbus.App/ViewModels/TableBrowseViewModel.cs
+++ b/PgNimbus.App/ViewModels/TableBrowseViewModel.cs
@@ -17,18 +17,18 @@ namespace PgNimbus.App.ViewModels;
 /// nothing itself: it just runs the SQL this view-model builds and reports how
 /// many rows came back.
 /// </summary>
-public sealed partial class TableBrowseViewModel : ObservableObject
+public sealed partial class TableBrowseViewModel(string schema, string name, IReadOnlyList<string> pkColumns, Func<string, Task<int>> execute) : ObservableObject
 {
     /// <summary>Rows fetched per page. One page past the fold is never loaded; paging is server-side.</summary>
     public const int PageSize = 100;
 
     // Runs the composed SQL through the owning tab's normal streaming path and
     // returns the number of rows the grid ended up showing.
-    private readonly Func<string, Task<int>> _execute;
+    private readonly Func<string, Task<int>> _execute = execute;
 
-    public string Schema { get; }
+    public string Schema { get; } = schema;
 
-    public string Name { get; }
+    public string Name { get; } = name;
 
     /// <summary>Raw SQL predicate (the text after <c>WHERE</c>), seeded by FK navigation. Empty means no filter.</summary>
     [ObservableProperty]
@@ -54,15 +54,7 @@ public sealed partial class TableBrowseViewModel : ObservableObject
     private bool _canGoNext;
 
     // Primary-key column names, in key order; empty for views / PK-less tables.
-    private readonly IReadOnlyList<string> _pkColumns;
-
-    public TableBrowseViewModel(string schema, string name, IReadOnlyList<string> pkColumns, Func<string, Task<int>> execute)
-    {
-        Schema = schema;
-        Name = name;
-        _pkColumns = pkColumns;
-        _execute = execute;
-    }
+    private readonly IReadOnlyList<string> _pkColumns = pkColumns;
 
     /// <summary>
     /// Composes the page query. Identifiers are quoted; the filter is inlined

--- a/PgNimbus.App/Views/MainWindow.axaml.cs
+++ b/PgNimbus.App/Views/MainWindow.axaml.cs
@@ -1439,7 +1439,7 @@ public partial class MainWindow : Window
     private static string SanitizeFileName(string title)
     {
         var invalid = Path.GetInvalidFileNameChars();
-        var cleaned = new string(title.Select(c => invalid.Contains(c) ? '_' : c).ToArray()).Trim();
+        var cleaned = new string([.. title.Select(c => invalid.Contains(c) ? '_' : c)]).Trim();
         return cleaned.Length == 0 ? "query" : cleaned;
     }
 

--- a/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
@@ -1072,7 +1072,7 @@ public partial class ResultsGridPanel : UserControl
     private static string SuggestTableName(string fileName)
     {
         var stem = Path.GetFileNameWithoutExtension(fileName).ToLowerInvariant();
-        var name = new string(stem.Select(c => char.IsAsciiLetterOrDigit(c) ? c : '_').ToArray()).Trim('_');
+        var name = new string([.. stem.Select(c => char.IsAsciiLetterOrDigit(c) ? c : '_')]).Trim('_');
         if (name.Length == 0)
         {
             name = "imported";

--- a/PgNimbus.App/Views/Security/PermissionsTabView.axaml
+++ b/PgNimbus.App/Views/Security/PermissionsTabView.axaml
@@ -14,7 +14,7 @@
             <ComboBox Grid.Column="1" ItemsSource="{Binding Schemas}" SelectedItem="{Binding SelectedSchema, Mode=TwoWay}"
                       MinWidth="150" Margin="8,0,0,0" VerticalAlignment="Center"
                       IsVisible="{Binding KindHasSchema}" PlaceholderText="Schema" />
-            <TextBox Grid.Column="2" Text="{Binding ObjectFilter}" Watermark="Filter objects"
+            <TextBox Grid.Column="2" Text="{Binding ObjectFilter}" PlaceholderText="Filter objects"
                      MinWidth="160" Margin="8,0,0,0" VerticalAlignment="Center" />
             <Button Grid.Column="3" Classes="soft" Content="Bulk grant…" Margin="8,0,0,0"
                     Command="{Binding BulkGrantCommand}"
@@ -75,7 +75,7 @@
                 </Border>
 
                 <Grid Grid.Row="1" ColumnDefinitions="*,Auto" Margin="0,0,0,6">
-                    <TextBox Grid.Column="0" Text="{Binding RoleFilter}" Watermark="Filter roles" MaxWidth="240"
+                    <TextBox Grid.Column="0" Text="{Binding RoleFilter}" PlaceholderText="Filter roles" MaxWidth="240"
                              HorizontalAlignment="Left" />
                     <ToggleButton Grid.Column="1" Classes="chip" Content="Built-in roles"
                                   IsChecked="{Binding ShowPredefinedRoles, Mode=TwoWay}"

--- a/PgNimbus.App/Views/Security/RoleDialog.axaml
+++ b/PgNimbus.App/Views/Security/RoleDialog.axaml
@@ -20,7 +20,7 @@
                 <!-- Identity -->
                 <StackPanel Spacing="6">
                     <TextBlock Text="NAME" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
-                    <TextBox Text="{Binding Name}" IsEnabled="{Binding CanEditName}" Watermark="app_ro" />
+                    <TextBox Text="{Binding Name}" IsEnabled="{Binding CanEditName}" PlaceholderText="app_ro" />
                 </StackPanel>
 
                 <!-- Login and password -->
@@ -61,7 +61,7 @@
                     <StackPanel Grid.Column="0" Spacing="4">
                         <TextBlock Text="CONNECTION LIMIT" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
                         <NumericUpDown Value="{Binding ConnectionLimitValue}" Minimum="0" Increment="1"
-                                       Watermark="no limit" FormatString="0" />
+                                       PlaceholderText="no limit" FormatString="0" />
                     </StackPanel>
                     <StackPanel Grid.Column="2" Spacing="4">
                         <TextBlock Text="VALID UNTIL" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
@@ -137,7 +137,7 @@
 
                 <StackPanel Spacing="4">
                     <TextBlock Text="COMMENT" FontSize="10" Opacity="0.55" FontWeight="SemiBold" />
-                    <TextBox Text="{Binding Comment}" Watermark="what this role is for" />
+                    <TextBox Text="{Binding Comment}" PlaceholderText="what this role is for" />
                 </StackPanel>
 
                 <!-- The preview is always the masked build. The real password goes

--- a/PgNimbus.Core.Tests/Monitoring/BlockingTreeTests.cs
+++ b/PgNimbus.Core.Tests/Monitoring/BlockingTreeTests.cs
@@ -20,9 +20,9 @@ public class BlockingTreeTests
         // 100 holds the lock, 200 waits on 100.
         var roots = BlockingTree.Build([Backend(100), Backend(200, 100)]);
 
-        await Assert.That(roots).HasCount(1);
+        await Assert.That(roots).Count().IsEqualTo(1);
         await Assert.That(roots[0].Backend.Pid).IsEqualTo(100);
-        await Assert.That(roots[0].Children).HasCount(1);
+        await Assert.That(roots[0].Children).Count().IsEqualTo(1);
         await Assert.That(roots[0].Children[0].Backend.Pid).IsEqualTo(200);
         await Assert.That(roots[0].BlockedDescendants).IsEqualTo(1);
     }
@@ -42,7 +42,7 @@ public class BlockingTreeTests
         // 1 blocks 2 blocks 3.
         var roots = BlockingTree.Build([Backend(1), Backend(2, 1), Backend(3, 2)]);
 
-        await Assert.That(roots).HasCount(1);
+        await Assert.That(roots).Count().IsEqualTo(1);
         await Assert.That(roots[0].Backend.Pid).IsEqualTo(1);
         await Assert.That(roots[0].BlockedDescendants).IsEqualTo(2);
 
@@ -56,7 +56,7 @@ public class BlockingTreeTests
     {
         var roots = BlockingTree.Build([Backend(1), Backend(2, 1), Backend(3, 1), Backend(4, 1)]);
 
-        await Assert.That(roots).HasCount(1);
+        await Assert.That(roots).Count().IsEqualTo(1);
         await Assert.That(roots[0].Children.Select(c => c.Backend.Pid)).Contains(2).And.Contains(3).And.Contains(4);
         await Assert.That(roots[0].BlockedDescendants).IsEqualTo(3);
     }
@@ -80,7 +80,7 @@ public class BlockingTreeTests
         // 200 is blocked by pid 999, which isn't in the snapshot (e.g. autovacuum).
         var roots = BlockingTree.Build([Backend(200, 999)]);
 
-        await Assert.That(roots).HasCount(1);
+        await Assert.That(roots).Count().IsEqualTo(1);
         await Assert.That(roots[0].Backend.Pid).IsEqualTo(200);
         await Assert.That(roots[0].Children).IsEmpty();
     }
@@ -97,7 +97,7 @@ public class BlockingTreeTests
         Collect(roots, pids);
 
         await Assert.That(pids.Distinct().Order()).IsEquivalentTo([1, 2]);
-        await Assert.That(pids).HasCount(2); // no pid rendered twice
+        await Assert.That(pids).Count().IsEqualTo(2); // no pid rendered twice
 
         static void Collect(IReadOnlyList<BlockingTreeNode> nodes, List<int> acc)
         {

--- a/PgNimbus.Core.Tests/Security/EffectivePrivilegeResolverTests.cs
+++ b/PgNimbus.Core.Tests/Security/EffectivePrivilegeResolverTests.cs
@@ -11,18 +11,12 @@ public class EffectivePrivilegeResolverTests
     /// exercised without a server (and without RoleGraph, which is the thing
     /// under test's collaborator, not its dependency).
     /// </summary>
-    private sealed class FakeLookup : IRoleMembershipLookup
+    private sealed class FakeLookup(
+        Dictionary<string, IReadOnlyList<string>>? groups = null,
+        params string[] superusers) : IRoleMembershipLookup
     {
-        private readonly Dictionary<string, IReadOnlyList<string>> _groups;
-        private readonly HashSet<string> _superusers;
-
-        public FakeLookup(
-            Dictionary<string, IReadOnlyList<string>>? groups = null,
-            params string[] superusers)
-        {
-            _groups = groups ?? [];
-            _superusers = new HashSet<string>(superusers, StringComparer.Ordinal);
-        }
+        private readonly Dictionary<string, IReadOnlyList<string>> _groups = groups ?? [];
+        private readonly HashSet<string> _superusers = new HashSet<string>(superusers, StringComparer.Ordinal);
 
         /// <summary>Nearest first, as the interface documents.</summary>
         public IReadOnlyList<string> InheritedGroups(string role) =>

--- a/PgNimbus.Core.Tests/Text/SqlCompletionContextTests.cs
+++ b/PgNimbus.Core.Tests/Text/SqlCompletionContextTests.cs
@@ -163,7 +163,7 @@ public class SqlCompletionContextTests
     {
         var tables = SqlCompletionContext.ExtractTables("SELECT * FROM orders");
 
-        await Assert.That(tables).HasCount().EqualTo(1);
+        await Assert.That(tables).Count().IsEqualTo(1);
         await Assert.That(tables[0]).IsEqualTo(new SqlCompletionContext.TableRef("", "orders", null));
     }
 
@@ -181,7 +181,7 @@ public class SqlCompletionContextTests
         var tables = SqlCompletionContext.ExtractTables(
             "SELECT * FROM customers c JOIN orders o ON c.id = o.customer_id LEFT JOIN order_items oi ON o.id = oi.order_id");
 
-        await Assert.That(tables).HasCount().EqualTo(3);
+        await Assert.That(tables).Count().IsEqualTo(3);
         await Assert.That(tables[0].Table).IsEqualTo("customers");
         await Assert.That(tables[0].Alias).IsEqualTo("c");
         await Assert.That(tables[1].Table).IsEqualTo("orders");
@@ -195,7 +195,7 @@ public class SqlCompletionContextTests
     {
         var tables = SqlCompletionContext.ExtractTables("SELECT * FROM customers c, orders o WHERE c.id = o.customer_id");
 
-        await Assert.That(tables).HasCount().EqualTo(2);
+        await Assert.That(tables).Count().IsEqualTo(2);
         await Assert.That(tables[0].Alias).IsEqualTo("c");
         await Assert.That(tables[1].Alias).IsEqualTo("o");
     }
@@ -241,7 +241,7 @@ public class SqlCompletionContextTests
         var tables = SqlCompletionContext.ExtractTables(
             "SELECT * FROM customers c -- order by signup date\nJOIN orders o ON c.id = o.customer_id");
 
-        await Assert.That(tables).HasCount().EqualTo(2);
+        await Assert.That(tables).Count().IsEqualTo(2);
         await Assert.That(tables[1].Table).IsEqualTo("orders");
     }
 

--- a/PgNimbus.Core.Tests/Text/SqlCteDefinitionTests.cs
+++ b/PgNimbus.Core.Tests/Text/SqlCteDefinitionTests.cs
@@ -57,7 +57,7 @@ public class SqlCteDefinitionTests
 
         await Assert.That(cte.Columns).IsEmpty();
         await Assert.That(cte.SelectsStar).IsTrue();
-        await Assert.That(cte.SourceTables).HasCount().EqualTo(1);
+        await Assert.That(cte.SourceTables).Count().IsEqualTo(1);
         await Assert.That(cte.SourceTables[0].Table).IsEqualTo("orders");
         await Assert.That(cte.SourceTables[0].Schema).IsEqualTo("public");
     }
@@ -78,7 +78,7 @@ public class SqlCteDefinitionTests
         var defs = SqlCompletionContext.ExtractCteDefinitions(
             "WITH a AS (SELECT id FROM t), b AS (SELECT * FROM a) SELECT * FROM b");
 
-        await Assert.That(defs).HasCount().EqualTo(2);
+        await Assert.That(defs).Count().IsEqualTo(2);
         await Assert.That(defs[0].Name).IsEqualTo("a");
         await Assert.That(defs[0].Columns).IsEquivalentTo(new[] { "id" });
         await Assert.That(defs[1].Name).IsEqualTo("b");

--- a/PgNimbus.Core/Connections/ConnectionProfileStore.cs
+++ b/PgNimbus.Core/Connections/ConnectionProfileStore.cs
@@ -8,14 +8,9 @@ namespace PgNimbus.Core.Connections;
 /// <see cref="ConnectionProfile"/> has no password property, there is
 /// nothing sensitive for this store to ever write to disk.
 /// </summary>
-public sealed class ConnectionProfileStore
+public sealed class ConnectionProfileStore(string? filePath = null)
 {
-    private readonly string _filePath;
-
-    public ConnectionProfileStore(string? filePath = null)
-    {
-        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "connections.json");
-    }
+    private readonly string _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "connections.json");
 
     public IReadOnlyList<ConnectionProfile> Load()
     {
@@ -45,7 +40,7 @@ public sealed class ConnectionProfileStore
             Directory.CreateDirectory(directory);
         }
 
-        var json = JsonSerializer.Serialize(profiles.ToList(), ConnectionProfileJsonContext.Default.ListConnectionProfile);
+        var json = JsonSerializer.Serialize([.. profiles], ConnectionProfileJsonContext.Default.ListConnectionProfile);
         File.WriteAllText(_filePath, json);
     }
 }

--- a/PgNimbus.Core/Connections/PlainFileCredentialStore.cs
+++ b/PgNimbus.Core/Connections/PlainFileCredentialStore.cs
@@ -8,14 +8,9 @@ namespace PgNimbus.Core.Connections;
 /// Keychain / Linux libsecret integration lands. The file is restricted to
 /// the owning user where the OS supports POSIX permissions.
 /// </summary>
-public sealed class PlainFileCredentialStore : ICredentialStore
+public sealed class PlainFileCredentialStore(string? directory = null) : ICredentialStore
 {
-    private readonly string _directory;
-
-    public PlainFileCredentialStore(string? directory = null)
-    {
-        _directory = directory ?? Path.Combine(AppDataPaths.GetRootDirectory(), "credentials");
-    }
+    private readonly string _directory = directory ?? Path.Combine(AppDataPaths.GetRootDirectory(), "credentials");
 
     public void SavePassword(Guid connectionId, string password)
     {

--- a/PgNimbus.Core/Connections/WindowsDpapiCredentialStore.cs
+++ b/PgNimbus.Core/Connections/WindowsDpapiCredentialStore.cs
@@ -10,14 +10,9 @@ namespace PgNimbus.Core.Connections;
 /// machine it was saved on) can decrypt it back.
 /// </summary>
 [SupportedOSPlatform("windows")]
-public sealed class WindowsDpapiCredentialStore : ICredentialStore
+public sealed class WindowsDpapiCredentialStore(string? directory = null) : ICredentialStore
 {
-    private readonly string _directory;
-
-    public WindowsDpapiCredentialStore(string? directory = null)
-    {
-        _directory = directory ?? Path.Combine(AppDataPaths.GetRootDirectory(), "credentials");
-    }
+    private readonly string _directory = directory ?? Path.Combine(AppDataPaths.GetRootDirectory(), "credentials");
 
     public void SavePassword(Guid connectionId, string password)
     {

--- a/PgNimbus.Core/Diagnostics/CrashLogger.cs
+++ b/PgNimbus.Core/Diagnostics/CrashLogger.cs
@@ -11,7 +11,7 @@ namespace PgNimbus.Core.Diagnostics;
 /// already tearing down. Every operation swallows its own failures: a logger
 /// that throws while logging a crash would only mask the original error.
 /// </summary>
-public sealed class CrashLog
+public sealed class CrashLog(string directory)
 {
     // Serializes appends across threads. A crash can surface on several threads
     // at once (UI + a faulted background task), and interleaved writes would
@@ -24,16 +24,10 @@ public sealed class CrashLog
     private const long MaxLogBytes = 1024 * 1024; // 1 MiB
 
     /// <summary>Directory that holds the log file(s). Created on demand.</summary>
-    public string Directory { get; }
+    public string Directory { get; } = directory;
 
     /// <summary>Full path to the current log file, shown to the user in the crash dialog.</summary>
-    public string FilePath { get; }
-
-    public CrashLog(string directory)
-    {
-        Directory = directory;
-        FilePath = Path.Combine(directory, "pgnimbus.log");
-    }
+    public string FilePath { get; } = Path.Combine(directory, "pgnimbus.log");
 
     /// <summary>
     /// Records a critical error with a short describing context and the

--- a/PgNimbus.Core/Import/ImportService.cs
+++ b/PgNimbus.Core/Import/ImportService.cs
@@ -13,14 +13,9 @@ public sealed record ImportColumn(string Name, string DataType);
 /// column types are restricted to <see cref="TypeInferrer.Types"/> because
 /// they're concatenated into DDL.
 /// </summary>
-public sealed class ImportService
+public sealed class ImportService(NpgsqlDataSource dataSource)
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public ImportService(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     /// <summary>Creates the table (when <paramref name="createTable"/>) and loads every row. Returns the number of rows imported.</summary>
     public async Task<long> ImportAsync(

--- a/PgNimbus.Core/Monitoring/ActivityService.cs
+++ b/PgNimbus.Core/Monitoring/ActivityService.cs
@@ -23,14 +23,9 @@ public sealed record BackendActivity(
 /// Live server activity: pg_stat_activity snapshots plus the two backend
 /// controls (cancel the running statement / terminate the whole backend).
 /// </summary>
-public sealed class ActivityService
+public sealed class ActivityService(NpgsqlDataSource dataSource)
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public ActivityService(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     /// <summary>Client backends other than our own, active ones first.</summary>
     public async Task<IReadOnlyList<BackendActivity>> GetActivityAsync(CancellationToken ct)

--- a/PgNimbus.Core/Monitoring/DatabaseStatsService.cs
+++ b/PgNimbus.Core/Monitoring/DatabaseStatsService.cs
@@ -68,14 +68,9 @@ public sealed record UnusedIndex(
 /// panel. Every query hits pg_catalog / the pg_stat_* views directly — nothing
 /// here writes, so it's always safe to run against production.
 /// </summary>
-public sealed class DatabaseStatsService
+public sealed class DatabaseStatsService(NpgsqlDataSource dataSource)
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public DatabaseStatsService(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     /// <summary>Current database name, size on disk, and the heap/index cache-hit ratios.</summary>
     public async Task<DatabaseOverview> GetOverviewAsync(CancellationToken ct)

--- a/PgNimbus.Core/Notifications/NotificationListener.cs
+++ b/PgNimbus.Core/Notifications/NotificationListener.cs
@@ -20,9 +20,9 @@ public sealed record DatabaseNotification(string Channel, string Payload, int Pr
 /// the UI can stop claiming to be listening. Anything that is not a connection
 /// loss stops immediately: re-running it would fail the same way.
 /// </summary>
-public sealed class NotificationListener : IAsyncDisposable
+public sealed class NotificationListener(NpgsqlDataSource dataSource) : IAsyncDisposable
 {
-    private readonly NpgsqlDataSource _dataSource;
+    private readonly NpgsqlDataSource _dataSource = dataSource;
     private NpgsqlConnection? _connection;
     private CancellationTokenSource? _cts;
     private Task? _listenLoop;
@@ -47,11 +47,6 @@ public sealed class NotificationListener : IAsyncDisposable
     /// from the listener's background loop, not the caller's thread.
     /// </summary>
     public event Action? Reconnected;
-
-    public NotificationListener(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
 
     public bool IsListening => _connection is not null;
 

--- a/PgNimbus.Core/Query/ExplainPlanTextParser.cs
+++ b/PgNimbus.Core/Query/ExplainPlanTextParser.cs
@@ -76,7 +76,7 @@ public static class ExplainPlanTextParser
         // the root sits at column 0 and child indentation stays relative.
         if (lines.Where(l => l.Length > 0).All(l => l.StartsWith(' ')))
         {
-            lines = lines.Select(l => l.Length > 0 ? l[1..] : l).ToList();
+            lines = [.. lines.Select(l => l.Length > 0 ? l[1..] : l)];
         }
 
         return string.Join("\n", lines);

--- a/PgNimbus.Core/Query/ExplainService.cs
+++ b/PgNimbus.Core/Query/ExplainService.cs
@@ -49,14 +49,9 @@ public sealed record ImportedPlan(ExplainResult Result, string DisplayText, stri
 /// into a navigable tree, rather than leaving callers to parse Postgres's
 /// raw JSON shape themselves.
 /// </summary>
-public sealed class ExplainService
+public sealed class ExplainService(NpgsqlDataSource dataSource)
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public ExplainService(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     public async Task<ExplainRun> ExplainAsync(string sql, bool analyze, CancellationToken ct)
     {

--- a/PgNimbus.Core/Query/QueryEngine.cs
+++ b/PgNimbus.Core/Query/QueryEngine.cs
@@ -10,22 +10,17 @@ namespace PgNimbus.Core.Query;
 /// batches so the caller can render the first screenful before the whole
 /// result set has arrived, and every execution can be cancelled mid-flight.
 /// </summary>
-public sealed class QueryEngine
+public sealed class QueryEngine(NpgsqlDataSource dataSource)
 {
     private const int BatchSize = 200;
 
-    private readonly NpgsqlDataSource _dataSource;
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     // Non-null while an explicit user transaction is open. Every execution then
     // runs on this one connection (instead of a fresh pooled one) so BEGIN and a
     // later COMMIT/ROLLBACK bracket the same session. Cleared — and the
     // connection disposed back to the pool — when the transaction ends.
     private NpgsqlConnection? _transactionConnection;
-
-    public QueryEngine(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
 
     /// <summary>True while an explicit BEGIN…COMMIT/ROLLBACK transaction is open.</summary>
     public bool IsInTransaction => _transactionConnection is not null;

--- a/PgNimbus.Core/Query/QueryHistoryStore.cs
+++ b/PgNimbus.Core/Query/QueryHistoryStore.cs
@@ -5,16 +5,11 @@ using PgNimbus.Core.Connections;
 namespace PgNimbus.Core.Query;
 
 /// <summary>Persists the last <see cref="MaxEntries"/> executions, most recent first.</summary>
-public sealed class QueryHistoryStore
+public sealed class QueryHistoryStore(string? filePath = null)
 {
     private const int MaxEntries = 200;
 
-    private readonly string _filePath;
-
-    public QueryHistoryStore(string? filePath = null)
-    {
-        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "history.json");
-    }
+    private readonly string _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "history.json");
 
     public IReadOnlyList<QueryHistoryEntry> Load()
     {
@@ -64,7 +59,7 @@ public sealed class QueryHistoryStore
             Directory.CreateDirectory(directory);
         }
 
-        var json = JsonSerializer.Serialize(entries.ToList(), QueryHistoryJsonContext.Default.ListQueryHistoryEntry);
+        var json = JsonSerializer.Serialize([.. entries], QueryHistoryJsonContext.Default.ListQueryHistoryEntry);
         File.WriteAllText(_filePath, json);
     }
 }

--- a/PgNimbus.Core/Query/SavedQueryStore.cs
+++ b/PgNimbus.Core/Query/SavedQueryStore.cs
@@ -5,14 +5,9 @@ using PgNimbus.Core.Connections;
 namespace PgNimbus.Core.Query;
 
 /// <summary>Persists user-named saved queries (no cap - the user manages these explicitly).</summary>
-public sealed class SavedQueryStore
+public sealed class SavedQueryStore(string? filePath = null)
 {
-    private readonly string _filePath;
-
-    public SavedQueryStore(string? filePath = null)
-    {
-        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "saved-queries.json");
-    }
+    private readonly string _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "saved-queries.json");
 
     public IReadOnlyList<SavedQuery> Load()
     {
@@ -42,7 +37,7 @@ public sealed class SavedQueryStore
             Directory.CreateDirectory(directory);
         }
 
-        var json = JsonSerializer.Serialize(queries.ToList(), SavedQueryJsonContext.Default.ListSavedQuery);
+        var json = JsonSerializer.Serialize([.. queries], SavedQueryJsonContext.Default.ListSavedQuery);
         File.WriteAllText(_filePath, json);
     }
 }

--- a/PgNimbus.Core/Schema/DdlService.cs
+++ b/PgNimbus.Core/Schema/DdlService.cs
@@ -11,14 +11,9 @@ namespace PgNimbus.Core.Schema;
 /// <c>format_type</c>) to render real Postgres semantics — identity columns,
 /// partition keys, matviews — rather than an approximation.
 /// </summary>
-public sealed class DdlService
+public sealed class DdlService(NpgsqlDataSource dataSource)
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public DdlService(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     /// <summary>
     /// Builds the DDL for <paramref name="schema"/>.<paramref name="name"/>.

--- a/PgNimbus.Core/Schema/SchemaEditor.cs
+++ b/PgNimbus.Core/Schema/SchemaEditor.cs
@@ -16,14 +16,9 @@ public static class ColumnTypes
 /// SqlIdentifier.Quote (never string-concatenated raw), and column types are
 /// restricted to <see cref="ColumnTypes.All"/> rather than accepting free text.
 /// </summary>
-public sealed class SchemaEditor
+public sealed class SchemaEditor(NpgsqlDataSource dataSource)
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public SchemaEditor(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     public Task AddColumnAsync(string schema, string table, string column, string dataType, bool isNullable, CancellationToken ct)
     {

--- a/PgNimbus.Core/Schema/SchemaService.cs
+++ b/PgNimbus.Core/Schema/SchemaService.cs
@@ -101,14 +101,9 @@ public sealed record ForeignKeyInfo(
 /// partitioned tables, actual type names) instead of the SQL-standard
 /// lowest common denominator.
 /// </summary>
-public sealed class SchemaService
+public sealed class SchemaService(NpgsqlDataSource dataSource)
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public SchemaService(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     public async Task<IReadOnlyList<SchemaInfo>> GetSchemasAsync(CancellationToken ct)
     {

--- a/PgNimbus.Core/Security/PrivilegeService.cs
+++ b/PgNimbus.Core/Security/PrivilegeService.cs
@@ -17,14 +17,9 @@ namespace PgNimbus.Core.Security;
 ///
 /// Everything here is read-only, so it is always safe to run against production.
 /// </summary>
-public sealed class PrivilegeService
+public sealed class PrivilegeService(NpgsqlDataSource dataSource)
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public PrivilegeService(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     /// <summary>
     /// Catalog schemas are hidden from the object picker unless the caller asks

--- a/PgNimbus.Core/Security/RoleService.cs
+++ b/PgNimbus.Core/Security/RoleService.cs
@@ -12,7 +12,7 @@ namespace PgNimbus.Core.Security;
 /// panel that assumes otherwise shows an error where perfectly readable data was
 /// available.
 /// </summary>
-public sealed class RoleService
+public sealed class RoleService(NpgsqlDataSource dataSource)
 {
     /// <summary>
     /// Cap on <see cref="GetGrantsHeldAsync"/>. A role granted on 50k tables must
@@ -21,12 +21,7 @@ public sealed class RoleService
     /// </summary>
     public const int GrantsHeldLimit = 200;
 
-    private readonly NpgsqlDataSource _dataSource;
-
-    public RoleService(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     /// <summary>
     /// Every role on the server, alphabetically. <paramref name="includePredefined"/>

--- a/PgNimbus.Core/Security/SecurityEditor.cs
+++ b/PgNimbus.Core/Security/SecurityEditor.cs
@@ -18,14 +18,9 @@ namespace PgNimbus.Core.Security;
 /// a three-statement drop-role recipe that fails on its second statement leaves
 /// the role exactly as it was rather than half-dismantled.
 /// </summary>
-public sealed class SecurityEditor
+public sealed class SecurityEditor(NpgsqlDataSource dataSource)
 {
-    private readonly NpgsqlDataSource _dataSource;
-
-    public SecurityEditor(NpgsqlDataSource dataSource)
-    {
-        _dataSource = dataSource;
-    }
+    private readonly NpgsqlDataSource _dataSource = dataSource;
 
     /// <summary>
     /// Executes <paramref name="script"/> — one or more statements — atomically.

--- a/PgNimbus.Core/Settings/AppSettingsStore.cs
+++ b/PgNimbus.Core/Settings/AppSettingsStore.cs
@@ -5,14 +5,9 @@ using PgNimbus.Core.Connections;
 namespace PgNimbus.Core.Settings;
 
 /// <summary>Persists <see cref="AppSettings"/> to a single JSON file under the app data root.</summary>
-public sealed class AppSettingsStore
+public sealed class AppSettingsStore(string? filePath = null)
 {
-    private readonly string _filePath;
-
-    public AppSettingsStore(string? filePath = null)
-    {
-        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "settings.json");
-    }
+    private readonly string _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "settings.json");
 
     /// <summary>
     /// Reads the saved settings, or returns defaults when there is no file yet.

--- a/PgNimbus.Core/Settings/WindowPlacementStore.cs
+++ b/PgNimbus.Core/Settings/WindowPlacementStore.cs
@@ -26,14 +26,9 @@ public sealed record WindowPlacement(int X, int Y, double Width, double Height, 
 /// windows open, the last one to close wins, same as the workspace store's
 /// per-connection snapshots.
 /// </summary>
-public sealed class WindowPlacementStore
+public sealed class WindowPlacementStore(string? filePath = null)
 {
-    private readonly string _filePath;
-
-    public WindowPlacementStore(string? filePath = null)
-    {
-        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "window.json");
-    }
+    private readonly string _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "window.json");
 
     /// <summary>
     /// The connection dialog's own placement file. Separate from the main

--- a/PgNimbus.Core/Settings/WorkspaceStore.cs
+++ b/PgNimbus.Core/Settings/WorkspaceStore.cs
@@ -20,16 +20,11 @@ public sealed record WorkspaceTab(string Sql, string? Title = null, string? File
 public sealed record WorkspaceEntry(string Connection, DateTimeOffset SavedAt, List<WorkspaceTab> Tabs, int ActiveTabIndex = 0);
 
 /// <summary>Persists the last <see cref="MaxEntries"/> per-connection workspaces, most recent first.</summary>
-public sealed class WorkspaceStore
+public sealed class WorkspaceStore(string? filePath = null)
 {
     private const int MaxEntries = 20;
 
-    private readonly string _filePath;
-
-    public WorkspaceStore(string? filePath = null)
-    {
-        _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "workspace.json");
-    }
+    private readonly string _filePath = filePath ?? Path.Combine(AppDataPaths.GetRootDirectory(), "workspace.json");
 
     private IReadOnlyList<WorkspaceEntry> Load()
     {
@@ -60,7 +55,7 @@ public sealed class WorkspaceStore
     {
         var entries = Load().ToList();
         entries.RemoveAll(e => string.Equals(e.Connection, connection, StringComparison.Ordinal));
-        entries.Insert(0, new WorkspaceEntry(connection, DateTimeOffset.UtcNow, tabs.ToList(), activeTabIndex));
+        entries.Insert(0, new WorkspaceEntry(connection, DateTimeOffset.UtcNow, [.. tabs], activeTabIndex));
 
         // Trim oldest-first - the list is most-recent-first, so drop from the end.
         for (var i = entries.Count - 1; i >= 0 && entries.Count > MaxEntries; i--)

--- a/PgNimbus.Core/Text/SqlCompletionContext.Ctes.cs
+++ b/PgNimbus.Core/Text/SqlCompletionContext.Ctes.cs
@@ -43,10 +43,9 @@ public static partial class SqlCompletionContext
             {
                 // WITH x (a, b) AS (…) — the declared list *is* the output shape.
                 var declared = match.Groups["cols"].Value.Trim();
-                columns = SplitTopLevel(declared[1..^1])
+                columns = [.. SplitTopLevel(declared[1..^1])
                     .Select(c => Unquote(c.Trim()))
-                    .Where(c => c.Length > 0)
-                    .ToList();
+                    .Where(c => c.Length > 0)];
             }
             else
             {


### PR DESCRIPTION
## Summary
- Replace obsolete `TextBox`/`NumericUpDown` `Watermark` with `PlaceholderText` (Avalonia 12 deprecated the former) in `RoleDialog.axaml` and `PermissionsTabView.axaml` — clears the 7 `AVLN5001`/`CS0618` build warnings.
- Apply `dotnet format style`'s IDE0290 (use primary constructor) / IDE0305 (simplify collection initialization) fixes across `PgNimbus.App` and `PgNimbus.Core`.
- Update `HasCount()` assertions the recent TUnit bump (1.65.38 → 1.65.68) made obsolete to `Count().IsEqualTo(...)`.

## Test plan
- [x] `dotnet build PgNimbus.slnx` — 0 warnings, 0 errors
- [x] `dotnet test PgNimbus.Core.Tests` — 764 passed, 18 skipped (need live Postgres), 0 failed
- [x] `dotnet test PgNimbus.App.Tests` — 62 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)