### PR TITLE
Show a capped preview in grid cells, so jsonb-heavy tables scroll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1102,13 +1102,36 @@ csproj / WiX / MSIX manifest reference them unchanged:
   do — no client-side syntax check (Postgres is the parser; the cast surfaces a
   precise error). `money` and `uuid` deliberately stay `Text` (they round-trip
   through decimal/Guid). The value shown in the grid must itself be a valid input
-  literal for the cast to accept the round-trip, so `RowIndexConverter` formats
+  literal for the cast to accept the round-trip, so `Converters/CellText` formats
   the CLR types whose `ToString` is useless: `byte[]`→`\x`-hex (capped preview),
   `Array`→Postgres `{…}` literal (`PgValueSyntax.FormatArray`), and
   `BitArray`→bit string (`10110001`, MSB first). Known edge: a `bit(1)` column
   surfaces from Npgsql as `bool` (displays `True`/`False`), so an inline edit of
   it fails loudly at the cast rather than corrupting — the inspector or a `bit(n)`
   column edits cleanly.
+- **A grid cell shows a preview, and a previewed cell never opens the inline
+  editor** (2026-09). `CellText` is the one place a result value becomes text: in
+  full for the cell inspector (`CellText.Full`), and capped at
+  `PreviewLength` (256) characters and folded onto a single line for the grid
+  (`CellText.Preview`, behind `RowIndexConverter`). The cap is what makes a
+  jsonb-heavy table scroll at all: a `DataGrid` cell is a bare `TextBlock` with
+  no wrapping and no trimming, so it shapes every character it is handed — even
+  the ones clipped off the right-hand edge of a 560 px column — and it does that
+  as each row is realized. On `scripts/demo/06_telemetry.sql` (47 columns, jsonb
+  payloads averaging 37 KB and reaching 300 KB) one wheel-scroll's worth of new
+  rows cost ~450 ms of layout, and ~30 ms with the cap; 256 is the smallest value
+  that leaves the floor untouched while staying ~3× what the widest column can
+  actually show. Folding newlines to spaces is the same argument from the other
+  side: a 40-line stack trace made its row 40 lines tall.
+  **The safety half is not optional.** The DataGrid pre-fills its inline editor
+  from the column's own display binding — i.e. from the preview — so a cell
+  showing less than it holds must not be edited inline, or committing an
+  untouched editor would save the preview over the real value.
+  `ResultsGridPanel.OnResultsGridBeginningEdit` asks `CellText.IsShortened` and
+  cancels into the cell inspector instead, exactly as json/jsonb already did
+  (that also closed the pre-existing hole where inline-editing a large `bytea`
+  committed its 24-byte hex preview). Everything else — sorting, copy, export,
+  the commit path itself — reads the raw row values and is untouched by the cap.
 - **A type Npgsql can't materialize must never fail a whole result set.** An
   unmapped composite (or an array/domain/range over one), an extension type with
   no plugin loaded (pgvector, PostGIS), `bit`/`hstore` whose CLR mapping has a

--- a/PgNimbus.App.Tests/CellTextTests.cs
+++ b/PgNimbus.App.Tests/CellTextTests.cs
@@ -1,0 +1,117 @@
+using System.Collections;
+using PgNimbus.App.Converters;
+
+namespace PgNimbus.App.Tests;
+
+/// <summary>
+/// The grid shows a capped, single-line form of each value (that cap is what
+/// makes a jsonb-heavy table scroll at all — see <see cref="CellText"/>), while
+/// the cell inspector shows the whole thing. Two properties have to hold for
+/// that to be safe rather than lossy, and both are asserted here: the preview
+/// never claims to be complete when it isn't, and <see cref="CellText.IsShortened"/>
+/// agrees with the preview on every shape of value — it is what stops the grid
+/// pre-filling an inline editor with a preview and saving it back.
+/// </summary>
+public class CellTextTests
+{
+    [Test]
+    public async Task Short_text_is_shown_as_it_is()
+    {
+        await Assert.That(CellText.Preview("hello")).IsEqualTo("hello");
+        await Assert.That(CellText.IsShortened("hello")).IsFalse();
+    }
+
+    [Test]
+    public async Task A_long_value_is_capped_and_marked()
+    {
+        var value = new string('x', CellText.PreviewLength * 4);
+        var preview = (string)CellText.Preview(value)!;
+
+        await Assert.That(preview.Length).IsEqualTo(CellText.PreviewLength + 1);
+        await Assert.That(preview).EndsWith(CellText.Ellipsis);
+        await Assert.That(CellText.IsShortened(value)).IsTrue();
+        // The inspector is where the rest of it lives.
+        await Assert.That(CellText.Full(value)).IsEqualTo(value);
+    }
+
+    /// <summary>
+    /// A cell is one line high. A value with newlines in it would otherwise
+    /// stretch its whole row, so the preview folds them to spaces — which also
+    /// means the cell is no longer showing the value verbatim, and inline
+    /// editing it would save the folded copy.
+    /// </summary>
+    [Test]
+    public async Task A_multiline_value_is_folded_onto_one_line()
+    {
+        const string value = "first\nsecond\tthird";
+
+        await Assert.That(CellText.Preview(value)).IsEqualTo("first second third" + CellText.Ellipsis);
+        await Assert.That(CellText.IsShortened(value)).IsTrue();
+        await Assert.That(CellText.Full(value)).IsEqualTo(value);
+    }
+
+    [Test]
+    public async Task Null_reads_as_the_placeholder()
+    {
+        await Assert.That(CellText.Preview(null)).IsEqualTo(CellText.NullPlaceholder);
+        await Assert.That(CellText.Full(null)).IsEqualTo(CellText.NullPlaceholder);
+        // Nothing to open the inspector for: the cell shows the whole value.
+        await Assert.That(CellText.IsShortened(null)).IsFalse();
+    }
+
+    /// <summary>
+    /// Numbers, dates and booleans are handed to the binding untouched, so the
+    /// grid keeps formatting them with the current culture. Turning them into
+    /// strings here would quietly change how every numeric column reads.
+    /// </summary>
+    [Test]
+    public async Task Values_that_read_correctly_already_are_passed_through()
+    {
+        var timestamp = new DateTime(2026, 9, 8, 12, 0, 0, DateTimeKind.Utc);
+
+        await Assert.That(CellText.Preview(42)).IsEqualTo(42);
+        await Assert.That(CellText.Preview(12.5m)).IsEqualTo(12.5m);
+        await Assert.That(CellText.Preview(timestamp)).IsEqualTo(timestamp);
+        await Assert.That(CellText.IsShortened(timestamp)).IsFalse();
+    }
+
+    /// <summary>
+    /// bytea is the one type whose preview was always short — a blob can be
+    /// megabytes, and rendering it as hex inline is pointless as well as slow.
+    /// It has to report itself shortened for the same reason the others do.
+    /// </summary>
+    [Test]
+    public async Task Bytea_shows_a_hex_preview_and_says_so()
+    {
+        var small = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF };
+        var big = new byte[512];
+
+        await Assert.That(CellText.Preview(small)).IsEqualTo("\\xDEADBEEF");
+        await Assert.That(CellText.IsShortened(small)).IsFalse();
+
+        await Assert.That((string)CellText.Preview(big)!).EndsWith(CellText.Ellipsis);
+        await Assert.That(CellText.IsShortened(big)).IsTrue();
+        await Assert.That(CellText.Full(big).Length).IsEqualTo(2 + (big.Length * 2));
+    }
+
+    [Test]
+    public async Task Arrays_and_hstore_keep_their_postgres_literal()
+    {
+        var array = new[] { "a", "b" };
+        var map = new Dictionary<string, string> { ["k"] = "v" };
+
+        await Assert.That(CellText.Preview(array)).IsEqualTo("{a,b}");
+        await Assert.That(CellText.Preview(map)).IsEqualTo("\"k\"=>\"v\"");
+        await Assert.That(CellText.IsShortened(array)).IsFalse();
+    }
+
+    [Test]
+    public async Task Bit_strings_render_most_significant_bit_first()
+    {
+        var bits = new BitArray([true, false, true, true]);
+
+        await Assert.That(CellText.Preview(bits)).IsEqualTo("1011");
+        await Assert.That(CellText.Full(bits)).IsEqualTo("1011");
+        await Assert.That(CellText.IsShortened(bits)).IsFalse();
+    }
+}

--- a/PgNimbus.App.Tests/ResultsGridTests.cs
+++ b/PgNimbus.App.Tests/ResultsGridTests.cs
@@ -4,7 +4,10 @@ using Avalonia.Headless;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
 using Avalonia.VisualTree;
+using PgNimbus.App.Converters;
+using PgNimbus.App.ViewModels;
 using PgNimbus.Core.Query;
+using PgNimbus.Core.Schema;
 using PgNimbus.Screenshot;
 
 namespace PgNimbus.App.Tests;
@@ -174,6 +177,92 @@ public class ResultsGridTests
             window.Close();
         });
     }
+
+    /// <summary>
+    /// The grid shows long values capped and folded onto one line (that is what
+    /// keeps a jsonb-heavy table scrolling — see <c>CellText</c>), and the inline
+    /// editor is pre-filled from exactly that display text. So a cell showing a
+    /// preview must never open one: committing an untouched editor would write
+    /// the preview over the real value. It opens the cell inspector instead,
+    /// which carries the whole thing.
+    /// </summary>
+    [Test]
+    public async Task A_previewed_cell_opens_the_inspector_instead_of_an_inline_editor()
+    {
+        await Ui.Run(async () =>
+        {
+            var (window, vm) = Scenarios.Shell();
+            Ui.Show(window);
+
+            var payload = new string('x', CellText.PreviewLength * 3);
+            SeedEditableCell(vm, payload);
+
+            var grid = FindResultsGrid(window)!;
+            BeginEditingTheCell(grid);
+
+            await Assert.That(vm.CellInspector.IsOpen).IsTrue();
+            // The whole value, not the preview the cell was showing.
+            await Assert.That(vm.CellInspector.DisplayText).IsEqualTo(payload);
+            await Assert.That(EditorTextBox(window)).IsNull();
+
+            window.Close();
+        });
+    }
+
+    /// <summary>
+    /// The other half of the pair: a value the cell is showing in full still
+    /// edits inline. Without this, the guard above would also pass if inline
+    /// editing had simply stopped working.
+    /// </summary>
+    [Test]
+    public async Task A_cell_showing_its_whole_value_still_edits_inline()
+    {
+        await Ui.Run(async () =>
+        {
+            var (window, vm) = Scenarios.Shell();
+            Ui.Show(window);
+
+            SeedEditableCell(vm, "short enough to read");
+
+            var grid = FindResultsGrid(window)!;
+            BeginEditingTheCell(grid);
+
+            await Assert.That(vm.CellInspector.IsOpen).IsFalse();
+            await Assert.That(EditorTextBox(window)?.Text).IsEqualTo("short enough to read");
+
+            window.Close();
+        });
+    }
+
+    // One editable row: a keyed table context is what makes the grid writable,
+    // which is the only state in which BeginningEdit fires at all.
+    private static void SeedEditableCell(MainViewModel vm, string payload)
+    {
+        var tab = vm.ActiveTab;
+        tab.SeedResult(
+            [new ColumnInfo("id", "bigint", typeof(long)), new ColumnInfo("payload", "text", typeof(string))],
+            [[1L, payload]]);
+        tab.EditContext = new EditableTableContext(
+            "public", "t", ["id"],
+            [new ColumnDetail("id", "bigint", NotNull: true, IsPrimaryKey: true),
+             new ColumnDetail("payload", "text", NotNull: false, IsPrimaryKey: false)]);
+        Ui.Settle();
+    }
+
+    private static void BeginEditingTheCell(DataGrid grid)
+    {
+        grid.SelectedIndex = 0;
+        grid.CurrentColumn = grid.Columns[1];
+        Ui.Settle();
+        grid.BeginEdit();
+        Ui.Settle();
+    }
+
+    private static TextBox? EditorTextBox(Window window) =>
+        window.GetVisualDescendants()
+            .OfType<DataGridCell>()
+            .SelectMany(cell => cell.GetVisualDescendants().OfType<TextBox>())
+            .FirstOrDefault();
 
     // A resize drag on a header's right edge: press inside the grip strip, move,
     // release. Sent as real pointer input so the DataGrid's own resize handling

--- a/PgNimbus.App/Converters/CellText.cs
+++ b/PgNimbus.App/Converters/CellText.cs
@@ -1,0 +1,168 @@
+using System.Collections;
+using PgNimbus.Core.Schema;
+
+namespace PgNimbus.App.Converters;
+
+/// <summary>
+/// How a result-set value is rendered as text, in two lengths: the whole thing
+/// (<see cref="Full"/>, what the cell inspector shows) and the short form the
+/// grid puts in a cell (<see cref="Preview"/>). One place, because they have to
+/// agree on what a value *is* — bytea as <c>\x</c>-hex, an array as a Postgres
+/// literal, hstore as <c>"k"=&gt;"v"</c> — and disagree only on how much of it.
+///
+/// The cap is not cosmetic, it is why the grid scrolls. A DataGrid cell is a
+/// plain <c>TextBlock</c> with no wrapping and no trimming, so it shapes and
+/// measures every character it is handed, however far past the column's edge
+/// they fall — and the grid measures each cell as its row is realized. On a wide
+/// log table with jsonb payloads (see <c>scripts/demo/06_telemetry.sql</c>:
+/// 37 KB per cell on average, 300 KB at the tail) that was ~450 ms of text
+/// shaping per band of rows a wheel scroll brought into view, all of it spent on
+/// characters clipped off the right-hand edge of a 560 px column.
+///
+/// Two rules keep the cap honest:
+/// <list type="bullet">
+/// <item>Nothing but the display reads it. Sorting, copy, export and every edit
+/// path work off the raw row values, and the inspector formats them with
+/// <see cref="Full"/>.</item>
+/// <item>A shortened cell never opens an inline editor — the grid pre-fills that
+/// editor from this same display text, so committing it would save the preview
+/// over the real value. <see cref="IsShortened"/> is what the results grid asks
+/// before it lets an edit begin; it opens the inspector instead.</item>
+/// </list>
+/// </summary>
+public static class CellText
+{
+    /// <summary>Shown for SQL NULL, dimmed, so it reads as a marker rather than as the string "NULL".</summary>
+    public const string NullPlaceholder = "NULL";
+
+    /// <summary>
+    /// The longest text a cell renders. Three times what the widest a column
+    /// auto-sizes to can show (560 px is roughly 80 characters), so the ellipsis
+    /// stays off-screen even in a hand-widened column — and measured to be the
+    /// point where the grid's layout is back at the cost of a result set with no
+    /// long values in it at all: on the telemetry demo table one scroll's worth
+    /// of rows takes ~450 ms uncapped, 33 ms at 256, 25 ms at 128.
+    /// </summary>
+    public const int PreviewLength = 256;
+
+    /// <summary>Bytes shown before a bytea preview is shortened — enough to read a magic number, not a whole blob.</summary>
+    private const int ByteaPreviewBytes = 24;
+
+    /// <summary>Marks a cell that is showing less than it holds (capped, or folded onto one line).</summary>
+    public const string Ellipsis = "…";
+
+    // Whitespace that would otherwise make a cell taller than its row, or wider
+    // than the character count suggests.
+    private static readonly char[] LineBreaks = ['\n', '\r', '\t'];
+
+    /// <summary>
+    /// The cell's display text: capped, and folded onto a single line. Values
+    /// whose own <c>ToString</c> already reads correctly (numbers, dates,
+    /// booleans) are passed through unchanged so the binding formats them with
+    /// the current culture, exactly as it did before the cap existed.
+    /// </summary>
+    public static object? Preview(object? value) => value switch
+    {
+        null => NullPlaceholder,
+        // bytea arrives as byte[]; its default ToString is the useless
+        // "System.Byte[]". Show a capped \x-hex preview (the cell inspector
+        // carries the full value) rather than materializing megabytes of hex
+        // for a large blob inline.
+        byte[] bytes => bytes.Length <= ByteaPreviewBytes
+            ? "\\x" + Convert.ToHexString(bytes)
+            : "\\x" + Convert.ToHexString(bytes.AsSpan(0, ByteaPreviewBytes)) + Ellipsis,
+        // bit/varbit arrive as a BitArray, whose default ToString is
+        // "System.Collections.BitArray". Render the bit string ("10110001",
+        // most-significant bit first, matching Postgres) so it reads and, for
+        // an editable table, round-trips through CAST(text AS bit(n)).
+        BitArray bits => FormatBits(bits, PreviewLength),
+        // Array columns render in Postgres's literal syntax ("{a,b}") instead
+        // of the CLR default ("System.String[]") — readable, and editable in
+        // place since the cell editor pre-fills from this text and the edit
+        // pipeline casts it back server-side.
+        Array array => Shorten(PgValueSyntax.FormatArray(array)),
+        // hstore arrives as a Dictionary<string,string>, whose default ToString
+        // is the CLR type name. Render the Postgres literal ("k"=>"v") so it
+        // reads in any result set — browse mode already re-requests it as text,
+        // but a hand-written SELECT gets the raw dictionary.
+        IDictionary map => Shorten(PgValueSyntax.FormatHstore(map)),
+        string text => Shorten(text),
+        var other => other,
+    };
+
+    /// <summary>
+    /// The value in full, the way the cell inspector shows it: the same
+    /// renderings <see cref="Preview"/> uses, with nothing left out.
+    /// </summary>
+    public static string Full(object? value) => value switch
+    {
+        null => NullPlaceholder,
+        byte[] bytes => "\\x" + Convert.ToHexString(bytes),
+        BitArray bits => FormatBits(bits, bits.Count),
+        Array array => PgValueSyntax.FormatArray(array),
+        IDictionary map => PgValueSyntax.FormatHstore(map),
+        _ => value.ToString() ?? string.Empty,
+    };
+
+    /// <summary>
+    /// Whether the grid is showing less than the whole value — capped, or folded
+    /// onto one line. The results grid asks this before beginning an inline
+    /// edit, since that editor is pre-filled from the display text.
+    /// </summary>
+    public static bool IsShortened(object? value) => value switch
+    {
+        null => false,
+        byte[] bytes => bytes.Length > ByteaPreviewBytes,
+        BitArray bits => bits.Count > PreviewLength,
+        Array array => NeedsShortening(PgValueSyntax.FormatArray(array)),
+        IDictionary map => NeedsShortening(PgValueSyntax.FormatHstore(map)),
+        string text => NeedsShortening(text),
+        _ => false,
+    };
+
+    private static bool NeedsShortening(string text) =>
+        text.Length > PreviewLength || text.AsSpan().IndexOfAny(LineBreaks) >= 0;
+
+    // Cap first, then fold what is left onto one line. Both matter for the same
+    // reason: a cell TextBlock lays out every character it is given, and one
+    // carrying newlines grows the row instead of running off the column's edge.
+    private static string Shorten(string text)
+    {
+        if (!NeedsShortening(text))
+        {
+            return text;
+        }
+
+        var cut = PreviewLength;
+        // Never cut a surrogate pair in half: a lone surrogate renders as the
+        // replacement glyph, so an emoji at the boundary would look corrupt.
+        if (text.Length > cut && char.IsHighSurrogate(text[cut - 1]))
+        {
+            cut--;
+        }
+
+        var span = text.Length > PreviewLength ? text.AsSpan(0, cut) : text.AsSpan();
+        var chars = span.ToArray();
+        for (var i = 0; i < chars.Length; i++)
+        {
+            if (chars[i] is '\n' or '\r' or '\t')
+            {
+                chars[i] = ' ';
+            }
+        }
+
+        return new string(chars) + Ellipsis;
+    }
+
+    private static string FormatBits(BitArray bits, int limit)
+    {
+        var length = Math.Min(bits.Count, limit);
+        var chars = new char[length];
+        for (var i = 0; i < length; i++)
+        {
+            chars[i] = bits[i] ? '1' : '0';
+        }
+
+        return length < bits.Count ? new string(chars) + Ellipsis : new string(chars);
+    }
+}

--- a/PgNimbus.App/Converters/RowIndexConverter.cs
+++ b/PgNimbus.App/Converters/RowIndexConverter.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using Avalonia;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
-using PgNimbus.Core.Schema;
 
 namespace PgNimbus.App.Converters;
 
@@ -16,61 +15,15 @@ namespace PgNimbus.App.Converters;
 /// <see cref="NullCellOpacityConverter"/>) so it's distinguishable from an
 /// empty string; MainWindow's cell-edit preparation clears the placeholder
 /// out of the editor so it can't be committed back as a literal string.
+/// How each value reads — and how much of a long one a cell shows — is
+/// <see cref="CellText"/>'s business, shared with the cell inspector.
 /// </summary>
 public sealed class RowIndexConverter(int index) : IValueConverter
 {
-    public const string NullPlaceholder = "NULL";
-
     private readonly int _index = index;
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is object?[] row && _index < row.Length
-            ? row[_index] switch
-            {
-                null => NullPlaceholder,
-                // bytea arrives as byte[]; its default ToString is the useless
-                // "System.Byte[]". Show a capped \x-hex preview (the same shape
-                // the cell inspector uses, which carries the full value) rather
-                // than materializing megabytes of hex for a large blob inline.
-                byte[] bytes => FormatByteaPreview(bytes),
-                // bit/varbit arrive as a BitArray, whose default ToString is
-                // "System.Collections.BitArray". Render the bit string ("10110001",
-                // most-significant bit first, matching Postgres) so it reads and,
-                // for an editable table, round-trips through CAST(text AS bit(n)).
-                System.Collections.BitArray bits => FormatBits(bits),
-                // Array columns render in Postgres's literal syntax ("{a,b}")
-                // instead of the CLR default ("System.String[]") — readable,
-                // and editable in place since the cell editor pre-fills from
-                // this text and the edit pipeline casts it back server-side.
-                Array array => PgValueSyntax.FormatArray(array),
-                // hstore arrives as a Dictionary<string,string>, whose default
-                // ToString is the CLR type name. Render the Postgres literal
-                // ("k"=>"v") so it reads in any result set — browse mode already
-                // re-requests it as text, but a hand-written SELECT gets the raw
-                // dictionary, and without this it showed the type name.
-                System.Collections.IDictionary map => PgValueSyntax.FormatHstore(map),
-                var cell => cell,
-            }
-            : null;
-
-    /// <summary>Bytes shown before a bytea preview is truncated — enough to read a magic number, not a whole blob.</summary>
-    private const int ByteaPreviewBytes = 24;
-
-    private static string FormatByteaPreview(byte[] bytes) =>
-        bytes.Length <= ByteaPreviewBytes
-            ? "\\x" + System.Convert.ToHexString(bytes)
-            : "\\x" + System.Convert.ToHexString(bytes.AsSpan(0, ByteaPreviewBytes)) + "…";
-
-    private static string FormatBits(System.Collections.BitArray bits)
-    {
-        var chars = new char[bits.Count];
-        for (var i = 0; i < bits.Count; i++)
-        {
-            chars[i] = bits[i] ? '1' : '0';
-        }
-
-        return new string(chars);
-    }
+        value is object?[] row && _index < row.Length ? CellText.Preview(row[_index]) : null;
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();
@@ -133,7 +86,7 @@ public sealed class BoolCellTextConverter(int index) : IValueConverter
         value is object?[] row && _index < row.Length
             ? row[_index] switch
             {
-                null => RowIndexConverter.NullPlaceholder,
+                null => CellText.NullPlaceholder,
                 bool => string.Empty,
                 var other => other.ToString(),
             }

--- a/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
+++ b/PgNimbus.App/ViewModels/CellInspectorViewModel.cs
@@ -6,6 +6,7 @@ using System.Text.Unicode;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using PgNimbus.App.Converters;
 using PgNimbus.Core.Json;
 using PgNimbus.Core.Schema;
 
@@ -289,17 +290,11 @@ public sealed partial class CellInspectorViewModel : ObservableObject
 
     private static (string Text, bool IsJson) Format(object? value)
     {
-        var text = value switch
-        {
-            null => "NULL",
-            byte[] bytes => $"\\x{Convert.ToHexString(bytes)}",
-            // Same Postgres-literal rendering the grid uses — never "System.String[]".
-            Array array => PgValueSyntax.FormatArray(array),
-            // hstore materializes as a Dictionary<string,string>; render its
-            // literal ("k"=>"v") like the grid, never the CLR type name.
-            System.Collections.IDictionary map => PgValueSyntax.FormatHstore(map),
-            _ => value.ToString() ?? string.Empty,
-        };
+        // Exactly what the grid cell renders, minus the length cap: the two must
+        // agree on what a value *is* (bytea as \x-hex, an array as a Postgres
+        // literal, hstore as "k"=>"v"), and this is the view that shows all of
+        // it. See CellText.
+        var text = CellText.Full(value);
 
         return TryPrettyPrintJson(text, out var pretty) ? (pretty, true) : (text, false);
     }

--- a/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
+++ b/PgNimbus.App/Views/ResultsGridPanel.axaml.cs
@@ -17,6 +17,7 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using AvaloniaEdit.Highlighting;
 using AvaloniaEdit.Highlighting.Xshd;
+using PgNimbus.App.Converters;
 using PgNimbus.App.ViewModels;
 using PgNimbus.Core.Import;
 using PgNimbus.Core.Query;
@@ -660,13 +661,32 @@ public partial class ResultsGridPanel : UserControl
 
     // Cancels the inline edit the DataGrid tries to start after a double-click
     // on a json/jsonb cell - OnResultsGridCellPointerPressed has already opened
-    // the inspector for it.
+    // the inspector for it. Also the guard for the other cells the inline editor
+    // must not have: the ones the grid is only showing part of.
     private void OnResultsGridBeginningEdit(object? sender, DataGridBeginningEditEventArgs e)
     {
         if (_suppressJsonInlineEdit)
         {
             _suppressJsonInlineEdit = false;
             e.Cancel = true;
+            return;
+        }
+
+        // The inline editor is pre-filled from the cell's display text (the
+        // column's own binding is what the DataGrid puts in the TextBox), and
+        // that text is capped and folded onto one line - see CellText. So for a
+        // value the cell is only previewing, committing an untouched editor
+        // would save the preview over the real value. Send those to the cell
+        // inspector, which carries the whole thing, exactly as json already is.
+        if (e.Row.DataContext is object?[] row
+            && e.Column is { } column
+            && column.DisplayIndex < row.Length
+            && CellText.IsShortened(row[column.DisplayIndex]))
+        {
+            e.Cancel = true;
+            // Posted: the grid is mid-edit-begin, and the inspector steals focus.
+            var index = column.DisplayIndex;
+            Dispatcher.UIThread.Post(() => OpenCellInspector(row, index, startEditing: true));
         }
     }
 

--- a/scripts/demo/06_telemetry.sql
+++ b/scripts/demo/06_telemetry.sql
@@ -1,0 +1,241 @@
+-- pgNimbus demo data — 06: the `telemetry` schema, a deliberately hostile grid.
+--
+-- Every other file here shows types off; this one exists to be *heavy*. It is
+-- the shape that made the results grid crawl in the field: one very wide table
+-- (46 columns) whose four jsonb columns hold documents of tens to hundreds of
+-- kilobytes each, so a single screen of rows carries several megabytes of text.
+-- Keep it in the demo set — a change to the grid's cell rendering should be
+-- scrolled through here before it ships.
+--
+-- Randomness note: the payload builders are correlated subqueries (they read
+-- s.g from the outer row), so PostgreSQL evaluates them per row. Do NOT rewrite
+-- them as uncorrelated `CROSS JOIN LATERAL (... ORDER BY random() LIMIT 1)` —
+-- that is evaluated once and every row gets the same "random" pick.
+
+BEGIN;
+
+DROP SCHEMA IF EXISTS telemetry CASCADE;
+CREATE SCHEMA telemetry;
+
+CREATE TABLE telemetry.api_events (
+    id                    bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    received_at           timestamptz NOT NULL,
+    trace_id              uuid        NOT NULL,
+    span_id               uuid        NOT NULL,
+    parent_span_id        uuid,
+    service               text        NOT NULL,
+    service_version       text        NOT NULL,
+    environment           text        NOT NULL,
+    region                text        NOT NULL,
+    availability_zone     text        NOT NULL,
+    host                  text        NOT NULL,
+    pod                   text        NOT NULL,
+    container_id          text        NOT NULL,
+    method                text        NOT NULL,
+    route                 text        NOT NULL,
+    path                  text        NOT NULL,
+    query_string          text,
+    status_code           integer     NOT NULL,
+    status_class          smallint GENERATED ALWAYS AS (status_code / 100) STORED,
+    is_error              boolean  GENERATED ALWAYS AS (status_code >= 400) STORED,
+    duration_ms           numeric(10,3) NOT NULL,
+    db_time_ms            numeric(10,3) NOT NULL,
+    queue_time_ms         numeric(10,3) NOT NULL,
+    bytes_in              bigint      NOT NULL,
+    bytes_out             bigint      NOT NULL,
+    client_ip             inet        NOT NULL,
+    user_agent            text        NOT NULL,
+    referrer              text,
+    user_id               uuid,
+    session_id            uuid,
+    tenant                text        NOT NULL,
+    api_key_prefix        text,
+    rate_limit_remaining  integer     NOT NULL,
+    cache_status          text        NOT NULL,
+    retry_count           smallint    NOT NULL DEFAULT 0,
+    error_code            text,
+    error_message         text,
+    stack_trace           text,
+    request_headers       jsonb       NOT NULL,
+    request_body          jsonb       NOT NULL,
+    response_headers      jsonb       NOT NULL,
+    response_body         jsonb       NOT NULL,
+    trace_spans           jsonb       NOT NULL,
+    context               jsonb       NOT NULL,
+    feature_flags         jsonb       NOT NULL,
+    tags                  text[]      NOT NULL DEFAULT '{}',
+    recorded_at           timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  telemetry.api_events               IS 'Wide (46-column) request log with multi-100 KB jsonb payloads — the results-grid stress case.';
+COMMENT ON COLUMN telemetry.api_events.request_body  IS 'Tens to hundreds of KB: the line items the request carried.';
+COMMENT ON COLUMN telemetry.api_events.response_body IS 'Tens to hundreds of KB: the records the response returned.';
+COMMENT ON COLUMN telemetry.api_events.trace_spans   IS 'One object per span of the distributed trace.';
+
+INSERT INTO telemetry.api_events
+    (received_at, trace_id, span_id, parent_span_id, service, service_version, environment,
+     region, availability_zone, host, pod, container_id, method, route, path, query_string,
+     status_code, duration_ms, db_time_ms, queue_time_ms, bytes_in, bytes_out, client_ip,
+     user_agent, referrer, user_id, session_id, tenant, api_key_prefix, rate_limit_remaining,
+     cache_status, retry_count, error_code, error_message, stack_trace,
+     request_headers, request_body, response_headers, response_body, trace_spans,
+     context, feature_flags, tags)
+SELECT
+    s.received_at,
+    s.trace_id,
+    s.span_id,
+    CASE WHEN s.g % 4 <> 0 THEN s.parent_span_id END,
+    (ARRAY['checkout-api','catalog-api','identity','search','billing','shipping'])[s.svci],
+    '2.' || (s.g % 9) || '.' || (s.g % 17),
+    (ARRAY['production','staging','canary'])[s.envi],
+    (ARRAY['eu-central-1','us-east-1','ap-southeast-2'])[s.regi],
+    (ARRAY['eu-central-1','us-east-1','ap-southeast-2'])[s.regi] || (ARRAY['a','b','c'])[s.azi],
+    'ip-10-' || (s.g % 250) || '-' || ((s.g * 7) % 250) || '-' || ((s.g * 13) % 250),
+    (ARRAY['checkout','catalog','identity','search','billing','shipping'])[s.svci] || '-' || substr(md5(s.g::text), 1, 10),
+    substr(md5('container' || s.g), 1, 24),
+    (ARRAY['GET','POST','PUT','PATCH','DELETE'])[s.methi],
+    (ARRAY['/v1/orders/{id}','/v1/carts/{id}/items','/v1/products','/v1/search','/v1/invoices/{id}','/v1/shipments'])[s.routei],
+    (ARRAY['/v1/orders/','/v1/carts/','/v1/products/','/v1/search/','/v1/invoices/','/v1/shipments/'])[s.routei] || s.g,
+    CASE WHEN s.g % 3 = 0 THEN 'page=' || (s.g % 40) || '&limit=100&expand=items,customer' END,
+    s.status_code,
+    round(s.duration::numeric, 3),
+    round((s.duration * 0.42)::numeric, 3),
+    round((s.duration * 0.06)::numeric, 3),
+    s.body_items * 180 + 512,
+    s.result_rows * 240 + 1024,
+    ('198.51.' || (s.g % 250) || '.' || ((s.g * 11) % 250))::inet,
+    (ARRAY['Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15',
+           'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36',
+           'checkout-sdk/4.2.1 (dotnet; net10.0; win-x64)',
+           'okhttp/4.12.0'])[s.uai],
+    CASE WHEN s.g % 5 <> 0 THEN 'https://shop.example.com/checkout?step=' || (s.g % 6) END,
+    s.user_id,
+    s.session_id,
+    'tenant-' || lpad(((s.g % 24) + 1)::text, 3, '0'),
+    'pk_live_' || substr(md5('key' || (s.g % 30)), 1, 12),
+    1000 - (s.g % 1000),
+    (ARRAY['HIT','MISS','BYPASS','STALE'])[s.cachei],
+    CASE WHEN s.status_code >= 500 THEN (s.g % 4)::smallint ELSE 0::smallint END,
+    CASE WHEN s.status_code >= 400
+         THEN (ARRAY['ERR_VALIDATION','ERR_UPSTREAM_TIMEOUT','ERR_CONFLICT','ERR_RATE_LIMIT','ERR_INTERNAL'])[s.erri] END,
+    CASE WHEN s.status_code >= 400
+         THEN 'Request ' || s.trace_id || ' failed after ' || round(s.duration::numeric, 1)
+              || ' ms while calling the ' || (ARRAY['pricing','inventory','tax','payment','fraud'])[s.erri] || ' service' END,
+    -- A few KB of plausible stack, so the long-text columns are heavy too.
+    CASE WHEN s.status_code >= 500 THEN (
+        SELECT string_agg(
+            '   at Shop.' || (ARRAY['Checkout','Pricing','Inventory','Payments','Tax','Fraud'])[1 + (f % 6)]
+                || '.' || (ARRAY['HandleAsync','ResolveAsync','ValidateAsync','CommitAsync','LoadAsync'])[1 + (f % 5)]
+                || '(Order order, CancellationToken ct) in /src/shop/' || substr(md5((s.g * f)::text), 1, 8)
+                || '.cs:line ' || (17 * f + s.g % 400),
+            chr(10) ORDER BY f)
+        FROM generate_series(1, 40) f) END,
+    -- Small documents: the headers.
+    jsonb_build_object(
+        'accept', 'application/json',
+        'accept-encoding', 'gzip, br',
+        'authorization', 'Bearer ' || substr(md5('tok' || s.g), 1, 24) || '...',
+        'content-type', 'application/json; charset=utf-8',
+        'traceparent', '00-' || replace(s.trace_id::text, '-', '') || '-' || substr(replace(s.span_id::text, '-', ''), 1, 16) || '-01',
+        'x-request-id', s.trace_id,
+        'x-forwarded-for', '198.51.' || (s.g % 250) || '.' || ((s.g * 11) % 250),
+        'user-agent', 'checkout-sdk/4.2.1'),
+    -- The heavy one: the request's line items.
+    (SELECT jsonb_agg(jsonb_build_object(
+                'seq', i,
+                'sku', 'SKU-' || lpad(((s.g * 97 + i * 13) % 999999)::text, 6, '0'),
+                'title', 'Item ' || i || ' - ' || substr(md5((s.g * i)::text), 1, 18),
+                'qty', 1 + (i % 7),
+                'unit_price', round(((5 + ((s.g * i) % 900)) / 7.0)::numeric, 2),
+                'currency', 'EUR',
+                'warehouse', 'WH-' || (1 + (i % 12)),
+                'attributes', jsonb_build_object(
+                    'color', (ARRAY['black','white','silver','blue','red','green'])[1 + (i % 6)],
+                    'size', (ARRAY['XS','S','M','L','XL'])[1 + (i % 5)],
+                    'gift_wrap', (i % 9) = 0,
+                    'note', 'handling note ' || substr(md5((i * 31 + s.g)::text), 1, 26)),
+                'promotions', jsonb_build_array(
+                    jsonb_build_object('code', 'PROMO-' || ((s.g + i) % 400), 'pct', (i % 30)),
+                    jsonb_build_object('code', 'LOYALTY-' || (i % 12), 'pct', (i % 7)))))
+     FROM generate_series(1, s.body_items) i),
+    jsonb_build_object(
+        'content-type', 'application/json; charset=utf-8',
+        'content-encoding', 'br',
+        'cache-control', 'private, max-age=0',
+        'x-ratelimit-remaining', 1000 - (s.g % 1000),
+        'server-timing', 'db;dur=' || round((s.duration * 0.42)::numeric, 1) || ', app;dur=' || round((s.duration * 0.5)::numeric, 1)),
+    -- The other heavy one: the records the response carried back.
+    jsonb_build_object(
+        'page', 1 + (s.g % 40),
+        'page_size', s.result_rows,
+        'total', s.result_rows * (3 + (s.g % 5)),
+        'results', (SELECT jsonb_agg(jsonb_build_object(
+                'id', md5((s.g * 7919 + r)::text),
+                'kind', (ARRAY['order','shipment','invoice','refund'])[1 + (r % 4)],
+                'created_at', to_char(now() - ((r % 400) || ' days')::interval, 'YYYY-MM-DD"T"HH24:MI:SSOF'),
+                'amount', round(((r * 37 + s.g) % 5000)::numeric / 13, 2),
+                'lines', 1 + (r % 9),
+                'customer', jsonb_build_object(
+                    'id', md5((r * 31 + s.g)::text),
+                    'name', 'Customer ' || ((r * 17 + s.g) % 9000),
+                    'email', 'c' || ((r * 17 + s.g) % 9000) || '@example.com',
+                    'segment', (ARRAY['retail','wholesale','partner','internal'])[1 + (r % 4)]),
+                'summary', 'Processed ' || (1 + (r % 9)) || ' lines for ' || substr(md5((r + s.g)::text), 1, 20)))
+            FROM generate_series(1, s.result_rows) r)),
+    -- The trace: one object per span.
+    (SELECT jsonb_agg(jsonb_build_object(
+                'span_id', substr(md5((s.g * 104729 + p)::text), 1, 16),
+                'name', (ARRAY['http.server','db.query','cache.get','rpc.call','queue.publish','json.serialize'])[1 + (p % 6)],
+                'start_ms', round((p * s.duration / GREATEST(s.spans, 1))::numeric, 3),
+                'duration_ms', round((s.duration / GREATEST(s.spans, 1))::numeric, 3),
+                'status', CASE WHEN (p % 23) = 0 THEN 'error' ELSE 'ok' END,
+                'attributes', jsonb_build_object(
+                    'db.statement', 'SELECT * FROM orders WHERE tenant_id = $1 AND created_at > $2 -- ' || substr(md5((p * s.g)::text), 1, 12),
+                    'db.rows', (p * 13 + s.g) % 4000,
+                    'peer.service', (ARRAY['postgres','redis','pricing','inventory','tax'])[1 + (p % 5)])))
+     FROM generate_series(1, s.spans) p),
+    jsonb_build_object(
+        'deployment', jsonb_build_object('commit', substr(md5('sha' || s.g), 1, 40), 'built_at', to_char(now() - ((s.g % 60) || ' days')::interval, 'YYYY-MM-DD')),
+        'client', jsonb_build_object('platform', (ARRAY['web','ios','android','pos'])[1 + (s.g % 4)], 'app_version', '5.' || (s.g % 12)),
+        'experiment_buckets', (SELECT jsonb_object_agg('exp_' || e, (s.g + e) % 4) FROM generate_series(1, 18) e)),
+    jsonb_build_object(
+        'new_checkout', (s.g % 2) = 0,
+        'async_tax', (s.g % 3) = 0,
+        'split_shipments', (s.g % 5) = 0),
+    (ARRAY['http','trace','billing','beta','slow','retried'])[1:1 + (s.g % 4)]
+FROM (
+    SELECT
+        g,
+        now() - ((random() * 45) || ' days')::interval               AS received_at,
+        gen_random_uuid()                                            AS trace_id,
+        gen_random_uuid()                                            AS span_id,
+        gen_random_uuid()                                            AS parent_span_id,
+        gen_random_uuid()                                            AS user_id,
+        gen_random_uuid()                                            AS session_id,
+        1 + floor(random() * 6)::int                                 AS svci,
+        1 + floor(random() * 3)::int                                 AS envi,
+        1 + floor(random() * 3)::int                                 AS regi,
+        1 + floor(random() * 3)::int                                 AS azi,
+        1 + floor(random() * 5)::int                                 AS methi,
+        1 + floor(random() * 6)::int                                 AS routei,
+        1 + floor(random() * 4)::int                                 AS uai,
+        1 + floor(random() * 4)::int                                 AS cachei,
+        1 + floor(random() * 5)::int                                 AS erri,
+        (ARRAY[200,200,200,201,204,400,404,409,429,500,502,504])[1 + floor(random() * 12)::int] AS status_code,
+        random() * 2400 + 3                                          AS duration,
+        -- Every 25th row is a monster (a few hundred KB across the two big
+        -- columns), so the worst case is always somewhere on screen.
+        CASE WHEN g % 25 = 0 THEN 700 + (g % 200) ELSE 25 + floor(random() * 110)::int END AS body_items,
+        CASE WHEN g % 25 = 0 THEN 500 + (g % 150) ELSE 20 + floor(random() * 90)::int  END AS result_rows,
+        CASE WHEN g % 25 = 0 THEN 220 + (g % 60)  ELSE 12 + floor(random() * 40)::int  END AS spans
+    FROM generate_series(1, 600) g
+) s;
+
+-- Realistic for a log table, and it gives the schema tree a GIN index to show.
+CREATE INDEX api_events_received_at_idx ON telemetry.api_events (received_at DESC);
+CREATE INDEX api_events_trace_idx       ON telemetry.api_events (trace_id);
+CREATE INDEX api_events_context_gin     ON telemetry.api_events USING gin (context jsonb_path_ops);
+
+ANALYZE telemetry.api_events;
+
+COMMIT;

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -1,13 +1,13 @@
 # pgNimbus demo data
 
-A type-rich, multi-schema PostgreSQL dataset (~46 MB) for exploring and
+A type-rich, multi-schema PostgreSQL dataset (~63 MB) for exploring and
 demoing pgNimbus. It's built to exercise the PostgreSQL-first parts of the
 UI — the schema tree, relation sizes, the Database Overview panel, and the
 result-grid / cell-inspector rendering of exotic types.
 
 ## What it creates
 
-Five schemas, loaded in order:
+Six schemas, loaded in order:
 
 | # | Schema | Highlights | Types on display |
 |---|--------|-----------|------------------|
@@ -16,6 +16,7 @@ Five schemas, loaded in order:
 | 03 | `iot` | 120 devices + **200 000 readings** in a monthly **RANGE-partitioned** table (8 partitions, ~33 MB — the largest relation). | macaddr, `bit`/`varbit`, polygon, partition tree |
 | 04 | `org` | An **`ltree`** org hierarchy (14 units) + 309 employees. | `int4range` salary bands, self-referencing `manager_id` |
 | 05 | `analytics` | 2 views, 2 materialized views, sql/plpgsql **functions**, then `REFRESH` + `ANALYZE`. | — |
+| 06 | `telemetry` | The heavy one: 600 request-log rows in a **46-column** table whose four jsonb payloads average 37 KB and reach 300 KB, plus 40-line stack traces. Scroll it before shipping a change to the results grid. | wide rows, **very large jsonb**, multi-line text, GIN index |
 
 Required extensions (created by `01_public.sql`): `citext`, `hstore`,
 `pgcrypto`, `pg_trgm`, `ltree`, `vector` (pgvector). The connecting role must
@@ -48,7 +49,7 @@ Omit the argument to fall back to libpq's `PG*` environment variables
 files by hand, in order:
 
 ```bash
-for f in 01_public 02_commerce 03_iot 04_org 05_analytics; do
+for f in 01_public 02_commerce 03_iot 04_org 05_analytics 06_telemetry; do
     psql "$CONN" -v ON_ERROR_STOP=1 -f "$f.sql"
 done
 ```

--- a/scripts/demo/seed.ps1
+++ b/scripts/demo/seed.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 # Loads the pgNimbus type-rich demo dataset into a PostgreSQL database by
-# running 01..05 in order with psql. Idempotent: each run drops and recreates
+# running 01..06 in order with psql. Idempotent: each run drops and recreates
 # the demo schemas, so it always ends in the same canonical state.
 #
 # Usage:
@@ -14,7 +14,7 @@ param([string]$ConnectionString)
 $ErrorActionPreference = 'Stop'
 $dir = $PSScriptRoot
 
-foreach ($f in '01_public','02_commerce','03_iot','04_org','05_analytics') {
+foreach ($f in '01_public','02_commerce','03_iot','04_org','05_analytics','06_telemetry') {
     Write-Host ">>> $f.sql"
     $file = Join-Path $dir "$f.sql"
     if ($ConnectionString) {

--- a/scripts/demo/seed.sh
+++ b/scripts/demo/seed.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Loads the pgNimbus type-rich demo dataset into a PostgreSQL database by
-# running 01..05 in order with psql. Idempotent: each run drops and recreates
+# running 01..06 in order with psql. Idempotent: each run drops and recreates
 # the demo schemas, so it always ends in the same canonical state.
 #
 # Usage:
@@ -22,7 +22,7 @@ run() {
     fi
 }
 
-for f in 01_public 02_commerce 03_iot 04_org 05_analytics; do
+for f in 01_public 02_commerce 03_iot 04_org 05_analytics 06_telemetry; do
     echo ">>> ${f}.sql"
     run "$DIR/${f}.sql"
 done


### PR DESCRIPTION
## What and why

Scrolling the results grid stuttered badly on a real table with many columns and
several jsonb columns holding very large documents. A `DataGrid` cell is a bare
`TextBlock` with no wrapping and no trimming, so it shapes and measures every
character it is handed — including the ones clipped off the right-hand edge of a
560 px column — and it does that as each row is realized. One wheel-scroll's
worth of new rows cost **~450 ms of layout**.

`Converters/CellText` is now the one place a result value becomes text: in full
for the cell inspector (`Full`), capped at 256 characters and folded onto a
single line for the grid (`Preview`, behind `RowIndexConverter`). Measured on the
new demo table below, one scroll step goes **450 ms → 33 ms** (median layout;
p90 743 → 50 ms), which is the same cost as a result set with no long values in
it at all. 256 is ~3× what the widest auto-sized column can show, so the ellipsis
stays off-screen even in a hand-widened column. Folding newlines to spaces is the
same argument from the other side: a 40-line stack trace made its row 40 lines
tall.

**The safety half.** The DataGrid pre-fills its inline editor from the column's
display binding — i.e. from the preview — so a cell showing less than it holds
must never open one, or committing an untouched editor would save the preview
over the real value. Those cells now cancel into the cell inspector, which
carries the whole value, exactly as json/jsonb already did. That also closes the
pre-existing hole where inline-editing a large `bytea` committed its 24-byte hex
preview. Nothing else reads the display text: sorting, copy, export and the
commit path all work off the raw row values.

**Demo data.** `scripts/demo/06_telemetry.sql` is the table this was found and
measured on, and it joins the demo set (`seed.sh`/`seed.ps1`) so the next change
to cell rendering has something to be scrolled through: 600 request-log rows, 46
columns, four jsonb payloads averaging 37 KB and reaching 300 KB, plus 40-line
stack traces. 17 MB on disk.

## Verified

- [x] `dotnet build PgNimbus.slnx` — 0 warnings, 0 errors
- [x] `dotnet test --project PgNimbus.Core.Tests/PgNimbus.Core.Tests.csproj`
      — 764 passed / 18 skipped, no live Postgres
- [x] `dotnet test --project PgNimbus.App.Tests/PgNimbus.App.Tests.csproj`
      — 79 passed, including 8 new `CellTextTests` and a new pair asserting that a
      previewed cell opens the inspector while a fully-shown cell still edits inline
- [x] Real app against a local Postgres seeded with the new demo table: 600 rows
      × 7 columns of jsonb scrolls smoothly, stack-trace rows are one line high
- [x] `tools/Screenshot` renders every scenario (no baseline diff expected — every
      fixture cell value is short and single-line, so no preview is shortened)
- [x] Timings above measured through the real `MainWindow`/`ResultsGridPanel` on
      Avalonia headless + Skia (real text shaping), before and after

Anything left unverified: no NativeAOT publish run locally (no new
reflection/serialization; the trim/AOT analyzers are on and the build is at zero
warnings). Baselines not refreshed — CI's visual check should stay green; if it
does not, that is a real regression to look at.

## Checklist

- [x] [CLAUDE.md](../CLAUDE.md) updated — new "a grid cell shows a preview"
      bullet under coding conventions, and the cast round-trip bullet now points
      at `CellText`
- [x] Does not touch `shared/nimbusUi`
- [x] `PgNimbus.Core` still has zero UI dependencies
- [x] No credentials persisted anywhere they weren't already

🤖 Generated with [Claude Code](https://claude.com/claude-code)
